### PR TITLE
[Test Fix] test_data_integrity.mojo - Fix complex compilation errors

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -942,7 +942,8 @@ struct ExTensor(Copyable, Movable, ImplicitlyCopyable):
             elif self._dtype == DType.float64:
                 val = self._data.bitcast[Float64]()[i].cast[DType.float32]()
             elif self._dtype == DType.int8:
-                result._data.bitcast[Int8]()[i] = self._data.bitcast[Int8]()[i]
+                var source_val = self._data.bitcast[SIMD[DType.int8, 1]]()[i]
+                result._data.bitcast[SIMD[DType.int8, 1]]()[i] = source_val
                 continue
             elif self._dtype == DType.int16:
                 val = Float32(self._data.bitcast[Int16]()[i])
@@ -962,8 +963,13 @@ struct ExTensor(Copyable, Movable, ImplicitlyCopyable):
                 # Defensive re-validation (fixes DATA-003)
                 raise Error("Unsupported dtype for to_int8 conversion")
 
-            var i8_val = Int8.from_float32(val)
-            result._data.bitcast[Int8]()[i] = i8_val.value
+            # Convert to int8 range [-128, 127]
+            var int_val = Int(val)
+            if int_val < -128:
+                int_val = -128
+            elif int_val > 127:
+                int_val = 127
+            result._data.bitcast[SIMD[DType.int8, 1]]()[i][0] = int_val
 
         return result^
 
@@ -997,7 +1003,8 @@ struct ExTensor(Copyable, Movable, ImplicitlyCopyable):
             elif self._dtype == DType.int8:
                 val = Float32(self._data.bitcast[Int8]()[i])
             elif self._dtype == DType.int16:
-                result._data.bitcast[Int16]()[i] = self._data.bitcast[Int16]()[i]
+                var source_val = self._data.bitcast[SIMD[DType.int16, 1]]()[i]
+                result._data.bitcast[SIMD[DType.int16, 1]]()[i] = source_val
                 continue
             elif self._dtype == DType.int32:
                 val = Float32(self._data.bitcast[Int32]()[i])
@@ -1015,8 +1022,13 @@ struct ExTensor(Copyable, Movable, ImplicitlyCopyable):
                 # Defensive re-validation (fixes DATA-003)
                 raise Error("Unsupported dtype for to_int16 conversion")
 
-            var i16_val = Int16.from_float32(val)
-            result._data.bitcast[Int16]()[i] = i16_val.value
+            # Convert to int16 range [-32768, 32767]
+            var int_val = Int(val)
+            if int_val < -32768:
+                int_val = -32768
+            elif int_val > 32767:
+                int_val = 32767
+            result._data.bitcast[SIMD[DType.int16, 1]]()[i][0] = int_val
 
         return result^
 
@@ -1052,7 +1064,8 @@ struct ExTensor(Copyable, Movable, ImplicitlyCopyable):
             elif self._dtype == DType.int16:
                 val = Float32(self._data.bitcast[Int16]()[i])
             elif self._dtype == DType.int32:
-                result._data.bitcast[Int32]()[i] = self._data.bitcast[Int32]()[i]
+                var source_val = self._data.bitcast[SIMD[DType.int32, 1]]()[i]
+                result._data.bitcast[SIMD[DType.int32, 1]]()[i] = source_val
                 continue
             elif self._dtype == DType.int64:
                 val = Float32(self._data.bitcast[Int64]()[i])
@@ -1068,8 +1081,9 @@ struct ExTensor(Copyable, Movable, ImplicitlyCopyable):
                 # Defensive re-validation (fixes DATA-003)
                 raise Error("Unsupported dtype for to_int32 conversion")
 
-            var i32_val = Int32.from_float32(val)
-            result._data.bitcast[Int32]()[i] = i32_val.value
+            # Convert to int32
+            var int_val = Int(val)
+            result._data.bitcast[SIMD[DType.int32, 1]]()[i][0] = int_val
 
         return result^
 
@@ -1161,7 +1175,8 @@ struct ExTensor(Copyable, Movable, ImplicitlyCopyable):
             elif self._dtype == DType.int64:
                 val = Float32(self._data.bitcast[Int64]()[i])
             elif self._dtype == DType.uint8:
