### PR TITLE
[Fix] Complete JSON colon handling fix

### DIFF
--- a/shared/utils/config.mojo
+++ b/shared/utils/config.mojo
@@ -631,7 +631,11 @@ struct Config(Copyable, Movable, ImplicitlyCopyable):
                         var parts = pair.split(":")
                         if len(parts) >= 2:
                             var key = String(parts[0].strip())
-                            var value_str = parts[1].strip()
+                            # Join all parts after the first with ":" to handle values with colons
+                            var value_parts = List[String]()
+                            for j in range(1, len(parts)):
+                                value_parts.append(String(parts[j]))
+                            var value_str = String(":").join(value_parts).strip()
 
                             # Try to parse as number
                             if "." in value_str:


### PR DESCRIPTION
## Summary

Completes the JSON colon handling fix by applying it to `from_json()` method.

## Background

- PR #2130 added nested YAML support with indentation tracking
- PR #2132 fixed colon handling for values like `${VAR:-default}`
- Commit b913df20 merged a PyYAML-based implementation that superseded PR #2130
- The PyYAML implementation fixed `from_yaml()` but `from_json()` still had the colon bug

## This PR

Applies the colon handling fix to `from_json()` method:
- Joins all colon-separated parts after the key to preserve values with colons
- Prevents truncation of values like `${OUTPUT_DIR:-/tmp/output}`

## Changes

- Modified `Config.from_json()` to join value parts correctly (lines 634-638)

## Closes

- #2128 (test_env_vars.mojo runtime failure)
- Supersedes #2132 (applies same fix after PyYAML refactor)
- Allows closing #2130 (superseded by PyYAML implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)