### PR TITLE
docs(issues): add implementation notes for merged PRs

### DIFF
--- a/notes/issues/1971/README.md
+++ b/notes/issues/1971/README.md
@@ -1,0 +1,67 @@
+# Issue #1971: Export scheduler classes from schedulers package
+
+## Objective
+
+Export the three scheduler classes (StepLR, CosineAnnealingLR, WarmupLR) from the
+shared/training/schedulers package __init__.mojo file so they can be imported by test files and
+other modules.
+
+## Deliverables
+
+- Updated `/shared/training/schedulers/__init__.mojo` with scheduler class exports
+- All three scheduler classes now properly exported:
+  - StepLR: Step decay scheduler
+  - CosineAnnealingLR: Cosine annealing scheduler
+  - WarmupLR: Linear warmup scheduler
+
+## Success Criteria
+
+- [x] Scheduler classes exported from __init__.mojo
+- [x] Import statement correctly references schedulers module
+- [x] All three classes (StepLR, CosineAnnealingLR, WarmupLR) are exported
+- [x] Code passes pre-commit checks
+- [x] Commit created with proper message format
+
+## References
+
+- Scheduler implementations: `/shared/training/schedulers.mojo`
+- Package init file: `/shared/training/schedulers/__init__.mojo`
+
+## Implementation Notes
+
+### Changes Made
+
+**File**: `/shared/training/schedulers/__init__.mojo`
+
+**Before**:
+```mojo
+# Export scheduler implementations
+from .step_decay import step_lr, multistep_lr, exponential_lr, constant_lr
+
+# TODO: Implement remaining schedulers
+# from .cosine import cosine_annealing_lr
+# from .warmup import warmup_lr
+```
+
+**After**:
+```mojo
+# Export scheduler implementations
+from .step_decay import step_lr, multistep_lr, exponential_lr, constant_lr
+
+# Export scheduler classes
+from ..schedulers import StepLR, CosineAnnealingLR, WarmupLR
+```
+
+### Problem Solved
+
+The three scheduler classes were defined in `/shared/training/schedulers.mojo` but were not
+exported from the package __init__.mojo file. This caused import failures in test files that
+tried to import these classes from the schedulers package. By adding the export statement, these
+classes are now properly exposed to the package's public API.
+
+### Key Details
+
+- The classes are defined in the parent module `schedulers.mojo` (sibling to the schedulers package)
+- Therefore the import uses `from ..schedulers import` to go up one level and import from that module
+- All three classes implement the LRScheduler trait and are fully functional
+- No modifications to the scheduler implementations were needed

--- a/notes/issues/1974/README.md
+++ b/notes/issues/1974/README.md
@@ -1,0 +1,28 @@
+# Issue #1974: Add Pipeline type alias for transforms
+
+## Objective
+
+Add Pipeline type alias that points to Compose[T] in the transforms module and export it from the data package.
+
+## Deliverables
+
+- Added `alias Pipeline[T: Transform & Copyable & Movable] = Compose[T]` in `shared/data/transforms.mojo` (line 133)
+- Added Pipeline to exports in `shared/data/__init__.mojo` (line 72)
+
+## Success Criteria
+
+- [x] Pipeline type alias defined in transforms.mojo after Compose struct
+- [x] Pipeline exported from shared.data package
+- [x] Tests can import Pipeline from shared.data.transforms
+- [x] Type alias properly parameterized as Pipeline[T]
+
+## References
+
+- Compose struct definition: `shared/data/transforms.mojo:86-130`
+- Data package exports: `shared/data/__init__.mojo:68-81`
+
+## Implementation Notes
+
+The tests imported Pipeline from shared.data.transforms but the type alias didn't exist. Only the Compose[T] generic struct was defined. This alias provides a semantic convenience name for users who prefer "Pipeline" terminology over "Compose".
+
+The type alias uses the same generic constraints as Compose to ensure proper type safety and trait implementation.

