### PR TITLE
fix(tests): Fix ExTensor static method calls and attribute access

### DIFF
--- a/tests/shared/training/test_training_loop.mojo
+++ b/tests/shared/training/test_training_loop.mojo
@@ -294,8 +294,8 @@ fn test_training_loop_backward_pass() raises:
     #
     # Check gradients are computed
     for param in model.parameters():
-        assert_not_none(param.grad)
-        assert_shape_equal(param.grad, param.shape())
+        assert_not_none(param._grad)
+        assert_shape_equal(param._grad, param.shape())
 
 
 @skip("Issue #2057 - Incomplete implementation")
@@ -316,11 +316,11 @@ fn test_training_loop_gradient_accumulation() raises:
     # First backward (gradients zeroed initially)
     model.zero_grad()
     var loss1 = training_loop.step(inputs, targets)
-    var grad_after_first = model.parameters()[0].grad.copy()
+    var grad_after_first = model.parameters()[0]._grad.copy()
     #
     # Second backward without zeroing
     var loss2 = training_loop.step(inputs, targets)
-    var grad_after_second = model.parameters()[0].grad
+    var grad_after_second = model.parameters()[0]._grad
     #
     # Gradients should be approximately 2x first gradients
     # (assuming same inputs/targets)
@@ -355,7 +355,7 @@ fn test_training_loop_updates_weights() raises:
     var training_loop = TrainingLoop(model^, optimizer^, loss_fn^)
     #
     # Get initial weights
-    var initial_weights = model.parameters()[0].data.copy()
+    var initial_weights = model.parameters()[0]._data.copy()
     #
     # Training step
     # TODO(ExTensor): Implement randn - var inputs = ExTensor.zeros(List[Int](4, 10), DType.float32)
@@ -363,7 +363,7 @@ fn test_training_loop_updates_weights() raises:
     var loss = training_loop.step(inputs, targets)
     #
     # Get updated weights
-    var updated_weights = model.parameters()[0].data
+    var updated_weights = model.parameters()[0]._data
     #
     # Weights should change
     assert_not_equal_tensor(initial_weights, updated_weights)
@@ -400,8 +400,8 @@ fn test_training_loop_respects_learning_rate() raises:
     loop2.step(inputs, targets)
     #
     # Weight changes
-    var change1 = (model1.parameters()[0].data - initial_weights).abs().sum()
-    var change2 = (model2.parameters()[0].data - initial_weights).abs().sum()
+    var change1 = (model1.parameters()[0]._data - initial_weights).abs().sum()
+    var change2 = (model2.parameters()[0]._data - initial_weights).abs().sum()
     #
     # Change2 should be ~10x larger
     assert_almost_equal(change2 / change1, 10.0, tolerance=0.5)

--- a/tests/shared/training/test_validation_loop.mojo
+++ b/tests/shared/training/test_validation_loop.mojo
@@ -25,6 +25,7 @@ from tests.shared.conftest import (
 )
 from shared.training import MSELoss, ValidationLoop, TrainingLoop, SGD, CrossEntropyLoss
 from shared.core.extensor import ExTensor
+from shared.core import ones, zeros
 
 
 # ============================================================================
@@ -53,8 +54,8 @@ fn test_validation_loop_single_batch() raises:
     var validation_loop = ValidationLoop(model, loss_fn)
     #
     # Create single batch
-    var inputs = ExTensor.ones(List[Int](4, 10), DType.float32)
-    var targets = ExTensor.zeros(List[Int](4, 1), DType.float32)
+    var inputs = ones(List[Int](4, 10), DType.float32)
+    var targets = zeros(List[Int](4, 1), DType.float32)
     #
     # Get initial weights
     var initial_weights = model.get_weights().copy()
@@ -113,7 +114,7 @@ fn test_validation_loop_no_weight_updates() raises:
     var data_loader = create_mock_dataloader(n_batches=100)
     #
     # Get initial weights
-    var initial_weights = [param.data.copy() for param in model.parameters()]
+    var initial_weights = [param._data.copy() for param in model.parameters()]
     #
     # Run multiple validation epochs
     for _ in range(10):
@@ -121,7 +122,7 @@ fn test_validation_loop_no_weight_updates() raises:
     #
     # Verify all weights unchanged
     for i, param in enumerate(model.parameters()):
-        assert_tensor_equal(param.data, initial_weights[i])
+        assert_tensor_equal(param._data, initial_weights[i])
 
 
 # ============================================================================
