### PR TITLE
docs(agents): clarify Package phase creates artifacts, not just documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,18 +389,25 @@ What this specific issue accomplishes (1-2 sentences)
 
 Every component follows a hierarchical workflow with clear dependencies:
 
-**Workflow**: Plan → [Test | Implementation | Packaging] → Cleanup
+**Workflow**: Plan → [Test | Implementation | Package] → Cleanup
 
 1. **Plan** - Design and documentation (MUST complete first)
 2. **Test** - Write tests following TDD (parallel after Plan)
 3. **Implementation** - Build the functionality (parallel after Plan)
-4. **Packaging** - Integration and packaging (parallel after Plan)
+4. **Package** - Create distributable packages (parallel after Plan)
+   - Build binary packages (`.mojopkg` files for Mojo modules)
+   - Create distribution archives (`.tar.gz`, `.zip` for tooling/docs)
+   - Configure package metadata and installation procedures
+   - Add components to existing packages
+   - Test package installation in clean environments
+   - Create CI/CD packaging workflows
+   - **NOT just documenting** - must create actual distributable artifacts
 5. **Cleanup** - Refactor and finalize (runs after parallel phases complete)
 
 **Key Points**:
 
 - Plan phase produces specifications for all other phases
-- Test/Implementation/Packaging can run in parallel after Plan completes
+- Test/Implementation/Package can run in parallel after Plan completes
 - Cleanup collects issues discovered during the parallel phases
 - Each phase has a separate GitHub issue with detailed instructions
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -166,9 +166,12 @@ Component Specialist
 
 - Levels 0-2: Orchestrators and designers create specifications
 
-**Phases 2-4: Test/Implementation/Packaging** (Parallel)
+**Phases 2-4: Test/Implementation/Package** (Parallel)
 
 - Levels 3-5: Specialists and engineers execute in parallel
+- **Package Phase**: Create distributable artifacts (.mojopkg files, archives, CI/CD workflows)
+  - NOT just documenting existing structures
+  - Must produce actual installable packages
 
 **Phase 5: Cleanup** (Sequential)
 

--- a/agents/agent-hierarchy.md
+++ b/agents/agent-hierarchy.md
@@ -307,12 +307,13 @@ Level 5: Junior Engineers
 - Document APIs and interfaces
 - Create usage examples
 - Write tutorials if needed
+- **Package Phase**: Create distribution documentation, installation guides, package metadata
 
 **Delegates To**: Documentation Writers (Level 4)
 
-**Artifacts**: READMEs, API docs, tutorials
+**Artifacts**: READMEs, API docs, tutorials, package documentation
 
-**Workflow Phase**: Plan, Packaging, Cleanup
+**Workflow Phase**: Plan, Package, Cleanup
 
 **Configuration File**: `.claude/agents/documentation-specialist.md`
 
@@ -437,10 +438,11 @@ Level 5: Junior Engineers
 - Create code examples
 - Write README sections
 - Update documentation as code changes
+- **Package Phase**: Write installation guides, package READMEs, distribution documentation
 
-**Artifacts**: Documentation files, docstrings
+**Artifacts**: Documentation files, docstrings, package documentation
 
-**Workflow Phase**: Packaging
+**Workflow Phase**: Package
 
 **Skills Used**: documentation_generation, example_extraction
 
@@ -646,7 +648,7 @@ Coordinates with: [Same level agents]
 | Plan | 0, 1, 2, 3 | Orchestrators and designers create specifications |
 | Test | 3, 4, 5 | Specialists and engineers write tests |
 | Implementation | 3, 4, 5 | Specialists and engineers build functionality |
-| Packaging | 3, 4, 5 | Specialists and engineers integrate artifacts |
+| Package | 3, 4, 5 | Specialists and engineers create distributable packages (.mojopkg, archives, CI/CD) |
 | Cleanup | All | All levels review and refactor their work |
 
 ---

--- a/agents/delegation-rules.md
+++ b/agents/delegation-rules.md
@@ -351,6 +351,50 @@ git merge --no-commit <branch>
 - Uses consistent patterns
 - Maintains conventions
 
