### PR TITLE
[Test Fix] test_accuracy.mojo - Fix runtime failure

### DIFF
--- a/shared/training/metrics/accuracy.mojo
+++ b/shared/training/metrics/accuracy.mojo
@@ -59,8 +59,8 @@ fn top1_accuracy(predictions: ExTensor, labels: ExTensor) raises -> Float64:
         # Predictions are logits, need to compute argmax
         pred_classes = argmax(predictions, axis=1)
     elif len(pred_shape) == 1:
-        # Predictions are already class indices (borrow reference, no copy needed)
-        pred_classes = predictions^
+        # Predictions are already class indices (copy since we can't transfer from read-only ref)
+        pred_classes = predictions
     else:
         raise Error("top1_accuracy: predictions must be 1D (class indices) or 2D (logits)")
 
@@ -299,8 +299,8 @@ fn per_class_accuracy(predictions: ExTensor, labels: ExTensor, num_classes: Int)
     if len(pred_shape) == 2:
         pred_classes = argmax(predictions, axis=1)
     elif len(pred_shape) == 1:
-        # Transfer ownership - predictions won't be used after this
-        pred_classes = predictions^
+        # Copy predictions (can't transfer from read-only reference)
+        pred_classes = predictions
     else:
         raise Error("per_class_accuracy: invalid predictions shape")
 

--- a/tests/training/test_accuracy.mojo
+++ b/tests/training/test_accuracy.mojo
@@ -31,6 +31,7 @@ fn test_top1_accuracy_perfect() raises:
 
     # Labels: 0, 1, 2, 3, 4, 0, 1, 2, 3, 4
     var labels_shape = List[Int]()
+    labels_shape.append(batch_size)
     var labels = ExTensor(labels_shape, DType.int32)
 
     for i in range(batch_size):
@@ -64,6 +65,7 @@ fn test_top1_accuracy_half_correct() raises:
     var logits = ExTensor(logits_shape, DType.float32)
 
     var labels_shape = List[Int]()
+    labels_shape.append(batch_size)
     var labels = ExTensor(labels_shape, DType.int32)
 
     # First 5 correct, last 5 incorrect
@@ -80,10 +82,11 @@ fn test_top1_accuracy_half_correct() raises:
                 else:
                     logits._data.bitcast[Float32]()[idx] = 0.0
         else:
-            # Incorrect prediction (predict class 0 when true is != 0)
+            # Incorrect prediction (predict wrong class)
+            var wrong_class = (true_class + 1) % num_classes
             for c in range(num_classes):
                 var idx = i * num_classes + c
-                if c == 0:
+                if c == wrong_class:
                     logits._data.bitcast[Float32]()[idx] = 10.0
                 else:
                     logits._data.bitcast[Float32]()[idx] = 0.0
@@ -104,10 +107,13 @@ fn test_top1_accuracy_with_indices() raises:
 
     # Predicted classes
     var preds_shape = List[Int]()
+    preds_shape.append(batch_size)
     var preds = ExTensor(preds_shape, DType.int32)
 
     # True labels
-    var labels = ExTensor(preds_shape, DType.int32)
+    var labels_shape = List[Int]()
+    labels_shape.append(batch_size)
+    var labels = ExTensor(labels_shape, DType.int32)
 
     # Set up: first 4 correct, last 4 incorrect
     for i in range(batch_size):
@@ -137,6 +143,7 @@ fn test_topk_accuracy_k1() raises:
     var logits = ExTensor(logits_shape, DType.float32)
 
     var labels_shape = List[Int]()
+    labels_shape.append(batch_size)
     var labels = ExTensor(labels_shape, DType.int32)
 
     # Perfect predictions
@@ -173,6 +180,7 @@ fn test_topk_accuracy_k3() raises:
     var logits = ExTensor(logits_shape, DType.float32)
 
     var labels_shape = List[Int]()
+    labels_shape.append(batch_size)
     var labels = ExTensor(labels_shape, DType.int32)
 
     # Sample 0: true=0, scores=[5, 4, 3, 2, 1] -> top-3=[0,1,2] -> correct
@@ -181,22 +189,28 @@ fn test_topk_accuracy_k3() raises:
     # Sample 3: true=4, scores=[5, 4, 3, 2, 1] -> top-3=[0,1,2] -> incorrect
     # Expected: 2/4 = 0.5
 
-    var scores = List[List[Float32]](batch_size)
-    scores.append(List[Float32]())
-    scores[0].append(5.0); scores[0].append(4.0); scores[0].append(3.0)
-    scores[0].append(2.0); scores[0].append(1.0)
+    # Create 2D array of scores using direct indexing
+    var scores = List[List[Float32]]()
 
