### PR TITLE
fix(samplers): Fix SIMD type inference and trait mutability in WeightedSampler

### DIFF
--- a/shared/data/samplers.mojo
+++ b/shared/data/samplers.mojo
@@ -21,7 +21,7 @@ trait Sampler:
         """Return the number of samples."""
         ...
 
-    fn __iter__(self) -> List[Int]:
+    fn __iter__(mut self) -> List[Int]:
         """Return an iterator over sample indices.
 
         Returns:
@@ -70,7 +70,7 @@ struct SequentialSampler(Sampler, Copyable, Movable):
         """Return number of samples."""
         return self.end_index - self.start_index
 
-    fn __iter__(self) -> List[Int]:
+    fn __iter__(mut self) -> List[Int]:
         """Return sequential indices.
 
         Returns:.            List of indices from start to end.
@@ -124,7 +124,7 @@ struct RandomSampler(Sampler, Copyable, Movable):
         """Return number of samples."""
         return self.num_samples
 
-    fn __iter__(self) -> List[Int]:
+    fn __iter__(mut self) -> List[Int]:
         """Return random indices.
 
         Returns:
@@ -220,7 +220,7 @@ struct WeightedSampler(Sampler, Copyable, Movable):
         """Return number of samples."""
         return self.num_samples
 
-    fn __iter__(self) -> List[Int]:
+    fn __iter__(mut self) -> List[Int]:
         """Return weighted random indices.
 
         Returns:.            List of indices sampled according to weights.
@@ -240,7 +240,7 @@ struct WeightedSampler(Sampler, Copyable, Movable):
 
         # Sample indices
         for _ in range(self.num_samples):
-            var r = random_si64(0, 1000000) / 1000000.0  # Random [0, 1)
+            var r = Float64(random_si64(0, 1000000)) / 1000000.0  # Random [0, 1)
 
             # Binary search for index
             var idx = 0
@@ -256,16 +256,16 @@ struct WeightedSampler(Sampler, Copyable, Movable):
                 self.weights[idx] = 0
                 # Renormalize remaining weights
                 total = Float64(0)
-                for w in self.weights:
-                    total += w[]
+                for i in range(len(self.weights)):
+                    total += self.weights[i]
                 if total > 0:
                     for i in range(len(self.weights)):
                         self.weights[i] = self.weights[i] / total
                     # Rebuild cumsum
                     cumsum.clear()
                     total = Float64(0)
-                    for w in self.weights:
-                        total += w[]
+                    for i in range(len(self.weights)):
+                        total += self.weights[i]
                         cumsum.append(total)
 
         return indices^


### PR DESCRIPTION
## Summary

Fixes SIMD type inference error in `tests/shared/data/samplers/test_weighted.mojo` by ensuring type consistency in random number generation and sampler trait signatures.

## Root Cause

The error occurred at `shared/data/samplers.mojo:248` where comparing an int64 value with a float64 cumsum value caused SIMD type inference to fail:

```
error: failed to infer parameter 'dtype' of parent struct 'SIMD',
       it inferred to two different values: 'DType.int64' and 'DType.float64'
```

The issue was that `random_si64(0, 1000000) / 1000000.0` produced an ambiguous type.

## Changes Made

1. **Fixed SIMD type inference**: Explicitly cast `random_si64` result to `Float64` before division
   ```mojo
   var r = Float64(random_si64(0, 1000000)) / 1000000.0
   ```

2. **Updated Sampler trait**: Changed `__iter__` signature from `self` to `mut self` to allow WeightedSampler to modify weights during sampling without replacement

3. **Updated all sampler implementations**: Updated SequentialSampler, RandomSampler, and WeightedSampler to use `mut self` in `__iter__`

4. **Fixed list iteration**: Changed from iterator syntax to indexed access for compatibility

## Testing

```bash
pixi run mojo run -I. tests/shared/data/samplers/test_weighted.mojo
```

Output:
```
Running weighted sampler tests...
✓ All weighted sampler tests passed!
```

## Impact

- Test now compiles and passes successfully
- All sampler implementations remain compatible with trait
- No behavioral changes to sampling logic

Closes #2105

🤖 Generated with [Claude Code](https://claude.com/claude-code)