### PR TITLE
[Impl] Training Loop Infrastructure - Issue #34

### DIFF
--- a/tests/shared/fixtures/mock_models.mojo
+++ b/tests/shared/fixtures/mock_models.mojo
@@ -17,6 +17,7 @@ from tests.shared.fixtures.mock_tensors import (
     create_zeros_tensor,
     create_ones_tensor,
 )
+from shared.core import zeros_like, zeros, ExTensor
 
 
 # ============================================================================
@@ -272,11 +273,63 @@ struct SimpleLinearModel:
 
 
 # ============================================================================
+# Parameter Structure
+# ============================================================================
+
+
+struct Parameter(Copyable, Movable):
+    """Trainable parameter with data and gradient.
+
+    Wraps an ExTensor for the parameter data with an associated gradient tensor.
+    Used in model layers to track trainable weights and biases.
+
+    Attributes:
+        data: The parameter tensor (weights or bias).
+        grad: The gradient tensor for backpropagation.
+    """
+
+    var data: ExTensor
+    var grad: ExTensor
+
+    fn __init__(out self, data: ExTensor) raises:
+        """Initialize parameter with data tensor and zero gradient.
+
+        Args:
+            data: The parameter tensor.
+
+        Raises:
+            Error: If gradient tensor cannot be created.
+
+        Example:
+            ```mojo
+            var param = Parameter(data_tensor)
+            # grad is automatically initialized to zeros_like(data_tensor)
+            ```
+        """
+        self.data = data
+        self.grad = zeros_like(data)
+
+    fn shape(self) -> List[Int]:
+        """Get the shape of the parameter.
+
+        Returns:
+            Shape of the parameter tensor.
+
+        Example:
+            ```mojo
+            var param = Parameter(tensor)
+            var s = param.shape()  # Same as param.data.shape()
+            ```
+        """
+        return self.data.shape()
+
+
+# ============================================================================
 # Simple Multi-Layer Perceptron
 # ============================================================================
 
 
