### PR TITLE
docs: add blog on cleanup and token limit annoyances

### DIFF
--- a/notes/blog/11-11-2025.md
+++ b/notes/blog/11-11-2025.md
@@ -1,0 +1,21 @@
+# 11-11-2025: The limits of agentic workflows
+
+So it didn't take long, but the limits that Anthropic puts on the 100$ Max plan isn't enough to run agents for 7 days. The biggest problem of this is that I was in the middle of a task when it just cut off. It wasn't that the Opus limit was hit, or that 5 hour limit were hit, but there is a third limit that is total usage. I think fixing the agent model selection will pay off and not run into this problem, but its a little late, so I have to wait a few more days in order to really test what I have.
+
+
+## Poorly thought side effects of the limits
+
+One of the biggest side effects of the limits is that I can no longer use claude chat at all. I can't even use the 'free' plan, since its associated with my phone number and my phone number is associated with my account. Its even to the point where `/feedback` of claude code doesn't work.... How is providing feedback counted against my account limits?
+
+## Benefits of the limits
+
+On the bright side, this gives me time to analyze and cleanup the code base while agents are 'asleep'. I've found in my experience that modifying the code in parallel to agents cause the agents to really mess up. I haven't yet got this coordination correct, so I'm basically giving agents exclusive access to parts, and sometimes all, of the codebase. This has worked, but I want to figure out a way to get agents to work well with others. So I'll be adding more commits cleaning up various things. I honestly could have done it earlier in the development process, but really, there are multiple levels of quality, and first draft quality, which is what I'm at now, doesn't need the same level of review as production quality. I have a basic philosophy of coding that the first draft is quick and dirty, but does what it is supposed to do, the second iteration learns from the first draft, and comes closer to production. It is only through usage and time that you realize exactly what you want to develop, and that feeds into the third and final draft. This is what I consider production code in that it is fully tested, well designed, documented, and has a solid foundational implementation. This production codebase can then be iterated and improved upon at a faster pace.
+
+
+## Final ideas for the day
+
+Here are some things I'd like to see, and might develop myself, if they don't show up when I get time:
+
+1. Have a programmable event driven agentic model instead of a prompt driven model so that I can be very clear about what I want.
+1. Have a way to visualize how the agents communicate, it isn't clear to me that the flow that I envision happening is actually happening, there is too much noise.
+1. Have a way to get more information on token usage so that I can optimize token usage for given agentic directions.


### PR DESCRIPTION
Add my blog entry on cleanup and token limit annoyances. I'll reformat it to match the others once I get the blog agent available again.