### PR TITLE
[Test Fix] test_edge_cases.mojo - Add NaN handling for modulo by zero

### DIFF
--- a/shared/core/arithmetic.mojo
+++ b/shared/core/arithmetic.mojo
@@ -4,6 +4,7 @@ Implements element-wise arithmetic operations following NumPy-style broadcasting
 """
 
 from collections import List
+from math import nan
 from .extensor import ExTensor
 from .broadcasting import broadcast_shapes, compute_broadcast_strides
 from .gradient_types import GradientPair
@@ -303,6 +304,12 @@ fn modulo(a: ExTensor, b: ExTensor) raises -> ExTensor:
     """
     @always_inline
     fn _mod_op[T: DType](x: Scalar[T], y: Scalar[T]) -> Scalar[T]:
+        # Check for modulo by zero - return NaN per IEEE 754 (for floating-point types)
+        @parameter
+        if T.is_floating_point():
+            if y == Scalar[T](0):
+                return Scalar[T](nan[T]())
+
         # Modulo: a % b = a - floor(a/b) * b
         var div_result = x / y
         var as_int = Int(div_result)


### PR DESCRIPTION
## Summary

Fixes the `test_modulo_by_zero` test in `tests/shared/core/test_edge_cases.mojo` by adding NaN handling for modulo by zero operations on floating-point types.

## Root Cause

The previous `modulo` implementation computed `x - floor(x/y) * y` without checking for division by zero. When `y = 0`:
- For floating-point types: `x / 0 = inf`
- The floor calculation produced a finite number
- The final result was not NaN as expected per IEEE 754 standards

## Changes

- **File**: `shared/core/arithmetic.mojo`
  - Added `from math import nan` import
  - Modified `_mod_op` function in `modulo`:
    - Added compile-time check for floating-point types using `@parameter if T.is_floating_point()`
    - Return `NaN` for modulo by zero (floating-point types only)
    - Integer types remain unchanged (modulo by zero is undefined)

## Test Results

### Before Fix
```
Testing modulo edge cases...
Unhandled exception caught during execution: x % 0 should be NaN
```

### After Fix
```
Testing modulo edge cases...
✓ test_modulo_by_zero passed
✓ test_modulo_with_negative_divisor passed
✓ test_modulo_both_negative passed

All modulo tests passed!
```

## Verification

Ran modulo-specific tests manually to confirm all edge cases pass:
- Modulo by zero returns NaN for floats
- Modulo with negative divisor works correctly (Python semantics)
- Modulo with both negative values works correctly

Closes #2139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>