@@ -156,9 +157,9 @@ fn test_validation_loop_no_gradient_computation() raises:
     #
     # Gradients should still be None or zero
     for param in model.parameters():
-        if param.grad is not None:
+        if param._grad is not None:
             # TODO(ExTensor): Implement zeros_like
-            pass  # assert_tensor_equal(param.grad, ExTensor.zeros_like(param.data))
+            pass  # assert_tensor_equal(param._grad, ExTensor.zeros_like(param._data))
 
 
 @skip("Issue #2057 - Incomplete implementation")


### PR DESCRIPTION
## Summary

Fixes 2 compilation errors by correcting ExTensor static method calls and updates attribute access patterns to use private attributes. This PR partially addresses Pattern 2 from the systematic test fixing effort.

## Errors Fixed

### 1. `test_validation_loop.mojo` (2 errors fixed ✅)

**Error**: `'ExTensor' value has no attribute 'ones'` / `'ExTensor' value has no attribute 'zeros'`

**Lines**: 56-57

**Fix**:
```mojo
# Before (WRONG - static method calls)
var inputs = ExTensor.ones(List[Int](4, 10), DType.float32)
var targets = ExTensor.zeros(List[Int](4, 1), DType.float32)

# After (CORRECT - standalone functions)
var inputs = ones(List[Int](4, 10), DType.float32)
var targets = zeros(List[Int](4, 10), DType.float32)
```

**Also added**: Import statement `from shared.core import ones, zeros`

### 2. Attribute Access Updates (both files)

Updated all occurrences to use private attributes:
- `.data` → `._data` (ExTensor's internal data pointer)
- `.grad` → `._grad` (attempted gradient access)

**Files affected**:
- `test_training_loop.mojo`: 8 attribute accesses updated (lines 297, 298, 319, 323, 358, 366, 403, 404)
- `test_validation_loop.mojo`: 4 attribute accesses updated (lines 117, 125, 160, 162)

## Compilation Status

### ✅ Fixed (2 errors)
- ExTensor.ones() static method call
- ExTensor.zeros() static method call

### ⚠️ Revealed Deeper Issues

The attribute access changes exposed underlying test implementation problems:

1. **Missing Parameter struct**: Tests assume parameters have a `_grad` attribute, but `ExTensor` doesn't have this. Gradients should be managed by a `Parameter` wrapper struct.
   - Error: `'ExTensor' value has no attribute '_grad'`

2. **Incorrect type comparisons**: Tests try to use `param._data` (UnsafePointer) where they should use the full parameter/tensor.
   - Error: `argument #0 cannot be converted from 'UnsafePointer[UInt8]' to 'ExTensor'`

3. **Incomplete implementations**: Many tests have undefined variables and incomplete logic (marked with `@skip` decorators).

## Pattern Identified

**Root Cause**: ExTensor doesn't implement PyTorch-style parameter tracking. Tests were written assuming parameter/gradient APIs that don't exist yet.

**Correct Pattern**:
- `ones()`, `zeros()`, etc. are standalone functions, not static methods
- `_data` is a private attribute containing the raw data pointer
- Gradient tracking requires a separate Parameter abstraction (not yet implemented)

## Next Steps (Out of Scope for This PR)

These issues need separate PRs:

1. **Implement Parameter struct** with gradient tracking:
   ```mojo
   struct Parameter:
       var data: ExTensor
       var grad: Optional[ExTensor]
       var requires_grad: Bool
   ```

2. **Fix test implementations**: Rewrite tests to use correct patterns once Parameter struct exists

3. **Mark incomplete tests**: Add `@skip` decorators to tests that can't run without full implementation

## Context

Part of systematic test compilation error fixes:
- PR #2054 ✅ Merged - Fixed 13 escaping keyword errors
- PR #2056 ✅ Merged - Fixed 6 infrastructure errors
- PR #2058 ✅ Merged - Fixed 6 core module errors
- PR #2059 ✅ Merged - Fixed 5 constructor signature errors
- PR #2064 ✅ Merged - Fixed 6 missing import errors
- **This PR** - Fixes 2 static method call errors

**Total progress**: 38 compilation errors fixed across 6 PRs

## Files Changed

- `tests/shared/training/test_validation_loop.mojo` - Fixed static method calls, added imports, updated attribute access
- `tests/shared/training/test_training_loop.mojo` - Updated attribute access to private attributes

## Testing

Both files compile further than before:
- ✅ Static method errors resolved
- ⚠️ Other errors remain (incomplete implementations, missing Parameter struct)