### PR TITLE
[Test Fix] test_benchmark_runner.mojo - Fix BenchmarkResult copy error

### DIFF
--- a/tests/tooling/benchmarks/test_benchmark_runner.mojo
+++ b/tests/tooling/benchmarks/test_benchmark_runner.mojo
@@ -228,7 +228,7 @@ fn test_json_output_format() raises:
 
     # Verify each result has required fields for JSON
     for i in range(len(results)):
-        var result = results[i]
+        ref result = results[i]
         assert_true(len(result.name) > 0, "Name should be present")
         assert_greater(Float32(result.duration_ms), Float32(0.0), "Duration should be positive")
         assert_greater(Float32(result.throughput), Float32(0.0), "Throughput should be positive")


### PR DESCRIPTION
## Summary

Fixes ownership error in `tests/tooling/benchmarks/test_benchmark_runner.mojo` where BenchmarkResult could not be implicitly copied.

## Changes

- Changed line 231 from `var result = results[i]` to `ref result = results[i]`
- Uses reference instead of copy to avoid implicit copy violation

## Explanation

`BenchmarkResult` is marked as `Copyable` but contains a `String` field, which is not `ImplicitlyCopyable`. When accessing list elements, we must use a reference (`ref`) instead of trying to copy the value.

## Test Results

```
=== Benchmark Runner Tests ===

✓ All 8 benchmark runner tests passed
```

Closes #2100

🤖 Generated with [Claude Code](https://claude.com/claude-code)