### PR TITLE
[Test Fix] test_layers.mojo - Fix numerical precision bug

### DIFF
--- a/tests/shared/core/test_layers.mojo
+++ b/tests/shared/core/test_layers.mojo
@@ -538,9 +538,15 @@ fn test_linear_matches_pytorch() raises:
         output = F.linear(x, weights, bias)
         print(output)
 
-        # Expected output:
+        # Expected output (manual calculation):
+        # Row 0: [1,2,3,4] @ W.T + bias
+        #      = [1,2,3,4] @ [[0.1,0.5,0.9],[0.2,0.6,1.0],[0.3,0.7,1.1],[0.4,0.8,1.2]] + [1,2,3]
+        #      = [3.0, 7.0, 11.0] + [1.0, 2.0, 3.0] = [4.0, 9.0, 14.0]
+        # Row 1: [5,6,7,8] @ W.T + bias
+        #      = [5,6,7,8] @ [[0.1,0.5,0.9],[0.2,0.6,1.0],[0.3,0.7,1.1],[0.4,0.8,1.2]] + [1,2,3]
+        #      = [7.0, 17.4, 27.8] + [1.0, 2.0, 3.0] = [8.0, 19.4, 30.8]
         # tensor([[ 4.0000,  9.0000, 14.0000],
-        #         [ 8.0000, 17.0000, 26.0000]])
+        #         [ 8.0000, 19.4000, 30.8000]])
         ```
     """
     # Create input: (2, 4)
@@ -586,14 +592,14 @@ fn test_linear_matches_pytorch() raises:
     # Forward pass
     var output = linear(input, weights, bias)
 
-    # Validate against PyTorch reference values
-    # Expected output: [[4.0, 9.0, 14.0], [8.0, 17.0, 26.0]]
+    # Validate against corrected reference values
+    # Expected output: [[4.0, 9.0, 14.0], [8.0, 19.4, 30.8]]
     assert_almost_equal(output._data.bitcast[Float32]()[0], 4.0, tolerance=1e-5)
     assert_almost_equal(output._data.bitcast[Float32]()[1], 9.0, tolerance=1e-5)
     assert_almost_equal(output._data.bitcast[Float32]()[2], 14.0, tolerance=1e-5)
     assert_almost_equal(output._data.bitcast[Float32]()[3], 8.0, tolerance=1e-5)
-    assert_almost_equal(output._data.bitcast[Float32]()[4], 17.0, tolerance=1e-5)
-    assert_almost_equal(output._data.bitcast[Float32]()[5], 26.0, tolerance=1e-5)
+    assert_almost_equal(output._data.bitcast[Float32]()[4], 19.4, tolerance=1e-5)
+    assert_almost_equal(output._data.bitcast[Float32]()[5], 30.8, tolerance=1e-5)
 
 
 fn test_relu_matches_pytorch() raises:


### PR DESCRIPTION
## Summary

Fixed incorrect expected values in `test_linear_matches_pytorch()`. The test was failing with error "19.4 !≈ 17.0 (diff: 2.3999996)", but this was due to incorrect test expectations, not a bug in the implementation.

## Root Cause

The test had hardcoded expected values that were mathematically incorrect:
- Expected `output[1,1] = 17.0`, but correct value is `19.4`
- Expected `output[1,2] = 26.0`, but correct value is `30.8`

## Mathematical Verification

For element `[1,1]`:
```
input[1] = [5, 6, 7, 8]
weights[1] = [0.5, 0.6, 0.7, 0.8]
Dot product: 5*0.5 + 6*0.6 + 7*0.7 + 8*0.8 = 17.4
With bias[1] = 2.0: 17.4 + 2.0 = 19.4 ✓
```

For element `[1,2]`:
```
input[1] = [5, 6, 7, 8]
weights[2] = [0.9, 1.0, 1.1, 1.2]
Dot product: 5*0.9 + 6*1.0 + 7*1.1 + 8*1.2 = 27.8
With bias[2] = 3.0: 27.8 + 3.0 = 30.8 ✓
```

## Changes

- Updated `test_linear_matches_pytorch()` expected values to match actual linear layer computation
- Added detailed calculation comments to show the correct mathematical derivation
- Implementation in `shared/core/linear.mojo`, `shared/core/matrix.mojo`, and `shared/core/arithmetic.mojo` was already correct

## Test Results

All tests now pass:
```
Running Linear layer tests...
Running Conv2D layer tests...
Running activation layer tests...
Running pooling layer tests...
Running property-based tests...
Running PyTorch validation tests...

All layer tests passed! ✓
```

Closes #2138

🤖 Generated with [Claude Code](https://claude.com/claude-code)