### PR TITLE
fix(tests): Add missing assertion function imports

### DIFF
--- a/tests/shared/core/test_normalization.mojo
+++ b/tests/shared/core/test_normalization.mojo
@@ -17,6 +17,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_equal_int,
     assert_shape,
+    assert_shape_equal,
     assert_true,
 )
 from tests.shared.conftest import TestFixtures

--- a/tests/shared/training/test_training_loop.mojo
+++ b/tests/shared/training/test_training_loop.mojo
@@ -19,6 +19,8 @@ from tests.shared.conftest import (
     assert_less,
     assert_greater,
     assert_not_equal_tensor,
+    assert_not_none,
+    assert_shape_equal,
     assert_tensor_equal,
     assert_type,
     create_simple_model,

--- a/tests/shared/training/test_validation_loop.mojo
+++ b/tests/shared/training/test_validation_loop.mojo
@@ -16,6 +16,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_almost_equal,
     assert_greater,
+    assert_less,
     assert_tensor_equal,
     create_simple_model,
     create_simple_dataset,


### PR DESCRIPTION
## Summary

Fixes 6 compilation errors by adding missing assertion function imports to test files. These functions exist in `conftest.mojo` but were not imported by the test files.

## Errors Fixed

### 1. `test_normalization.mojo` (3 errors)
- **Error**: `use of unknown declaration 'assert_shape_equal'`
- **Fix**: Added `assert_shape_equal` to imports from `tests.shared.conftest`
- **Lines affected**: 382, 383, 384

### 2. `test_training_loop.mojo` (2 errors)
- **Errors**: 
  - `use of unknown declaration 'assert_not_none'`
  - `use of unknown declaration 'assert_shape_equal'`
- **Fix**: Added `assert_not_none` and `assert_shape_equal` to imports
- **Lines affected**: 295, 296

### 3. `test_validation_loop.mojo` (1 error)
- **Error**: `use of unknown declaration 'assert_less'`
- **Fix**: Added `assert_less` to imports from `tests.shared.conftest`
- **Line affected**: 260

## Pattern Identified

**Root Cause**: Assertion functions defined in `conftest.mojo` but not imported by test files.

**Fix Strategy**: Add missing imports to the `from tests.shared.conftest import (...)` blocks.

## Verification

Tested compilation of all three files:
- ✅ `test_normalization.mojo` - compiles without errors (all 3 fixed)
- ✅ `test_training_loop.mojo` - 2 import errors resolved (other errors remain from incomplete implementations)
- ✅ `test_validation_loop.mojo` - 1 import error resolved (other errors remain from incomplete implementations)

## Context

Part of systematic test compilation error fixes:
- PR #2054 ✅ Merged - Fixed 13 escaping keyword errors
- PR #2056 ✅ Merged - Fixed 6 infrastructure errors
- PR #2058 ✅ Merged - Fixed 6 core module errors
- PR #2059 ✅ Merged - Fixed 5 constructor signature errors
- **This PR** - Fixes 6 missing import errors

**Total progress**: 36 compilation errors fixed across 6 PRs

## Files Changed

- `tests/shared/core/test_normalization.mojo` - Added `assert_shape_equal` import
- `tests/shared/training/test_training_loop.mojo` - Added `assert_not_none`, `assert_shape_equal` imports
- `tests/shared/training/test_validation_loop.mojo` - Added `assert_less` import

## Next Steps

Remaining error patterns to address in follow-up PRs:
- ExTensor attribute access errors (`.grad` → `._grad`, `.data` → `._data`)
- `testing.skip` decorator issues
- Incomplete test implementations (mark with `@skip`)