### PR TITLE
fix(data): correct __init__ and __moveinit__ signatures to use 'out self'

### DIFF
--- a/shared/data/datasets.mojo
+++ b/shared/data/datasets.mojo
@@ -121,7 +121,7 @@ struct FileDataset(Dataset, Copyable, Movable):
     var _cache: Dict[Int, Tuple[ExTensor, ExTensor]]
 
     fn __init__(
-        mut self,
+        out self,
         var file_paths: List[String],
         var labels: List[Int],
         cache: Bool = False,

--- a/shared/data/loaders.mojo
+++ b/shared/data/loaders.mojo
@@ -26,7 +26,7 @@ struct Batch(Copyable, Movable):
     var indices: List[Int]
 
     fn __init__(
-        mut self,
+        out self,
         var data: ExTensor,
         var labels: ExTensor,
         var indices: List[Int],
@@ -60,7 +60,7 @@ struct BaseLoader(Copyable, Movable):
     var _len: Int
 
     fn __init__(
-        mut self,
+        out self,
         var dataset: Dataset,
         batch_size: Int = 1,
         drop_last: Bool = False,
@@ -113,7 +113,7 @@ struct BatchLoader(Copyable, Movable):
     var shuffle: Bool
 
     fn __init__(
-        mut self,
+        out self,
         var dataset: Dataset,
         batch_size: Int = 32,
         shuffle: Bool = False,

--- a/tests/shared/data/loaders/test_base_loader.mojo
+++ b/tests/shared/data/loaders/test_base_loader.mojo
@@ -37,7 +37,7 @@ struct StubBatch:
     fn __init__(out self, capacity: Int):
         self.batch_size = capacity
 
-    fn __moveinit__(mut self, var existing: Self):
+    fn __moveinit__(out self, deinit existing: Self):
         """Move initializer."""
         self.batch_size = existing.batch_size
 
@@ -57,7 +57,7 @@ struct StubDataLoader:
     var num_batches: Int
 
     fn __init__(
-        mut self,
+        out self,
         dataset: StubDataset,
         batch_size: Int,
         drop_last: Bool = False,


### PR DESCRIPTION
## Summary

Fixes incorrect `mut self` usage in constructors and move initializers to comply with Mojo v0.25.7+ standards.

### Changes Made

Fixed 6 incorrect signatures across 3 files:

**shared/data/datasets.mojo:**
- `FileDataset.__init__` (line 124): `mut self` → `out self`

**shared/data/loaders.mojo:**
- `Batch.__init__` (line 29): `mut self` → `out self`
- `BaseLoader.__init__` (line 63): `mut self` → `out self`
- `BatchLoader.__init__` (line 116): `mut self` → `out self`

**tests/shared/data/loaders/test_base_loader.mojo:**
- `StubDataLoader.__init__` (line 60): `mut self` → `out self`
- `StubBatch.__moveinit__` (line 40): `mut self, var existing` → `out self, deinit existing`

### Mojo v0.25.7+ Convention

- **Constructors (`__init__`)**: Must use `out self` (creates new instance)
- **Move initializers (`__moveinit__`)**: Must use `out self` and `deinit existing`
- **Mutating methods**: Use `mut self` (modifies existing instance)

### Testing

Verified compilation of affected test files:
- ✅ `tests/shared/data/loaders/test_base_loader.mojo` compiles successfully
- ✅ `tests/shared/core/test_gradient_checking.mojo` compiles successfully

Note: `tests/shared/data/datasets/test_file_dataset.mojo` has unrelated compilation errors (Dict mutation, ExTensor constructor issues) that are outside the scope of this fix.

## Test plan

- [x] Fixed all `__init__` signatures to use `out self`
- [x] Fixed `__moveinit__` to use `out self` and `deinit existing`
- [x] Verified test compilation passes
- [x] No other `mut self` in constructors remain

Closes #2032

🤖 Generated with [Claude Code](https://claude.com/claude-code)