### PR TITLE
fix(tests): add main() stub to test_io_helpers.mojo

### DIFF
--- a/tests/shared/fixtures/test_io_helpers.mojo
+++ b/tests/shared/fixtures/test_io_helpers.mojo
@@ -462,3 +462,9 @@ fn get_models_dir() -> String:
 fn get_reference_dir() -> String:
     """Get path to reference outputs directory."""
     return get_fixtures_dir() + "reference/"
+
+
+fn main() raises:
+    print("test_io_helpers.mojo - This is a HELPER MODULE, not a test file")
+    print("It provides utilities for file I/O in tests")
+    print("No tests are executed from this file")


### PR DESCRIPTION
## Summary

Fixes "module does not define a main function" error for `test_io_helpers.mojo` in comprehensive-tests.yml workflow.

## Changes

- Added `main()` function to `tests/shared/fixtures/test_io_helpers.mojo`
- Function clarifies this is a HELPER MODULE, not a test file
- Explains that no tests are executed from this file
- File now executes successfully when run with `mojo` command

## Context

The `.github/workflows/comprehensive-tests.yml` workflow runs all files matching the `test_*.mojo` pattern. This file is named `test_io_helpers.mojo` but is actually a helper module providing utilities for file I/O operations in tests, not a test file itself.

The file contains 465 lines of helper functions like:
- `create_temp_file()`
- `create_temp_dir()`
- `cleanup_temp_files()`
- `read_test_file()`
- etc.

These utilities are used by other test files but don't contain any tests themselves.

## Testing

```bash
pixi run mojo -I . tests/shared/fixtures/test_io_helpers.mojo
```

**Output:**
```
test_io_helpers.mojo - This is a HELPER MODULE, not a test file
It provides utilities for file I/O in tests
No tests are executed from this file
```

## Related Test Groups

This fixes the "Utils & Fixtures" test group in comprehensive-tests.yml which includes `fixtures/test_*.mojo` pattern.

## Future Consideration

This file could be renamed to `io_helpers.mojo` (without `test_` prefix) to avoid confusion, but that would require updating imports in all files that use these utilities. The current fix maintains backward compatibility while clarifying the module's purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)