### PR TITLE
chore: update .gitignore for Mojo builds and training artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,21 @@ datasets/
 site/
 .cache/
 
+# Mojo build artifacts
+*.o
+*.a
+train
+examples/*/train
+examples/*/inference
+test_*
+!tests/**
+
+# Training artifacts
+*.log
+training_*.txt
+*_weights/
+checkpoints/
+
+# Editor files
 *.swp
 .coverage


### PR DESCRIPTION
## Summary

Updates .gitignore to properly ignore build artifacts and training outputs from the Mojo 0.25.7 migration.

## Changes

Adds patterns to ignore:
- **Mojo binaries**: , , , 
- **Training logs**: , 
- **Model weights**: , 
- **Temporary test files**:  (except files in  directory)

## Why This Matters

After PR #1881 (Mojo 0.25.7 migration), building and training creates several artifacts:
- Compiled binaries (, )
- Training logs (, etc.)
- Saved model weights ()
- Verification test files ()

These should not be committed to the repository.

## Verification

The gitignore correctly:
- ✅ Ignores compiled binaries in root and examples/
- ✅ Ignores training logs and outputs  
- ✅ Ignores saved model weights
- ✅ Ignores test_* files in root and examples/
- ✅ Preserves test_* files in tests/ directory (via !tests/**)

## Impact

- Cleaner On branch chore/update-gitignore
Your branch is up to date with 'origin/chore/update-gitignore'.

nothing to commit, working tree clean output
- Prevents accidental commits of large binary files
- Follows best practices for ignoring build artifacts