### PR TITLE
Fix RMSprop optimizer type and syntax errors

### DIFF
--- a/shared/training/optimizers/rmsprop.mojo
+++ b/shared/training/optimizers/rmsprop.mojo
@@ -129,7 +129,7 @@ fn rmsprop_step(
     var alpha_tensor = full_like(square_avg, alpha)
     var one_minus_alpha = full_like(square_avg, 1.0 - alpha)
 
-    var grad_squared = power(effective_gradients, 2.0)
+    var grad_squared = multiply(effective_gradients, effective_gradients)
     var avg_term1 = multiply(alpha_tensor, square_avg)
     var avg_term2 = multiply(one_minus_alpha, grad_squared)
     var new_square_avg = add(avg_term1, avg_term2)
@@ -199,7 +199,7 @@ fn rmsprop_step_simple(
     var (new_params, new_square_avg, _) = rmsprop_step(
         params, gradients, square_avg, 1,  # t=1 (not used without momentum/wd)
         learning_rate, alpha, epsilon,
-        weight_decay=0.0, momentum=0.0, buf=None
+        0.0, 0.0, None
     )
 
     return (new_params, new_square_avg)


### PR DESCRIPTION
Closes #2005

## Summary

Fixed two critical errors in the RMSprop optimizer that were preventing compilation.

## Changes

**Line 132: Fix invalid power() call**
- FROM: `power(effective_gradients, 2.0)`
- TO: `multiply(effective_gradients, effective_gradients)`
- Reason: power() expects two ExTensor args, not ExTensor + FloatLiteral

**Line 202: Remove invalid keyword arguments**  
- FROM: `weight_decay=0.0, momentum=0.0, buf=None`
- TO: `0.0, 0.0, None`
- Reason: Mojo doesn't support keyword arguments

## Testing

Fixes 10 failing test groups:
- test_batch_loader
- test_cross_entropy_loss
- test_dropout
- test_flatten
- test_linear
- test_max_pool2d
- test_relu
- test_schedulers
- test_sgd
- test_softmax

## Supersedes

This PR supersedes and replaces:
- PR #2003 (power fix only)
- PR #2004 (kwargs fix only)