### PR TITLE
[Test Fix] test_random.mojo - Fix runtime assertion failure

### DIFF
--- a/shared/data/samplers.mojo
+++ b/shared/data/samplers.mojo
@@ -139,7 +139,7 @@ struct RandomSampler(Sampler, Copyable, Movable):
         if self.replacement:
             # Sample with replacement
             for _ in range(self.num_samples):
-                indices.append(Int(random_si64(0, self.data_source_len)))
+                indices.append(Int(random_si64(0, self.data_source_len - 1)))
         else:
             # Create shuffled indices
             var all_indices = List[Int](capacity=self.data_source_len)
@@ -148,7 +148,7 @@ struct RandomSampler(Sampler, Copyable, Movable):
 
             # Fisher-Yates shuffle
             for i in range(self.data_source_len - 1, 0, -1):
-                var j = Int(random_si64(0, i + 1))
+                var j = Int(random_si64(0, i))
                 var temp = all_indices[i]
                 all_indices[i] = all_indices[j]
                 all_indices[j] = temp

--- a/tests/shared/data/samplers/test_random.mojo
+++ b/tests/shared/data/samplers/test_random.mojo
@@ -165,7 +165,7 @@ fn test_random_sampler_no_duplicates() raises:
 
     # Check for duplicates by counting occurrences
     var seen = List[Bool](capacity=50)
-    for i in range(50):
+    for _ in range(50):
         seen.append(False)
 
     for i in range(len(indices)):


### PR DESCRIPTION
## Summary

Fixed runtime assertion failure in `test_random_sampler_with_replacement` caused by off-by-one error in `random_si64()` calls.

## Root Cause

The `random_si64(min, max)` function is inclusive on both ends, generating values in range [min, max]. This caused two bugs:

1. **Replacement sampling** (line 142): `random_si64(0, data_source_len)` could return `data_source_len`, which is out of bounds for a dataset of size `data_source_len`
2. **Fisher-Yates shuffle** (line 151): `random_si64(0, i + 1)` could return `i + 1`, causing out-of-bounds array access

## Changes

- **shared/data/samplers.mojo**:
  - Line 142: Changed `random_si64(0, self.data_source_len)` to `random_si64(0, self.data_source_len - 1)`
  - Line 151: Changed `random_si64(0, i + 1)` to `random_si64(0, i)`
  
- **tests/shared/data/samplers/test_random.mojo**:
  - Line 168: Changed unused `i` to `_` to fix compiler warning

## Test Results

All 13 tests in `test_random.mojo` now pass:
- ✓ Creation tests (3)
- ✓ Randomization tests (3)
- ✓ Correctness tests (3)
- ✓ Replacement tests (2)
- ✓ Integration tests (1)
- ✓ Performance tests (1)

Closes #2120