### PR TITLE
[Test Fix] test_core_operations.mojo - Fix runtime failure

### DIFF
--- a/tests/test_core_operations.mojo
+++ b/tests/test_core_operations.mojo
@@ -79,8 +79,8 @@ fn test_forward_pass_with_metrics() raises:
     print("Testing forward pass with metrics...")
 
     # Initialize a simple 2-layer network
-    var w1_shape = List[Int](4, 3)  # 3 inputs, 4 hidden
-    var w2_shape = List[Int](3, 4)  # 4 hidden, 3 outputs
+    var w1_shape = List[Int](3, 4)  # 3 inputs, 4 hidden
+    var w2_shape = List[Int](4, 3)  # 4 hidden, 3 outputs
 
     var w1 = kaiming_uniform(3, 4, w1_shape, seed_val=1)
     var b1 = constant(List[Int](), 0.0)
@@ -102,6 +102,7 @@ fn test_forward_pass_with_metrics() raises:
 
     # Create fake labels
     var labels_shape = List[Int]()
+    labels_shape.append(5)
     var labels = ExTensor(labels_shape, DType.int32)
     labels._data.bitcast[Int32]()[0] = 0
     labels._data.bitcast[Int32]()[1] = 1
@@ -132,8 +133,8 @@ fn test_training_loop_simulation() raises:
     var batch_size = 4
 
     # Initialize weights
-    var w1 = kaiming_uniform(input_dim, hidden_dim, List[Int](hidden_dim, input_dim), seed_val=1)
-    var w2 = xavier_uniform(hidden_dim, output_dim, List[Int](output_dim, hidden_dim), seed_val=2)
+    var w1 = kaiming_uniform(input_dim, hidden_dim, List[Int](input_dim, hidden_dim), seed_val=1)
+    var w2 = xavier_uniform(hidden_dim, output_dim, List[Int](hidden_dim, output_dim), seed_val=2)
 
     # Setup metrics
     var accuracy = AccuracyMetric()
@@ -155,6 +156,7 @@ fn test_training_loop_simulation() raises:
             # Create fake batch
             var input = normal(List[Int](batch_size, input_dim), seed_val=epoch * 100 + batch_idx)
             var labels_shape = List[Int]()
+            labels_shape.append(batch_size)
             var labels = ExTensor(labels_shape, DType.int32)
 
             for i in range(batch_size):
@@ -262,7 +264,7 @@ fn test_batch_processing_pipeline() raises:
     var num_classes = 3
 
     # Initialize network
-    var weights = kaiming_uniform(num_features, num_classes, List[Int](num_classes, num_features), seed_val=1)
+    var weights = kaiming_uniform(num_features, num_classes, List[Int](num_features, num_classes), seed_val=1)
 
     # Setup metrics
     var accuracy = AccuracyMetric()
@@ -274,6 +276,7 @@ fn test_batch_processing_pipeline() raises:
         # Generate batch
         var input = normal(List[Int](batch_size, num_features), seed_val=batch_idx)
         var labels_shape = List[Int]()
+        labels_shape.append(batch_size)
         var labels = ExTensor(labels_shape, DType.int32)
 
         for i in range(batch_size):
@@ -314,13 +317,13 @@ fn test_multi_layer_network_integration() raises:
     var layer_sizes = List[Int](784, 256, 128, 10)
 
     # Initialize all layers with appropriate methods
-    var w1 = kaiming_uniform(784, 256, List[Int](256, 784), seed_val=1)
+    var w1 = kaiming_uniform(784, 256, List[Int](784, 256), seed_val=1)
     var b1 = constant(List[Int](), 0.0)
 
-    var w2 = kaiming_uniform(256, 128, List[Int](128, 256), seed_val=2)
+    var w2 = kaiming_uniform(256, 128, List[Int](256, 128), seed_val=2)
     var b2 = constant(List[Int](), 0.0)
 
-    var w3 = xavier_uniform(128, 10, List[Int](10, 128), seed_val=3)
+    var w3 = xavier_uniform(128, 10, List[Int](128, 10), seed_val=3)
     var b3 = constant(List[Int](), 0.0)
 
     # Verify all weights initialized
@@ -331,6 +334,7 @@ fn test_multi_layer_network_integration() raises:
     # Create fake mini-batch (batch_size=4)
     var input = normal(List[Int](4, 784), seed_val=42)
     var labels_shape = List[Int]()
+    labels_shape.append(4)
     var labels = ExTensor(labels_shape, DType.int32)
     labels._data.bitcast[Int32]()[0] = 7
     labels._data.bitcast[Int32]()[1] = 2


### PR DESCRIPTION
## Summary
Fixes runtime failures in `test_core_operations.mojo` caused by two types of errors:

1. **Matmul dimension mismatches** - Weight matrices had backwards shapes
2. **Uninitialized label shapes** - Label tensors created with empty shape but accessed with batch indices

## Root Cause

### Issue 1: Matmul Dimension Mismatches
Weight matrices were initialized with shape `(out_features, in_features)` but the code performed `input @ weights` which requires shape `(in_features, out_features)`.

**Example error**: `Incompatible dimensions for matmul: 3 != 4`
- Input shape: `(5, 3)` (batch=5, features=3)
- Weight shape: `(4, 3)` (wrong - should be `(3, 4)`)
- Attempted: `(5, 3) @ (4, 3)` → Invalid (inner dims 3 ≠ 4)

### Issue 2: Uninitialized Label Shapes
Label tensors were created with empty shape `List[Int]()` but code accessed `batch_size` elements without initializing the shape dimension.

**Example error**: `ConfusionMatrix.update: batch sizes must match`
- Labels shape: `()` (0-dimensional scalar)
- Expected shape: `(batch_size,)` to match predictions batch dimension

## Changes Made

### Fixed Weight Shapes (8 locations):
1. `test_forward_pass_with_metrics`: 
   - `w1`: `(4, 3)` → `(3, 4)` 
   - `w2`: `(3, 4)` → `(4, 3)`
2. `test_training_loop_simulation`:
   - `w1`: `(hidden_dim, input_dim)` → `(input_dim, hidden_dim)`
   - `w2`: `(output_dim, hidden_dim)` → `(hidden_dim, output_dim)`
3. `test_batch_processing_pipeline`:
   - `weights`: `(num_classes, num_features)` → `(num_features, num_classes)`
4. `test_multi_layer_network_integration`:
   - `w1`: `(256, 784)` → `(784, 256)`
   - `w2`: `(128, 256)` → `(256, 128)`
   - `w3`: `(10, 128)` → `(128, 10)`

### Fixed Label Shapes (4 locations):
Added `labels_shape.append(batch_size)` before creating ExTensor in:
- `test_forward_pass_with_metrics` (batch_size=5)
- `test_training_loop_simulation` (batch_size=4)
- `test_batch_processing_pipeline` (batch_size=8)
- `test_multi_layer_network_integration` (batch_size=4)

## Test Results
✅ All 8 tests pass successfully:
- Component Integration Tests (4 tests)
- Workflow Integration Tests (3 tests)
- Robustness Tests (1 test)

## Test Plan
- [x] Run test locally: `pixi run mojo run -I. tests/test_core_operations.mojo`
- [x] All 8 tests pass
- [x] No runtime errors
- [x] Metrics compute correctly (accuracy, loss tracking, confusion matrix)

Closes #2150

🤖 Generated with [Claude Code](https://claude.com/claude-code)