### PR TITLE
[Fix] Missing methods/attributes - 12 test files

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -211,6 +211,38 @@ struct ExTensor(Copyable, Movable, ImplicitlyCopyable):
         self.__init__(shape, DType.float64)
         self._data.bitcast[Float64]()[] = value
 
+    fn __init__(out self, var data: List[Float32]) raises:
+        """Create 1D tensor from List[Float32].
+
+        Args:
+            data: List of Float32 values
+
+        Example:
+            var values = List[Float32](1.0, 2.0, 3.0)
+            var tensor = ExTensor(values)
+        """
+        var shape = List[Int]()
+        shape.append(len(data))
+        self.__init__(shape, DType.float32)
+        for i in range(len(data)):
+            self._set_float32(i, data[i])
+
+    fn __init__(out self, var data: List[Int]) raises:
+        """Create 1D tensor from List[Int].
+
+        Args:
+            data: List of Int values
+
+        Example:
+            var values = List[Int](1, 2, 3)
+            var tensor = ExTensor(values)
+        """
+        var shape = List[Int]()
+        shape.append(len(data))
+        self.__init__(shape, DType.int64)
+        for i in range(len(data)):
+            self._data.bitcast[Int64]()[i] = Int64(data[i])
+
     fn __copyinit__(out self, existing: Self):
         """Copy constructor - creates shared ownership with reference counting.
 

--- a/shared/data/text_transforms.mojo
+++ b/shared/data/text_transforms.mojo
@@ -74,8 +74,8 @@ fn split_words(text: String) raises -> List[String]:
     # Filter out empty strings that may result from multiple spaces
     var words = List[String]()
     for i in range(len(parts)):
-        if len(parts[i]) > 0:
-            words.append(parts[i])
+        if len(String(parts[i])) > 0:
+            words.append(String(parts[i]))
 
     return words^
 
@@ -234,17 +234,17 @@ struct RandomInsertion(TextTransform, Copyable, Movable):
     var n: Int  # Number of words to insert
     var vocabulary: List[String]  # Words to insert from
 
-    fn __init__(out self, p: Float64 = 0.1, n: Int = 1, var vocabulary: List[String]):
+    fn __init__(out self, var vocabulary: List[String], p: Float64 = 0.1, n: Int = 1):
         """Create random insertion transform.
 
         Args:
+            vocabulary: List of words to choose from for insertion.
             p: Probability of performing insertion (0.0 to 1.0).
             n: Number of words to insert.
-            vocabulary: List of words to choose from for insertion.
         """
+        self.vocabulary = vocabulary^
         self.p = p
         self.n = n
-        self.vocabulary = vocabulary^
 
     fn __call__(self, text: String) raises -> String:
         """Insert random words from vocabulary into text.
@@ -305,15 +305,15 @@ struct RandomSynonymReplacement(TextTransform, Copyable, Movable):
     var p: Float64  # Probability of replacing each word
     var synonyms: Dict[String, List[String]]  # Synonym dictionary
 
-    fn __init__(out self, p: Float64 = 0.2, var synonyms: Dict[String, List[String]]):
+    fn __init__(out self, var synonyms: Dict[String, List[String]], p: Float64 = 0.2):
         """Create random synonym replacement transform.
 
         Args:
-            p: Probability of replacing each word (0.0 to 1.0).
             synonyms: Dictionary mapping words to lists of synonyms.
+            p: Probability of replacing each word (0.0 to 1.0).
         """
-        self.p = p
         self.synonyms = synonyms^
+        self.p = p
 
     fn __call__(self, text: String) raises -> String:
         """Replace random words with synonyms.

--- a/shared/data/transforms.mojo
+++ b/shared/data/transforms.mojo
@@ -242,7 +242,7 @@ struct Reshape(Transform, Copyable, Movable):
         # Calculate total elements in target shape
         var target_elements = 1
         for dim in self.target_shape:
-            target_elements *= dim[]
+            target_elements *= dim
 
         # Validate element count matches
         if target_elements != data.num_elements():
@@ -279,7 +279,7 @@ struct Resize(Transform, Copyable, Movable):
     var interpolation: String
 
     fn __init__(
-        mut self, size: Tuple[Int, Int], interpolation: String = "bilinear"
+        out self, size: Tuple[Int, Int], interpolation: String = "bilinear"
     ):
         """Create resize transform.
 
