### PR TITLE
fix(tests): correct syntax errors in normalization and dropout tests

### DIFF
--- a/shared/core/normalization.mojo
+++ b/shared/core/normalization.mojo
@@ -445,7 +445,7 @@ fn batch_norm2d_backward(
     var x_shape = x.shape()
     var grad_shape = grad_output.shape()
 
-    if x_shape.size != 4 or grad_shape.size != 4:
+    if len(x_shape) != 4 or len(grad_shape) != 4:
         raise Error("batch_norm2d_backward requires 4D inputs (batch, channels, height, width)")
 
     var batch = x_shape[0]

--- a/tests/shared/core/test_dropout.mojo
+++ b/tests/shared/core/test_dropout.mojo
@@ -232,10 +232,10 @@ fn test_dropout_backward_gradient() raises:
 fn test_dropout2d_shapes() raises:
     """Test that dropout2d returns correct output and mask shapes."""
     var shape = List[Int]()
-    shape.append(2  # batch)
-    shape.append(3  # channels)
-    shape.append(4  # height)
-    shape.append(4  # width)
+    shape.append(2)  # batch
+    shape.append(3)  # channels
+    shape.append(4)  # height
+    shape.append(4)  # width
     var x = ones(shape, DType.float32)
 
     # Training mode
@@ -251,10 +251,10 @@ fn test_dropout2d_shapes() raises:
 fn test_dropout2d_channel_level() raises:
     """Test that dropout2d drops entire channels (all spatial positions)."""
     var shape = List[Int]()
-    shape.append(1  # batch)
-    shape.append(4  # channels)
-    shape.append(3  # height)
-    shape.append(3  # width)
+    shape.append(1)  # batch
+    shape.append(4)  # channels
+    shape.append(3)  # height
+    shape.append(3)  # width
     var x = ones(shape, DType.float32)
 
     var (output, mask) = dropout2d(x, p=0.5, training=True, seed=42)

--- a/tests/shared/core/test_normalization.mojo
+++ b/tests/shared/core/test_normalization.mojo
@@ -38,10 +38,10 @@ from shared.core.reduction import sum as reduce_sum
 fn test_batch_norm2d_shapes() raises:
     """Test that batch_norm2d returns correct output shape."""
     var shape = List[Int]()
-    shape.append(2  # batch)
-    shape.append(3  # channels)
-    shape.append(4  # height)
-    shape.append(4  # width)
+    shape.append(2)  # batch
+    shape.append(3)  # channels
+    shape.append(4)  # height
+    shape.append(4)  # width
     var x = ones(shape, DType.float32)
 
     # Create gamma, beta, running_mean, running_var for 3 channels
@@ -72,10 +72,10 @@ fn test_batch_norm2d_shapes() raises:
 fn test_batch_norm2d_training_mode() raises:
     """Test that batch_norm2d computes batch statistics in training mode."""
     var shape = List[Int]()
-    shape.append(2  # batch)
-    shape.append(1  # channels)
-    shape.append(2  # height)
-    shape.append(2  # width)
+    shape.append(2)  # batch
+    shape.append(1)  # channels
+    shape.append(2)  # height
+    shape.append(2)  # width
     var x = zeros(shape, DType.float32)
 
     # Set specific values: [0, 1, 2, 3, 4, 5, 6, 7]
@@ -108,10 +108,10 @@ fn test_batch_norm2d_training_mode() raises:
 fn test_batch_norm2d_inference_mode() raises:
     """Test that batch_norm2d uses running statistics in inference mode."""
     var shape = List[Int]()
-    shape.append(2  # batch)
-    shape.append(1  # channels)
-    shape.append(2  # height)
-    shape.append(2  # width)
+    shape.append(2)  # batch
+    shape.append(1)  # channels
+    shape.append(2)  # height
+    shape.append(2)  # width
     var x = ones(shape, DType.float32)
 
     var param_shape = List[Int]()
@@ -159,10 +159,10 @@ fn test_batch_norm2d_inference_mode() raises:
 fn test_batch_norm2d_scale_shift() raises:
     """Test that batch_norm2d applies gamma and beta correctly."""
     var shape = List[Int]()
-    shape.append(1  # batch)
-    shape.append(2  # channels)
-    shape.append(2  # height)
-    shape.append(2  # width)
+    shape.append(1)  # batch
+    shape.append(2)  # channels
+    shape.append(2)  # height
+    shape.append(2)  # width
     var x = zeros(shape, DType.float32)
 
     var param_shape = List[Int]()
@@ -211,10 +211,10 @@ fn test_batch_norm2d_scale_shift() raises:
 fn test_batch_norm2d_zero_variance() raises:
     """Test that batch_norm2d handles zero variance with epsilon."""
     var shape = List[Int]()
-    shape.append(2  # batch)
-    shape.append(1  # channels)
-    shape.append(1  # height)
-    shape.append(1  # width)
+    shape.append(2)  # batch
+    shape.append(1)  # channels
+    shape.append(1)  # height
+    shape.append(1)  # width
     var x = ones(shape, DType.float32)  # All values are 1.0 - zero variance
 
     var param_shape = List[Int]()
@@ -250,10 +250,10 @@ fn test_batch_norm2d_backward_gradient_input() raises:
     """
     # Small tensor for gradient checking (computational cost is O(n²))
     var shape = List[Int]()
-    shape.append(2  # batch)
-    shape.append(2  # channels)
-    shape.append(2  # height)
-    shape.append(2  # width)
+    shape.append(2)  # batch
+    shape.append(2)  # channels
+    shape.append(2)  # height
+    shape.append(2)  # width
 
     # Create test input with varying values
     var x = zeros(shape, DType.float32)
@@ -312,10 +312,10 @@ fn test_batch_norm2d_backward_training_vs_inference() raises:
     Inference mode: Gradients bypass statistics (use running stats)
     """
     var shape = List[Int]()
-    shape.append(2  # batch)
-    shape.append(1  # channels)
-    shape.append(2  # height)
-    shape.append(2  # width)
+    shape.append(2)  # batch
+    shape.append(1)  # channels
+    shape.append(2)  # height
+    shape.append(2)  # width
 
     var x = zeros(shape, DType.float32)
     for i in range(8):
@@ -360,10 +360,10 @@ fn test_batch_norm2d_backward_training_vs_inference() raises:
 fn test_batch_norm2d_backward_shapes() raises:
     """Test that batch_norm2d_backward returns correct gradient shapes."""
     var shape = List[Int]()
-    shape.append(3  # batch)
-    shape.append(4  # channels)
-    shape.append(5  # height)
-    shape.append(5  # width)
+    shape.append(3)  # batch
+    shape.append(4)  # channels
+    shape.append(5)  # height
+    shape.append(5)  # width
 
     var x = ones(shape, DType.float32)
     var grad_output = ones(shape, DType.float32)
@@ -398,8 +398,8 @@ fn test_batch_norm2d_backward_shapes() raises:
 fn test_layer_norm_shapes_2d() raises:
     """Test that layer_norm returns correct shape for 2D input."""
     var shape = List[Int]()
-    shape.append(4  # batch)
-    shape.append(10  # features)
+    shape.append(4)  # batch
+    shape.append(10)  # features
     var x = ones(shape, DType.float32)
 
     var param_shape = List[Int]()
@@ -417,10 +417,10 @@ fn test_layer_norm_shapes_2d() raises:
 fn test_layer_norm_shapes_4d() raises:
     """Test that layer_norm returns correct shape for 4D input."""
     var shape = List[Int]()
-    shape.append(2  # batch)
-    shape.append(3  # channels)
-    shape.append(4  # height)
-    shape.append(4  # width)
+    shape.append(2)  # batch
+    shape.append(3)  # channels
+    shape.append(4)  # height
+    shape.append(4)  # width
     var x = ones(shape, DType.float32)
 
     # For 4D input, normalize over C*H*W
@@ -442,8 +442,8 @@ fn test_layer_norm_shapes_4d() raises:
 fn test_layer_norm_normalization_2d() raises:
     """Test that layer_norm normalizes each sample independently."""
     var shape = List[Int]()
-    shape.append(2  # batch)
-    shape.append(4  # features)
+    shape.append(2)  # batch
+    shape.append(4)  # features
     var x = zeros(shape, DType.float32)
 
     # Sample 1: [0, 1, 2, 3]
@@ -493,8 +493,8 @@ fn test_layer_norm_normalization_2d() raises:
 fn test_layer_norm_scale_shift() raises:
     """Test that layer_norm applies gamma and beta correctly."""
     var shape = List[Int]()
-    shape.append(1  # batch)
-    shape.append(3  # features)
+    shape.append(1)  # batch
+    shape.append(3)  # features
     var x = zeros(shape, DType.float32)
 
     var param_shape = List[Int]()
@@ -535,8 +535,8 @@ fn test_layer_norm_scale_shift() raises:
 fn test_layer_norm_zero_variance() raises:
     """Test that layer_norm handles zero variance with epsilon."""
     var shape = List[Int]()
-    shape.append(2  # batch)
-    shape.append(3  # features)
+    shape.append(2)  # batch
+    shape.append(3)  # features
     var x = ones(shape, DType.float32)  # All values are 1.0 - zero variance
 
     var param_shape = List[Int]()


### PR DESCRIPTION
Closes #1958

Fixes syntax compilation errors in comprehensive-tests.yml workflow.

## Problem

Invalid Mojo syntax: comments placed inside function call parentheses, and using `.size` attribute instead of `len()` function on List[Int].

## Changes

**1. test_normalization.mojo** - 40 syntax fixes
- Moved inline comments outside `append()` parentheses
- Example: `shape.append(2  # batch)` → `shape.append(2)  # batch`

**2. test_dropout.mojo** - 8 syntax fixes  
- Moved inline comments outside `append()` parentheses

**3. shared/core/normalization.mojo** - 1 API fix
- Line 448: Changed `.size` to `len()` for List[Int]

## Testing

Local compilation - syntax errors resolved. Note: test_normalization.mojo has additional unrelated errors (`assert_shape_equal` missing) which need separate investigation.

## Impact

Resolves 49 syntax errors across 3 files, unblocking compilation for normalization and dropout tests.