### PR TITLE
fix(benchmarks): add main functions and fix List return syntax for Issue #2028

### DIFF
--- a/tests/shared/benchmarks/bench_data_loading.mojo
+++ b/tests/shared/benchmarks/bench_data_loading.mojo
@@ -1,0 +1,96 @@
+"""Performance benchmarks for data loading implementations.
+
+Benchmarks measure:
+- Data loading throughput (samples/second)
+- Batching performance
+- Memory usage during data loading
+- Comparison to PyTorch DataLoader performance
+
+Target: Within 2x of PyTorch DataLoader performance
+
+Note: This file contains TODO comments representing placeholder code
+that will be implemented once the shared library components are available.
+"""
+
+from tests.shared.conftest import (
+    BenchmarkResult,
+    print_benchmark_results,
+    measure_time,
+    TestFixtures,
+)
+
+
+# ============================================================================
+# Data Loading Benchmarks
+# ============================================================================
+
+
+fn bench_batch_loading_speed() raises -> List[BenchmarkResult]:
+    """Benchmark batch loading throughput.
+
+    Measures:
+        - Batches per second for various batch sizes
+        - Scaling with dataset size
+        - Memory bandwidth utilization
+
+    Performance Target:
+        - > 1000 batches/second on test hardware
+        - Within 2x of PyTorch DataLoader performance
+    """
+    # TODO: Implement when DataLoader is available
+    # Placeholder for TDD
+    var results = List[BenchmarkResult]()
+    results.append(
+        BenchmarkResult(
+            name="BatchLoading-placeholder",
+            duration_ms=0.0,
+            throughput=0.0,
+            memory_mb=0.0,
+        )
+    )
+    return results^
+
+
+fn bench_data_preprocessing() raises -> BenchmarkResult:
+    """Benchmark data preprocessing performance.
+
+    Measures:
+        - Preprocessing throughput (samples/second)
+        - Memory overhead of preprocessing pipeline
+        - Impact of various transformations
+
+    Performance Target:
+        - Preprocessing should not be bottleneck (> 10k samples/sec)
+    """
+    # TODO: Implement when data preprocessing utilities are available
+    # Placeholder for TDD
+    return BenchmarkResult(
+        name="DataPreprocessing-placeholder",
+        duration_ms=0.0,
+        throughput=0.0,
+        memory_mb=0.0,
+    )
+
+
+# ============================================================================
+# Test Main
+# ============================================================================
+
+
+fn main() raises:
+    """Run all data loading benchmarks and print results."""
+    print("\n=== Data Loading Performance Benchmarks ===\n")
+
+    print("Running batch loading benchmarks...")
+    var batch_results = bench_batch_loading_speed()
+    print_benchmark_results(batch_results)
+
+    print("\nRunning data preprocessing benchmarks...")
+    var preprocessing_result = bench_data_preprocessing()
+    preprocessing_result.print_result()
+
+    print("\n=== Benchmarks Complete ===")
+    print("\nPerformance Targets:")
+    print("  - Batch loading: > 1000 batches/second")
+    print("  - Data preprocessing: > 10k samples/second")
+    print("  - Within 2x of PyTorch DataLoader performance")