+## Package Phase Success Criteria
+
+### What Defines Package Phase Completion
+
+**Package phase is complete ONLY when**:
+
+✅ **For Mojo Library Modules**:
+
+- `.mojopkg` binary package file exists in `dist/`
+- Package installs successfully in clean environment
+- Installation verification script passes
+- Package metadata is complete (version, dependencies, license)
+
+✅ **For Tooling/Benchmarks**:
+
+- Distribution archive (`.tar.gz` or `.zip`) exists in `dist/`
+- Archive extracts and runs in clean environment
+- CI/CD workflow file exists and passes
+- Executable scripts have proper permissions
+
+✅ **For Documentation**:
+
+- Static site built successfully (`site/` directory exists)
+- GitHub Pages deployment workflow configured
+- All links in built site are valid
+- Offline archive available for distribution
+
+**Package phase is NOT complete if**:
+
+❌ Only documentation files created (README.md, notes/issues/XX/README.md)
+❌ Only `__init__.mojo` files exist without binary package
+❌ No actual artifacts in `dist/` directory
+❌ No installation testing performed
+❌ No CI/CD workflows created
+
+### Package Phase Artifacts by Component Type
+
+| Component Type | Required Artifacts | Verification |
+|----------------|-------------------|--------------|
+| Mojo Library | `dist/<module>-<version>.mojopkg` | `mojo package shared/<module> -o dist/<module>-<version>.mojopkg` |
+| Tooling | `dist/<tool>-<version>.tar.gz` | Extract and run in fresh directory |
+| Documentation | `site/` + `.github/workflows/docs.yml` | `mkdocs build && mkdocs serve` |
+| Benchmarks | Archive + `.github/workflows/benchmark.yml` | Workflow runs successfully in CI |
+
 ## Quick Decision Tree
 
 ```text

--- a/agents/guides/package-phase-guide.md
+++ b/agents/guides/package-phase-guide.md
@@ -1,0 +1,697 @@
+# Package Phase Guide
+
+## Overview
+
+The **Package phase** is one of the 5 phases in the ml-odyssey development workflow. Its purpose is to create
+**distributable packages** that can be installed and used by others.
+
+**Critical Understanding**: Package phase creates actual artifacts (.mojopkg files, archives, CI/CD workflows),
+NOT just documentation about existing file structures.
+
+## What Package Phase IS
+
+### Primary Objective
+
+Transform implemented code into distributable, installable packages.
+
+### Core Activities
+
+✅ **Build Binary Packages**:
+
+- Create `.mojopkg` files for Mojo library modules
+- Compile source code into distributable binaries
+- Include all necessary dependencies and metadata
+
+✅ **Create Distribution Archives**:
+
+- Generate `.tar.gz` or `.zip` archives for tooling
+- Package documentation for offline use
+- Include installation scripts and README files
+
+✅ **Configure Package Metadata**:
+
+- Set version numbers (SemVer format: 0.1.0)
+- Specify dependencies and requirements
+- Add license information
+- Create package manifests
+
+✅ **Test Package Installation**:
+
+- Install packages in clean environments
+- Verify all dependencies resolve correctly
+- Test that installed package works as expected
+- Validate import paths and module structure
+
+✅ **Create CI/CD Workflows**:
+
+- Set up automated package building
+- Configure deployment pipelines
+- Add version tagging and release automation
+- Test packages in CI environment
+
+✅ **Add Components to Existing Packages**:
+
+- Integrate new modules into existing `.mojopkg` files
+- Update package metadata for new components
+- Rebuild packages with new functionality
+- Version bump appropriately (patch/minor/major)
+
+### Expected Deliverables
+
+**For Mojo Library Modules** (Training, Data, Utils):
+
+```text
+dist/
+├── training-0.1.0.mojopkg      # Binary package file
+├── data-0.1.0.mojopkg          # Binary package file
+└── utils-0.1.0.mojopkg         # Binary package file
+
+scripts/
+└── install_verify.sh           # Installation verification script
+
+README.md                       # Distribution README with install instructions
+```
+
+**For Tooling/Benchmarks**:
+
+```text
+dist/
+└── benchmarks-0.1.0.tar.gz     # Distribution archive
+
+.github/workflows/
+└── benchmark.yml               # CI/CD workflow for benchmarking
+
+scripts/benchmarks/
+├── run_benchmark.sh            # Executable benchmark scripts
+└── README.md                   # Usage instructions
+```
+
+**For Documentation**:
+
+```text
+site/                           # Built static site (HTML/CSS/JS)
+├── index.html
+├── getting-started/
+├── core/
+├── advanced/
+└── dev/
+
+.github/workflows/
+└── docs.yml                    # GitHub Pages deployment workflow
+
+dist/
+└── docs-offline-0.1.0.zip      # Offline documentation archive
+```
+
+## What Package Phase is NOT
+
+### Common Misconceptions
+
+❌ **Just Documenting Structure**:
+
+- Package phase is NOT about writing notes/issues/XX/README.md
+- NOT about documenting that `__init__.mojo` exists
+- NOT about verifying directory structure
+
+❌ **Verification-Only**:
+
+- NOT just checking that files exist
+- NOT just confirming exports are correct
+- NOT just documenting success criteria as "already met"
+
+❌ **Documentation-Only Deliverables**:
+
+- Creating only markdown files is NOT package phase
+- Notes about packaging are NOT packaging
+- Plans for packaging are NOT packaging
+
+### What Doesn't Count as Package Phase Completion
+
+These activities, while useful, do NOT constitute Package phase completion:
+
+- ❌ Writing comprehensive README.md files
+- ❌ Creating notes/issues/XX/README.md documentation
+- ❌ Verifying `__init__.mojo` exports are correct
+- ❌ Documenting that "package structure is ready"
+- ❌ Listing files that exist in the module
+- ❌ Confirming success criteria are met (without artifacts)
+
+**Example of INCORRECT Package Phase**:
+
+```text
+Issue #40: [Package] Data Module
+
+Deliverables:
+✅ Created notes/issues/40/README.md documenting structure
+✅ Verified shared/data/__init__.mojo has 19 exports
+✅ Confirmed README.md is comprehensive (546 lines)
+✅ Documented that module is "production-ready"
+
+PR #1594: "docs(data): complete package phase verification"
+```
+
+This is WRONG because:
+
+- No .mojopkg file created
+- No artifacts in dist/
+- No installation testing performed
+- Only documentation created
+
+**Example of CORRECT Package Phase**:
+
+```text
+Issue #40: [Package] Data Module
+
+Deliverables:
+✅ Built dist/data-0.1.0.mojopkg binary package
+✅ Created installation verification script
+✅ Tested installation in clean environment
+✅ Added to dist/ml-odyssey-0.1.0.mojopkg meta-package
+✅ Created distribution README with install instructions
+
+PR #1594: "feat(data): create distributable package with installation testing"
+
+Files changed:
++ dist/data-0.1.0.mojopkg
++ scripts/install_verify_data.sh
++ INSTALL.md
+M shared/data/mojo.toml
+```
+
+## Package Phase Workflow
+
+### Step-by-Step Process
+
+#### 1. Prepare Package Metadata
+
+Create or update `mojo.toml` configuration:
+
+```toml
+[project]
+name = "ml-odyssey-data"
+version = "0.1.0"
+description = "Data utilities for ML Odyssey"
+authors = ["ML Odyssey Contributors"]
+license = "BSD-3-Clause"
+
+[dependencies]
+# List required packages
+```
+
+#### 2. Build Binary Package
+
+For Mojo modules:
+
+```bash
+# Build .mojopkg file
+mojo package shared/data -o dist/data-0.1.0.mojopkg
+
+# Verify package was created
+ls -lh dist/data-0.1.0.mojopkg
+```
+
+For tooling (create archive):
+
+```bash
+# Create distribution archive
+tar -czf dist/benchmarks-0.1.0.tar.gz \
+    scripts/benchmarks/ \
+    benchmarks/ \
+    README.md \
+    LICENSE
+
+# Verify archive
+tar -tzf dist/benchmarks-0.1.0.tar.gz
+```
+
+#### 3. Test Installation
+
+Create verification script:
+
+```bash
+#!/bin/bash
+# scripts/install_verify_data.sh
+
+set -e
+
+echo "Testing data package installation..."
+
+# Create temporary directory
+TEMP_DIR=$(mktemp -d)
+cd "$TEMP_DIR"
+
+# Install package
+mojo install /path/to/dist/data-0.1.0.mojopkg
+
+# Test import
+echo "Testing imports..."
+mojo run -c "from data import Dataset, DataLoader; print('Success!')"
+
+# Cleanup
+cd -
+rm -rf "$TEMP_DIR"
+
+echo "Data package verification complete!"
+```
+
+Run verification:
+
+```bash
+chmod +x scripts/install_verify_data.sh
+./scripts/install_verify_data.sh
+```
+
+#### 4. Create CI/CD Workflow
+
+Add `.github/workflows/package.yml`:
+
+```yaml
+name: Build and Test Packages
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    paths:
+      - 'shared/**'
+      - 'dist/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Mojo
+        uses: modular/setup-mojo@v1
+
+      - name: Build packages
+        run: |
+          mojo package shared/data -o dist/data-${{ github.ref_name }}.mojopkg
+          mojo package shared/training -o dist/training-${{ github.ref_name }}.mojopkg
+          mojo package shared/utils -o dist/utils-${{ github.ref_name }}.mojopkg
+
+      - name: Test installation
+        run: |
+          ./scripts/install_verify_data.sh
+          ./scripts/install_verify_training.sh
+          ./scripts/install_verify_utils.sh
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: dist/*.mojopkg
+```
+
+#### 5. Document Distribution
+
+Create `INSTALL.md`:
+
+```markdown
+# Installation Guide
+
+## Installing from Binary Packages
+
+### Data Module
+
+```bash
+mojo install dist/data-0.1.0.mojopkg
+```
+
+### Training Module
+
+```bash
+mojo install dist/training-0.1.0.mojopkg
+```
+
+## Verification
+
+Test your installation:
+
+```bash
+mojo run -c "from data import Dataset; print('Data module works!')"
+mojo run -c "from training import Optimizer; print('Training module works!')"
+```
+
+## Package Phase Checklist
+
+Use this checklist to verify Package phase is truly complete:
+
+### For Mojo Library Modules
+
+- [ ] `.mojopkg` file exists in `dist/` directory
+- [ ] Package filename includes version number (e.g., `data-0.1.0.mojopkg`)
+- [ ] `mojo.toml` configuration file complete
+- [ ] Installation verification script created and passing
+- [ ] Package tested in clean environment (not development environment)
+- [ ] All exports work correctly when package is installed
+- [ ] Dependencies documented in package metadata
+- [ ] License included in package
+
+### For Tooling/Benchmarks
+
+- [ ] Distribution archive created (`.tar.gz` or `.zip`)
+- [ ] Archive includes all necessary scripts and files
+- [ ] Executable scripts have proper permissions (`chmod +x`)
+- [ ] Archive extracts and runs in clean environment
+- [ ] CI/CD workflow configured (`.github/workflows/`)
+- [ ] Workflow runs successfully in CI
+- [ ] README with usage instructions included
+
+### For Documentation
+
+- [ ] Static site built successfully (`mkdocs build`)
+- [ ] `site/` directory exists with HTML files
+- [ ] GitHub Pages deployment workflow configured
+- [ ] All internal links work correctly
+- [ ] External links validated
+- [ ] Offline archive created for distribution
+- [ ] Documentation versioned appropriately
+
+### Common to All
+
+- [ ] Version number follows SemVer (0.1.0)
+- [ ] CHANGELOG.md updated with changes
+- [ ] Distribution README created
+- [ ] Installation instructions documented
+- [ ] No artifacts committed to git (add to .gitignore)
+- [ ] PR description clearly states artifacts created
+
+## Anti-Patterns to Avoid
+
+### Anti-Pattern 1: Documentation-Only PRs
+
+**Wrong**:
+
+```text
+PR Title: "docs(training): complete package phase verification"
+
+Changes:
+- Added notes/issues/35/README.md
+- Updated README to say "package is ready"
+- Verified __init__.mojo exports
+```
+
+**Right**:
+
+```text
+PR Title: "feat(training): create distributable package"
+
+Changes:
++ dist/training-0.1.0.mojopkg
++ scripts/install_verify_training.sh
++ INSTALL.md
+M shared/training/mojo.toml
+```
+
+### Anti-Pattern 2: Assuming Existing Structure is "Packaged"
+
+**Wrong**:
+
+> "The module already has **init**.mojo and README.md, so it's packaged!"
+
+**Right**:
+
+> "The module has source files. Now we need to build the .mojopkg binary package."
+
+### Anti-Pattern 3: No Installation Testing
+
+**Wrong**:
+
+```bash
+# Just build the package
+mojo package shared/data -o dist/data-0.1.0.mojopkg
+# PR created without testing
+```
+
+**Right**:
+
+```bash
+# Build package
+mojo package shared/data -o dist/data-0.1.0.mojopkg
+
+# Test in clean environment
+TEMP_DIR=$(mktemp -d)
+cd "$TEMP_DIR"
+mojo install /path/to/dist/data-0.1.0.mojopkg
+mojo run -c "from data import Dataset"  # Verify import works
+cd - && rm -rf "$TEMP_DIR"
+
+# Now PR can be created
+```
+
+## Examples by Component Type
+
+### Example 1: Training Module Package
+
+**Component**: `shared/training/`
+
+**Package Phase Tasks**:
+
+1. Create `shared/training/mojo.toml`:
+
+```toml
+[project]
+name = "ml-odyssey-training"
+version = "0.1.0"
+description = "Training utilities for ML Odyssey"
+authors = ["ML Odyssey Contributors"]
+license = "BSD-3-Clause"
+
+[dependencies]
+ml-odyssey-utils = "0.1.0"
+```
+
+1. Build package:
+
+```bash
+mojo package shared/training -o dist/training-0.1.0.mojopkg
+```
+
+1. Create verification script:
+
+```bash
+#!/bin/bash
+# scripts/install_verify_training.sh
+set -e
+TEMP_DIR=$(mktemp -d)
+cd "$TEMP_DIR"
+mojo install /path/to/dist/training-0.1.0.mojopkg
+mojo run -c "from training import Optimizer; print('Training module OK')"
+cd - && rm -rf "$TEMP_DIR"
+```
+
+1. Test installation:
+
+```bash
+chmod +x scripts/install_verify_training.sh
+./scripts/install_verify_training.sh
+```
+
+1. Create PR with artifacts:
+
+```text
+feat(training): create distributable package
+
+- Built dist/training-0.1.0.mojopkg binary package
+- Created installation verification script
+- Tested installation in clean environment
+- Added mojo.toml configuration
+
+Closes #35
+```
+
+### Example 2: Benchmarks Tooling Package
+
+**Component**: `benchmarks/` + `scripts/benchmarks/`
+
+**Package Phase Tasks**:
+
+1. Create distribution archive:
+
+```bash
+tar -czf dist/benchmarks-0.1.0.tar.gz \
+    scripts/benchmarks/ \
+    benchmarks/ \
+    README.md \
+    LICENSE
+```
+
+1. Create CI/CD workflow `.github/workflows/benchmark.yml`:
+
+```yaml
+name: Run Benchmarks
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Mojo
+        uses: modular/setup-mojo@v1
+      - name: Run benchmarks
+        run: ./scripts/benchmarks/run_all.sh
+```
+
+1. Test archive extraction:
+
+```bash
+TEMP_DIR=$(mktemp -d)
+cd "$TEMP_DIR"
+tar -xzf /path/to/dist/benchmarks-0.1.0.tar.gz
+./scripts/benchmarks/run_all.sh  # Verify works
+cd - && rm -rf "$TEMP_DIR"
+```
+
+1. Create PR:
+
+```text
+feat(benchmarks): create distributable package and CI workflow
+
+- Created dist/benchmarks-0.1.0.tar.gz distribution archive
+- Added .github/workflows/benchmark.yml for automated benchmarking
+- Tested archive extraction and execution in clean environment
+- Scripts include README with usage instructions
+
+Closes #55
+```
+
+### Example 3: Documentation Package
+
+**Component**: `docs/`
+
+**Package Phase Tasks**:
+
+1. Build static site:
+
+```bash
+mkdocs build
+# Produces site/ directory
+```
+
+1. Create GitHub Pages workflow `.github/workflows/docs.yml`:
+
+```yaml
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material
+      - run: mkdocs gh-deploy --force
+```
+
+1. Create offline archive:
+
+```bash
+zip -r dist/docs-offline-0.1.0.zip site/
+```
+
+1. Test deployment:
+
+```bash
+mkdocs serve  # Test locally at http://127.0.0.1:8000
+```
+
+1. Create PR:
+
+```text
+feat(docs): build static site and configure GitHub Pages deployment
+
+- Built static site in site/ directory
+- Added .github/workflows/docs.yml for auto-deployment
+- Created dist/docs-offline-0.1.0.zip for offline use
+- Tested local serving and deployment
+
+Closes #60
+```
+
+## Agent Responsibilities
+
+### Level 3: Component Specialists
+
+**Package Phase Role**: Design packaging strategy
+
+- Specify .mojopkg requirements and structure
+- Plan CI/CD workflows and automation
+- Define installation testing approach
+- Determine version numbering strategy
+
+### Level 4: Implementation Engineers
+
+**Package Phase Role**: Build packages
+
+- Execute `mojo package` commands
+- Create distribution archives
+- Implement packaging scripts
+- Build CI/CD workflow files
+- Write installation verification scripts
+
+### Level 5: Junior Engineers
+
+**Package Phase Role**: Execute packaging commands
+
+- Run package builds as instructed
+- Verify installations work
+- Execute packaging commands
+- Test basic functionality after install
+
+## Troubleshooting
+
+### Issue: "mojo package" command fails
+
+**Solution**:
+
+- Verify `mojo.toml` exists and is valid
+- Check all source files compile individually
+- Ensure `__init__.mojo` has correct exports
+- Review Mojo version compatibility
+
+### Issue: Package installs but imports fail
+
+**Solution**:
+
+- Verify package structure matches source structure
+- Check import paths are correct
+- Ensure all dependencies are listed in mojo.toml
+- Test with `mojo run -c "import <module>"`
+
+### Issue: CI/CD workflow doesn't run
+
+**Solution**:
+
+- Check workflow file is in `.github/workflows/`
+- Verify YAML syntax is correct
+- Ensure workflow triggers are configured
+- Check GitHub Actions are enabled for repo
+
+## References
+
+- [Mojo Packaging Documentation](https://docs.modular.com/mojo/manual/packages/)
+- [GitHub Actions Documentation](https://docs.github.com/en/actions)
+- [Semantic Versioning](https://semver.org/)
+- [MkDocs Documentation](https://www.mkdocs.org/)
+
+## Version History
+
+- **v1.0** (2025-11-14): Initial creation based on Package phase misunderstanding lessons learned
+- Clarified that Package phase creates artifacts, not just documentation
+- Added comprehensive examples and anti-patterns
+- Defined success criteria and checklists

--- a/agents/hierarchy.md
+++ b/agents/hierarchy.md
@@ -96,24 +96,27 @@
 - **Agents**: 5 types (Implementation, Test, Docs, Performance, Security)
 - **Scope**: Components within modules
 - **Decisions**: Component implementation approach
-- **Phase**: Plan, Test, Implementation, Packaging
+- **Phase**: Plan, Test, Implementation, Package
 - **Language Context**: Chooses Mojo patterns (fn vs def, struct vs class, SIMD usage)
+- **Package Phase**: Design packaging strategy, specify .mojopkg requirements, plan CI/CD workflows
 
 ### Level 4: Implementation Engineers
 
 - **Agents**: 5 types (Senior, Standard, Test, Docs, Performance)
 - **Scope**: Functions and classes
 - **Decisions**: Implementation details
-- **Phase**: Test, Implementation, Packaging
+- **Phase**: Test, Implementation, Package
 - **Language Context**: Writes Mojo code, uses Mojo standard library, implements algorithms
+- **Package Phase**: Build .mojopkg files, create distribution archives, implement packaging scripts
 
 ### Level 5: Junior Engineers
 
 - **Agents**: 3 types (Implementation, Test, Documentation)
 - **Scope**: Simple functions, boilerplate
 - **Decisions**: None (follows instructions)
-- **Phase**: Test, Implementation, Packaging
+- **Phase**: Test, Implementation, Package
 - **Language Context**: Generates Mojo boilerplate, applies formatting
+- **Package Phase**: Run package builds, verify installations, execute packaging commands
 
 ## Mojo-Specific Considerations
 


### PR DESCRIPTION
## Summary

This PR clarifies that the **Package phase** creates actual distributable artifacts (.mojopkg files, archives, CI/CD workflows), NOT just documentation about existing structures.

## Problem

Issues #35, #40, #45, #55, #60 (Package phase) were initially completed with only documentation deliverables. The Package phase was misunderstood as "verify and document existing package structure" instead of "create actual distributable packages".

This led to PRs (#1593-1597) that only created `notes/issues/XX/README.md` files without building any:
- .mojopkg binary packages
- Distribution archives
- CI/CD workflows
- Installation verification scripts

## Solution

Updated all agent documentation to clearly define what Package phase IS and is NOT:

### What Package Phase IS
✅ Build .mojopkg binary packages for Mojo modules
✅ Create distribution archives (.tar.gz, .zip) for tooling
✅ Configure package metadata and installation
✅ Test package installation in clean environments
✅ Create CI/CD packaging workflows
✅ Build static sites and deployment for documentation

### What Package Phase is NOT
❌ Just documenting existing file structure
❌ Only verifying __init__.mojo exports
❌ Creating only notes/issues/XX/README.md files
❌ No actual artifacts in dist/ directory

## Changes

### Core Documentation Updates
- **CLAUDE.md**: Expanded Package phase description with bullet points of deliverables
- **agents/README.md**: Added explicit note that Package phase creates .mojopkg files
- **agents/hierarchy.md**: Added Package phase responsibilities for Levels 3-5
- **agents/agent-hierarchy.md**: Updated workflow phase info and deliverables
- **agents/delegation-rules.md**: Added comprehensive Package Phase Success Criteria section

### New Comprehensive Guide
- **agents/guides/package-phase-guide.md** (650+ lines):
  - Clear definitions of what Package phase IS vs is NOT
  - Step-by-step workflow for Mojo modules, tooling, and documentation
  - Component-specific examples (Training, Benchmarks, Docs)
  - Complete checklists for verification
  - Anti-patterns to avoid with wrong/right examples
  - Agent responsibilities by level

## Impact

- Prevents future misunderstanding of Package phase requirements
- Provides clear success criteria for Package phase completion
- Establishes checklists to verify all artifacts are created
- Gives step-by-step instructions for each component type

## Next Steps

After this PR merges:
1. Close PRs #1593-1597 (incorrect deliverables)
2. Redo Package phase for issues #35, #40, #45, #55, #60 with actual artifacts
3. Proceed with Cleanup phase after Package artifacts are created

## Review Checklist

- [x] All documentation files updated consistently
- [x] Package phase clearly defined with concrete deliverables
- [x] Success criteria established
- [x] Examples provided for each component type
- [x] Markdown linting passes
- [x] Pre-commit hooks pass