### PR TITLE
[Test Fix] Fix ExTensor List constructors - uninitialized self._data

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -223,7 +223,33 @@ struct ExTensor(Copyable, Movable, ImplicitlyCopyable):
         """
         var shape = List[Int]()
         shape.append(len(data))
-        _ = self.__init__(shape, DType.float32)
+
+        # Initialize fields manually (delegating constructor doesn't satisfy compiler)
+        self._shape = List[Int]()
+        self._shape.append(len(data))
+        self._dtype = DType.float32
+        self._is_view = False
+        self._original_numel_quantized = -1
+
+        # Calculate numel
+        self._numel = len(data)
+
+        # Calculate strides
+        self._strides = List[Int]()
+        self._strides.append(1)
+
+        # Allocate memory
+        var dtype_size = ExTensor._get_dtype_size_static(DType.float32)
+        var total_bytes = self._numel * dtype_size
+
+        if total_bytes > MAX_TENSOR_BYTES:
+            raise Error("Tensor too large: " + String(total_bytes) + " bytes exceeds maximum " + String(MAX_TENSOR_BYTES) + " bytes")
+
+        self._data = alloc[UInt8](total_bytes)
+        self._refcount = alloc[Int](1)
+        self._refcount[] = 1
+
+        # Copy data
         for i in range(len(data)):
             self._set_float32(i, data[i])
 
@@ -239,7 +265,33 @@ struct ExTensor(Copyable, Movable, ImplicitlyCopyable):
         """
         var shape = List[Int]()
         shape.append(len(data))
-        _ = self.__init__(shape, DType.int64)
+
+        # Initialize fields manually (delegating constructor doesn't satisfy compiler)
+        self._shape = List[Int]()
+        self._shape.append(len(data))
+        self._dtype = DType.int64
+        self._is_view = False
+        self._original_numel_quantized = -1
+
+        # Calculate numel
+        self._numel = len(data)
+
+        # Calculate strides
+        self._strides = List[Int]()
+        self._strides.append(1)
+
+        # Allocate memory
+        var dtype_size = ExTensor._get_dtype_size_static(DType.int64)
+        var total_bytes = self._numel * dtype_size
+
+        if total_bytes > MAX_TENSOR_BYTES:
+            raise Error("Tensor too large: " + String(total_bytes) + " bytes exceeds maximum " + String(MAX_TENSOR_BYTES) + " bytes")
+
+        self._data = alloc[UInt8](total_bytes)
+        self._refcount = alloc[Int](1)
+        self._refcount[] = 1
+
+        # Copy data
         for i in range(len(data)):
             self._data.bitcast[Int64]()[i] = Int64(data[i])
 


### PR DESCRIPTION
Fixes #2102

## Summary

Fixed compilation errors in ExTensor's List[Float32] and List[Int] constructors by manually inlining field initialization instead of using delegating constructors.

## Root Cause

Mojo's compiler doesn't track field initialization through delegating constructor calls (self.__init__()). When constructors call another constructor internally, the compiler still considers fields uninitialized when accessed afterward.

Error:
```
error: use of uninitialized value 'self._data'
    self._set_float32(i, data[i])
```

## Solution

Manually inline all field initialization logic instead of delegating:
- Initialize all struct fields directly
- Allocate memory inline
- Set reference count inline

This preserves the same behavior while satisfying the compiler's initialization tracking.

## Test Results

✅ test_augmentations.mojo compiles successfully
✅ All affected test files can now import ExTensor without compilation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)