### PR TITLE
fix(core): Correct __moveinit__ signatures and fix test attribute access

### DIFF
--- a/shared/core/conv.mojo
+++ b/shared/core/conv.mojo
@@ -27,11 +27,11 @@ struct Conv2dBackwardResult(Movable):
         self.grad_kernel = grad_kernel^
         self.grad_bias = grad_bias^
 
-    fn __moveinit__(mut self, deinit other: Self):
+    fn __moveinit__(out self, deinit existing: Self):
         """Move constructor."""
-        self.grad_input = other.grad_input^
-        self.grad_kernel = other.grad_kernel^
-        self.grad_bias = other.grad_bias^
+        self.grad_input = existing.grad_input^
+        self.grad_kernel = existing.grad_kernel^
+        self.grad_bias = existing.grad_bias^
 
 
 fn conv2d(
@@ -354,10 +354,10 @@ struct Conv2dNoBiasBackwardResult(Movable):
         self.grad_input = grad_input^
         self.grad_kernel = grad_kernel^
 
-    fn __moveinit__(mut self, deinit other: Self):
+    fn __moveinit__(out self, deinit existing: Self):
         """Move constructor."""
-        self.grad_input = other.grad_input^
-        self.grad_kernel = other.grad_kernel^
+        self.grad_input = existing.grad_input^
+        self.grad_kernel = existing.grad_kernel^
 
 
 fn conv2d_no_bias_backward(

--- a/shared/core/linear.mojo
+++ b/shared/core/linear.mojo
@@ -25,11 +25,11 @@ struct LinearBackwardResult(Movable):
         self.grad_weights = grad_weights^
         self.grad_bias = grad_bias^
 
-    fn __moveinit__(mut self, deinit other: Self):
+    fn __moveinit__(out self, deinit existing: Self):
         """Move constructor."""
-        self.grad_input = other.grad_input^
-        self.grad_weights = other.grad_weights^
-        self.grad_bias = other.grad_bias^
+        self.grad_input = existing.grad_input^
+        self.grad_weights = existing.grad_weights^
+        self.grad_bias = existing.grad_bias^
 
 
 struct LinearNoBiasBackwardResult(Movable):
@@ -45,10 +45,10 @@ struct LinearNoBiasBackwardResult(Movable):
         self.grad_input = grad_input^
         self.grad_weights = grad_weights^
 
-    fn __moveinit__(mut self, deinit other: Self):
+    fn __moveinit__(out self, deinit existing: Self):
         """Move constructor."""
-        self.grad_input = other.grad_input^
-        self.grad_weights = other.grad_weights^
+        self.grad_input = existing.grad_input^
+        self.grad_weights = existing.grad_weights^
 
 
 fn linear(x: ExTensor, weights: ExTensor, bias: ExTensor) raises -> ExTensor:

--- a/tests/shared/core/test_backward.mojo
+++ b/tests/shared/core/test_backward.mojo
@@ -256,7 +256,7 @@ fn test_conv2d_backward_shapes() raises:
     assert_equal(gi_shape[2], in_h)
     assert_equal(gi_shape[3], in_w)
 
-    var gk_shape = grads.grad_weights.shape()
+    var gk_shape = grads.grad_kernel.shape()
     assert_equal(gk_shape[0], out_channels)
     assert_equal(gk_shape[1], in_channels)
     assert_equal(gk_shape[2], kh)


### PR DESCRIPTION
## Summary

Fix incorrect move constructor signatures in backward result structs for linear and conv modules, plus fix incorrect attribute access in test_backward.mojo.

## Root Cause

The `__moveinit__` methods were using incorrect Mojo v0.25.7+ syntax:
- **Wrong**: `fn __moveinit__(mut self, deinit other: Self)`
- **Correct**: `fn __moveinit__(out self, deinit existing: Self)`

According to Mojo constructor conventions:
- `__init__` uses `out self`
- `__moveinit__` uses `out self, deinit existing: Self`
- `__copyinit__` uses `out self, existing: Self`
- Regular mutating methods use `mut self`

## Changes Made

### shared/core/linear.mojo
- Fixed `LinearBackwardResult.__moveinit__` signature (line 28)
- Fixed `LinearNoBiasBackwardResult.__moveinit__` signature (line 48)

### shared/core/conv.mojo
- Fixed `Conv2dBackwardResult.__moveinit__` signature (line 30)
- Fixed `Conv2dNoBiasBackwardResult.__moveinit__` signature (line 357)

### tests/shared/core/test_backward.mojo
- Fixed attribute access: `grads.grad_weights` → `grads.grad_kernel` (line 259)
  - Conv2dBackwardResult uses `grad_kernel` not `grad_weights`

## Errors Fixed

Resolved 5 compilation errors:
```
shared/core/linear.mojo:28:8: error: __init__ method must return Self type with 'out' argument
shared/core/linear.mojo:28:38: error: only 'self' arguments in struct methods may be 'deinit'
shared/core/conv.mojo:30:8: error: __init__ method must return Self type with 'out' argument
shared/core/conv.mojo:30:38: error: only 'self' arguments in struct methods may be 'deinit'
tests/shared/core/test_backward.mojo:259:25: error: 'Conv2dBackwardResult' value has no attribute 'grad_weights'
```

## Tests Verified

✅ tests/shared/core/test_backward.mojo now compiles successfully

## References

- [CLAUDE.md Constructor Convention Table](https://github.com/mvillmow/ml-odyssey/blob/main/CLAUDE.md#2-constructor-signatures-25-of-failures)
- Mojo v0.25.7+ parameter conventions
- Part of ongoing Phase 3 test compilation fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)