### PR TITLE
chore: Add false positives to gitleaksignore for security docs

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,3 +1,7 @@
 fb5c26eb271ec822be5e05d71085f806d7eda54c:configs/BEST_PRACTICES.md:generic-api-key:21
 457a94f70d274f5c3301df6ee328f46109467edd:configs/BEST_PRACTICES.md:generic-api-key:21
 666b22b6ce7da601c689162723e9c4ebe530aa75:configs/BEST_PRACTICES.md:generic-api-key:21
+# False positive: Example showing what NOT to do in security documentation
+b54cf79584dbb3aef0c5c9df524a300d5963f113:.claude/agents/security-review-specialist.md:generic-api-key:78
+61bfd040ca12d7a83ef9c11035fcad77fa4e51e0:.claude/agents/security-review-specialist.md:generic-api-key:78
+9d3e871381c55deed24efc1ed7ff3ce5ba673e6a:.claude/agents/security-review-specialist.md:generic-api-key:80


### PR DESCRIPTION
## Summary

Fixes the secret-scan CI failure on main branch by adding false positive entries to `.gitleaksignore`.

The `security-review-specialist.md` file contains an example of what NOT to do (showing a fake API key like `sk_test_123456789`). This is documentation showing bad practices, not an actual secret.

## Changes

Added fingerprints for all commits that contain this example:
- `b54cf795...` (line 78)
- `61bfd040...` (line 78)
- `9d3e8713...` (line 80)

## Test plan

- [ ] secret-scan CI check passes
- [ ] No actual secrets are being ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)