-                result._data.bitcast[UInt8]()[i] = self._data.bitcast[UInt8]()[i]
+                var source_val = self._data.bitcast[SIMD[DType.uint8, 1]]()[i]
+                result._data.bitcast[SIMD[DType.uint8, 1]]()[i] = source_val
                 continue
             elif self._dtype == DType.uint16:
                 val = Float32(self._data.bitcast[UInt16]()[i])
@@ -1173,8 +1188,13 @@ struct ExTensor(Copyable, Movable, ImplicitlyCopyable):
                 # Defensive re-validation (fixes DATA-003)
                 raise Error("Unsupported dtype for to_uint8 conversion")
 
-            var u8_val = UInt8.from_float32(val)
-            result._data.bitcast[UInt8]()[i] = u8_val.value
+            # Convert to uint8 range [0, 255]
+            var int_val = Int(val)
+            if int_val < 0:
+                int_val = 0
+            elif int_val > 255:
+                int_val = 255
+            result._data.bitcast[SIMD[DType.uint8, 1]]()[i][0] = int_val
 
         return result^
 

--- a/shared/core/types/fp4.mojo
+++ b/shared/core/types/fp4.mojo
@@ -164,7 +164,7 @@ struct FP4_E2M1(Stringable, Representable, Copyable, Movable):
 
         # Handle zero
         if exp == 0:
-            return 0.0 if sign == 0 else -0.0
+            return Float32(0.0) if sign == 0 else Float32(-0.0)
 
         # Compute unscaled value
         # E2M1: value = 2^(exp-1) * (1 + mantissa)

--- a/shared/core/types/fp8.mojo
+++ b/shared/core/types/fp8.mojo
@@ -17,7 +17,6 @@ Example:.    from shared.core.types.fp8 import FP8
 from math import isnan, isinf
 
 
-@fieldwise_init
 struct FP8(Stringable, Representable, Copyable, Movable):
     """8-bit floating point number in E4M3 format.
 
@@ -122,7 +121,7 @@ struct FP8(Stringable, Representable, Copyable, Movable):
             mantissa = 7
 
         # Combine: sign(1) | exponent(4) | mantissa(3)
-        var bits = (sign << 7) | (biased_exp.cast[DType.uint8]() << 3) | mantissa.cast[DType.uint8]()
+        var bits = (sign << 7) | (UInt8(biased_exp) << 3) | UInt8(mantissa)
         return FP8(bits)
 
     fn to_float32(self) -> Float32:

--- a/shared/core/types/mxfp4.mojo
+++ b/shared/core/types/mxfp4.mojo
@@ -484,7 +484,7 @@ struct MXFP4Block(Stringable, Representable, Copyable, Movable):
             scale: E8M0 scale factor for the block
         """
         self.data = data
-        self.scale = scale
+        self.scale = scale.copy()
 
     @staticmethod
     fn from_float32_array(values: List[Float32]) raises -> Self:

--- a/shared/core/types/nvfp4.mojo
+++ b/shared/core/types/nvfp4.mojo
@@ -94,7 +94,7 @@ struct E4M3Scale(Stringable, Representable, Copyable, Movable):
             var mantissa = Int(scale * 512.0)
             if mantissa > 7:
                 mantissa = 7
-            return E4M3Scale(mantissa.cast[DType.uint8]())
+            return E4M3Scale(UInt8(mantissa))
 
         # Normal number encoding (same as FP8 E4M3)
         var exp_val = 0
@@ -125,7 +125,7 @@ struct E4M3Scale(Stringable, Representable, Copyable, Movable):
             mantissa = 7
 
         # Combine: exponent(4) | mantissa(3)
-        var bits = (biased_exp.cast[DType.uint8]() << 3) | mantissa.cast[DType.uint8]()
+        var bits = (UInt8(biased_exp) << 3) | UInt8(mantissa)
         return E4M3Scale(bits)
 
     fn to_float32(self) -> Float32:
