### PR TITLE
Add BF feature

### DIFF
--- a/examples/bf8_example.mojo
+++ b/examples/bf8_example.mojo
@@ -1,0 +1,139 @@
+"""Example demonstrating BF8 data type usage.
+
+This example shows:
+1. Creating BF8 values from Float32
+2. Converting BF8 back to Float32
+3. Converting tensors to/from BF8 format
+4. Memory savings with BF8 (8-bit vs 32-bit)
+5. Comparing BF8 (E5M2) vs FP8 (E4M3) characteristics
+"""
+
+from shared.core import ExTensor, zeros, BF8, FP8
+from collections.vector import DynamicVector
+
+
+fn main() raises:
+    print("\n=== BF8 Data Type Example ===\n")
+
+    # 1. Basic BF8 conversion
+    print("1. Basic BF8 Value Conversion")
+    print("-" * 40)
+
+    var values = List[Float32](0.0, 1.0, -2.5, 10.0, -100.0, 1000.0, 10000.0)
+    print("Original values:")
+    for i in range(len(values)):
+        print("  ", values[i])
+
+    print("\nBF8 encoded and decoded:")
+    for i in range(len(values)):
+        var bf8_val = BF8.from_float32(values[i])
+        var decoded = bf8_val.to_float32()
+        var error = abs(decoded - values[i])
+        print("  ", values[i], " -> ", decoded, " (error: ", error, ")")
+
+    # 2. Tensor conversion to BF8
+    print("\n2. Tensor Conversion to BF8")
+    print("-" * 40)
+
+    var shape = DynamicVector[Int](2)
+    shape[0] = 3
+    shape[1] = 4
+
+    # Create a Float32 tensor
+    var tensor_f32 = zeros(shape, DType.float32)
+    for i in range(12):
+        tensor_f32._data.bitcast[Float32]()[i] = Float32(i) * 10.0 - 50.0
+
+    print("Original Float32 tensor (3x4):")
+    print("  Shape:", tensor_f32.shape()[0], "x", tensor_f32.shape()[1])
+    print("  DType:", tensor_f32.dtype())
+    print("  Size: 12 elements × 4 bytes = 48 bytes")
+    print("  Values:")
+    for i in range(12):
+        print("    [", i, "]:", tensor_f32._data.bitcast[Float32]()[i])
+
+    # Convert to BF8
+    var tensor_bf8 = tensor_f32.to_bf8()
+
+    print("\nBF8-encoded tensor (stored as uint8):")
+    print("  Shape:", tensor_bf8.shape()[0], "x", tensor_bf8.shape()[1])
+    print("  DType:", tensor_bf8.dtype())
+    print("  Size: 12 elements × 1 byte = 12 bytes")
+    print("  Memory savings: 75% (48 bytes -> 12 bytes)")
+
+    # Convert back to Float32
+    var tensor_restored = tensor_bf8.from_bf8()
+
+    print("\nRestored Float32 tensor:")
+    print("  Shape:", tensor_restored.shape()[0], "x", tensor_restored.shape()[1])
+    print("  DType:", tensor_restored.dtype())
+    print("  Values (with BF8 precision loss):")
+    for i in range(12):
+        var original = tensor_f32._data.bitcast[Float32]()[i]
+        var restored = tensor_restored._data.bitcast[Float32]()[i]
+        var error = abs(restored - original)
+        print("    [", i, "]:", original, " ->", restored, " (error:", error, ")")
+
+    # 3. Memory efficiency demonstration
+    print("\n3. Memory Efficiency")
+    print("-" * 40)
+
+    var large_shape = DynamicVector[Int](2)
+    large_shape[0] = 1000
+    large_shape[1] = 1000
+
+    var large_tensor = zeros(large_shape, DType.float32)
+    var large_bf8 = large_tensor.to_bf8()
+
+    var f32_bytes = 1000 * 1000 * 4  # 4 bytes per float32
+    var bf8_bytes = 1000 * 1000 * 1  # 1 byte per bf8
+
+    print("Large tensor (1000x1000):")
+    print("  Float32 size:", f32_bytes, "bytes (", f32_bytes / 1024 / 1024, "MB)")
+    print("  BF8 size:", bf8_bytes, "bytes (", bf8_bytes / 1024 / 1024, "MB)")
+    print("  Memory savings:", 100 - (bf8_bytes * 100 // f32_bytes), "%")
+
+    # 4. BF8 vs FP8 comparison
+    print("\n4. BF8 (E5M2) vs FP8 (E4M3) Comparison")
+    print("-" * 40)
+
+    # Test values that show the difference
+    var test_values = List[Float32](1.0, 100.0, 1000.0, 10000.0)
+
+    print("Value    BF8 (E5M2)    FP8 (E4M3)    BF8 Error    FP8 Error")
+    print("-" * 70)
+
+    for i in range(len(test_values)):
+        var val = test_values[i]
+
+        # BF8 conversion
+        var bf8_val = BF8.from_float32(val)
+        var bf8_decoded = bf8_val.to_float32()
+        var bf8_error = abs(bf8_decoded - val)
+
+        # FP8 conversion
+        var fp8_val = FP8.from_float32(val)
+        var fp8_decoded = fp8_val.to_float32()
+        var fp8_error = abs(fp8_decoded - val)
+
+        print(
+            val,
+            "    ",
+            bf8_decoded,
+            "    ",
+            fp8_decoded,
+            "    ",
+            bf8_error,
+            "    ",
+            fp8_error
+        )
+
+    print("\n=== BF8 Example Complete ===\n")
+    print("Key Takeaways:")
+    print("  • BF8 reduces memory by 75% (vs Float32)")
+    print("  • BF8 range: ~±57,344 (much larger than FP8's ~±240)")
+    print("  • BF8 precision: 2 mantissa bits (less than FP8's 3 bits)")
+    print("  • Use BF8 when range is more important than precision")
+    print("  • Use FP8 when precision is more important than range")
+    print("  • Trade-off: 8× memory savings for precision loss")
+    print("")

--- a/shared/core/__init__.mojo
+++ b/shared/core/__init__.mojo
@@ -13,7 +13,7 @@ Architecture:
 
 Modules:
     extensor: Core tensor type and creation functions
-    types: Custom data types (FP8 for 8-bit floating point)
+    types: Custom data types (FP8 for E4M3, BF8 for E5M2 8-bit floating point)
     arithmetic: Element-wise arithmetic operations (add, subtract, multiply, divide)
     matrix: Matrix operations (matmul, transpose, dot, outer)
     activation: Activation functions (relu, sigmoid, tanh, softmax, gelu)
@@ -70,6 +70,7 @@ from .extensor import (
 # ============================================================================
 
 from .types.fp8 import FP8
+from .types.bf8 import BF8
 
 # ============================================================================
 # Arithmetic Operations

--- a/shared/core/types/__init__.mojo
+++ b/shared/core/types/__init__.mojo
@@ -10,11 +10,12 @@ Components:
     - DType: Data type definitions and conversions
     - Slice: Tensor slicing utilities
     - FP8: 8-bit floating point type (E4M3 format)
+    - BF8: 8-bit floating point type (E5M2 format)
     - Int8, Int16, Int32, Int64: Signed integer types
     - UInt8, UInt16, UInt32, UInt64: Unsigned integer types
 
 Example:
-    from shared.core.types import Tensor, Shape, DType, FP8
+    from shared.core.types import Tensor, Shape, DType, FP8, BF8
     from shared.core.types import Int8, Int16, Int32, Int64
     from shared.core.types import UInt8, UInt16, UInt32, UInt64
 
@@ -27,6 +28,10 @@ Example:
     var fp8_val = FP8.from_float32(3.14159)
     var float_val = fp8_val.to_float32()
 
+    # Work with BF8 values
+    var bf8_val = BF8.from_float32(100.0)
+    var float_val2 = bf8_val.to_float32()
+
     # Work with integer types
     var i8 = Int8(42)
     var u32 = UInt32.from_float32(255.5)
@@ -34,6 +39,7 @@ Example:
 
 # Type exports
 from .fp8 import FP8
+from .bf8 import BF8
 from .integer import Int8, Int16, Int32, Int64
 from .unsigned import UInt8, UInt16, UInt32, UInt64
 

--- a/shared/core/types/bf8.mojo
+++ b/shared/core/types/bf8.mojo
@@ -1,0 +1,228 @@
+"""BF8 (8-bit floating point) data type implementation.
+
+This module implements BF8 E5M2 format:
+- 1 sign bit
+- 5 exponent bits (bias = 15)
+- 2 mantissa bits
+
+BF8 E5M2 provides a larger range than FP8 E4M3 but with less precision.
+It is used for memory-efficient training and inference in modern ML workloads.
+Supported range: approximately ±57,344 with reduced precision.
+
+Example:
+    from shared.core.types.bf8 import BF8
+
+    var x = BF8.from_float32(3.14159)
+    var y = x.to_float32()
+"""
+
+from math import isnan, isinf
+
+
+@value
+struct BF8(Stringable, Representable):
+    """8-bit floating point number in E5M2 format.
+
+    Memory layout (1 byte):
+    - Bit 7: Sign bit
+    - Bits 6-2: Exponent (5 bits, bias = 15)
+    - Bits 1-0: Mantissa (2 bits)
+
+    Special values:
+    - Zero: exp=0, mantissa=0
+    - NaN: exp=31, mantissa!=0
+    - Inf: exp=31, mantissa=0
+    """
+    var value: UInt8
+
+    fn __init__(inout self, value: UInt8 = 0):
+        """Initialize BF8 from raw UInt8 bits.
+
+        Args:
+            value: Raw 8-bit representation
+        """
+        self.value = value
+
+    @staticmethod
+    fn from_float32(x: Float32) -> Self:
+        """Convert Float32 to BF8 E5M2 format.
+
+        Args:
+            x: Float32 value to convert
+
+        Returns:
+            BF8 representation (with potential precision loss)
+
+        Note:
+            Values outside BF8 range are clamped to max/min representable values.
+        """
+        # Handle special cases
+        if isnan(x):
+            return BF8(0b01111101)  # NaN: exp=31, mantissa!=0
+
+        if isinf(x):
+            if x > 0:
+                return BF8(0b01111100)  # +Inf: sign=0, exp=31, mantissa=0
+            else:
+                return BF8(0b11111100)  # -Inf: sign=1, exp=31, mantissa=0
+
+        if x == 0.0:
+            return BF8(0)  # +0
+
+        # Extract sign
+        var sign: UInt8 = 0
+        var abs_x = x
+        if x < 0:
+            sign = 1
+            abs_x = -x
+
+        # BF8 E5M2 max value is approximately 57344 (2^(31-15) * (1.75))
+        # Clamp to representable range
+        if abs_x >= 57344.0:
+            # Return max BF8 value
+            var bits = (sign << 7) | 0b01111011  # exp=30, mantissa=3
+            return BF8(bits)
+
+        # BF8 E5M2 min normal value is 2^-14 = 0.00006103515625
+        if abs_x < 0.00006103515625:
+            # Return min normal value or zero
+            if abs_x < 0.000030517578125:  # Below subnormal range
+                return BF8(sign << 7)  # Zero
+            # Subnormal handling: exp=0, encode in mantissa
+            var mantissa = int(abs_x * 16384.0)  # Scale to 2-bit range
+            if mantissa > 3:
+                mantissa = 3
+            var bits = (sign << 7) | mantissa.cast[DType.uint8]()
+            return BF8(bits)
+
+        # Normal number encoding
+        # Find exponent (log2 of abs_x)
+        var exp_val = 0
+        var scaled = abs_x
+
+        # Scale to range [1, 2)
+        while scaled >= 2.0:
+            scaled /= 2.0
+            exp_val += 1
+
+        while scaled < 1.0:
+            scaled *= 2.0
+            exp_val -= 1
+
+        # Apply bias (15 for E5M2)
+        var biased_exp = exp_val + 15
+
+        # Clamp exponent to valid range [1, 30]
+        if biased_exp <= 0:
+            biased_exp = 0
+            # Subnormal
+        elif biased_exp >= 31:
+            biased_exp = 30
+
+        # Extract mantissa (2 bits)
+        # scaled is in [1, 2), we want the fractional part
+        var mantissa_val = scaled - 1.0  # Now in [0, 1)
+        var mantissa = int(mantissa_val * 4.0)  # Scale to 2-bit range [0, 3]
+        if mantissa > 3:
+            mantissa = 3
+
+        # Combine: sign(1) | exponent(5) | mantissa(2)
+        var bits = (sign << 7) | (biased_exp.cast[DType.uint8]() << 2) | mantissa.cast[DType.uint8]()
+        return BF8(bits)
+
+    fn to_float32(self) -> Float32:
+        """Convert BF8 E5M2 to Float32.
+
+        Returns:
+            Float32 representation of the BF8 value
+        """
+        # Extract components
+        var sign = (self.value >> 7) & 0x1
+        var exp = (self.value >> 2) & 0x1F  # 5 bits
+        var mantissa = self.value & 0x3     # 2 bits
+
+        # Handle special cases
+        if exp == 31:
+            if mantissa != 0:
+                return Float32(0.0) / Float32(0.0)  # NaN
+            else:
+                if sign == 1:
+                    return -Float32(1.0) / Float32(0.0)  # -Inf
+                else:
+                    return Float32(1.0) / Float32(0.0)   # +Inf
+
+        # Handle zero
+        if exp == 0 and mantissa == 0:
+            if sign == 1:
+                return -0.0
+            else:
+                return 0.0
+
+        # Compute value
+        var result: Float32
+
+        if exp == 0:
+            # Subnormal number
+            # value = (-1)^sign * 2^(-14) * (mantissa / 4)
+            result = Float32(mantissa.cast[DType.float32]()) / 4.0
+            result *= 0.00006103515625  # 2^-14
+        else:
+            # Normal number
+            # value = (-1)^sign * 2^(exp - 15) * (1 + mantissa / 4)
+            var exponent = exp.cast[DType.int32]() - 15
+            var base = Float32(1.0) + (Float32(mantissa.cast[DType.float32]()) / 4.0)
+
+            # Compute 2^exponent
+            var scale = Float32(1.0)
+            if exponent > 0:
+                for _ in range(exponent):
+                    scale *= 2.0
+            elif exponent < 0:
+                for _ in range(-exponent):
+                    scale /= 2.0
+
+            result = base * scale
+
+        # Apply sign
+        if sign == 1:
+            result = -result
+
+        return result
+
+    fn __str__(self) -> String:
+        """String representation showing BF8 value as Float32.
+
+        Returns:
+            String representation
+        """
+        return "BF8(" + str(self.to_float32()) + ")"
+
+    fn __repr__(self) -> String:
+        """Detailed representation showing both bits and value.
+
+        Returns:
+            Detailed string representation
+        """
+        return "BF8(bits=0x" + hex(self.value) + ", value=" + str(self.to_float32()) + ")"
+
+    fn __eq__(self, other: Self) -> Bool:
+        """Check equality by comparing raw bits.
+
+        Args:
+            other: Other BF8 value
+
+        Returns:
+            True if bit patterns match
+        """
+        return self.value == other.value
+
+    fn __ne__(self, other: Self) -> Bool:
+        """Check inequality.
+
+        Args:
+            other: Other BF8 value
+
+        Returns:
+            True if bit patterns differ
+        """
+        return self.value != other.value

--- a/tests/shared/core/test_bf8.mojo
+++ b/tests/shared/core/test_bf8.mojo
@@ -1,0 +1,354 @@
+"""Tests for BF8 data type and tensor conversions.
+
+Tests cover:
+- BF8 creation from Float32
+- BF8 to Float32 conversion
+- Special values (zero, NaN, Inf)
+- Range clamping (±57344 max value)
+- Tensor conversion (to_bf8, from_bf8)
+- Round-trip conversion accuracy
+"""
+
+from tests.shared.conftest import (
+    assert_true,
+    assert_equal,
+    assert_almost_equal,
+    assert_shape_equal,
+    TestFixtures,
+)
+from shared.core.extensor import (
+    ExTensor,
+    zeros,
+    ones,
+    full,
+)
+from shared.core.types.bf8 import BF8
+from collections.vector import DynamicVector
+from math import isnan, isinf
+
+
+# ============================================================================
+# BF8 Basic Conversion Tests
+# ============================================================================
+
+
+fn test_bf8_zero() raises:
+    """Test BF8 representation of zero."""
+    var bf8_zero = BF8.from_float32(0.0)
+    var result = bf8_zero.to_float32()
+
+    assert_equal(bf8_zero.value, 0)
+    assert_almost_equal(result, Float32(0.0), tolerance=1e-7)
+
+
+fn test_bf8_positive_values() raises:
+    """Test BF8 encoding of positive values."""
+    # Test small positive value
+    var bf8_small = BF8.from_float32(1.0)
+    var result_small = bf8_small.to_float32()
+    assert_almost_equal(result_small, Float32(1.0), tolerance=0.3)
+
+    # Test medium positive value
+    var bf8_medium = BF8.from_float32(10.0)
+    var result_medium = bf8_medium.to_float32()
+    assert_almost_equal(result_medium, Float32(10.0), tolerance=3.0)
+
+    # Test large positive value
+    var bf8_large = BF8.from_float32(100.0)
+    var result_large = bf8_large.to_float32()
+    assert_almost_equal(result_large, Float32(100.0), tolerance=30.0)
+
+    # Test very large positive value (within BF8 range)
+    var bf8_vlarge = BF8.from_float32(1000.0)
+    var result_vlarge = bf8_vlarge.to_float32()
+    assert_almost_equal(result_vlarge, Float32(1000.0), tolerance=300.0)
+
+
+fn test_bf8_negative_values() raises:
+    """Test BF8 encoding of negative values."""
+    # Test small negative value
+    var bf8_small = BF8.from_float32(-1.0)
+    var result_small = bf8_small.to_float32()
+    assert_almost_equal(result_small, Float32(-1.0), tolerance=0.3)
+
+    # Test medium negative value
+    var bf8_medium = BF8.from_float32(-10.0)
+    var result_medium = bf8_medium.to_float32()
+    assert_almost_equal(result_medium, Float32(-10.0), tolerance=3.0)
+
+    # Test large negative value
+    var bf8_large = BF8.from_float32(-100.0)
+    var result_large = bf8_large.to_float32()
+    assert_almost_equal(result_large, Float32(-100.0), tolerance=30.0)
+
+    # Test very large negative value (within BF8 range)
+    var bf8_vlarge = BF8.from_float32(-1000.0)
+    var result_vlarge = bf8_vlarge.to_float32()
+    assert_almost_equal(result_vlarge, Float32(-1000.0), tolerance=300.0)
+
+
+fn test_bf8_range_clamping() raises:
+    """Test BF8 clamping of values outside representable range."""
+    # BF8 E5M2 max value is approximately 57344
+
+    # Test positive overflow
+    var bf8_overflow = BF8.from_float32(100000.0)
+    var result_overflow = bf8_overflow.to_float32()
+    assert_true(result_overflow <= 57344.0, "BF8 should clamp large positive values")
+    assert_true(result_overflow > 50000.0, "BF8 max should be near 57344")
+
+    # Test negative overflow
+    var bf8_underflow = BF8.from_float32(-100000.0)
+    var result_underflow = bf8_underflow.to_float32()
+    assert_true(result_underflow >= -57344.0, "BF8 should clamp large negative values")
+    assert_true(result_underflow < -50000.0, "BF8 min should be near -57344")
+
+
+fn test_bf8_subnormal_values() raises:
+    """Test BF8 encoding of very small (subnormal) values."""
+    # BF8 E5M2 min normal value is 2^-14 = 0.00006103515625
+
+    # Test value in subnormal range
+    var bf8_tiny = BF8.from_float32(0.00005)
+    var result_tiny = bf8_tiny.to_float32()
+    assert_true(result_tiny >= 0.0, "BF8 subnormal should be non-negative")
+    assert_true(result_tiny < 0.0001, "BF8 subnormal should be small")
+
+    # Test value below subnormal range (should be zero)
+    var bf8_very_tiny = BF8.from_float32(0.00001)
+    var result_very_tiny = bf8_very_tiny.to_float32()
+    assert_almost_equal(result_very_tiny, Float32(0.0), tolerance=1e-7)
+
+
+fn test_bf8_special_values_nan() raises:
+    """Test BF8 encoding of NaN."""
+    var nan_val = Float32(0.0) / Float32(0.0)
+    var bf8_nan = BF8.from_float32(nan_val)
+    var result = bf8_nan.to_float32()
+
+    # Check that result is NaN
+    assert_true(isnan(result), "BF8 should preserve NaN")
+
+
+fn test_bf8_special_values_inf() raises:
+    """Test BF8 encoding of infinity."""
+    # Positive infinity
+    var pos_inf = Float32(1.0) / Float32(0.0)
+    var bf8_pos_inf = BF8.from_float32(pos_inf)
+    var result_pos = bf8_pos_inf.to_float32()
+    assert_true(isinf(result_pos) and result_pos > 0, "BF8 should preserve +Inf")
+
+    # Negative infinity
+    var neg_inf = Float32(-1.0) / Float32(0.0)
+    var bf8_neg_inf = BF8.from_float32(neg_inf)
+    var result_neg = bf8_neg_inf.to_float32()
+    assert_true(isinf(result_neg) and result_neg < 0, "BF8 should preserve -Inf")
+
+
+fn test_bf8_equality() raises:
+    """Test BF8 equality comparison."""
+    var bf8_a = BF8.from_float32(3.14)
+    var bf8_b = BF8.from_float32(3.14)
+    var bf8_c = BF8.from_float32(2.71)
+
+    assert_true(bf8_a == bf8_b, "Equal BF8 values should compare equal")
+    assert_true(bf8_a != bf8_c, "Different BF8 values should compare not equal")
+
+
+# ============================================================================
+# Tensor Conversion Tests
+# ============================================================================
+
+
+fn test_tensor_to_bf8() raises:
+    """Test converting Float32 tensor to BF8."""
+    var shape = DynamicVector[Int](2)
+    shape[0] = 2
+    shape[1] = 3
+
+    # Create Float32 tensor with specific values
+    var t = zeros(shape, DType.float32)
+    t._data.bitcast[Float32]()[0] = 1.0
+    t._data.bitcast[Float32]()[1] = -2.5
+    t._data.bitcast[Float32]()[2] = 10.0
+    t._data.bitcast[Float32]()[3] = -5.0
+    t._data.bitcast[Float32]()[4] = 0.5
+    t._data.bitcast[Float32]()[5] = 1000.0
+
+    # Convert to BF8
+    var bf8_tensor = t.to_bf8()
+
+    # Check dtype is uint8
+    assert_true(bf8_tensor.dtype() == DType.uint8, "BF8 tensor should have uint8 dtype")
+
+    # Check shape is preserved
+    assert_shape_equal(bf8_tensor.shape(), t.shape())
+
+    # Check that values are encoded (not zero)
+    var has_nonzero = False
+    for i in range(6):
+        if bf8_tensor._data.bitcast[UInt8]()[i] != 0:
+            has_nonzero = True
+    assert_true(has_nonzero, "BF8 tensor should have encoded values")
+
+
+fn test_tensor_from_bf8() raises:
+    """Test converting BF8 tensor back to Float32."""
+    var shape = DynamicVector[Int](2)
+    shape[0] = 2
+    shape[1] = 2
+
+    # Create Float32 tensor
+    var original = ones(shape, DType.float32)
+    original._data.bitcast[Float32]()[0] = 3.0
+    original._data.bitcast[Float32]()[1] = -1.5
+    original._data.bitcast[Float32]()[2] = 7.0
+    original._data.bitcast[Float32]()[3] = -10.0
+
+    # Convert to BF8 and back
+    var bf8_tensor = original.to_bf8()
+    var restored = bf8_tensor.from_bf8()
+
+    # Check dtype is float32
+    assert_true(restored.dtype() == DType.float32, "Restored tensor should have float32 dtype")
+
+    # Check shape is preserved
+    assert_shape_equal(restored.shape(), original.shape())
+
+    # Check values are approximately restored (with BF8 precision loss)
+    # BF8 has less precision than FP8, so use larger tolerances
+    assert_almost_equal(
+        restored._data.bitcast[Float32]()[0],
+        Float32(3.0),
+        tolerance=1.0
+    )
+    assert_almost_equal(
+        restored._data.bitcast[Float32]()[1],
+        Float32(-1.5),
+        tolerance=0.5
+    )
+    assert_almost_equal(
+        restored._data.bitcast[Float32]()[2],
+        Float32(7.0),
+        tolerance=2.0
+    )
+    assert_almost_equal(
+        restored._data.bitcast[Float32]()[3],
+        Float32(-10.0),
+        tolerance=3.0
+    )
+
+
+fn test_tensor_bf8_roundtrip() raises:
+    """Test round-trip conversion Float32 -> BF8 -> Float32."""
+    var shape = DynamicVector[Int](1)
+    shape[0] = 5
+
+    # Create tensor with various values
+    var original = zeros(shape, DType.float32)
+    original._data.bitcast[Float32]()[0] = 0.0
+    original._data.bitcast[Float32]()[1] = 1.0
+    original._data.bitcast[Float32]()[2] = -5.0
+    original._data.bitcast[Float32]()[3] = 20.0
+    original._data.bitcast[Float32]()[4] = -50.0
+
+    # Round-trip conversion
+    var bf8_tensor = original.to_bf8()
+    var restored = bf8_tensor.from_bf8()
+
+    # Verify approximate equality (accounting for BF8 precision loss)
+    # BF8 has only 2 mantissa bits, so precision loss is significant
+    for i in range(5):
+        var orig_val = original._data.bitcast[Float32]()[i]
+        var restored_val = restored._data.bitcast[Float32]()[i]
+
+        # Use tolerance proportional to magnitude (larger than FP8)
+        var tolerance = max(abs(orig_val) * 0.25, Float32(0.5))
+        assert_almost_equal(restored_val, orig_val, tolerance=tolerance)
+
+
+fn test_tensor_to_bf8_requires_float() raises:
+    """Test that to_bf8() requires floating-point tensor."""
+    var shape = DynamicVector[Int](1)
+    shape[0] = 3
+
+    # Create int32 tensor
+    var int_tensor = zeros(shape, DType.int32)
+
+    # Try to convert to BF8 (should raise error)
+    var raised_error = False
+    try:
+        var _ = int_tensor.to_bf8()
+    except:
+        raised_error = True
+
+    assert_true(raised_error, "to_bf8() should raise error for non-float tensor")
+
+
+fn test_tensor_from_bf8_requires_uint8() raises:
+    """Test that from_bf8() requires uint8 tensor."""
+    var shape = DynamicVector[Int](1)
+    shape[0] = 3
+
+    # Create float32 tensor (not uint8)
+    var float_tensor = zeros(shape, DType.float32)
+
+    # Try to convert from BF8 (should raise error)
+    var raised_error = False
+    try:
+        var _ = float_tensor.from_bf8()
+    except:
+        raised_error = True
+
+    assert_true(raised_error, "from_bf8() should raise error for non-uint8 tensor")
+
+
+# ============================================================================
+# Main Test Runner
+# ============================================================================
+
+
+fn main() raises:
+    """Run all BF8 tests."""
+    print("\n=== BF8 Basic Conversion Tests ===")
+    test_bf8_zero()
+    print("✓ BF8 zero encoding")
+
+    test_bf8_positive_values()
+    print("✓ BF8 positive values")
+
+    test_bf8_negative_values()
+    print("✓ BF8 negative values")
+
+    test_bf8_range_clamping()
+    print("✓ BF8 range clamping")
+
+    test_bf8_subnormal_values()
+    print("✓ BF8 subnormal values")
+
+    test_bf8_special_values_nan()
+    print("✓ BF8 NaN handling")
+
+    test_bf8_special_values_inf()
+    print("✓ BF8 infinity handling")
+
+    test_bf8_equality()
+    print("✓ BF8 equality comparison")
+
+    print("\n=== Tensor Conversion Tests ===")
+    test_tensor_to_bf8()
+    print("✓ Tensor to BF8 conversion")
+
+    test_tensor_from_bf8()
+    print("✓ Tensor from BF8 conversion")
+
+    test_tensor_bf8_roundtrip()
+    print("✓ Tensor BF8 round-trip")
+
+    test_tensor_to_bf8_requires_float()
+    print("✓ to_bf8() type validation")
+
+    test_tensor_from_bf8_requires_uint8()
+    print("✓ from_bf8() type validation")
+
+    print("\n=== All BF8 Tests Passed! ===\n")


### PR DESCRIPTION
Add BF8 (E5M2 format) as a new 8-bit floating point type, complementing the existing FP8 (E4M3) implementation. BF8 provides larger range (~±57,344) with less precision (2 mantissa bits) compared to FP8's smaller range (~±240) with more precision (3 mantissa bits).

Changes:
- shared/core/types/bf8.mojo: New BF8 struct with E5M2 encoding
  - 1 sign bit, 5 exponent bits (bias=15), 2 mantissa bits
  - from_float32() and to_float32() conversion methods
  - Special value handling (NaN, ±Inf, zero, subnormals)
  - Range clamping to ±57,344

- shared/core/extensor.mojo: Tensor conversion methods
  - to_bf8(): Convert float tensors to BF8 (stored as uint8)
  - from_bf8(): Decode BF8 tensors back to Float32

- shared/core/types/__init__.mojo: Export BF8 type
- shared/core/__init__.mojo: Re-export BF8 for easy access

- tests/shared/core/test_bf8.mojo: Comprehensive test suite
  - 13 test functions covering conversions, special values, range
  - Tensor conversion tests with precision tolerance checks
  - Type validation for to_bf8()/from_bf8() methods

- examples/bf8_example.mojo: Usage examples
  - Basic BF8 value conversion
  - Tensor conversion demonstration
  - Memory efficiency comparison (75% savings vs Float32)
  - BF8 vs FP8 characteristic comparison

Use case: BF8 is ideal for workloads requiring larger dynamic range at the cost of precision (e.g., training with large gradients). FP8 remains better for precision-critical tasks.

## Description

Brief description of changes (1-2 sentences).

## Related Issues

Closes #

## Changes

- Change 1
- Change 2
- Change 3
