### PR TITLE
[Test Fix] Fix list ownership error in test_creation.mojo

### DIFF
--- a/tests/shared/core/test_creation.mojo
+++ b/tests/shared/core/test_creation.mojo
@@ -497,7 +497,7 @@ fn test_creation_high_dimensional() raises:
     """Test creating tensor with many dimensions (e.g., 8D)."""
     var shape = List[Int]()
     for i in range(8):
-        shape[i] = 2
+        shape.append(2)
     var t = zeros(shape, DType.float32)
 
     assert_dim(t, 8, "8D tensor should have 8 dimensions")


### PR DESCRIPTION
## Summary

Fixes ownership execution error in `test_creation_high_dimensional()` test.

## Changes

- Replaced `shape[i] = 2` with `shape.append(2)` at line 500
- This follows the documented pattern: use `append()` to add new elements instead of assigning to uninitialized indices

## Root Cause

The test was attempting to assign to uninitialized list indices, which causes an ownership execution error because the list has no elements yet.

## Testing

The fix follows the pattern documented in CLAUDE.md:
- ❌ NEVER: Assign to list indices without appending first
- ✅ ALWAYS: Use `append()` to add new elements

Closes #2076

🤖 Generated with [Claude Code](https://claude.com/claude-code)