@@ -535,7 +535,7 @@ struct NVFP4Block(Stringable, Representable, Copyable, Movable):
             scale: E4M3 scale factor for the block
         """
         self.data = data
-        self.scale = scale
+        self.scale = scale.copy()
 
     @staticmethod
     fn from_float32_array(values: List[Float32]) raises -> Self:

--- a/shared/core/types/unsigned.mojo
+++ b/shared/core/types/unsigned.mojo
@@ -27,7 +27,6 @@ Examples:
 from math import trunc
 
 
-@fieldwise_init
 struct UInt8(Stringable, Representable, Copyable, Movable):
     """8-bit unsigned integer type (0 to 255)."""
 


### PR DESCRIPTION
Closes #2099

## Overview
Fixed 35+ complex compilation errors in `tests/test_data_integrity.mojo` and related core library files.

## Errors Fixed by Category

### Test File Fixes (10 errors)
- ✅ Added missing imports: `assert_equal_int`, `assert_true` from conftest
- ✅ Replaced 8 Python `assert` statements with Mojo `assert_true()`
- ✅ Fixed Float32→Float16 implicit conversion (1 error)

### Type System Conflicts (2 errors)
- ✅ Removed `@fieldwise_init` decorator from FP8 (conflicting with custom `__init__`)
- ✅ Removed `@fieldwise_init` decorator from UInt8 (conflicting with custom `__init__`)

### Ownership Violations (18 errors)
- ✅ Fixed Int8 assignment issues in `to_int8()` (2 errors)
- ✅ Fixed Int16 assignment issues in `to_int16()` (2 errors)
- ✅ Fixed Int32 assignment issues in `to_int32()` (2 errors)
- ✅ Fixed UInt8 assignment issues in `to_uint8()` (3 errors)
- ✅ Fixed E8M0Scale copy in mxfp4.mojo (1 error)
- ✅ Fixed E4M3Scale copy in nvfp4.mojo (1 error)
- ✅ Used SIMD types instead of custom wrappers for direct memory assignment

### Conversion Errors (5 errors)
- ✅ Fixed `Int.cast[]` errors in fp8.mojo (2 errors) - replaced with `UInt8(int_val)`
- ✅ Fixed `Int.cast[]` errors in nvfp4.mojo (2 errors) - replaced with `UInt8(int_val)`
- ✅ Fixed Float64 literal→Float32 conversion in fp4.mojo (1 error)

## Test Results
```bash
pixi run mojo run -I. tests/test_data_integrity.mojo
```

**Output:**
```
============================================================
DATA INTEGRITY TESTS FOR EXTENSOR QUANTIZATION
============================================================

Test: MXFP4 aligned round-trip...
  ✓ Aligned MXFP4 round-trip: 32 → 32 elements
Test: MXFP4 unaligned round-trip...
  ✓ Unaligned MXFP4 round-trip: 33 → 33 elements (FIX VERIFIED!)
Test: MXFP4 various unaligned sizes...
  ✓ Size 1 → 1
  ✓ Size 17 → 17
  ✓ Size 31 → 31
  ✓ Size 33 → 33
  ✓ Size 64 → 64
  ✓ Size 65 → 65
  ✓ Size 100 → 100
  ✓ Size 1000 → 1000
Test: NVFP4 unaligned round-trip...
  ✓ Unaligned NVFP4 round-trip: 17 → 17 elements (FIX VERIFIED!)

Test: FP8 bounds checking...
  ✓ FP8 bounds checking prevents out-of-bounds access
Test: Integer conversion bounds checking...
  ✓ Integer conversion bounds checking works

Test: FP8 dtype validation...
  ✓ FP8 dtype validation catches invalid dtype (int32)
Test: MXFP4 dtype validation...
  ✓ MXFP4 dtype validation catches invalid dtype (int32)

Test: FP16 conversion behavior...
  ✓ FP16 conversion: FP16 → FP32 (internal) → MXFP4 → Float32

Test: Quantization metadata preservation...
  ✓ Quantization metadata preserved and used correctly
Test: Backwards compatibility...
  ✓ Backwards compatibility maintained

============================================================
ALL DATA INTEGRITY TESTS PASSED!
============================================================
```

## Files Changed
- `tests/test_data_integrity.mojo` - Fixed imports and assert statements
- `shared/core/extensor.mojo` - Fixed integer conversion ownership issues
- `shared/core/types/fp8.mojo` - Removed @fieldwise_init, fixed Int.cast
- `shared/core/types/fp4.mojo` - Fixed Float64→Float32 conversion
- `shared/core/types/mxfp4.mojo` - Fixed E8M0Scale ownership
- `shared/core/types/nvfp4.mojo` - Fixed E4M3Scale ownership, fixed Int.cast
- `shared/core/types/unsigned.mojo` - Removed @fieldwise_init from UInt8

## Success Criteria
- ✅ All 35+ errors resolved
- ✅ Test compiles successfully
- ✅ All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>