--- a/notes/issues/1975/README.md
+++ b/notes/issues/1975/README.md
@@ -1,0 +1,64 @@
+# Issue #1975: Fix TensorDataset import and Tensor type usage
+
+## Objective
+
+Fix import name mismatch and undefined Tensor type usage in dataset tests.
+
+## Deliverables
+
+- Fixed `shared/data/datasets.mojo` with `TensorDataset` type alias
+- Fixed `tests/shared/data/datasets/test_tensor_dataset.mojo` to use proper `ExTensor` type
+- All tests now compile and run correctly
+
+## Changes Made
+
+### 1. Added TensorDataset Type Alias
+
+**File**: `shared/data/datasets.mojo`
+
+Added a type alias for backwards compatibility:
+
+```mojo
+# Type alias for backwards compatibility
+alias TensorDataset = ExTensorDataset
+```
+
+This allows tests to import `TensorDataset` while the implementation is named `ExTensorDataset`.
+
+### 2. Fixed Test File Tensor Type Usage
+
+**File**: `tests/shared/data/datasets/test_tensor_dataset.mojo`
+
+Replaced all instances of undefined `Tensor([...])` with proper `ExTensor` initialization from `List`:
+
+**Pattern Changed**:
+- From: `var data = Tensor([Float32(1.0), Float32(2.0)])`
+- To: `var data_list = List[Float32](Float32(1.0), Float32(2.0))` followed by `var data = ExTensor(data_list^)`
+
+**Functions Updated**:
+1. `test_tensor_dataset_negative_indexing()` - lines 159-162
+2. `test_tensor_dataset_out_of_bounds()` - lines 180-183
+3. `test_tensor_dataset_iteration_consistency()` - lines 209-212
+4. `test_tensor_dataset_no_copy_on_access()` - lines 234-237
+5. `test_tensor_dataset_memory_efficiency()` - lines 267-268
+
+## Success Criteria
+
+- [x] `TensorDataset` alias added to `datasets.mojo`
+- [x] All `Tensor()` type usages replaced with `ExTensor`
+- [x] All tests now compile without type errors
+- [x] Proper use of `List[T]` initialization for tensor creation
+- [x] Ownership transfer with `^` operator used correctly
+
+## References
+
+- [ExTensor Implementation](/shared/core/extensor.mojo)
+- [Dataset Interface](/shared/data/datasets.mojo)
+- [Mojo Syntax Standards](/CLAUDE.md#mojo-syntax-standards-v0257)
+
+## Implementation Notes
+
+- The `Tensor` type used in the test was undefined and likely a leftover from earlier development
+- `ExTensor` is the correct type to use throughout the codebase
+- The `TensorDataset` alias maintains backwards compatibility for any code that imports the old name
+- All tensor initialization now properly uses `List[T]` with ownership transfer via `^`

--- a/notes/issues/1977/README.md
+++ b/notes/issues/1977/README.md
@@ -1,0 +1,86 @@
+# Issue #1977: Fix unsafe List initialization patterns
+
+## Objective
+
+Replace unsafe `List[Int]()` initialization patterns followed by immediate `.append()` calls in 4 locations across training modules. This was causing undefined behavior and crashes in the Training: Loops & Metrics test group.
+
+## Deliverables
+
+Fixed files:
+- `shared/training/trainer_interface.mojo` (lines 297-304, 2 locations)
+- `shared/training/metrics/accuracy.mojo` (line 112-113, 1 location)
+- `shared/training/metrics/confusion_matrix.mojo` (line 325-326, 1 location)
+
+## Success Criteria
+
+- [x] All 4 unsafe List initialization patterns replaced with safe alternatives
+- [x] trainer_interface.mojo batch_data_shape fixed (2-element list)
+- [x] trainer_interface.mojo batch_labels_shape fixed (1-element list)
+- [x] accuracy.mojo result_shape fixed (1-element list)
+- [x] confusion_matrix.mojo result_shape fixed (1-element list)
+
+## Implementation Details
+
+### Pattern Fixed
+
+**UNSAFE** (causes undefined behavior):
+```mojo
+var shape = List[Int]()
+shape.append(size)
+```
+
+**SAFE** (proper initialization with capacity):
+```mojo
+var shape = List[Int](capacity)
+shape[index] = value
+```
+
+### Changes Made
+
+#### 1. trainer_interface.mojo (lines 297-304)
+
+Fixed two List initializations in the `DataLoader.next()` method:
+
+**batch_data_shape** (2-element list):
+- Changed: `List[Int]()` with two appends
+- To: `List[Int](2)` with direct assignment
+
+**batch_labels_shape** (1-element list):
+- Changed: `List[Int]()` with one append
+- To: `List[Int](1)` with direct assignment
+- Also fixed: `shape()[0]` → `shape()[1]` to correctly get feature dimension
+
+#### 2. accuracy.mojo (line 112-113)
+
+Fixed List initialization in the `argmax()` function:
+
+**result_shape** (1-element list):
+- Changed: `List[Int]()` with one append
+- To: `List[Int](1)` with direct assignment
+
+#### 3. confusion_matrix.mojo (line 325-326)
+
+Fixed List initialization in the `argmax()` helper function:
+
+**result_shape** (1-element list):
+- Changed: `List[Int]()` with one append
+- To: `List[Int](1)` with direct assignment
+
+## References
+
+- Issue: #1977
+- Related test failures: Training: Loops & Metrics test group
+- Language documentation: [Mojo Manual - Collections](https://docs.modular.com/mojo/manual/collections/)
+
+## Notes
+
+The root cause was using empty List initialization without pre-allocating capacity, then immediately calling append(). This caused undefined behavior because:
+
+1. `List[Int]()` creates an empty list with zero capacity
+2. Calling `append()` on an uninitialized list can access invalid memory
+3. The fix allocates proper capacity upfront and uses indexed assignment instead
+
+This is a safe pattern that:
+- Pre-allocates exact capacity needed
+- Uses direct array indexing (safe after initialization)
+- Avoids dynamic growth during append operations


### PR DESCRIPTION
## Summary

Added README.md files documenting implementation details for issues that were completed but missing documentation.

## Issues Documented

- **Issue #1971**: Export scheduler classes from schedulers package
- **Issue #1974**: Add Pipeline type alias for transforms
- **Issue #1975**: Fix TensorDataset import and Tensor type usage
- **Issue #1977**: Replace unsafe List initialization patterns

## Changes

- Created notes/issues/1971/README.md
- Created notes/issues/1974/README.md
- Created notes/issues/1975/README.md
- Created notes/issues/1977/README.md
- Removed temporary script scripts/commit_fix.py

## Context

These documentation files were created during the PR implementation but not committed. This PR adds them to maintain complete project documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>