### PR TITLE
fix(tests): add main() stub to test_module.mojo

### DIFF
--- a/tests/shared/core/test_module.mojo
+++ b/tests/shared/core/test_module.mojo
@@ -1,0 +1,7 @@
+"""Tests for Module base class.
+
+TODO: Implement module tests once Module class is finalized.
+"""
+
+fn main() raises:
+    print("test_module.mojo - Placeholder (tests not yet implemented)")


### PR DESCRIPTION
## Summary

Fixes "module does not define a main function" error for `test_module.mojo` in comprehensive-tests.yml workflow.

## Changes

- Added `main()` function with placeholder message to `tests/shared/core/test_module.mojo`
- Added TODO comment explaining this is a placeholder file
- File now executes successfully when run with `mojo` command

## Context

The `.github/workflows/comprehensive-tests.yml` workflow runs all test files with the `mojo` command, which requires every `.mojo` file to define a `main()` function as the entry point. This file was empty (0 bytes) and causing test execution to fail.

## Testing

```bash
pixi run mojo -I . tests/shared/core/test_module.mojo
```

**Output:**
```
test_module.mojo - Placeholder (tests not yet implemented)
```

## Related Test Groups

This fixes the "Core: Advanced Layers" test group in comprehensive-tests.yml which includes `test_module.mojo` in its pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)