### PR TITLE
fix(tests): resolve gradient check function signature mismatches

### DIFF
--- a/shared/core/activation.mojo
+++ b/shared/core/activation.mojo
@@ -481,7 +481,7 @@ fn _relu_backward_op[T: DType](grad: Scalar[T], x: Scalar[T]) -> Scalar[T]:
     return grad if x > Scalar[T](0) else Scalar[T](0)
 
 
-fn relu_backward(grad_output: ExTensor, x: ExTensor) raises -> ExTensor:
+fn relu_backward(grad_output: ExTensor, x: ExTensor) raises escaping -> ExTensor:
     """Compute gradient of ReLU activation.
 
     ReLU gradient: ∂L/∂x = ∂L/∂y * (x > 0)
@@ -524,7 +524,7 @@ fn _leaky_relu_backward_impl[dtype: DType](
         result_ptr[i] = grad if x_val > Scalar[dtype](0) else grad * alpha_typed
 
 
-fn leaky_relu_backward(grad_output: ExTensor, x: ExTensor, alpha: Float64 = 0.01) raises -> ExTensor:
+fn leaky_relu_backward(grad_output: ExTensor, x: ExTensor, alpha: Float64 = 0.01) raises escaping -> ExTensor:
     """Compute gradient of Leaky ReLU activation.
 
     Leaky ReLU gradient: ∂L/∂x = ∂L/∂y * (1 if x > 0 else alpha)
