### PR TITLE
[Test Fix] test_tensor_dataset.mojo - Fix Float32/Float64 type mismatches

### DIFF
--- a/tests/shared/data/datasets/test_tensor_dataset.mojo
+++ b/tests/shared/data/datasets/test_tensor_dataset.mojo
@@ -163,11 +163,11 @@ fn test_tensor_dataset_negative_indexing() raises:
     var dataset = TensorDataset(data^, labels^)
 
     var last_sample = dataset[-1]
-    assert_almost_equal(last_sample[0][0], Float32(3.0))
+    assert_almost_equal(last_sample[0][0], Float64(3.0))
     assert_equal(last_sample[1][0], 2)
 
     var second_last_sample = dataset[-2]
-    assert_almost_equal(second_last_sample[0][0], Float32(2.0))
+    assert_almost_equal(second_last_sample[0][0], Float64(2.0))
     assert_equal(second_last_sample[1][0], 1)
 
 
@@ -208,7 +208,7 @@ fn test_tensor_dataset_iteration_consistency() raises:
     """
     var data_list = List[Float32](Float32(1.0), Float32(2.0))
     var data = ExTensor(data_list^)
-    var labels_list = List[Int](0)
+    var labels_list = List[Int](0, 1)
     var labels = ExTensor(labels_list^)
     var dataset = TensorDataset(data^, labels^)
 
@@ -241,12 +241,12 @@ fn test_tensor_dataset_no_copy_on_access() raises:
     var sample = dataset[0]
 
     # Verify we get the correct data (view behavior is implicit in implementation)
-    assert_almost_equal(sample[0][0], Float32(1.0))
+    assert_almost_equal(sample[0][0], Float64(1.0))
     assert_equal(sample[1][0], 0)
 
     # Access second sample to verify independent views
     var sample2 = dataset[1]
-    assert_almost_equal(sample2[0][0], Float32(2.0))
+    assert_almost_equal(sample2[0][0], Float64(2.0))
     assert_equal(sample2[1][0], 1)
 
 
@@ -273,15 +273,15 @@ fn test_tensor_dataset_memory_efficiency() raises:
 
     # Spot check a few samples to verify data integrity
     var first = dataset[0]
-    assert_almost_equal(first[0][0], Float32(0.0))
+    assert_almost_equal(first[0][0], Float64(0.0))
     assert_equal(first[1][0], 0)
 
     var mid = dataset[500]
-    assert_almost_equal(mid[0][0], Float32(500.0))
+    assert_almost_equal(mid[0][0], Float64(500.0))
     assert_equal(mid[1][0], 500)
 
     var last = dataset[999]
-    assert_almost_equal(last[0][0], Float32(999.0))
+    assert_almost_equal(last[0][0], Float64(999.0))
     assert_equal(last[1][0], 999)
 
 


### PR DESCRIPTION
## Summary

Fixes 7 Float32/Float64 type mismatch errors in `test_tensor_dataset.mojo` and related issues in the dataset implementation and ExTensor constructors.

## Changes Made

### Test Fixes (7 type mismatches)
- Line 166, 170: Fixed negative indexing test assertions
- Line 244, 249: Fixed no-copy access test assertions  
- Line 276, 280, 284: Fixed memory efficiency test assertions
- Line 211: Fixed mismatched data/labels sizes (was 2 vs 1, now 2 vs 2)

### Implementation Fixes
- `datasets.mojo:102`: Changed from scalar indexing to `slice()` to return ExTensor views
- `datasets.mojo:8`: Removed unused `Index` import
- `extensor.mojo`: Fixed List[Float32] and List[Int] constructors that were broken by commit 0774ef94

### Root Cause
`ExTensor[Int]` returns `Float64`, but tests compared with `Float32` literals causing type mismatch errors in `assert_almost_equal()`.

## ExTensor Constructor Fix

Commit 0774ef94 incorrectly changed `self.__init__(...)` to `_ = self.__init__(...)` in delegating constructors. This caused the compiler to think `self` was never initialized. Fixed by:
- Directly initializing all struct fields instead of delegating
- Properly setting `_is_view = False` and `_original_numel_quantized = -1`

## Test Results

All 10 tests now pass successfully:
- ✓ test_tensor_dataset_creation
- ✓ test_tensor_dataset_with_matching_sizes  
- ✓ test_tensor_dataset_size_mismatch_error
- ✓ test_tensor_dataset_empty
- ✓ test_tensor_dataset_getitem
- ✓ test_tensor_dataset_negative_indexing
- ✓ test_tensor_dataset_out_of_bounds
- ✓ test_tensor_dataset_iteration_consistency
- ✓ test_tensor_dataset_no_copy_on_access
- ✓ test_tensor_dataset_memory_efficiency

Closes #2104

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>