### PR TITLE
docs: Add Day 6 blog post on codifying development principles

### DIFF
--- a/notes/blog/11-12-2025.md
+++ b/notes/blog/11-12-2025.md
@@ -1,0 +1,159 @@
+# Day Six: Principles Over Chaos
+
+**Project:** ML Odyssey Manual
+**Date:** November 12, 2025
+**Branch:** `main`
+**Tags:** #development-principles #documentation #quiet-day #oversight #setup
+
+---
+
+## TL;DR
+
+Realized I'd built the entire agent system and infrastructure without explicitly documenting the
+development principles that should guide it. Spent the day fixing that oversight: added KISS, YAGNI,
+TDD, DRY, SOLID, Modularity, and POLA to CLAUDE.md with explanations and references. Single focused
+commit. Pull request #1555 merged quickly. This is what happens when you're moving fast and forget to
+write down the rules you're already following.
+
+**Key commits:** [`3b94bbd`](https://github.com/mvillmow/ml-odyssey/commit/3b94bbd) (coding principles)
+
+---
+
+## Wait, Where Are The Principles?
+
+Day 5 was a sprint. Day 6 started quiet, and that's when it hit me:
+
+**I built a six-level agent hierarchy, designed an entire infrastructure, established development
+workflows, and never once wrote down the principles that should guide all of it.**
+
+I had been *following* these principles the whole time—the agent system follows SOLID, the cleanup
+focused on DRY, the scripts handle YAGNI. But they weren't documented. They weren't in CLAUDE.md where
+the whole team (which is currently me, but theoretically could be more) would see them.
+
+That's a big gap.
+
+Most good developers already know these things. They're foundational. But here's the thing: **if you
+don't write them down, people don't follow them consistently.** Especially when moving fast, when
+you're tired, or when you're juggling multiple priorities.
+
+So I fixed it.
+
+---
+
+## Seven Principles That Should Have Been There From Day One
+
+I added a "Key Development Principles" section to CLAUDE.md with seven core principles that every
+decision should check against:
+
+**KISS** - Keep It Simple Stupid. The simplest solution that works beats elegant complexity.
+
+**YAGNI** - You Ain't Gonna Need It. Don't build features you *might* need. Build what you need
+*now*.
+
+**TDD** - Test Driven Development. Write tests first, then code. Tests clarify intent and catch
+regressions.
+
+**DRY** - Don't Repeat Yourself. Each piece of knowledge should have one authoritative place. (Day 5
+taught me this the hard way.)
+
+**SOLID** - Five architectural principles rolled into one: Single Responsibility, Open-Closed, Liskov
+Substitution, Interface Segregation, Dependency Inversion.
+
+**Modularity** - Independent modules through well-defined interfaces. This is why the agent hierarchy
+works at all.
+
+**POLA** - Principle of Least Astonishment. Interfaces should be intuitive. Don't surprise users
+(including future you).
+
+None of these are original ideas. They're decades old. But that's the point—they're *proven* because
+they work. The fact that I was already following them meant I should have just written them down
+earlier.
+
+---
+
+## Why I Forgot And Why It Matters
+
+I was moving fast:
+
+- Day 1: Build the planning structure (331 files, 1,655 potential issues)
+- Day 2: Set up automation (scripts for issue creation)
+- Day 3-4: Create the agent system (48 agents across 6 levels)
+- Day 5: Cleanup marathon (1,100+ errors, rebuild after hitting token limits)
+
+By that point, I was deep in execution mode. Principles feel abstract when you're in the weeds. You
+don't think "I'm following SOLID today," you think "let me make this specialist agent handle one
+responsibility."
+
+But without writing them down, they're not *shared*. They're just what I happen to be doing. And
+that's fragile.
+
+Here's what I learned: **write down the principles *before* you're in deep execution.** Or at least,
+do it as soon as you notice you're *already* following them.
+
+---
+
+## The Commit
+
+Small, focused:
+
+```text
+docs: add coding principles to CLAUDE.md
+```
+
+What went in:
+
+- "Key Development Principles" section with all seven principles explained
+- Why each principle matters for *this project specifically*
+- Four reference links for developers who want to dive deeper:
+  - Core Principles of Software Development
+  - 7 Common Programming Principles
+  - Software Development Principles
+  - Clean Coding Principles
+- Also added `*.swp` to .gitignore (vim swap files—preventing future annoyances)
+
+Small change. But it's a change that should have been there on Day 1.
+
+---
+
+## What's Next
+
+Immediate priorities:
+
+1. **Audit the Agent System** - Make sure all 48 agents actually follow these principles
+2. **Code Review Against Principles** - Day 5's cleanup code should check against these standards
+3. **Mojo Implementation** - When we write the neural network code, start with KISS, not complexity
+4. **Test Infrastructure** - TDD means we need solid testing framework first
+5. **Documentation Consistency** - Every doc should reflect these principles
+
+---
+
+## Reflections
+
+This day was a reminder that **obvious things need to be written down.**
+
+I knew these principles. I was following them. But they weren't documented, which means:
+
+- New developers wouldn't know them
+- I might slip on them under pressure
+- There's no shared reference point for discussing trade-offs
+
+The best practices in your head aren't practices—they're just habits. Writing them down turns them
+into *principles*, which is stronger.
+
+Also? It felt good to pause and do one thing well. Day 5 was about volume. Day 6 was about clarity.
+Both are necessary, but clarity is easier to remember.
+
+---
+
+**Status:** Development principles documented and committed. Foundation now has both code and
+philosophy.
+
+**Next:** Audit existing system against principles, prepare for Mojo implementation
+
+**Stats:**
+
+- 1 commit (focused, intentional)
+- 7 core principles documented
+- 4 external references added
+- 1 major oversight corrected
+- 1 developer who remembered to breathe


