### PR TITLE
fix(tests): Fix List[Int] ImplicitlyCopyable violations in test_properties.mojo

### DIFF
--- a/tests/shared/core/test_properties.mojo
+++ b/tests/shared/core/test_properties.mojo
@@ -181,7 +181,7 @@ fn test_strides_1d() raises:
     shape.append(10)
     var t = ones(shape, DType.float32)
 
-    var strides = t._strides
+    var strides = List[Int](t._strides)
     assert_equal_int(len(strides), 1, "1D tensor should have 1 stride")
     assert_equal_int(strides[0], 1, "1D stride should be 1")
 
@@ -193,7 +193,7 @@ fn test_strides_2d_row_major() raises:
     shape.append(4)
     var t = ones(shape, DType.float32)
 
-    var strides = t._strides
+    var strides = List[Int](t._strides)
     assert_equal_int(len(strides), 2, "2D tensor should have 2 strides")
     assert_equal_int(strides[0], 4, "Outer stride should be 4 (row length)")
     assert_equal_int(strides[1], 1, "Inner stride should be 1")
@@ -207,7 +207,7 @@ fn test_strides_3d_row_major() raises:
     shape.append(4)
     var t = ones(shape, DType.float32)
 
-    var strides = t._strides
+    var strides = List[Int](t._strides)
     assert_equal_int(len(strides), 3, "3D tensor should have 3 strides")
     assert_equal_int(strides[0], 12, "Stride 0 should be 12 (3*4)")
     assert_equal_int(strides[1], 4, "Stride 1 should be 4")


### PR DESCRIPTION
## Summary

Fixes #2069 - Resolves ImplicitlyCopyable violations in `test_properties.mojo` by using explicit `List[Int]` copy constructor.

## Changes

Fixed three violations on lines 184, 196, and 210:
- **Before**: `var strides = t._strides` (violates ownership rules)
- **After**: `var strides = List[Int](t._strides)` (explicit copy)

## Root Cause

`List[Int]` is NOT `ImplicitlyCopyable`, so direct assignment from a struct field violates Mojo's ownership rules. The explicit copy constructor resolves this.

## Testing

- ✅ Successfully compiled with `mojo build tests/shared/core/test_properties.mojo`
- ✅ No new compilation errors introduced
- ✅ Only unrelated warnings from `extensor.mojo` (pre-existing)

## Test Plan

- [ ] CI passes all checks
- [ ] No regression in other test files
- [ ] Ownership violations resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)