@@ -593,7 +593,7 @@ fn _prelu_backward_impl[dtype: DType](
             grad_alpha_ptr[alpha_idx] += grad * x_val
 
 
-fn prelu_backward(grad_output: ExTensor, x: ExTensor, alpha: ExTensor) raises -> GradientPair:
+fn prelu_backward(grad_output: ExTensor, x: ExTensor, alpha: ExTensor) raises escaping -> GradientPair:
     """Compute gradients of PReLU activation.
 
     PReLU gradients:
@@ -634,7 +634,7 @@ fn _sigmoid_backward_op[T: DType](grad: Scalar[T], y: Scalar[T]) -> Scalar[T]:
     return grad * y * (Scalar[T](1.0) - y)
 
 
-fn sigmoid_backward(grad_output: ExTensor, output: ExTensor) raises -> ExTensor:
+fn sigmoid_backward(grad_output: ExTensor, output: ExTensor) raises escaping -> ExTensor:
     """Compute gradient of sigmoid activation.
 
     Sigmoid gradient: ∂L/∂x = ∂L/∂y * y * (1 - y)
@@ -664,7 +664,7 @@ fn _tanh_backward_op[T: DType](grad: Scalar[T], y: Scalar[T]) -> Scalar[T]:
     return grad * (Scalar[T](1.0) - y * y)
 
 
-fn tanh_backward(grad_output: ExTensor, output: ExTensor) raises -> ExTensor:
+fn tanh_backward(grad_output: ExTensor, output: ExTensor) raises escaping -> ExTensor:
     """Compute gradient of tanh activation.
 
     Tanh gradient: ∂L/∂x = ∂L/∂y * (1 - y²)
@@ -686,7 +686,7 @@ fn tanh_backward(grad_output: ExTensor, output: ExTensor) raises -> ExTensor:
     return dispatch_float_binary[_tanh_backward_op](grad_output, output)
 
 
-fn gelu_backward(grad_output: ExTensor, x: ExTensor, approximate: Bool = False) raises -> ExTensor:
+fn gelu_backward(grad_output: ExTensor, x: ExTensor, approximate: Bool = False) raises escaping -> ExTensor:
     """Compute gradient of GELU activation.
 
     GELU gradient (exact): ∂L/∂x = ∂L/∂y * [Φ(x) + x*φ(x)]
@@ -799,7 +799,7 @@ fn gelu_backward(grad_output: ExTensor, x: ExTensor, approximate: Bool = False) 
     return result
 
 
-fn softmax_backward(grad_output: ExTensor, output: ExTensor, axis: Int = -1) raises -> ExTensor:
+fn softmax_backward(grad_output: ExTensor, output: ExTensor, axis: Int = -1) raises escaping -> ExTensor:
     """Compute gradient of softmax activation.
 
     Softmax gradient (along axis):
@@ -1105,7 +1105,7 @@ fn exp_scalar_f64(x: Float64) -> Float64:
 # ============================================================================
 
 
-fn swish_backward(grad_output: ExTensor, x: ExTensor) raises -> ExTensor:
+fn swish_backward(grad_output: ExTensor, x: ExTensor) raises escaping -> ExTensor:
     """Backward pass for Swish activation.
 
     The derivative of swish is:
@@ -1139,7 +1139,7 @@ fn swish_backward(grad_output: ExTensor, x: ExTensor) raises -> ExTensor:
     return multiply(grad_output, derivative)
 
 
-fn mish_backward(grad_output: ExTensor, x: ExTensor) raises -> ExTensor:
+fn mish_backward(grad_output: ExTensor, x: ExTensor) raises escaping -> ExTensor:
     """Backward pass for Mish activation.
 
     The derivative involves the derivative of tanh(softplus(x)).
@@ -1189,7 +1189,7 @@ fn mish_backward(grad_output: ExTensor, x: ExTensor) raises -> ExTensor:
     return multiply(grad_output, derivative)
 
 
-fn elu_backward(grad_output: ExTensor, x: ExTensor, alpha: Float64 = 1.0) raises -> ExTensor:
+fn elu_backward(grad_output: ExTensor, x: ExTensor, alpha: Float64 = 1.0) raises escaping -> ExTensor:
     """Backward pass for ELU activation.
 
     The derivative is:

--- a/tests/helpers/gradient_checking.mojo
+++ b/tests/helpers/gradient_checking.mojo
@@ -206,11 +206,14 @@ fn check_gradient(
             var x = ExTensor(List[Int](), DType.float32)
             # ... initialize x with test values ...
 
-            fn forward(inp: ExTensor) raises -> ExTensor:
+            fn forward(inp: ExTensor) raises escaping -> ExTensor:
                 return relu(inp)
 
+            fn backward_wrapper(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+                return relu_backward(grad, x)
+
             var grad_out = ones_like(relu(x))
-            check_gradient(forward, relu_backward, x, grad_out)
+            check_gradient(forward, backward_wrapper, x, grad_out)
     """
     # Compute analytical gradient
     var analytical = backward_fn(grad_output, x)

--- a/tests/shared/core/test_activations.mojo
+++ b/tests/shared/core/test_activations.mojo
@@ -114,14 +114,18 @@ fn test_relu_backward() raises:
     x._data.bitcast[Float32]()[3] = 2.0
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
-        return relu(inp)
+    fn forward(x: ExTensor) raises escaping -> ExTensor:
+        return relu(x)
 
     var y = relu(x)
     var grad_out = ones_like(y)
 
+    # Backward function wrapper
+    fn backward_wrapper(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+        return relu_backward(grad, x)
+
     # Use numerical gradient checking (gold standard)
-    check_gradient(forward, relu_backward, x, grad_out, rtol=1e-4, atol=1e-7)
+    check_gradient(forward, backward_wrapper, x, grad_out, rtol=1e-4, atol=1e-7)
 
 
 fn test_relu_shape() raises:
@@ -242,15 +246,15 @@ fn test_leaky_relu_backward() raises:
     x._data.bitcast[Float32]()[1] = 1.0
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
-        return leaky_relu(inp, alpha=0.1)
+    fn forward(x: ExTensor) raises escaping -> ExTensor:
+        return leaky_relu(x, alpha=0.1)
 
     var y = leaky_relu(x, alpha=0.1)
     var grad_out = ones_like(y)
 
     # Use numerical gradient checking (gold standard)
-    fn backward_wrapper(grad: ExTensor, inp: ExTensor) raises -> ExTensor:
-        return leaky_relu_backward(grad, inp, alpha=0.1)
+    fn backward_wrapper(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+        return leaky_relu_backward(grad, x, alpha=0.1)
 
     check_gradient(forward, backward_wrapper, x, grad_out, rtol=1e-4, atol=1e-7)
 
@@ -346,15 +350,15 @@ fn test_prelu_backward() raises:
     alpha._data.bitcast[Float32]()[1] = 0.5
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
-        return prelu(inp, alpha)
+    fn forward(x: ExTensor) raises escaping -> ExTensor:
+        return prelu(x, alpha)
 
     var y = prelu(x, alpha)
     var grad_out = ones_like(y)
 
     # Validate gradient w.r.t. input using numerical checking
-    fn backward_input(grad: ExTensor, inp: ExTensor) raises -> ExTensor:
-        var result = prelu_backward(grad, inp, alpha)
+    fn backward_input(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+        var result = prelu_backward(grad, x, alpha)
         return result.grad_a
 
     check_gradient(forward, backward_input, x, grad_out, rtol=1e-4, atol=1e-7)
@@ -394,15 +398,15 @@ fn test_sigmoid_backward() raises:
     x._data.bitcast[Float32]()[2] = 1.0
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
-        return sigmoid(inp)
+    fn forward(x: ExTensor) raises escaping -> ExTensor:
+        return sigmoid(x)
 
     var y = sigmoid(x)
     var grad_out = ones_like(y)
 
     # Note: sigmoid_backward takes output y, not input x
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises -> ExTensor:
-        var out = sigmoid(inp)  # Recompute output inside wrapper
+    fn backward_fn(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+        var out = sigmoid(x)  # Recompute output inside wrapper
         return sigmoid_backward(grad, out)
 
     # Use numerical gradient checking (gold standard)
@@ -541,15 +545,15 @@ fn test_tanh_backward() raises:
     x._data.bitcast[Float32]()[2] = 1.0
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
-        return tanh(inp)
+    fn forward(x: ExTensor) raises escaping -> ExTensor:
+        return tanh(x)
 
     var y = tanh(x)
     var grad_out = ones_like(y)
 
     # Note: tanh_backward takes output y, not input x
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises -> ExTensor:
-        var out = tanh(inp)  # Recompute output inside wrapper
+    fn backward_fn(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+        var out = tanh(x)  # Recompute output inside wrapper
         return tanh_backward(grad, out)
 
     # Use numerical gradient checking (gold standard)
@@ -684,15 +688,15 @@ fn test_softmax_backward() raises:
     x._data.bitcast[Float32]()[5] = 1.5
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
-        return softmax(inp, axis=1)
+    fn forward(x: ExTensor) raises escaping -> ExTensor:
+        return softmax(x, axis=1)
 
     var y = softmax(x, axis=1)
     var grad_out = ones_like(y)
 
     # Note: softmax_backward takes output y, not input x
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises -> ExTensor:
-        var out = softmax(inp, axis=1)  # Recompute output inside wrapper
+    fn backward_fn(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+        var out = softmax(x, axis=1)  # Recompute output inside wrapper
         return softmax_backward(grad, out, axis=1)
 
     # Use numerical gradient checking (gold standard)
@@ -856,15 +860,15 @@ fn test_gelu_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 0.5
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
-        return gelu(inp, approximate=False)
+    fn forward(x: ExTensor) raises escaping -> ExTensor:
+        return gelu(x, approximate=False)
 
     var y = gelu(x, approximate=False)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises -> ExTensor:
-        return gelu_backward(grad, inp, approximate=False)
+    fn backward_fn(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+        return gelu_backward(grad, x, approximate=False)
 
     # Use numerical gradient checking (gold standard)
     check_gradient(forward, backward_fn, x, grad_out, rtol=1e-3, atol=1e-6)
@@ -915,15 +919,15 @@ fn test_swish_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 0.5
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
-        return swish(inp)
+    fn forward(x: ExTensor) raises escaping -> ExTensor:
+        return swish(x)
 
     var y = swish(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises -> ExTensor:
-        return swish_backward(grad, inp)
+    fn backward_fn(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+        return swish_backward(grad, x)
 
     # Use numerical gradient checking (gold standard)
     check_gradient(forward, backward_fn, x, grad_out, rtol=1e-3, atol=1e-6)
@@ -975,15 +979,15 @@ fn test_mish_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 0.5
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
-        return mish(inp)
+    fn forward(x: ExTensor) raises escaping -> ExTensor:
+        return mish(x)
 
     var y = mish(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises -> ExTensor:
-        return mish_backward(grad, inp)
+    fn backward_fn(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+        return mish_backward(grad, x)
 
     # Use numerical gradient checking (gold standard)
     check_gradient(forward, backward_fn, x, grad_out, rtol=1e-3, atol=1e-6)
@@ -1025,15 +1029,15 @@ fn test_elu_backward() raises:
     x._data.bitcast[Float32]()[2] = 1.0
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
-        return elu(inp, alpha=1.0)
+    fn forward(x: ExTensor) raises escaping -> ExTensor:
+        return elu(x, alpha=1.0)
 
     var y = elu(x, alpha=1.0)
     var grad_out = ones_like(y)
 
     # Note: elu_backward takes x, y, and alpha
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises -> ExTensor:
-        return elu_backward(grad, inp, alpha=1.0)
+    fn backward_fn(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+        return elu_backward(grad, x, alpha=1.0)
 
     # Use numerical gradient checking (gold standard)
     check_gradient(forward, backward_fn, x, grad_out, rtol=1e-4, atol=1e-7)

--- a/tests/shared/core/test_dropout.mojo
+++ b/tests/shared/core/test_dropout.mojo
@@ -211,12 +211,12 @@ fn test_dropout_backward_gradient() raises:
     var grad_out = ones_like(output)
 
     # Forward function wrapper - dropout doesn't need input after forward pass
-    fn forward(inp: ExTensor) raises -> ExTensor:
-        var (out, _) = dropout(inp, p=0.3, training=True, seed=42)
+    fn forward(x: ExTensor) raises escaping -> ExTensor:
+        var (out, _) = dropout(x, p=0.3, training=True, seed=42)
         return out
 
     # Backward function wrapper - use stored mask instead of regenerating
-    fn backward(grad: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
         # Use the mask from forward pass to ensure consistency
         return dropout_backward(grad, mask, p=0.3)
 
@@ -341,12 +341,12 @@ fn test_dropout2d_backward_gradient() raises:
     var grad_out = ones_like(output)
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
-        var (out, _) = dropout2d(inp, p=0.2, training=True, seed=42)
+    fn forward(x: ExTensor) raises escaping -> ExTensor:
+        var (out, _) = dropout2d(x, p=0.2, training=True, seed=42)
         return out
 
     # Backward function wrapper - use stored mask instead of regenerating
-    fn backward(grad: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
         # Use the mask from forward pass to ensure consistency
         return dropout2d_backward(grad, mask, p=0.2)
 


### PR DESCRIPTION
Closes #1955

Fixes compilation errors in comprehensive-tests.yml workflow caused by function signature mismatches when calling `check_gradient()`.

## Problem

The `check_gradient` function expects functions with the `escaping` keyword, and Mojo treats parameter names as part of the function type. Tests were failing because:
1. Forward/backward functions were missing `escaping` keyword
2. Library backward functions were missing `escaping` keyword
3. Some tests passed backward functions directly without type-compatible wrappers

## Changes

1. **Added `escaping` keyword** to all forward/backward test functions
2. **Added `escaping` keyword** to 10 library backward functions in `shared/core/activation.mojo`
3. **Added wrapper function** in `test_relu_backward` to match expected signature
4. **Updated docstring** in `tests/helpers/gradient_checking.mojo` to show correct usage

## Files Modified

- `shared/core/activation.mojo` - Added `escaping` to 10 backward functions
- `tests/shared/core/test_activations.mojo` - Added `escaping` + wrapper for relu test  
- `tests/shared/core/test_dropout.mojo` - Added `escaping` to forward/backward functions
- `tests/helpers/gradient_checking.mojo` - Updated docstring example

## Testing

Local compilation tested:
- `test_activations.mojo` - Gradient check signature errors resolved (remaining `exp` function errors are separate issue)
- `test_dropout.mojo` - Gradient check signature errors resolved (remaining errors addressed in W4/W5)

CI will run comprehensive-tests.yml to verify fixes across all test groups.

## Impact

Resolves gradient check signature errors that were blocking approximately 40 tests across `test_activations.mojo` and `test_dropout.mojo`.

**Note**: Some test files still have unrelated compilation errors (`exp` function issues in activation.mojo, syntax errors, type conversions) which are addressed in separate PRs (#1956, #1957, #1958, #1959).