-    scores.append(List[Float32]())
-    scores[1].append(1.0); scores[1].append(2.0); scores[1].append(5.0)
-    scores[1].append(4.0); scores[1].append(3.0)
+    # Sample 0
+    var s0 = List[Float32]()
+    s0.append(5.0); s0.append(4.0); s0.append(3.0); s0.append(2.0); s0.append(1.0)
+    scores.append(s0^)
 
-    scores.append(List[Float32]())
-    scores[2].append(3.0); scores[2].append(4.0); scores[2].append(5.0)
-    scores[2].append(1.0); scores[2].append(2.0)
+    # Sample 1
+    var s1 = List[Float32]()
+    s1.append(1.0); s1.append(2.0); s1.append(5.0); s1.append(4.0); s1.append(3.0)
+    scores.append(s1^)
 
-    scores.append(List[Float32]())
-    scores[3].append(5.0); scores[3].append(4.0); scores[3].append(3.0)
-    scores[3].append(2.0); scores[3].append(1.0)
+    # Sample 2
+    var s2 = List[Float32]()
+    s2.append(3.0); s2.append(4.0); s2.append(5.0); s2.append(1.0); s2.append(2.0)
+    scores.append(s2^)
+
+    # Sample 3
+    var s3 = List[Float32]()
+    s3.append(5.0); s3.append(4.0); s3.append(3.0); s3.append(2.0); s3.append(1.0)
+    scores.append(s3^)
 
     # Fill logits
     for i in range(batch_size):
@@ -229,6 +243,7 @@ fn test_per_class_accuracy() raises:
     var logits = ExTensor(logits_shape, DType.float32)
 
     var labels_shape = List[Int]()
+    labels_shape.append(batch_size)
     var labels = ExTensor(labels_shape, DType.int32)
 
     # Class 0: 4 samples, 3 correct -> 75%
@@ -285,6 +300,7 @@ fn test_accuracy_metric_incremental() raises:
     var logits1_shape = List[Int](batch1_size, 3)
     var logits1 = ExTensor(logits1_shape, DType.float32)
     var labels1_shape = List[Int]()
+    labels1_shape.append(batch1_size)
     var labels1 = ExTensor(labels1_shape, DType.int32)
 
     for i in range(batch1_size):
@@ -313,6 +329,7 @@ fn test_accuracy_metric_incremental() raises:
     var logits2_shape = List[Int](batch2_size, 3)
     var logits2 = ExTensor(logits2_shape, DType.float32)
     var labels2_shape = List[Int]()
+    labels2_shape.append(batch2_size)
     var labels2 = ExTensor(labels2_shape, DType.int32)
 
     for i in range(batch2_size):


### PR DESCRIPTION
## Summary
Fixes runtime failure in tests/training/test_accuracy.mojo (Phase 4.2).

## Root Cause Analysis

**Issue 1: Invalid List constructor**
- Line 184: `List[List[Float32]](batch_size)` - Cannot initialize nested List with positional argument
- Mojo List constructor requires keyword-only args or explicit element initialization

**Issue 2: Ownership transfer from immutable reference**
- Lines 63 & 303 in accuracy.mojo: `predictions^` - Cannot transfer ownership from read-only reference
- Function parameters are `read` by default in Mojo v0.25.7+

**Issue 3: Uninitialized tensor shape**
- Multiple locations: `labels_shape = List[Int]()` creates 0D scalar (1 element)
- Accessing multiple indices caused out-of-bounds errors
- Need `labels_shape.append(batch_size)` to create 1D array

**Issue 4: Test logic error**
- test_top1_accuracy_half_correct: Predicted class 0 when true label could also be 0
- Resulted in 7/10 correct (0.7) instead of expected 5/10 (0.5)

## Changes Made

1. **Test file (tests/training/test_accuracy.mojo)**:
   - Fixed nested List initialization using explicit append() calls
   - Added labels_shape.append(batch_size) to all 7 test functions
   - Fixed test logic to predict (true_class + 1) % num_classes for incorrect predictions

2. **Metrics file (shared/training/metrics/accuracy.mojo)**:
   - Removed ownership transfer operator (^) from immutable references
   - Use implicit copy instead (ExTensor is ImplicitlyCopyable)

## Test Results

```
ALL ACCURACY METRICS TESTS PASSED ✓
- test_top1_accuracy_perfect
- test_top1_accuracy_half_correct
- test_top1_accuracy_with_indices
- test_topk_accuracy_k1
- test_topk_accuracy_k3
- test_per_class_accuracy
- test_accuracy_metric_incremental
- test_accuracy_metric_empty
```

## Verification

- [x] All 8 test functions pass
- [x] No compilation errors
- [x] No runtime errors
- [x] Accuracy calculations verified (perfect=1.0, half=0.5, top-k=0.5, etc.)

Closes #2152

🤖 Generated with [Claude Code](https://claude.com/claude-code)