### PR TITLE
[Test Fix] Add reduction operations exports to shared.core

### DIFF
--- a/shared/core/__init__.mojo
+++ b/shared/core/__init__.mojo
@@ -313,5 +313,20 @@ from .dtype_dispatch import (
     dispatch_float_scalar,
 )
 
+# ============================================================================
+# Reduction Operations
+# ============================================================================
+
+from .reduction import (
+    sum,
+    mean,
+    max_reduce,
+    min_reduce,
+    sum_backward,
+    mean_backward,
+    max_reduce_backward,
+    min_reduce_backward,
+)
+
 # Note: Mojo does not support Python's __all__ mechanism.
 # All imported symbols are automatically available to package consumers.


### PR DESCRIPTION
## Summary

Fixes import errors in `test_reduction_forward.mojo` by adding missing exports for reduction operations to `shared/core/__init__.mojo`.

## Problem

The test file `tests/shared/core/test_reduction_forward.mojo` attempted to import reduction functions from `shared.core`:
```mojo
from shared.core import sum, mean, max_reduce, min_reduce
```

However, these functions were not exported in `shared/core/__init__.mojo`, causing compilation errors.

## Solution

Added a new "Reduction Operations" section to `shared/core/__init__.mojo` that exports:

**Forward operations:**
- `sum` - Sum tensor elements along an axis
- `mean` - Compute mean along an axis  
- `max_reduce` - Find maximum along an axis
- `min_reduce` - Find minimum along an axis

**Backward operations:**
- `sum_backward` - Gradient for sum reduction
- `mean_backward` - Gradient for mean reduction
- `max_reduce_backward` - Gradient for max reduction
- `min_reduce_backward` - Gradient for min reduction

## Testing

Verified that the exports work correctly by:
1. Creating a minimal test file that imports the reduction functions
2. Successfully compiling with `mojo build` (no import errors)
3. Confirmed all reduction operations are now accessible from `shared.core`

## Files Modified

- `shared/core/__init__.mojo` - Added reduction operations export section

## Notes

The test file `test_reduction_forward.mojo` has a separate typo bug (`vara2d` vs `var a2d` on line 183) that prevents full test execution, but this is unrelated to the export fix. That typo should be addressed in a separate issue/PR.

Closes #2079

🤖 Generated with [Claude Code](https://claude.com/claude-code)