### PR TITLE
fix(tests): correct add/subtract backward calls to pass shapes

### DIFF
--- a/tests/shared/core/test_arithmetic.mojo
+++ b/tests/shared/core/test_arithmetic.mojo
@@ -142,7 +142,7 @@ fn test_add_backward() raises:
     var b = ones(shape, DType.float32)
     var grad_output = ones(shape, DType.float32)
 
-    var grads = add_backward(grad_output, a, b)
+    var grads = add_backward(grad_output, a.shape(), b.shape())
     var grad_a = grads.grad_a
     var grad_b = grads.grad_b
 
@@ -252,7 +252,7 @@ fn test_subtract_backward() raises:
     var b = ones(shape, DType.float32)
     var grad_output = ones(shape, DType.float32)
 
-    var grads = subtract_backward(grad_output, a, b)
+    var grads = subtract_backward(grad_output, a.shape(), b.shape())
     var grad_a = grads.grad_a
     var grad_b = grads.grad_b
 


### PR DESCRIPTION
## Summary

Fixed `test_arithmetic.mojo` backward function calls to match function signatures:
- `add_backward` and `subtract_backward` expect `List[Int]` shapes
- `multiply_backward` and `divide_backward` expect `ExTensor` objects

## Changes

Updated 2 function calls in `tests/shared/core/test_arithmetic.mojo`:
- Line 145: `add_backward(grad_output, a, b)` → `add_backward(grad_output, a.shape(), b.shape())`
- Line 255: `subtract_backward(grad_output, a, b)` → `subtract_backward(grad_output, a.shape(), b.shape())`

Left multiply/divide calls unchanged (they correctly pass tensors).

## Function Signatures

```mojo
fn add_backward(grad_output: ExTensor, a_shape: List[Int], b_shape: List[Int]) -> GradientPair
fn subtract_backward(grad_output: ExTensor, a_shape: List[Int], b_shape: List[Int]) -> GradientPair
fn multiply_backward(grad_output: ExTensor, a: ExTensor, b: ExTensor) -> GradientPair
fn divide_backward(grad_output: ExTensor, a: ExTensor, b: ExTensor) -> GradientPair
```

## Testing

- Local pre-commit checks pass
- Changes isolated to test code only

🤖 Generated with [Claude Code](https://claude.com/claude-code)