### PR TITLE
fix(ci): Standardize Mojo import paths with REPO_ROOT

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -67,6 +67,9 @@ jobs:
 
       - name: Run integration test suite - ${{ matrix.test-suite }}
         run: |
+          # Set repository root for Mojo imports
+          REPO_ROOT="$(pwd)"
+
           echo "Running integration tests for: ${{ matrix.test-suite }}"
           mkdir -p test-results
 
@@ -80,7 +83,7 @@ jobs:
                 for file in tests/integration/*.mojo; do
                   if [ -f "$file" ]; then
                     echo "Running $file..."
-                    pixi run mojo -I . "$file" || EXIT_CODE=$?
+                    pixi run mojo -I "$REPO_ROOT" -I . "$file" || EXIT_CODE=$?
                   fi
                 done
                 exit $EXIT_CODE
@@ -114,7 +117,7 @@ jobs:
                 for file in tests/shared/integration/*.mojo; do
                   if [ -f "$file" ]; then
                     echo "Running $file..."
-                    pixi run mojo -I . "$file" || EXIT_CODE=$?
+                    pixi run mojo -I "$REPO_ROOT" -I . "$file" || EXIT_CODE=$?
                   fi
                 done
                 exit $EXIT_CODE

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -47,6 +47,9 @@ jobs:
 
       - name: Run Mojo unit tests
         run: |
+          # Set repository root for Mojo imports
+          REPO_ROOT="$(pwd)"
+
           # Check if Mojo tests exist
           if [ -d "tests/unit" ] && [ -n "$(find tests/unit -name '*.mojo' -o -name '*.🔥' 2>/dev/null)" ]; then
             echo "Running Mojo unit tests..."
@@ -63,7 +66,7 @@ jobs:
                 echo "=================================================="
                 test_count=$((test_count + 1))
 
-                if pixi run mojo -I . "$test_file"; then
+                if pixi run mojo -I "$REPO_ROOT" -I . "$test_file"; then
                   echo "✅ PASSED: $test_file"
                 else
                   echo "❌ FAILED: $test_file"


### PR DESCRIPTION
## Summary

Standardizes Mojo import path configuration across all CI/CD workflow files to use consistent `-I "$REPO_ROOT" -I .` pattern.

## Problem

Workflows used inconsistent import path configurations:
- `comprehensive-tests.yml`: Uses `-I "$REPO_ROOT" -I .` ✅
- `unit-tests.yml`: Only uses `-I .` ❌
- `integration-tests.yml`: Only uses `-I .` ❌

This inconsistency caused tests to fail when importing modules from the repository root.

## Changes

### `.github/workflows/unit-tests.yml`
- Added `REPO_ROOT="$(pwd)"` before test execution
- Updated mojo command to use `-I "$REPO_ROOT" -I . "$test_file"`

### `.github/workflows/integration-tests.yml`
- Added `REPO_ROOT="$(pwd)"` before test execution
- Updated mojo-integration and shared-integration test cases to use consistent import paths

## Impact

- **Before**: Tests could fail with import errors depending on working directory
- **After**: All workflows have consistent import resolution from repository root and current directory

## Benefits

- Repository root modules importable by absolute path from any working directory
- Current directory modules still supported with `-I .`
- Consistent import resolution between CI/CD and local development
- Prevents hard-to-diagnose import path issues

## Part of CI/CD Fix Initiative

This is **Phase 2** of a 3-phase parallel CI/CD fix:
- Phase 1: Fix syntax errors - CRITICAL
- Phase 2: Standardize import paths (this PR) - HIGH
- Phase 3: Add pytest dependencies - MEDIUM

## Testing

- ✅ Pre-commit hooks pass (YAML validation)
- ✅ No changes to test logic, only import path configuration
- ✅ Matches pattern already working in comprehensive-tests.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)