### PR TITLE
Fix undefined str() usage in test_cross_entropy_crash.mojo

### DIFF
--- a/tests/unit/test_cross_entropy_crash.mojo
+++ b/tests/unit/test_cross_entropy_crash.mojo
@@ -46,7 +46,7 @@ fn test_cross_entropy_small_batch() raises:
 
     try:
         var loss = cross_entropy(logits, targets)
-        print("Loss computed successfully! Shape:", str(loss.shape()))
+        print("Loss computed successfully! Shape:", loss.shape())
         print("Loss value:", loss[0])
     except e:
         print("ERROR:", e)


### PR DESCRIPTION
## Summary

Fixes compilation error in `test_cross_entropy_crash.mojo` caused by using undefined `str()` function.

## Changes

**File**: `tests/unit/test_cross_entropy_crash.mojo` line 49

**Before**:
```mojo
print("Loss computed successfully! Shape:", str(loss.shape()))
```

**After**:
```mojo
print("Loss computed successfully! Shape:", loss.shape())
```

## Error Fixed

```
test_cross_entropy_crash.mojo:49:53: error: use of unknown declaration 'str'
    print("Loss computed successfully! Shape:", str(loss.shape()))
                                                    ^~~
```

## Impact

- ✅ Test file now compiles successfully
- ✅ Unblocks unit test execution in CI
- ✅ Simple one-line fix with no side effects

## Testing

- File compiles without errors after fix
- Direct printing of `loss.shape()` works correctly in Mojo

Fixes #1940

🤖 Generated with [Claude Code](https://claude.com/claude-code)