### PR TITLE
[Test Fix] Fix YAML/JSON parsing for values containing colons

### DIFF
--- a/shared/utils/config.mojo
+++ b/shared/utils/config.mojo
@@ -518,7 +518,11 @@ struct Config(Copyable, Movable, ImplicitlyCopyable):
                         var parts = line.split(":")
                         if len(parts) >= 2:
                             var key = String(parts[0].strip())
-                            var value_str = parts[1].strip()
+                            # Join all parts after the first with ":" to handle values with colons
+                            var value_parts = List[String]()
+                            for j in range(1, len(parts)):
+                                value_parts.append(String(parts[j]))
+                            var value_str = String(":").join(value_parts).strip()
 
                             # Try to parse as number
                             if "." in value_str:
@@ -581,7 +585,11 @@ struct Config(Copyable, Movable, ImplicitlyCopyable):
                         var parts = pair.split(":")
                         if len(parts) >= 2:
                             var key = String(parts[0].strip())
-                            var value_str = parts[1].strip()
+                            # Join all parts after the first with ":" to handle values with colons
+                            var value_parts = List[String]()
+                            for j in range(1, len(parts)):
+                                value_parts.append(String(parts[j]))
+                            var value_str = String(":").join(value_parts).strip()
 
                             # Try to parse as number
                             if "." in value_str:

--- a/tests/configs/test_env_vars.mojo
+++ b/tests/configs/test_env_vars.mojo
@@ -262,7 +262,7 @@ fn test_substitute_malformed_pattern() raises:
     config.set("value2", "$MISSING}")  # Missing opening brace
     config.set("value3", "${}")        # Empty variable name
 
-    var substituted = config.substitute_env_vars()
+    _ = config.substitute_env_vars()
 
     # Malformed patterns should be left as-is
     # Implementation may vary - this tests expected behavior
@@ -278,7 +278,7 @@ fn test_substitute_nested_variables() raises:
     var config = Config()
     config.set("path", "${BASE_${LEVEL}}")
 
-    var substituted = config.substitute_env_vars()
+    _ = config.substitute_env_vars()
 
     # Nested variables typically not supported - should leave as-is
     # This test documents expected behavior


### PR DESCRIPTION
## Summary

Fixes test_env_vars.mojo runtime failure caused by incorrect YAML/JSON parsing of values containing colons.

## Problem

The Config.from_yaml() and Config.from_json() methods were splitting configuration lines on ALL colons, not just the first one separating the key from the value. This caused values like `${OUTPUT_DIR:-/tmp/output}` to be truncated to `${OUTPUT_DIR`, losing the default value syntax.

## Root Cause

Lines 501 and 585 in shared/utils/config.mojo used `line.split(":")` which splits on every colon. When processing:
```yaml
output_dir: ${OUTPUT_DIR:-/tmp/output}
```

It would split into:
- parts[0] = "output_dir"
- parts[1] = " ${OUTPUT_DIR"
- parts[2] = "-/tmp/output}"

But only parts[1] was used, losing the rest.

## Solution

Modified both YAML and JSON parsers to:
1. Split the line on colons
2. Take the first part as the key
3. Join ALL remaining parts with ":" to reconstruct the full value
4. Also fixed StringSlice to String conversion for Mojo v0.25.7+ compatibility

## Changes

- Modified Config.from_yaml() to join value parts correctly
- Modified Config.from_json() to join value parts correctly
- Fixed unused variable warnings in test_env_vars.mojo (lines 265, 281)

## Test Results

test_env_vars.mojo now passes all 16 tests:
- ✅ All basic substitution tests pass
- ✅ All default value syntax tests pass
- ✅ File-based substitution test passes (was failing before)
- ✅ All edge case tests pass
- ✅ All integration tests pass

## Additional Notes

This fix is part of Phase 2.1 config test fixes (parallel with 4 other config test fixes).

Closes #2128

🤖 Generated with [Claude Code](https://claude.com/claude-code)