### PR TITLE
fix(tests): correct assertion and reduction imports in loss tests

### DIFF
--- a/tests/shared/core/test_losses.mojo
+++ b/tests/shared/core/test_losses.mojo
@@ -9,13 +9,13 @@ from tests.shared.conftest import (
     assert_true,
     assert_false,
     assert_equal_int,
-    assert_equal_float,
+    assert_almost_equal,
     assert_close_float,
 )
 from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
 from shared.core.loss import binary_cross_entropy, binary_cross_entropy_backward
 from shared.core.loss import mean_squared_error, mean_squared_error_backward
-from shared.core.extensor import mean
+from shared.core.reduction import mean
 from tests.helpers.gradient_checking import check_gradient
 
 


### PR DESCRIPTION
Closes #1956

Fixes import compilation errors in comprehensive-tests.yml workflow for `test_losses.mojo`.

## Problem

The test file was using incorrect import references:
1. `assert_equal_float` (doesn't exist in conftest)
2. `mean` imported from `extensor` instead of `reduction`

## Changes

**Line 12**: Changed `assert_equal_float` → `assert_almost_equal` (correct function name)  
**Line 18**: Changed `mean` import from `shared.core.extensor` → `shared.core.reduction` (correct module)

## Files Modified

- `tests/shared/core/test_losses.mojo` (2 import lines)

## Testing

Local compilation tested - import errors resolved. Remaining syntax errors (variable declarations like `val`, `loss_val`) are addressed in PR #1957.

## Impact

Resolves import compilation errors blocking `test_losses.mojo`. Required for PR #1957 to proceed with syntax fixes.