### PR TITLE
Fix RMSprop power() call with invalid FloatLiteral

### DIFF
--- a/shared/training/optimizers/rmsprop.mojo
+++ b/shared/training/optimizers/rmsprop.mojo
@@ -129,7 +129,7 @@ fn rmsprop_step(
     var alpha_tensor = full_like(square_avg, alpha)
     var one_minus_alpha = full_like(square_avg, 1.0 - alpha)
 
-    var grad_squared = power(effective_gradients, 2.0)
+    var grad_squared = multiply(effective_gradients, effective_gradients)
     var avg_term1 = multiply(alpha_tensor, square_avg)
     var avg_term2 = multiply(one_minus_alpha, grad_squared)
     var new_square_avg = add(avg_term1, avg_term2)


### PR DESCRIPTION
Closes #2001

## Summary

Fixed invalid  call in RMSprop optimizer by replacing it with element-wise multiplication.

## Changes

- Line 132: Changed  to 

## Root Cause

The  function expects two ExTensor arguments, but was being passed an ExTensor and a FloatLiteral (2.0).

## Solution

Element-wise multiplication is mathematically equivalent for squaring and more efficient.

## Testing

Fixes 10 failing test groups:
- test_batch_loader
- test_cross_entropy_loss
- test_dropout
- test_flatten
- test_linear
- test_max_pool2d
- test_relu
- test_schedulers
- test_sgd
- test_softmax