### PR TITLE
Fix RMSprop invalid keyword arguments

### DIFF
--- a/shared/training/optimizers/rmsprop.mojo
+++ b/shared/training/optimizers/rmsprop.mojo
@@ -199,7 +199,7 @@ fn rmsprop_step_simple(
     var (new_params, new_square_avg, _) = rmsprop_step(
         params, gradients, square_avg, 1,  # t=1 (not used without momentum/wd)
         learning_rate, alpha, epsilon,
-        weight_decay=0.0, momentum=0.0, buf=None
+        0.0, 0.0, None
     )
 
     return (new_params, new_square_avg)


### PR DESCRIPTION
Closes #2002

## Summary

Fixed invalid keyword arguments in  by using positional arguments.

## Changes

- Line 202: Changed  to 

## Root Cause

Mojo doesn't support keyword arguments like Python does. Arguments must be passed positionally.

## Testing

Fixes 10 failing test groups:
- test_batch_loader
- test_cross_entropy_loss
- test_dropout
- test_flatten
- test_linear
- test_max_pool2d
- test_relu
- test_schedulers
- test_sgd
- test_softmax