### PR TITLE
docs: add Day 4 blog post on agents vs linters

### DIFF
--- a/notes/blog/11-10-2025.md
+++ b/notes/blog/11-10-2025.md
@@ -11,10 +11,11 @@
 
 Spent the day analyzing why AI-generated code doesn't pass linters, then optimized the agent system
 to use cheaper models where they're good enough. The core insight: training data is polluted with
-unlinted code, so models learn to generate unlinted output. Fixed that by optimizing model tier
-assignments (Opus for planning, Sonnet for design, Haiku for simple tasks). Made 2 commits analyzing
-the linting cost problem and model-tier optimization. Also read Anthropic's multi-agent research
-blog and realized I've independently stumbled into the same patterns they're experimenting with.
+unlinted code, so models learn to generate unlinted output, increasing token count. Working around
+that by optimizing model tier assignments (Opus for planning, Sonnet for design, Haiku for simple
+tasks). Made 2 commits analyzing the linting cost problem and model-tier optimization. Also read
+[Anthropic's multi-agent research blog](https://www.anthropic.com/engineering/multi-agent-research-system)
+and realized I've independently stumbled into the same patterns they're experimenting with.
 
 **Key commits:** [`fbf9a13`](https://github.com/mvillmow/ml-odyssey/commit/fbf9a13) (agentic
 workflows notes), [`404486f`](https://github.com/mvillmow/ml-odyssey/commit/404486f) (optimize
@@ -27,7 +28,7 @@ model tier assignments)
 AI agents produce code that doesn't pass linters. This seems obvious in retrospect, but it's worth
 digging into *why*.
 
-Most developers don't use linters. That means the training data—the internet's code repositories,
+Many developers don't use linters. That means the training data—the internet's code repositories,
 GitHub, tutorials, examples—is polluted with unlinted code. When you train a model on that data, it
 learns to generate unlinted code.
 
@@ -140,6 +141,8 @@ Absolute paths break the link checker. Needs relative paths.
 Rough estimate: **10k tokens per round of linting analysis, multiple rounds per day**. Extrapolate
 that across a 1,655-issue project and you're looking at serious token burn.
 
+This doesn't seem like a big deal, but small inefficencies at scale are expensive!
+
 ### The Solution (For Model Owners)
 
 This is a training data problem, not an inference problem. Model owners should:
@@ -148,8 +151,8 @@ This is a training data problem, not an inference problem. Model owners should:
 2. **Establish standard format** - Use one linter per language as the canonical format
 3. **Verify at training time** - Make sure models learn to generate linter-compliant output
 
-Cost upfront: Higher token usage during training. Cost downtime: Massive token savings for every
-user relying on that model for code generation.
+Cost upfront: Data cleanup cost and higher token usage during training.
+Cost downtime: Massive token savings for every user relying on that model for code generation.
 
 ---
 
@@ -159,7 +162,7 @@ While thinking about linting inefficiency, I also realized something else: **I'm
 models for the wrong tasks**.
 
 Token limits killed me on day 3. I was burning through budget because every agent was using the
-most capable model (Haiku, which is the cheapest, but still...). Actually wait, let me reconsider.
+most capable 4.5 model(Sonnet).
 
 Looking at my current setup, I was running most tasks on what I thought was optimized. But then I
 looked at the actual model capabilities and realized: **not all tasks need the same reasoning power**.
@@ -174,9 +177,8 @@ High-level tasks need high-level reasoning:
 
 Looking at Anthropic's own benchmarks:
 
-- Haiku 4 is nearly at Opus 4.1 level on many tasks
+- Haiku 4.5 is nearly at Opus 4 level on many tasks and competitive with Sonnet 4
 - Sonnet 4.5 is ahead of Opus 4.1 on most metrics
-- Haiku 4.5 should be competitive with Sonnet 4
 
 So the question isn't "what's the best model?" but "what's the best model *for this specific task*?"
 
@@ -195,7 +197,7 @@ assignments across the 48-agent hierarchy.
 The math:
 
 - All Haiku: Fast but might miss nuance
-- All Opus: Guaranteed quality but burns tokens (what I was doing)
+- All Opus or Sonnet: Guaranteed quality but burns tokens (what I was doing)
 - Mixed tiers: Best quality-per-token ratio
 
 ---
@@ -207,13 +209,13 @@ While researching this, I found Anthropic's blog post on multi-agent research sy
 
 This is *remarkably* similar to what I've independently built:
 
-- **Multi-level hierarchy** - My 6 levels mirror their planning/execution/coordination structure
+- **Multi-level hierarchy** - My 6 levels extends their planning/execution/coordination structure
 - **Specialized roles** - My 48 agents with specific domains mirrors their specialist pattern
 - **Token efficiency** - They're solving the exact same "how do we avoid re-planning?" problem I hit
 - **Orchestration patterns** - Similar routing logic to get tasks to the right specialist
 
 They mention using tool servers (like Claude's MCP protocol) to offload repetitive work. I haven't
-done that yet, but it's next on my list.
+done that yet, but it's on my list.
 
 ---
 
@@ -224,14 +226,14 @@ done that yet, but it's next on my list.
 Poor training data (unlinted code) produces poor outputs (unlinted code), which burns tokens fixing
 it downstream. This is a market failure that model owners could fix by cleaning their training data.
 
-The hidden cost of serving unlinted models is borne by users, not model makers.
+The hidden cost of serving unlinted code generated models is borne by users, not model makers.
 
 ### Discovery 2: Model Selection Is Task-Specific
 
-I was over-specifying by using one model tier for everything. The right approach is:
+I was over-specifying by using one model tier for everything. I currently believe the right approach is:
 
 - **Use Opus only for high-complexity planning tasks**
-- **Use Sonnet for design and coordination**
+- **Use Sonnet for design, coordination, and complex implementation**
 - **Use Haiku for straightforward execution**
 
 This reduces token burn while maintaining quality. It's a classic optimization: the right tool for
@@ -249,12 +251,10 @@ Probably both.
 
 ## What's Next
 
-Immediate priorities:
-
 1. **Implement MCP servers** - Offload repetitive operations to avoid token burn on boilerplate
 2. **Build agent token tracking** - Measure actual token usage per agent to optimize further
-3. **Create agentic language** - Design a DSL for dynamic workflows that doesn't require LLM reasoning
-4. **Start Mojo implementation** - Foundation is done, time for actual ML code
+3. **Create agentic language** - Design, or use, a DSL for dynamic workflows that doesn't require LLM reasoning
+4. **Start Mojo implementation** - Foundation is almost done, soon it will be time for actual ML code
 5. **Continue model tier tuning** - Gather data on which models work best for each task
 
 The infrastructure is solid. Now it's about making it *efficient* before diving into the core ML
@@ -266,14 +266,16 @@ work.
 
 This day was less about building and more about *analyzing what I built*:
 
-1. **Linting is a training data problem** - Not something users should have to fix
+1. **Linting is a training data problem** - Not something users should have to pay to fix
 2. **Model selection matters** - Using the right model for the task saves tokens and time
 3. **Anthropic's research validates the approach** - Good sign that others are exploring similar
    patterns
 4. **Token budgets force better design** - Constraints breed innovation
 
 I'm not yet into the core Mojo neural network work. Still in infrastructure and optimization. But
-that's probably fine—getting this right now means the actual ML work will be faster and cheaper.
+that's probably fine, getting this right now means the actual ML work will be faster and cheaper.
+This kind of work used to take weeks/months, now it can be done in days, so the cost of focusing on
+it up front will pay off quickly.
 
 Let's see if the tiered model approach actually helps.
 


### PR DESCRIPTION
## Summary

Added Day 4 development blog post analyzing AI-generated code linting issues and agent system optimization:

- **The Linting Problem**: AI models generate unlinted code because training data is polluted with unlinted code
- **The Model Tier Problem**: Optimized 48-agent hierarchy to use tiered models (Opus/Sonnet/Haiku) based on task complexity
- **The Discovery**: Found alignment with Anthropic's multi-agent research patterns

## Key Insights

- Linting fixes burn ~10k tokens per round; training data should be pre-linted to avoid this
- Token efficiency improves with task-specific model selection (Opus for planning, Sonnet for design, Haiku for execution)
- Multi-agent architecture independently matches Anthropic's experimental patterns

## Changes

- Added `notes/blog/11-10-2025.md` (209 lines, cycle format compliant)
- Proper metadata, TL;DR, discoveries, and reflections sections
- Markdown linting compliant (blank lines, code blocks, line length <120)

## Test plan

- [x] Blog post follows established cycle format (matches 11-7, 11-8, 11-9 structure)
- [x] Markdown linting passes (markdownlint-cli2: 0 errors)
- [x] Pre-commit hooks pass (trailing whitespace, end of file, line endings)
- [x] Links are valid and properly formatted
- [x] Code blocks have language tags and blank lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)