### PR TITLE
[Test Fix] test_metrics_coordination.mojo - Fix compilation and runtime errors

### DIFF
--- a/shared/training/metrics/accuracy.mojo
+++ b/shared/training/metrics/accuracy.mojo
@@ -17,6 +17,7 @@ Issues covered:
 
 from shared.core import ExTensor
 from collections import List
+from .base import Metric
 
 
 # ============================================================================
@@ -355,7 +356,7 @@ fn per_class_accuracy(predictions: ExTensor, labels: ExTensor, num_classes: Int)
 # ============================================================================
 
 
-struct AccuracyMetric:
+struct AccuracyMetric(Metric):
     """Incremental accuracy metric for efficient accumulation across batches.
 
     Maintains running count of correct predictions and total samples,

--- a/shared/training/metrics/base.mojo
+++ b/shared/training/metrics/base.mojo
@@ -94,7 +94,7 @@ struct MetricResult(Copyable, Movable):
         return self.tensor_value
 
 
-struct MetricCollection:
+struct MetricCollection(Sized):
     """Collection of metrics for training/evaluation.
 
     Manages multiple metrics with a unified interface:
@@ -141,6 +141,14 @@ struct MetricCollection:
         self.metric_names.append(name)
         self.num_metrics += 1
 
+    fn __len__(self) -> Int:
+        """Get number of metrics in collection (Sized trait).
+
+        Returns:
+            Number of metrics
+        """
+        return self.num_metrics
+
     fn size(self) -> Int:
         """Get number of metrics in collection.
 
@@ -153,9 +161,9 @@ struct MetricCollection:
         """Get names of all metrics.
 
         Returns:
-            Vector of metric names
+            Copy of metric names vector
         """
-        return self.metric_names^
+        return List[String](self.metric_names)
 
     fn contains(self, name: String) -> Bool:
         """Check if metric exists in collection.

--- a/shared/training/metrics/confusion_matrix.mojo
+++ b/shared/training/metrics/confusion_matrix.mojo
@@ -16,6 +16,7 @@ Issues covered:
 from shared.core import ExTensor
 from collections import List
 from math import sqrt
+from .base import Metric
 
 
 # ============================================================================
@@ -23,7 +24,7 @@ from math import sqrt
 # ============================================================================
 
 
-struct ConfusionMatrix:
+struct ConfusionMatrix(Metric):
     """Confusion matrix for classification analysis.
 
     Maintains an NxN matrix where matrix[i, j] represents the count of samples.

--- a/shared/training/metrics/loss_tracker.mojo
+++ b/shared/training/metrics/loss_tracker.mojo
@@ -15,6 +15,8 @@ Issues covered:
 
 from collections import List
 from math import sqrt
+from .base import Metric
+from shared.core import ExTensor
 # min and max are now builtins in Mojo - no import needed
 
 
@@ -196,7 +198,7 @@ struct ComponentTracker(Copyable, Movable):
 # ============================================================================
 
 
-struct LossTracker:
+struct LossTracker(Metric):
     """Track loss values with statistics and moving averages.
 
     Supports multi-component loss tracking (e.g., total, reconstruction, regularization)
