### PR TITLE
[Test Fix] test_core_operations.mojo - Fix transfer violations

### DIFF
--- a/shared/training/metrics/accuracy.mojo
+++ b/shared/training/metrics/accuracy.mojo
@@ -395,8 +395,8 @@ struct AccuracyMetric:
         if len(pred_shape) == 2:
             pred_classes = argmax(predictions, axis=1)
         elif len(pred_shape) == 1:
-            # Transfer ownership - predictions won't be used after this
-            pred_classes = predictions^
+            # Copy predictions (ImplicitlyCopyable - creates shared reference)
+            pred_classes = predictions
         else:
             raise Error("AccuracyMetric.update: invalid predictions shape")
 

--- a/shared/training/metrics/confusion_matrix.mojo
+++ b/shared/training/metrics/confusion_matrix.mojo
@@ -92,8 +92,8 @@ struct ConfusionMatrix:
             # Logits - need argmax
             pred_classes = argmax(predictions)
         elif len(pred_shape) == 1:
-            # Already class indices - transfer ownership
-            pred_classes = predictions^
+            # Already class indices - copy (ImplicitlyCopyable - creates shared reference)
+            pred_classes = predictions
         else:
             raise Error("ConfusionMatrix.update: predictions must be 1D or 2D")
 


### PR DESCRIPTION
## Summary
Fixed transfer violation compilation errors in `tests/test_core_operations.mojo`:
- **File**: `shared/training/metrics/accuracy.mojo:399`
- **File**: `shared/training/metrics/confusion_matrix.mojo:96`

## Root Cause
Both `AccuracyMetric.update()` and `ConfusionMatrix.update()` attempted to transfer ownership from an immutable reference using `predictions^`, which is invalid.

## Solution
Replaced ownership transfer with implicit copy:
```mojo
# Before (error)
pred_classes = predictions^

# After (fixed)
pred_classes = predictions  # Uses ImplicitlyCopyable trait
```

ExTensor implements `ImplicitlyCopyable`, so assignment creates a safe shared reference with reference counting.

## Testing
- Test file compiles successfully (no transfer violation errors)
- Only warnings remain (unused loop variables - pre-existing)

## Note
Test has a separate runtime error (matmul dimension mismatch) that is unrelated to the transfer violations fixed here.

Closes #2103

🤖 Generated with [Claude Code](https://claude.com/claude-code)