@@ -620,7 +620,7 @@ struct RandomRotation(Transform, Copyable, Movable):
     var fill_value: Float64
 
     fn __init__(
-        mut self, degrees: Tuple[Float64, Float64], fill_value: Float64 = 0.0
+        out self, degrees: Tuple[Float64, Float64], fill_value: Float64 = 0.0
     ):
         """Create random rotation transform.
 
@@ -723,7 +723,7 @@ struct RandomErasing(Transform, Copyable, Movable):
     var value: Float64  # Fill value (0 for black, can be random)
 
     fn __init__(
-        mut self,
+        out self,
         p: Float64 = 0.5,
         scale: Tuple[Float64, Float64] = (0.02, 0.33),
         ratio: Tuple[Float64, Float64] = (0.3, 3.3),

--- a/shared/training/stubs.mojo
+++ b/shared/training/stubs.mojo
@@ -34,7 +34,7 @@ struct MockTrainer(Copyable, Movable):
     var epoch_count: Int
     var should_fail: Bool
 
-    fn __init__(mut self):
+    fn __init__(out self):
         """Initialize mock trainer."""
         self.epoch_count = 0
         self.should_fail = False

--- a/tests/shared/data/transforms/test_augmentations.mojo
+++ b/tests/shared/data/transforms/test_augmentations.mojo
@@ -18,6 +18,9 @@ from shared.data.transforms import (
 )
 from shared.core.extensor import ExTensor
 
+# Type alias for compatibility
+alias Tensor = ExTensor
+
 
 # ============================================================================
 # Random Augmentation Tests

--- a/tests/shared/training/test_trainer_interface.mojo
+++ b/tests/shared/training/test_trainer_interface.mojo
@@ -39,13 +39,13 @@ fn test_trainer_interface_required_methods() raises:
 
     var trainer = MockTrainer()
 
-    Verify all required methods are callable
+    # Verify all required methods are callable
     _ = trainer.train(epochs=1)
     _ = trainer.validate()
     trainer.save_checkpoint("test.pt")
     trainer.load_checkpoint("test.pt")
 
-    Test passes if no errors raised
+    # Test passes if no errors raised
     assert_true(True)
 
 
@@ -70,11 +70,11 @@ fn test_trainer_train_signature() raises:
 
     var trainer = MockTrainer()
 
-    Train for 3 epochs
+    # Train for 3 epochs
     var results = trainer.train(epochs=3)
 
-    Verify return type contains train and val losses
-    Stub returns train_loss_0, train_loss_1, ... format
+    # Verify return type contains train and val losses
+    # Stub returns train_loss_0, train_loss_1, ... format
     assert_true("train_loss_0" in results)
     assert_true("val_loss_0" in results)
     assert_true("train_loss_2" in results)
@@ -95,10 +95,10 @@ fn test_trainer_validate_signature() raises:
 
     var trainer = MockTrainer()
 
-    Run validation
+    # Run validation
     var results = trainer.validate()
 
-    Verify return type contains loss and accuracy
+    # Verify return type contains loss and accuracy
     assert_true("loss" in results)
     assert_true("accuracy" in results)
 
@@ -118,11 +118,11 @@ fn test_trainer_checkpoint_path() raises:
 
     var trainer = MockTrainer()
 
-    Test save/load with different paths (no-op in stub but tests signature)
+    # Test save/load with different paths (no-op in stub but tests signature)
     trainer.save_checkpoint("checkpoints/model_epoch_10.pt")
     trainer.load_checkpoint("checkpoints/model_epoch_10.pt")
 
-    Test passes if no errors raised
+    # Test passes if no errors raised
     assert_true(True)
 
 
@@ -252,7 +252,8 @@ fn test_trainer_checkpoint_model_only() raises:
         - Useful for inference or transfer learning
     """
     # TODO(#34): Implement if model-only checkpointing is supported
-    This is a nice-to-have feature, may be deferred
+    # This is a nice-to-have feature, may be deferred
+    pass
 
 
 # ============================================================================
@@ -317,7 +318,8 @@ fn test_trainer_property_forward_backward_consistency() raises:
     the same loss used for backward pass.
     """
     # TODO(#34): Implement when Trainer is available
-    This tests internal consistency of the training loop
+    # This tests internal consistency of the training loop
+    pass
 
 
 fn test_trainer_property_batch_independence() raises:
@@ -327,7 +329,8 @@ fn test_trainer_property_batch_independence() raises:
     (within stochastic variance).
     """
     # TODO(#34): Implement when Trainer is available
-    This is a statistical property test
+    # This is a statistical property test
+    pass
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Implements fixes for all missing methods and attributes identified in Issue #2036, affecting 12 test files across the training, data, and optimization modules.

Closes #2036

## Changes by Phase

### Phase 1: ExTensor API Extensions (HIGH PRIORITY)

**File**: `shared/core/extensor.mojo`

Added constructors to enable test code patterns:
- `ExTensor.__init__(List[Float32])` - Creates 1D float32 tensor from list
- `ExTensor.__init__(List[Int])` - Creates 1D int64 tensor from list

**Impact**: Enables test fixture creation: `var tensor = ExTensor(List[Float32](1.0, 2.0, 3.0))`

### Phase 2: Transform API Fixes (HIGH PRIORITY)

**File**: `shared/data/transforms.mojo`
- Fix `Resize.__init__`: `mut self` → `out self` (line 282)
- Fix `RandomRotation.__init__`: `mut self` → `out self` (line 623)
- Fix `RandomErasing.__init__`: `mut self` → `out self` (line 726)
- Fix iterator bug: `dim[]` → `dim` in Reshape loop (line 245)

**File**: `shared/data/text_transforms.mojo`
- Fix `RandomInsertion.__init__`: Move `var vocabulary` before optional parameters
- Fix `RandomSynonymReplacement.__init__`: Move `var synonyms` before optional parameters
- Fix StringSlice conversion: `String(parts[i])` instead of `parts[i]` (line 78)

**Impact**: All transform constructors now use correct Mojo syntax (`out self` for constructors)

### Phase 3: Test Code Fixes (MEDIUM PRIORITY)

**File**: `tests/shared/data/transforms/test_augmentations.mojo`
- Add type alias: `alias Tensor = ExTensor`

**File**: `tests/shared/training/test_trainer_interface.mojo`
- Fix comment prefixes (lines 42, 73, 98, 121, 255, 320, 330)

**File**: `shared/training/stubs.mojo`
- Fix `MockTrainer.__init__`: `mut self` → `out self` (line 37)

**Impact**: All test files now have proper comment syntax and type aliases

## Testing

All 12 affected test files should now compile:
- `tests/shared/data/transforms/test_augmentations.mojo`
- `tests/shared/training/test_trainer_interface.mojo`
- 10 other test files (see Issue #2036 for full list)

## References

- Based on comprehensive analysis in `/notes/issues/2036/README.md`
- Follows Mojo v0.25.7+ syntax conventions from `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)