### PR TITLE
fix(core): add explicit float32 conversions in dropout module

### DIFF
--- a/shared/core/dropout.mojo
+++ b/shared/core/dropout.mojo
@@ -7,7 +7,7 @@ Dropout randomly zeros some elements of the input tensor with probability p duri
 This helps prevent overfitting by randomly "dropping out" neurons.
 """
 
-from .extensor import ExTensor, zeros_like, ones_like
+from .extensor import ExTensor, zeros, zeros_like, ones_like
 from .arithmetic import multiply, divide
 from .extensor import full_like
 import random
@@ -75,7 +75,7 @@ fn dropout(
     if x.dtype() == DType.float32:
         for i in range(size):
             var rand_val = Float32(random.random_float64())
-            mask_ptr.bitcast[Float32]()[i] = 1.0 if rand_val > Float32(p) else 0.0
+            mask_ptr.bitcast[Float32]()[i] = Float32(1.0) if rand_val > Float32(p) else Float32(0.0)
     elif x.dtype() == DType.float64:
         for i in range(size):
             var rand_val = random.random_float64()
@@ -167,7 +167,7 @@ fn dropout2d(
             for c in range(channels):
                 var rand_val = Float32(random.random_float64())
                 var idx = b * channels + c
-                mask_ptr.bitcast[Float32]()[idx] = 1.0 if rand_val > Float32(p) else 0.0
+                mask_ptr.bitcast[Float32]()[idx] = Float32(1.0) if rand_val > Float32(p) else Float32(0.0)
     elif x.dtype() == DType.float64:
         for b in range(batch):
             for c in range(channels):


### PR DESCRIPTION
Closes #1959

Fixes type conversion compilation errors in comprehensive-tests.yml workflow.

## Problem

Mojo does not allow implicit Float64 to Float32 conversions. The dropout module was using Float64 literals (`1.0`, `0.0`) where Float32 was expected, causing compilation errors.

## Changes

**shared/core/dropout.mojo**:
- Line 78: Added `Float32()` conversions to literals in conditional expression
- Line 170: Added `Float32()` conversions to literals in conditional expression  
- Line 10: Added missing `zeros` import from extensor module

**Before**:
```mojo
mask_ptr[i] = 1.0 if condition else 0.0  # Implicit Float64
```

**After**:
```mojo  
mask_ptr[i] = Float32(1.0) if condition else Float32(0.0)  # Explicit Float32
```

## Testing

Local compilation - type conversion errors resolved.

## Impact

Resolves 2 type conversion errors in dropout module, unblocking dropout tests.