--- a/tests/shared/benchmarks/bench_layers.mojo
+++ b/tests/shared/benchmarks/bench_layers.mojo
@@ -1,0 +1,131 @@
+"""Performance benchmarks for layer implementations.
+
+Benchmarks measure:
+- Forward pass throughput (samples/second)
+- Backward pass performance
+- Memory usage during forward/backward passes
+- Comparison to PyTorch layer performance
+
+Target: Within 2x of PyTorch layer performance
+
+Note: This file contains TODO comments representing placeholder code
+that will be implemented once the shared library components are available.
+"""
+
+from tests.shared.conftest import (
+    BenchmarkResult,
+    print_benchmark_results,
+    measure_time,
+    TestFixtures,
+)
+
+
+# ============================================================================
+# Linear Layer Benchmarks
+# ============================================================================
+
+
+fn bench_linear_forward() raises -> List[BenchmarkResult]:
+    """Benchmark Linear layer forward pass throughput.
+
+    Measures:
+        - Forward pass speed for various layer sizes
+        - Scaling with batch size and layer dimensions
+        - Memory bandwidth utilization
+
+    Performance Target:
+        - > 1M samples/second for typical layer sizes
+        - Within 2x of PyTorch Linear layer performance
+    """
+    # TODO: Implement when Linear layer is available
+    # Placeholder for TDD
+    var results = List[BenchmarkResult]()
+    results.append(
+        BenchmarkResult(
+            name="LinearForward-placeholder",
+            duration_ms=0.0,
+            throughput=0.0,
+            memory_mb=0.0,
+        )
+    )
+    return results^
+
+
+fn bench_linear_backward() raises -> BenchmarkResult:
+    """Benchmark Linear layer backward pass performance.
+
+    Measures:
+        - Backward pass speed
+        - Gradient computation throughput
+        - Memory overhead during backpropagation
+
+    Performance Target:
+        - Backward pass within 2x of forward pass time
+    """
+    # TODO: Implement when Linear layer backward is available
+    # Placeholder for TDD
+    return BenchmarkResult(
+        name="LinearBackward-placeholder",
+        duration_ms=0.0,
+        throughput=0.0,
+        memory_mb=0.0,
+    )
+
+
+# ============================================================================
+# Activation Layer Benchmarks
+# ============================================================================
+
+
+fn bench_activation_functions() raises -> List[BenchmarkResult]:
+    """Benchmark activation function performance.
+
+    Measures:
+        - Throughput of ReLU, Sigmoid, Tanh, etc.
+        - SIMD vectorization efficiency
+        - Memory access patterns
+
+    Performance Target:
+        - > 10M elements/second for all activation functions
+    """
+    # TODO: Implement when activation layers are available
+    # Placeholder for TDD
+    var results = List[BenchmarkResult]()
+    results.append(
+        BenchmarkResult(
+            name="Activations-placeholder",
+            duration_ms=0.0,
+            throughput=0.0,
+            memory_mb=0.0,
+        )
+    )
+    return results^
+
+
+# ============================================================================
+# Test Main
+# ============================================================================
+
+
+fn main() raises:
+    """Run all layer benchmarks and print results."""
+    print("\n=== Layer Performance Benchmarks ===\n")
+
+    print("Running Linear layer forward benchmarks...")
+    var linear_forward_results = bench_linear_forward()
+    print_benchmark_results(linear_forward_results)
+
+    print("\nRunning Linear layer backward benchmarks...")
+    var linear_backward_result = bench_linear_backward()
+    linear_backward_result.print_result()
+
+    print("\nRunning activation function benchmarks...")
+    var activation_results = bench_activation_functions()
+    print_benchmark_results(activation_results)
+
+    print("\n=== Benchmarks Complete ===")
+    print("\nPerformance Targets:")
+    print("  - Linear forward: > 1M samples/second")
+    print("  - Backward pass: within 2x of forward pass time")
+    print("  - Activation functions: > 10M elements/second")
+    print("  - Within 2x of PyTorch layer performance")

--- a/tests/shared/benchmarks/bench_optimizers.mojo
+++ b/tests/shared/benchmarks/bench_optimizers.mojo
@@ -83,7 +83,7 @@ fn bench_sgd_update_speed() raises -> List[BenchmarkResult]:
             memory_mb=0.0,
         )
     )
-    return results
+    return results^
 
 
 fn bench_sgd_momentum_overhead() raises -> BenchmarkResult:
@@ -190,7 +190,7 @@ fn bench_adam_update_speed() raises -> List[BenchmarkResult]:
             memory_mb=0.0,
         )
     )
-    return results
+    return results^
 
 
 fn bench_adam_memory_usage() raises -> BenchmarkResult:
@@ -303,7 +303,7 @@ fn bench_optimizer_comparison() raises -> List[BenchmarkResult]:
             memory_mb=0.0,
         )
     )
-    return results
+    return results^
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Fixes missing main() functions in benchmark files and corrects List return syntax:

- **bench_data_loading.mojo**: Added main() function with batch loading and preprocessing benchmarks
- **bench_layers.mojo**: Added main() function with Linear layer and activation function benchmarks  
- **bench_optimizers.mojo**: Fixed existing code by adding transfer operator (^) to List returns

All three files now compile successfully and can be executed as standalone benchmarks.

## Changes Made

1. Created main() functions for bench_data_loading.mojo and bench_layers.mojo following the same pattern as bench_optimizers.mojo
2. Added placeholder benchmark functions with proper structure for future implementation
3. Fixed List return syntax by adding transfer operator (^) in all three files to resolve compilation errors

## Test Results

All files compile and run successfully:
```bash
pixi run mojo build tests/shared/benchmarks/bench_data_loading.mojo  # ✓ Success
pixi run mojo build tests/shared/benchmarks/bench_layers.mojo        # ✓ Success
pixi run mojo build tests/shared/benchmarks/bench_optimizers.mojo    # ✓ Success
```

Verified execution:
```bash
./bench_data_loading   # ✓ Runs and displays benchmark results
./bench_layers         # ✓ Runs and displays benchmark results
./bench_optimizers     # ✓ Runs and displays benchmark results
```

## Success Criteria

- [x] All 3 benchmark files compile successfully
- [x] Benchmarks can be executed with `mojo build` and `mojo run`
- [x] Changes follow Mojo syntax standards (using `^` transfer operator for List returns)
- [x] Benchmark output is properly formatted

Closes #2028

🤖 Generated with [Claude Code](https://claude.com/claude-code)