-struct SimpleMLP:
+struct SimpleMLP(Copyable, Movable, ImplicitlyCopyable):
     """Simple multi-layer perceptron (2-3 layers).
 
     Provides a minimal MLP for testing multi-layer forward passes,
@@ -307,7 +360,7 @@ struct SimpleMLP:
     var layer3_bias: List[Float32]
 
     fn __init__(
-        mut self,
+        out self,
         input_dim: Int,
         hidden_dim: Int,
         output_dim: Int,
@@ -491,3 +544,191 @@ struct SimpleMLP:
         if self.num_hidden_layers == 2:
             total += len(self.layer3_weights) + len(self.layer3_bias)
         return total
+
+    fn get_weights(self) raises -> ExTensor:
+        """Get flattened weights as ExTensor.
+
+        Returns:
+            ExTensor containing all weights flattened.
+
+        Example:
+            ```mojo
+            var mlp = SimpleMLP(10, 20, 5)
+            var weights = mlp.get_weights()
+            ```
+        """
+        # Flatten all weight lists into a single list
+        var all_weights = List[Float32]()
+        for i in range(len(self.layer1_weights)):
+            all_weights.append(self.layer1_weights[i])
+        for i in range(len(self.layer2_weights)):
+            all_weights.append(self.layer2_weights[i])
+        for i in range(len(self.layer3_weights)):
+            all_weights.append(self.layer3_weights[i])
+
+        # Create ExTensor from flattened weights
+        var shape = List[Int](len(all_weights))
+        var tensor = zeros(shape, DType.float32)
+
+        # Copy weights into tensor
+        for i in range(len(all_weights)):
+            tensor._set_float32(i, all_weights[i])
+
+        return tensor
+
+    fn parameters(self) raises -> List[Parameter]:
+        """Get list of Parameter objects.
+
+        Returns:
+            List of Parameter objects wrapping weights and biases.
+
+        Example:
+            ```mojo
+            var mlp = SimpleMLP(10, 20, 5)
+            var params = mlp.parameters()
+            for param in params:
+                print(param.shape())
+            ```
+        """
+        var param_list = List[Parameter]()
+
+        # Layer 1 weights parameter
+        var w1_shape = List[Int](self.hidden_dim, self.input_dim)
+        var w1_tensor = zeros(w1_shape, DType.float32)
+        for i in range(len(self.layer1_weights)):
+            w1_tensor._set_float32(i, self.layer1_weights[i])
+        param_list.append(Parameter(w1_tensor))
+
+        # Layer 1 bias parameter
+        var b1_shape = List[Int](self.hidden_dim)
+        var b1_tensor = zeros(b1_shape, DType.float32)
+        for i in range(len(self.layer1_bias)):
+            b1_tensor._set_float32(i, self.layer1_bias[i])
+        param_list.append(Parameter(b1_tensor))
+
+        # Layer 2 weights parameter
+        var w2_dim_in = self.hidden_dim
+        var w2_dim_out = (
+            self.output_dim if self.num_hidden_layers == 1 else self.hidden_dim
+        )
+        var w2_shape = List[Int](w2_dim_out, w2_dim_in)
+        var w2_tensor = zeros(w2_shape, DType.float32)
+        for i in range(len(self.layer2_weights)):
+            w2_tensor._set_float32(i, self.layer2_weights[i])
+        param_list.append(Parameter(w2_tensor))
+
+        # Layer 2 bias parameter
+        var b2_shape = List[Int](w2_dim_out)
+        var b2_tensor = zeros(b2_shape, DType.float32)
+        for i in range(len(self.layer2_bias)):
+            b2_tensor._set_float32(i, self.layer2_bias[i])
+        param_list.append(Parameter(b2_tensor))
+
+        # Layer 3 parameters (only if num_hidden_layers == 2)
+        if self.num_hidden_layers == 2:
+            var w3_shape = List[Int](self.output_dim, self.hidden_dim)
+            var w3_tensor = zeros(w3_shape, DType.float32)
+            for i in range(len(self.layer3_weights)):
+                w3_tensor._set_float32(i, self.layer3_weights[i])
+            param_list.append(Parameter(w3_tensor))
+
+            var b3_shape = List[Int](self.output_dim)
+            var b3_tensor = zeros(b3_shape, DType.float32)
+            for i in range(len(self.layer3_bias)):
+                b3_tensor._set_float32(i, self.layer3_bias[i])
+            param_list.append(Parameter(b3_tensor))
+
+        return param_list^
+
+    fn zero_grad(mut self):
+        """Zero all gradients.
+
+        Example:
+            ```mojo
+            var mlp = SimpleMLP(10, 20, 5)
+            mlp.zero_grad()
+            ```
+        """
+        # This is a placeholder - actual gradient zeroing would happen
+        # on Parameter objects during backpropagation
+        pass
+
+    fn state_dict(self) raises -> Dict[String, ExTensor]:
+        """Export weights as state dictionary.
+
+        Returns:
+            Dictionary mapping parameter names to their tensor values.
+
+        Example:
+            ```mojo
+            var mlp = SimpleMLP(10, 20, 5)
+            var state = mlp.state_dict()
+            ```
+        """
+        var state = Dict[String, ExTensor]()
+
+        # Layer 1 weights
+        var w1_shape = List[Int](self.hidden_dim, self.input_dim)
+        var w1_tensor = zeros(w1_shape, DType.float32)
+        for i in range(len(self.layer1_weights)):
+            w1_tensor._set_float32(i, self.layer1_weights[i])
+        state["layer1_weights"] = w1_tensor
+
+        # Layer 1 bias
+        var b1_shape = List[Int](self.hidden_dim)
+        var b1_tensor = zeros(b1_shape, DType.float32)
+        for i in range(len(self.layer1_bias)):
+            b1_tensor._set_float32(i, self.layer1_bias[i])
+        state["layer1_bias"] = b1_tensor
+
+        # Layer 2 weights
+        var w2_dim_in = self.hidden_dim
+        var w2_dim_out = (
+            self.output_dim if self.num_hidden_layers == 1 else self.hidden_dim
+        )
+        var w2_shape = List[Int](w2_dim_out, w2_dim_in)
+        var w2_tensor = zeros(w2_shape, DType.float32)
+        for i in range(len(self.layer2_weights)):
+            w2_tensor._set_float32(i, self.layer2_weights[i])
+        state["layer2_weights"] = w2_tensor
+
+        # Layer 2 bias
+        var b2_shape = List[Int](w2_dim_out)
+        var b2_tensor = zeros(b2_shape, DType.float32)
+        for i in range(len(self.layer2_bias)):
+            b2_tensor._set_float32(i, self.layer2_bias[i])
+        state["layer2_bias"] = b2_tensor
+
+        # Layer 3 parameters (only if num_hidden_layers == 2)
+        if self.num_hidden_layers == 2:
+            var w3_shape = List[Int](self.output_dim, self.hidden_dim)
+            var w3_tensor = zeros(w3_shape, DType.float32)
+            for i in range(len(self.layer3_weights)):
+                w3_tensor._set_float32(i, self.layer3_weights[i])
+            state["layer3_weights"] = w3_tensor
+
+            var b3_shape = List[Int](self.output_dim)
+            var b3_tensor = zeros(b3_shape, DType.float32)
+            for i in range(len(self.layer3_bias)):
+                b3_tensor._set_float32(i, self.layer3_bias[i])
+            state["layer3_bias"] = b3_tensor
+
+        return state
+
+    fn load_state_dict(mut self, state: Dict[String, ExTensor]):
+        """Load weights from state dictionary.
+
+        Args:
+            state: Dictionary mapping parameter names to their tensor values.
+
+        Example:
+            ```mojo
+            var mlp = SimpleMLP(10, 20, 5)
+            mlp.load_state_dict(state)
+            ```
+
+        Note:
+            This is a placeholder implementation for now.
+        """
+        # Placeholder for weight loading
+        pass

--- a/tests/shared/training/test_training_loop.mojo
+++ b/tests/shared/training/test_training_loop.mojo
@@ -16,6 +16,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_almost_equal,
     assert_less,
+    assert_greater,
     assert_not_equal_tensor,
     assert_tensor_equal,
     assert_type,
@@ -27,6 +28,7 @@ from tests.shared.conftest import (
 )
 from shared.training import SGD, MSELoss, TrainingLoop
 from shared.core.extensor import ExTensor
+from shared.core import ones, zeros
 
 
 # ============================================================================
@@ -55,8 +57,8 @@ fn test_training_loop_single_batch() raises:
     var training_loop = TrainingLoop(model, optimizer, loss_fn)
     #
     # Create single batch
-    var inputs = ExTensor.ones(List[Int](4, 10), DType.float32)  # batch_size=4, input_dim=10
-    var targets = ExTensor.zeros(List[Int](4, 1), DType.float32)  # batch_size=4, output_dim=1
+    var inputs = ones(List[Int](4, 10), DType.float32)  # batch_size=4, input_dim=10
+    var targets = zeros(List[Int](4, 1), DType.float32)  # batch_size=4, output_dim=1
     #
     # Get initial weights
     var initial_weights = model.get_weights().copy()


### PR DESCRIPTION
## Summary
Implements core training loop infrastructure for Issue #34 with ~60% completion:
- ✅ SimpleMLP fixture with full Parameter support
- ✅ TrainingLoop struct with training orchestration methods
- ⚠️  Type compatibility issue between Py Thon Object and Mojo types
- ❌ Full training cycle requires gradient/backprop implementation

## What's Been Implemented ✅

### Track 1: SimpleMLP Parameter Support
- **Parameter struct** - Wraps ExTensor with `.data` and `.grad` attributes
- **Constructor fix** - `mut self` → `out self` (Mojo v0.25.7 convention)
- **New methods:**
  - `get_weights()` - Returns flattened weights as ExTensor
  - `parameters()` - Returns `List[Parameter]` for all weights/biases
  - `zero_grad()` - Gradient zeroing (placeholder for backprop integration)
  - `state_dict()` / `load_state_dict()` - Weight serialization (placeholders)
- **Traits** - Made SimpleMLP `ImplicitlyCopyable`

### Track 2: TrainingLoop Implementation
- **Core methods implemented:**
  - `step()` - Single training iteration (forward + loss + backward + optimize)
  - `forward()` - Forward pass delegation to model
  - `compute_loss()` - Loss computation via loss function
  - `run_epoch()` - Full epoch iteration with loss averaging
- **Python interop** - Added `PythonObject` import

### Track 3: Test Infrastructure Fixes
- Added missing `assert_greater` import from conftest
- Fixed `ExTensor.ones()`/`zeros()` calls → use factory functions `ones()`/`zeros()`
- Fixed method signature syntax (`raises` keyword positioning)
- Fixed `.store()` calls → `_set_float32()` (correct ExTensor API)

## Known Issues 🔨

### 1. Type Compatibility (Critical)
**Problem:** TrainingLoop expects `PythonObject` types but tests pass native Mojo types:
```mojo
var model = SimpleMLP(...)      # Mojo struct
var optimizer = SGD(...)        # Mojo struct  
var loss_fn = MSELoss(...)      # Mojo struct
var loop = TrainingLoop(model, optimizer, loss_fn)  # ❌ Type mismatch
```

**Resolution Options:**
1. **Trait-based approach** (recommended when Mojo supports it):
   ```mojo
   struct TrainingLoop[M: Model, O: Optimizer, L: Loss]:
       var model: M
       var optimizer: O
       var loss_fn: L
   ```
2. **Python interop wrappers** - Wrap Mojo types as PythonObject
3. **Concrete types** - Change TrainingLoop to accept SimpleMLP/SGD/MSELoss directly (less flexible)

### 2. Test Status
- All tests marked `# TODO(#34): Implement when TrainingLoop is available`
- Tests define TDD API before implementation exists
- Many tests have incomplete code blocks (variables used before declaration)

### 3. Missing Implementations
- **Backward pass** - Gradient computation not yet implemented  
- **Optimizer.step()** - Weight update logic placeholder
- **Model.forward()** - SimpleMLP needs actual tensor forward pass
- **Data loaders** - `run_epoch()` expects iterable data loader

## Files Changed
- `shared/training/__init__.mojo` - Added PythonObject import, implemented TrainingLoop methods
- `tests/shared/fixtures/mock_models.mojo` - Enhanced SimpleMLP, created Parameter struct
- `tests/shared/training/test_training_loop.mojo` - Fixed imports and factory function calls

## Compilation Status
```bash
pixi run mojo build tests/shared/training/test_training_loop.mojo
# ❌ Fails due to type compatibility issue (SimpleMLP → PythonObject)
# ❌ Many tests have incomplete code blocks (expected for TDD)
```

## Assessment: 60% Complete

| Component | Status | Notes |
|-----------|--------|-------|
| Parameter struct | ✅ Complete | Full .data/.grad support |
| SimpleMLP methods | ✅ Complete | All required methods implemented |  
| TrainingLoop structure | ✅ Complete | Methods defined and documented |
| Type compatibility | ⚠️  In Progress | Needs resolution |
| Gradient computation | ❌ Not Started | Requires backprop implementation |
| Full training cycle | ❌ Not Started | Needs all components integrated |

## Next Steps
1. **Resolve type compatibility** - Use trait-based approach or Python wrappers
2. **Implement SimpleMLP.forward()** - Actual tensor forward pass (currently returns input)
3. **Implement SGD.step()** - Weight updates based on gradients
4. **Add gradient computation** - Backward pass through network layers
5. **Complete test implementations** - Remove TODO blocks with real code

## Testing
Once type compatibility is resolved:
```bash
# Build tests
pixi run mojo build tests/shared/training/test_training_loop.mojo

# Run tests
./test_training_loop
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)