### PR TITLE
fix(tests): add escaping keyword to closure functions in gradient tests

### DIFF
--- a/tests/shared/core/test_backward.mojo
+++ b/tests/shared/core/test_backward.mojo
@@ -496,11 +496,11 @@ fn test_maxpool2d_backward_gradient() raises:
         x._data.bitcast[Float32]()[i] = Float32(i) * 0.1 - 1.6
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: ExTensor) raises escaping -> ExTensor:
         return maxpool2d(inp, kernel_size=2, stride=2, padding=0)
 
     # Backward function wrapper (only return grad_input)
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward(grad_out: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
         return maxpool2d_backward(grad_out, inp, kernel_size=2, stride=2, padding=0)
 
     var output = forward(x)
@@ -525,11 +525,11 @@ fn test_avgpool2d_backward_gradient() raises:
         x._data.bitcast[Float32]()[i] = Float32(i) * 0.1 - 1.6
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: ExTensor) raises escaping -> ExTensor:
         return avgpool2d(inp, kernel_size=2, stride=2, padding=0)
 
     # Backward function wrapper (only return grad_input)
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward(grad_out: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
         return avgpool2d_backward(grad_out, inp, kernel_size=2, stride=2, padding=0)
 
     var output = forward(x)

--- a/tests/shared/core/test_elementwise.mojo
+++ b/tests/shared/core/test_elementwise.mojo
@@ -121,14 +121,14 @@ fn test_abs_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 1.5
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: ExTensor) raises escaping -> ExTensor:
         return abs(inp)
 
     var y = abs(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward_fn(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
         return abs_backward(grad, inp)
 
     # Use numerical gradient checking (gold standard)
@@ -226,14 +226,14 @@ fn test_exp_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 0.5
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: ExTensor) raises escaping -> ExTensor:
         return exp(inp)
 
     var y = exp(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward_fn(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
         return exp_backward(grad, inp)
 
     # Use numerical gradient checking (gold standard)
@@ -305,14 +305,14 @@ fn test_log_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 2.0
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: ExTensor) raises escaping -> ExTensor:
         return log(inp)
 
     var y = log(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward_fn(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
         return log_backward(grad, inp)
 
     # Use numerical gradient checking (gold standard)
@@ -349,14 +349,14 @@ fn test_log10_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 2.0
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: ExTensor) raises escaping -> ExTensor:
         return log10(inp)
 
     var y = log10(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward_fn(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
         return log10_backward(grad, inp)
 
     # Use numerical gradient checking (gold standard)
@@ -393,14 +393,14 @@ fn test_log2_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 2.0
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: ExTensor) raises escaping -> ExTensor:
         return log2(inp)
 
     var y = log2(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward_fn(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
         return log2_backward(grad, inp)
 
     # Use numerical gradient checking (gold standard)
@@ -475,14 +475,14 @@ fn test_sqrt_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 2.0
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: ExTensor) raises escaping -> ExTensor:
         return sqrt(inp)
 
     var y = sqrt(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward_fn(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
         return sqrt_backward(grad, inp)
 
     # Use numerical gradient checking (gold standard)
@@ -605,14 +605,14 @@ fn test_clip_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 0.5
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: ExTensor) raises escaping -> ExTensor:
         return clip(inp, min_val=-1.0, max_val=1.0)
 
     var y = clip(x, min_val=-1.0, max_val=1.0)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward_fn(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
         return clip_backward(grad, inp, min_val=-1.0, max_val=1.0)
 
     # Use numerical gradient checking (gold standard)

--- a/tests/shared/core/test_matrix.mojo
+++ b/tests/shared/core/test_matrix.mojo
@@ -794,11 +794,11 @@ fn test_transpose_backward_gradient() raises:
         x._data.bitcast[Float32]()[i] = Float32(i) * 0.15 - 2.0
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: ExTensor) raises escaping -> ExTensor:
         return transpose(inp)
 
     # Backward function wrapper
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward(grad_out: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
         return transpose_backward(grad_out)
 
     var output = forward(x)


### PR DESCRIPTION
## Summary

Fixes #2051

Add the `escaping` keyword to local function definitions that are passed to `check_gradient()`, which requires `escaping` closures per Mojo v0.25.7+ requirements.

This resolves 13 compilation errors across multiple test files.

## Changes

- **test_elementwise.mojo**: Add `escaping` to 7 forward/backward_fn pairs
- **test_backward.mojo**: Add `escaping` to 2 forward/backward pairs  
- **test_matrix.mojo**: Add `escaping` to 1 forward/backward pair

## Technical Details

When a function parameter expects an `escaping` closure, all functions passed to it must also be declared with the `escaping` keyword. The `check_gradient()` function signature requires:

```mojo
fn check_gradient(
    forward_fn: fn(ExTensor) raises escaping -> ExTensor,
    backward_fn: fn(ExTensor, ExTensor) raises escaping -> ExTensor,
    ...
)
```

Therefore, local functions passed as arguments must match this signature.

## Verification

All escaping keyword errors have been eliminated:
- ✅ test_elementwise.mojo compiles (no escaping errors)
- ✅ test_backward.mojo compiles (no escaping errors)
- ✅ test_matrix.mojo compiles (no escaping errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)