### PR TITLE
fix(tests): add main() stubs to data test files

### DIFF
--- a/tests/shared/data/test_datasets.mojo
+++ b/tests/shared/data/test_datasets.mojo
@@ -1,0 +1,8 @@
+"""Tests for dataset abstractions.
+
+TODO: Implement high-level dataset integration tests.
+Individual dataset tests exist in datasets/test_*.mojo files.
+"""
+
+fn main() raises:
+    print("test_datasets.mojo - Placeholder (see datasets/ subdirectory for actual tests)")

--- a/tests/shared/data/test_loaders.mojo
+++ b/tests/shared/data/test_loaders.mojo
@@ -1,0 +1,8 @@
+"""Tests for data loaders.
+
+TODO: Implement high-level loader integration tests.
+Individual loader tests exist in loaders/test_*.mojo files.
+"""
+
+fn main() raises:
+    print("test_loaders.mojo - Placeholder (see loaders/ subdirectory for actual tests)")

--- a/tests/shared/data/test_transforms.mojo
+++ b/tests/shared/data/test_transforms.mojo
@@ -1,0 +1,8 @@
+"""Tests for data transforms.
+
+TODO: Implement high-level transform integration tests.
+Individual transform tests exist in transforms/test_*.mojo files.
+"""
+
+fn main() raises:
+    print("test_transforms.mojo - Placeholder (see transforms/ subdirectory for actual tests)")


### PR DESCRIPTION
## Summary

Fixes "module does not define a main function" errors for 3 data test files in comprehensive-tests.yml workflow.

## Changes

Added `main()` function stubs to the following empty test files:
- `tests/shared/data/test_datasets.mojo` - References `datasets/` subdirectory
- `tests/shared/data/test_loaders.mojo` - References `loaders/` subdirectory  
- `tests/shared/data/test_transforms.mojo` - References `transforms/` subdirectory

Each file now includes:
- TODO comment explaining these are high-level integration test placeholders
- Reference to subdirectory containing actual implementation tests
- `main()` function that prints placeholder message

## Context

The `.github/workflows/comprehensive-tests.yml` workflow requires all test files to have a `main()` function. These files were empty (0 bytes) and causing test execution failures.

The actual tests already exist and are passing in subdirectories:
- **datasets/**: `test_base_dataset.mojo`, `test_file_dataset.mojo`, `test_tensor_dataset.mojo` ✅
- **loaders/**: `test_base_loader.mojo`, `test_batch_loader.mojo`, `test_parallel_loader.mojo` ✅
- **transforms/**: `test_augmentations.mojo`, `test_generic_transforms.mojo`, `test_image_transforms.mojo`, etc. ✅

These placeholder files serve as central reference points for high-level data integration testing.

## Testing

```bash
pixi run mojo -I . tests/shared/data/test_datasets.mojo
pixi run mojo -I . tests/shared/data/test_loaders.mojo
pixi run mojo -I . tests/shared/data/test_transforms.mojo
```

**Expected Output:**
```
test_datasets.mojo - Placeholder (see datasets/ subdirectory for actual tests)
test_loaders.mojo - Placeholder (see loaders/ subdirectory for actual tests)
test_transforms.mojo - Placeholder (see transforms/ subdirectory for actual tests)
```

## Related Test Groups

This fixes three test groups in comprehensive-tests.yml:
- "Data: Datasets" - includes `test_datasets.mojo`
- "Data: Loaders & Samplers" - includes `test_loaders.mojo`
- "Data: Transforms" - includes `test_transforms.mojo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)