### PR DESCRIPTION
## Summary

New blog post documenting Day 6 (November 12, 2025) - the day of codifying development principles after Day 5's cleanup chaos.

## Content

**Core Narrative:**
- Realization that the entire system was built following principles never written down
- Single focused commit adding 7 core principles to CLAUDE.md
- Contrast between Day 5's sprint (8 commits) and Day 6's clarity (1 commit)
- Reflection on why explicit documentation matters for team coordination

**Seven Principles Documented:**
1. **KISS** - Keep It Simple Stupid
2. **YAGNI** - You Ain't Gonna Need It
3. **TDD** - Test Driven Development
4. **DRY** - Don't Repeat Yourself
5. **SOLID** - Single Responsibility, Open-Closed, Liskov, Interface Segregation, Dependency Inversion
6. **Modularity** - Independent modules with well-defined interfaces
7. **POLA** - Principle of Least Astonishment

**Format:**
- ✅ Follows established cycle format from Days 1-5
- ✅ Complete metadata header block (Project/Date/Branch/Tags)
- ✅ TL;DR with commit and PR references
- ✅ Structured narrative sections
- ✅ "What's Next" and "Reflections" sections
- ✅ Status footer with project stats

**Markdown Compliance:**
- ✅ All blank lines around lists, headings, code blocks
- ✅ All lines under 120 characters
- ✅ Proper spacing and formatting
- ✅ Passes markdownlint validation
- ✅ Pre-commit hooks pass

**Length:** Shorter than Day 5 (reflects the quieter, more focused nature of the day)

## Test Plan

- [x] Blog post follows established cycle format
- [x] All markdown linting passes (0 errors)
- [x] Commit links are accurate (commit 3b94bbd)
- [x] PR links are accurate (PRs #1553, #1554, #1555)
- [x] Content flows naturally
- [x] Tone matches Days 1-5 (informal but professional)
- [x] Pre-commit hooks pass

## Links

**Commit referenced:** https://github.com/mvillmow/ml-odyssey/commit/3b94bbd
**PRs referenced:** #1553, #1554, #1555

🤖 Generated with [Claude Code](https://claude.com/claude-code)