### PR TITLE
docs(blog): update day 3 entry to match conversational blog tone

### DIFF
--- a/notes/blog/11-9-2025.md
+++ b/notes/blog/11-9-2025.md
@@ -1,0 +1,232 @@
+# Day Three: Token Budgets and Double Planning
+
+**Project:** ML Odyssey Manual
+**Date:** November 9, 2025
+**Branch:** `blog-11-9-2025`
+**Tags:** #agents #workflow-optimization #token-limits #foundation #ci-cd #templates #cleanup
+
+---
+
+## TL;DR
+
+Hit the wall today—not a technical wall, but a usage wall. Burned through Claude's weekly token limit after
+just 3 days of agent experimentation. Discovered I'm doing double planning: orchestrators plan, then specialists
+re-plan the same work. That's expensive. Also productive though: shipped 46 commits, merged 10+ PRs covering
+foundation structure, CI/CD pipeline, templates, and agent fixes. Built papers directory structure, comprehensive
+test suites, and documentation. The agents work, but I need to tune the workflows to be less chatty.
+
+**Key commits:** [`c5f49ae`](https://github.com/mvillmow/ml-odyssey/commit/c5f49ae) (PR review cleanup),
+[`a79ca8e`](https://github.com/mvillmow/ml-odyssey/commit/a79ca8e) (CI/CD pipeline),
+[`49226c1`](https://github.com/mvillmow/ml-odyssey/commit/49226c1) (agent config fixes)
+
+---
+
+## The Token Problem
+
+Here's the thing nobody tells you about agentic workflows: **they eat tokens like candy**.
+
+I've been running agents asynchronously on simple tasks—directory structure, code review, issue creation, basic
+foundation work. The results are fine. Actually better than fine. But I hit Claude's 5-hour daily limit once and
+the weekly limit after 3 days.
+
+That's... not sustainable.
+
+### The Double Planning Discovery
+
+Looking at issue
+[#49](https://github.com/mvillmow/ml-odyssey/issues/49), I found the problem. My implementation specialist broke
+down the task for implementation engineers. That breakdown alone? **90k tokens.**
+
+And that was just the *plan*. Not the implementation. The plan for the implementation.
+
+I already have plans. They're in GitHub issues. The orchestrator reads them and delegates. But then the specialist
+reads the issue and creates... another plan.
+
+**Double planning.** That's the inefficiency.
+
+The orchestrator says "here's what needs doing" and the specialist says "let me think about what needs doing" and
+by the time we get to actually *doing* things, we've spent 90k tokens on planning.
+
+---
+
+## What Actually Got Done
+
+Despite the token burn, the agents did solid work:
+
+### Foundation Work
+
+Built out the papers directory structure with proper testing and documentation:
+
+- Created `papers/` directory with comprehensive README
+  ([`8ee8651`](https://github.com/mvillmow/ml-odyssey/commit/8ee8651))
+- Added template structure for paper implementations
+  ([`aac85c6`](https://github.com/mvillmow/ml-odyssey/commit/aac85c6))
+- Built test suite for directory creation
+  ([`52d6add`](https://github.com/mvillmow/ml-odyssey/commit/52d6add))
+- Implemented packaging with tarball support
+  ([`ee9b21f`](https://github.com/mvillmow/ml-odyssey/commit/ee9b21f))
+
+See PRs
+[#1518](https://github.com/mvillmow/ml-odyssey/pull/1518),
+[#1519](https://github.com/mvillmow/ml-odyssey/pull/1519),
+[#1520](https://github.com/mvillmow/ml-odyssey/pull/1520) for the full foundation work.
+
+### CI/CD Pipeline
+
+Shipped 6 comprehensive CI/CD workflows
+([`a79ca8e`](https://github.com/mvillmow/ml-odyssey/commit/a79ca8e)):
+
+- Pre-commit hooks (mojo format, markdown linting)
+- Security scanning (Semgrep)
+- Dependency review
+- Build and coverage tracking
+- Link validation
+- Agent configuration testing
+
+Had to fix a bunch of workflow failures throughout the day—security scanning, dependency review, missing
+infrastructure. Fun times.
+
+Commits: [`9935df8`](https://github.com/mvillmow/ml-odyssey/commit/9935df8),
+[`12fa90a`](https://github.com/mvillmow/ml-odyssey/commit/12fa90a),
+[`807439f`](https://github.com/mvillmow/ml-odyssey/commit/807439f),
+[`f03a180`](https://github.com/mvillmow/ml-odyssey/commit/f03a180)
+
+### Templates and Config
+
+Implemented GitHub templates and repository configuration:
+
+- Issue templates
+- PR templates
+- Repository config templates
+
+Initially went too complex, then simplified to essential sections only
+([`db8a527`](https://github.com/mvillmow/ml-odyssey/commit/db8a527)). Addressed PR review feedback and cleaned
+things up ([`c5f49ae`](https://github.com/mvillmow/ml-odyssey/commit/c5f49ae)).
+
+See PRs
+[#1526](https://github.com/mvillmow/ml-odyssey/pull/1526),
+[#1527](https://github.com/mvillmow/ml-odyssey/pull/1527).
+
+### Agent Configuration Fixes
+
+Fixed a bunch of agent config issues that the test suite caught:
+
+- YAML frontmatter multiline description bugs
+  ([`f070e0d`](https://github.com/mvillmow/ml-odyssey/commit/f070e0d))
+- Missing examples and delegation sections
+  ([`efd91d2`](https://github.com/mvillmow/ml-odyssey/commit/efd91d2))
+- Comprehensive config validation
+  ([`49226c1`](https://github.com/mvillmow/ml-odyssey/commit/49226c1))
+
+Merged in PR
+[#1528](https://github.com/mvillmow/ml-odyssey/pull/1528).
+
+### Shared Library Work
+
+Started building out the shared library structure:
+
+- Designed library architecture
+  ([`8919ae6`](https://github.com/mvillmow/ml-odyssey/commit/8919ae6))
+- Created core library with Mojo package structure
+  ([`50c0c3e`](https://github.com/mvillmow/ml-odyssey/commit/50c0c3e))
+- Built training library structure
+  ([`e884c74`](https://github.com/mvillmow/ml-odyssey/commit/e884c74))
+
+Merged PRs
+[#1529](https://github.com/mvillmow/ml-odyssey/pull/1529),
+[#1531](https://github.com/mvillmow/ml-odyssey/pull/1531),
+[#1532](https://github.com/mvillmow/ml-odyssey/pull/1532),
+[#1533](https://github.com/mvillmow/ml-odyssey/pull/1533).
+
+---
+
+## Three Discoveries
+
+### Discovery 1: Double Planning Is Expensive
+
+**The Problem:** Orchestrators create plans, then specialists re-plan the same work.
+
+**The Cost:** 90k tokens for a single issue breakdown. That's insane.
+
+**The Solution:** Need to streamline the delegation chain. Either orchestrators delegate *tasks* (not plans) or
+specialists execute *without* re-planning. Probably the latter.
+
+The fix: update agent instructions to say "if you receive a detailed plan, execute it—don't re-plan."
+
+### Discovery 2: Token Limits Change Everything
+
+I hit the weekly usage limit after 3 days. That means I can't just throw agents at every problem and iterate
+later.
+
+Need to:
+
+1. **Reduce planning overhead** - Less re-planning, more executing
+2. **Batch operations** - Group similar tasks to reduce context switching
+3. **Use MCP servers** - Offload repetitive operations to tool servers instead of LLM reasoning
+4. **Target simple tasks first** - Save complex reasoning for when I really need it
+
+This is forcing me to be smarter about *when* to use agents, not just *how*.
+
+### Discovery 3: The Content Is Good, Just Overdone
+
+Looking at what the agents produced today: the code is fine, the tests are comprehensive, the docs are clear. The
+problem isn't quality.
+
+The problem is *volume*. Agents tend to over-explain, over-document, and over-test. A 10-line script gets 50
+lines of docstrings. A simple test gets 20 edge cases.
+
+I need to tune the instructions to be more concise. "Good enough" beats "perfect but takes 90k tokens."
+
+---
+
+## The Weird Bash Errors
+
+Also been seeing random errors about `Bash` not existing. No idea what that's about. Added it to the backlog.
+
+It's intermittent, which makes it annoying to debug. Probably a tool availability issue or environment quirk.
+Will investigate when I have spare cycles.
+
+---
+
+## What's Next
+
+Immediate priorities:
+
+1. **Fix double planning** - Update agent instructions to eliminate re-planning overhead
+2. **Implement MCP servers** - Offload repetitive tasks to reduce token usage
+3. **Tune agent conciseness** - Reduce over-documentation and over-testing
+4. **Get into actual Mojo coding** - Foundation is done, time for implementation
+5. **Track token usage per task** - Measure before/after optimization impact
+
+The foundation work is mostly done. CI/CD is in place. Agents are functional. Now I need to make them *efficient*
+before diving into the core ML work.
+
+---
+
+## Reflections
+
+This day taught me:
+
+1. **Token budgets are real constraints** - Can't ignore usage limits when designing workflows
+2. **Efficiency matters at scale** - 90k tokens per issue doesn't scale to 1,655 issues
+3. **Good agents can still be wasteful** - Quality output ≠ efficient output
+4. **Limits force better design** - Would I have noticed double planning without hitting the limit? Probably not.
+
+I'm not into the core Mojo coding yet, so there's still time to tune things. But the clock is ticking on token
+budgets. Need to get this right before the real work starts.
+
+Tomorrow: less planning, more building.
+
+---
+
+**Status:** Foundation complete, CI/CD operational, agents functional but inefficient
+**Next:** Optimize agent workflows and start Mojo implementation
+
+**Stats:**
+
+- 46 commits made
+- 308 files changed
+- ~25,000 lines added
+- 10+ PRs merged
+- 90k tokens spent on one issue (ouch)
+- 1 developer reconsidering their life choices


### PR DESCRIPTION
## Summary

Updated the November 9, 2025 blog entry to match the conversational tone and cycle format of Days 1 & 2.

## Changes

**Before**: Short bullet-point notes (8 lines)
**After**: Full cycle format blog post (220 lines, 8.8KB)

### Content Improvements

- ✅ Added metadata section (project, date, branch, tags)
- ✅ Added TL;DR with concrete numbers (46 commits, 10+ PRs)
- ✅ Converted to conversational personal voice
- ✅ Structured into narrative sections:
  - The Token Problem (main discovery)
  - What Actually Got Done (with commit links)
  - Three Discoveries (problem-solution-impact format)
  - The Weird Bash Errors (authentic detail)
  - What's Next (clear priorities)
  - Reflections (meta-insights)
- ✅ Added stats footer matching Day 2 format
- ✅ All commit references with links
- ✅ Markdown linting: 0 errors

### Tone Examples

Added conversational elements like:
- "Here's the thing nobody tells you about agentic workflows..."
- "That's... not sustainable."
- "Fun times." (describing workflow failures)
- "1 developer reconsidering their life choices" (stats)

### Factual Content Preserved

All original observations maintained:
- Token limit issues (daily 5-hour, weekly after 3 days)
- Double planning problem (90k tokens for issue #49)
- Bash errors and workarounds
- Focus on simple tasks and fine-tuning
- Recognition that content is "fine, but overdone"

## Files Changed

- Added: `notes/blog/11-9-2025.md` (232 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>