@@ -337,3 +339,25 @@ struct LossTracker:
         """
         # Create a copy of the components list
         return List[String](self.components)
+
+    # Metric trait implementation (for coordination interface)
+    fn update(mut self, predictions: ExTensor, labels: ExTensor) raises:
+        """Update metric with predictions and labels (Metric trait).
+
+        Note: LossTracker doesn't use predictions/labels directly.
+        This method exists for trait compliance but should not be called.
+        Use update(loss: Float32, component: String) instead.
+
+        Raises:
+            Error indicating this method should not be used
+        """
+        raise Error("LossTracker.update(predictions, labels) not applicable - use update(loss, component) instead")
+
+    fn reset(mut self):
+        """Reset all components (Metric trait version).
+
+        Resets statistics for all tracked components.
+        """
+        # Reset all components
+        for i in range(len(self.trackers)):
+            self.trackers[i].reset()

--- a/tests/training/test_metrics_coordination.mojo
+++ b/tests/training/test_metrics_coordination.mojo
@@ -54,7 +54,9 @@ fn test_metric_result_tensor() raises:
     """Test MetricResult with tensor values."""
     print("Testing MetricResult tensor...")
 
-    var tensor = ExTensor(List[Int](), DType.float32)
+    var tensor_shape = List[Int]()
+    tensor_shape.append(3)
+    var tensor = ExTensor(tensor_shape, DType.float32)
     tensor._data.bitcast[Float32]()[0] = 0.9
     tensor._data.bitcast[Float32]()[1] = 0.8
     tensor._data.bitcast[Float32]()[2] = 0.95
@@ -130,8 +132,12 @@ fn test_accuracy_metric_interface_compliance() raises:
     var metric = AccuracyMetric()
 
     # Create test data
-    var preds = ExTensor(List[Int](), DType.int32)
-    var labels = ExTensor(List[Int](), DType.int32)
+    var preds_shape = List[Int]()
+    preds_shape.append(4)
+    var preds = ExTensor(preds_shape, DType.int32)
+    var labels_shape = List[Int]()
+    labels_shape.append(4)
+    var labels = ExTensor(labels_shape, DType.int32)
 
     preds._data.bitcast[Int32]()[0] = 0  # ✓
     preds._data.bitcast[Int32]()[1] = 1  # ✓
@@ -164,8 +170,12 @@ fn test_confusion_matrix_integration() raises:
     var cm = ConfusionMatrix(num_classes=3)
 
     # Create test data
-    var preds = ExTensor(List[Int](), DType.int32)
-    var labels = ExTensor(List[Int](), DType.int32)
+    var preds_shape = List[Int]()
+    preds_shape.append(5)
+    var preds = ExTensor(preds_shape, DType.int32)
+    var labels_shape = List[Int]()
+    labels_shape.append(5)
+    var labels = ExTensor(labels_shape, DType.int32)
 
     preds._data.bitcast[Int32]()[0] = 0
     preds._data.bitcast[Int32]()[1] = 1
@@ -340,8 +350,12 @@ fn test_multi_metric_training_simulation() raises:
         # Simulate 5 batches per epoch
         for batch in range(5):
             # Create fake batch data
-            var preds = ExTensor(List[Int](), DType.int32)
-            var labels = ExTensor(List[Int](), DType.int32)
+            var preds_shape = List[Int]()
+            preds_shape.append(4)
+            var preds = ExTensor(preds_shape, DType.int32)
+            var labels_shape = List[Int]()
+            labels_shape.append(4)
+            var labels = ExTensor(labels_shape, DType.int32)
 
             for i in range(4):
                 var pred_class = (i + batch + epoch) % 3
@@ -382,8 +396,12 @@ fn test_metric_interface_consistency() raises:
     var confusion = ConfusionMatrix(num_classes=3)
 
     # Create test data
-    var preds = ExTensor(List[Int](), DType.int32)
-    var labels = ExTensor(List[Int](), DType.int32)
+    var preds_shape = List[Int]()
+    preds_shape.append(2)
+    var preds = ExTensor(preds_shape, DType.int32)
+    var labels_shape = List[Int]()
+    labels_shape.append(2)
+    var labels = ExTensor(labels_shape, DType.int32)
     preds._data.bitcast[Int32]()[0] = 0
     preds._data.bitcast[Int32]()[1] = 1
     labels._data.bitcast[Int32]()[0] = 0


### PR DESCRIPTION
## Summary

Fixes compilation and runtime errors in `tests/training/test_metrics_coordination.mojo` for Phase 4.4 metrics coordination testing.

## Root Cause Analysis

### 1. Compilation Errors

**MetricCollection missing Sized trait**: Test called `len(collection)` but `MetricCollection` didn't implement the `Sized` trait.

**Metric trait conformance**: `AccuracyMetric`, `LossTracker`, and `ConfusionMatrix` implement the required methods but didn't explicitly declare trait conformance.

**Ownership transfer in get_names()**: Method used `return self.metric_names^` which transfers ownership, making the collection unusable after calling `get_names()`.

### 2. Runtime Errors

**Uninitialized tensor shapes**: Tests created tensors with `ExTensor(List[Int](), DType.int32)` which creates 0D scalars (numel=1), then tried to access multiple indices causing segfaults.

## Changes Made

### Trait Implementations
- Added `__len__()` method and `Sized` trait to `MetricCollection`
- Added explicit `Metric` trait to struct declarations:
  - `struct AccuracyMetric(Metric)`
  - `struct ConfusionMatrix(Metric)`
  - `struct LossTracker(Metric)` with wrapper methods for trait compliance

### Ownership Fix
- Changed `get_names()` to return `List[String](self.metric_names)` (copy) instead of `self.metric_names^` (transfer)

### Test Fixes
Fixed tensor initialization in 5 test functions:
- `test_metric_result_tensor`: shape [3]
- `test_accuracy_metric_interface_compliance`: shape [4]
- `test_confusion_matrix_integration`: shape [5]
- `test_multi_metric_training_simulation`: shape [4] per batch
- `test_metric_interface_consistency`: shape [2]

## Test Results

```bash
pixi run mojo run -I. tests/training/test_metrics_coordination.mojo
```

All 13 tests pass:
- ✓ MetricResult scalar/tensor handling
- ✓ MetricCollection management
- ✓ Metric interface compliance
- ✓ MetricLogger history tracking
- ✓ Multi-metric training simulation

## Files Modified

- `shared/training/metrics/base.mojo`
- `shared/training/metrics/accuracy.mojo`
- `shared/training/metrics/confusion_matrix.mojo`
- `shared/training/metrics/loss_tracker.mojo`
- `tests/training/test_metrics_coordination.mojo`

Closes #2151

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>