### PR TITLE
fix(tests): correct variable declaration syntax in loss tests

### DIFF
--- a/tests/shared/core/test_losses.mojo
+++ b/tests/shared/core/test_losses.mojo
@@ -29,14 +29,14 @@ fn test_binary_cross_entropy_perfect_prediction() raises:
 
     # Perfect predictions: pred = target
     for i in range(4):
-        varval = 1.0 if i % 2 == 0 else 0.0
+        var val = 1.0 if i % 2 == 0 else 0.0
         predictions._set_float64(i, val)
         targets._set_float64(i, val)
 
     var loss = binary_cross_entropy(predictions, targets)
     var avg_loss = mean(loss)
 
-    varloss_val = avg_loss._get_float64(0)
+    var loss_val = avg_loss._get_float64(0)
     print("  Perfect prediction loss:", loss_val)
 
     # Should be very close to 0 (within epsilon tolerance)
@@ -56,15 +56,15 @@ fn test_binary_cross_entropy_worst_prediction() raises:
 
     # Worst predictions: pred = 1 - target
     for i in range(4):
-        vartarget_val = 1.0 if i % 2 == 0 else 0.0
-        varpred_val = 1.0 - target_val  # Opposite
+        var target_val = 1.0 if i % 2 == 0 else 0.0
+        var pred_val = 1.0 - target_val  # Opposite
         predictions._set_float64(i, pred_val)
         targets._set_float64(i, target_val)
 
     var loss = binary_cross_entropy(predictions, targets)
     var avg_loss = mean(loss)
 
-    varloss_val = avg_loss._get_float64(0)
+    var loss_val = avg_loss._get_float64(0)
     print("  Worst prediction loss:", loss_val)
 
     # Should be high (> 1.0)
@@ -112,14 +112,14 @@ fn test_mean_squared_error_zero_loss() raises:
 
     # Identical values
     for i in range(5):
-        varval = Float64(i) * 0.5
+        var val = Float64(i) * 0.5
         predictions._set_float64(i, val)
         targets._set_float64(i, val)
 
     var loss = mean_squared_error(predictions, targets)
     var avg_loss = mean(loss)
 
-    varloss_val = avg_loss._get_float64(0)
+    var loss_val = avg_loss._get_float64(0)
     print("  MSE zero loss:", loss_val)
 
     # Should be exactly 0
@@ -154,12 +154,12 @@ fn test_mean_squared_error_known_values() raises:
     var loss = mean_squared_error(predictions, targets)
     var avg_loss = mean(loss)
 
-    varloss_val = avg_loss._get_float64(0)
+    var loss_val = avg_loss._get_float64(0)
     print("  MSE known value:", loss_val)
 
     # Should be approximately 0.666...
-    varexpected = 2.0 / 3.0
-    vardiff = abs(loss_val - expected)
+    var expected = 2.0 / 3.0
+    var diff = abs(loss_val - expected)
     if diff > 0.01:
         raise Error("MSE loss doesn't match expected value")
 
@@ -194,9 +194,9 @@ fn test_mean_squared_error_gradient() raises:
     var grad_pred = mean_squared_error_backward(grad_output, predictions, targets)
 
     # Check values
-    vargrad0 = grad_pred._get_float64(0)
-    vargrad1 = grad_pred._get_float64(1)
-    vargrad2 = grad_pred._get_float64(2)
+    var grad0 = grad_pred._get_float64(0)
+    var grad1 = grad_pred._get_float64(1)
+    var grad2 = grad_pred._get_float64(2)
 
     print("  Gradients: [", grad0, ",", grad1, ",", grad2, "]")
 
@@ -230,7 +230,7 @@ fn test_loss_numerical_stability() raises:
     var loss = binary_cross_entropy(predictions, targets)
     var avg_loss = mean(loss)
 
-    varloss_val = avg_loss._get_float64(0)
+    var loss_val = avg_loss._get_float64(0)
     print("  BCE with extreme values:", loss_val)
 
     # Should be finite (not NaN or Inf)


### PR DESCRIPTION
Closes #1957

Fixes variable declaration syntax errors in comprehensive-tests.yml workflow.

## Problem

Missing spaces between `var` keyword and variable names caused 14 compilation errors.

## Changes

**tests/shared/core/test_losses.mojo** - 14 syntax fixes:
- `varloss_val` → `var loss_val`
- `varpred_val` → `var pred_val`
- `vartarget_val` → `var target_val`
- `vardiff` → `var diff`
- `varexpected` → `var expected`
- `varval` → `var val`
- `vargrad0/1/2` → `var grad0/1/2`

Lines affected: 32, 39, 59, 60, 67, 115, 122, 157, 161, 162, 197-199, 233

## Testing

Local compilation - file compiles successfully. Syntax errors resolved.

Note: Some tests may have runtime errors (crashes), which are separate issues beyond compilation scope.

## Impact

Resolves 14 compilation errors in loss tests. Depends on PR #1961 (merged).