### PR TITLE
docs(agents): Update agents/ documentation to match current implementation

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -79,12 +79,14 @@ User: "Use the architecture design agent to plan the auth module"
 - Code Review Orchestrator
 - Coordinates 13 specialized review agents
 
-### Level 3: Component Specialists
+### Level 3: Component Specialists & Review Specialists
 
-### Implementation Specialists
+**Implementation/Execution Specialists** (11 agents):
 
 - Implementation, Test, Documentation, Performance, Security Specialists
-- Handle specific component aspects
+- Blog Writer, Numerical Stability, Test Flakiness, PR Cleanup Specialists
+- Mojo Syntax Validator, CI Failure Analyzer
+- Handle specific component aspects and execution planning
 
 **Code Review Specialists** (13 agents):
 
@@ -92,8 +94,7 @@ User: "Use the architecture design agent to plan the auth module"
 - Security, Safety Review Specialists
 - Mojo Language, Performance Review Specialists
 - Algorithm, Architecture Review Specialists
-- Data Engineering Review Specialist
-- Paper, Research Review Specialists
+- Data Engineering, Paper, Research Review Specialists
 - Dependency Review Specialist
 
 ### Level 4: Implementation Engineers
@@ -305,7 +306,7 @@ model: sonnet
 
 ## Operational Agents
 
-The operational agent configurations are in `.claude/agents/` (23 agents total):
+The operational agent configurations are in `.claude/agents/` (44 agents total):
 
 ### Level 0: Meta-Orchestrator (1 agent)
 
@@ -320,27 +321,58 @@ The operational agent configurations are in `.claude/agents/` (23 agents total):
 - `cicd-orchestrator.md` - Section 05 (testing, deployment pipelines)
 - `agentic-workflows-orchestrator.md` - Section 06 (research assistant, code review, documentation agents)
 
-### Level 2: Module Design Agents (3 agents)
+### Level 2: Module Design Agents & Review Orchestrators (4 agents)
+
+**Design Agents:**
 
 - `architecture-design.md` - Component breakdown, interface design, data flow
 - `integration-design.md` - Cross-component APIs, integration testing, Python-Mojo interop
 - `security-design.md` - Threat modeling, security requirements, vulnerability prevention
 
-### Level 3: Component Specialists (5 agents)
+**Review Orchestrators:**
+
+- `code-review-orchestrator.md` - Routes PR changes to 13 specialist reviewers, consolidates feedback
+
+### Level 3: Component Specialists & Review Specialists (24 agents)
+
+**Implementation/Execution Specialists:**
 
 - `implementation-specialist.md` - Break components into functions/classes, coordinate implementation
 - `test-specialist.md` - Test planning, test case definition, coverage requirements
 - `documentation-specialist.md` - Component READMEs, API docs, usage examples
 - `performance-specialist.md` - Performance requirements, benchmarking, optimization
 - `security-specialist.md` - Security implementation, testing, vulnerability remediation
+- `blog-writer-specialist.md` - Development blog posts in narrative cycle format
+- `numerical-stability-specialist.md` - Numerical precision and stability analysis for ML code
+- `test-flakiness-specialist.md` - Analyzes and fixes flaky tests
+- `pr-cleanup-specialist.md` - Handles PR cleanup and final polish before merge
+- `mojo-syntax-validator.md` - Validates Mojo syntax and patterns
+- `ci-failure-analyzer.md` - Analyzes CI failure logs and identifies root causes
 
-### Level 4: Implementation Engineers (5 agents)
+**Code Review Specialists (13 agents):**
+
+- `implementation-review-specialist.md` - Code correctness, logic, maintainability
+- `documentation-review-specialist.md` - Markdown, comments, docstrings, API docs
+- `test-review-specialist.md` - Test coverage, quality, assertions
+- `security-review-specialist.md` - Vulnerabilities, OWASP top 10, input validation
+- `safety-review-specialist.md` - Memory safety, type safety, undefined behavior
+- `mojo-language-review-specialist.md` - Ownership, SIMD, fn vs def, traits
+- `performance-review-specialist.md` - Algorithmic complexity, cache efficiency
+- `algorithm-review-specialist.md` - ML algorithm correctness, numerical stability
+- `architecture-review-specialist.md` - System design, modularity, patterns
+- `data-engineering-review-specialist.md` - Data pipelines, preprocessing
+- `paper-review-specialist.md` - Academic writing, citations
+- `research-review-specialist.md` - Experimental design, reproducibility
+- `dependency-review-specialist.md` - Version management, licenses
+
+### Level 4: Implementation Engineers (6 agents)
 
 - `senior-implementation-engineer.md` - Complex functions, performance-critical code, SIMD optimization
 - `implementation-engineer.md` - Standard functions and classes, following specifications
 - `test-engineer.md` - Unit and integration tests, test fixtures, test maintenance
 - `documentation-engineer.md` - Docstrings, code examples, README updates
 - `performance-engineer.md` - Benchmark code, profiling, optimization implementation
+- `log-analyzer.md` - Parses build, test, and execution logs to extract diagnostic information
 
 ### Level 5: Junior Engineers (3 agents)
 

--- a/agents/docs/agent-catalog.md
+++ b/agents/docs/agent-catalog.md
@@ -16,7 +16,7 @@
 
 ## Overview
 
-This catalog lists all 23 agent types in the ML Odyssey hierarchical agent system. Each entry includes:
+This catalog lists all 44 agents in the ML Odyssey hierarchical agent system. Each entry includes:
 
 - **Name**: Agent identifier
 - **Description**: What the agent does
@@ -24,9 +24,11 @@ This catalog lists all 23 agent types in the ML Odyssey hierarchical agent syste
 - **Capabilities**: What it can do
 - **Example Use Cases**: Concrete scenarios
 
-**Total Agents**: 23 types across 6 levels
+**Total Agents**: 44 agents across 6 levels (1 L0 + 6 L1 + 4 L2 + 24 L3 + 6 L4 + 3 L5)
 
 ## Quick Reference Table
+
+Representative sample of 44 agents (see detailed sections below for complete list):
 
 | Level | Agent Name | Primary Focus | Scope |
 |-------|-----------|---------------|-------|
@@ -40,16 +42,22 @@ This catalog lists all 23 agent types in the ML Odyssey hierarchical agent syste
 | **2** | Architecture Design Agent | Module architecture | Module design |
 | **2** | Integration Design Agent | Cross-module integration | Module integration |
 | **2** | Security Design Agent | Security architecture | Security design |
+| **2** | Code Review Orchestrator | PR review coordination | Code review |
 | **3** | Implementation Specialist | Implementation coordination | Component implementation |
 | **3** | Test Specialist | Test coordination | Component testing |
 | **3** | Documentation Specialist | Documentation coordination | Component docs |
 | **3** | Performance Specialist | Performance optimization | Component performance |
-| **3** | Security Specialist | Security implementation | Component security |
+| **3** | Blog Writer Specialist | Development blog posts | Narrative content |
+| **3** | Implementation Review Specialist | Code correctness review | PR dimensions |
+| **3** | Safety Review Specialist | Memory safety review | PR dimensions |
+| **3** | Mojo Language Review Specialist | Language patterns review | PR dimensions |
+| **3** | *+ 11 more Level 3 specialists* | *Various review dimensions* | *PR reviews* |
 | **4** | Senior Implementation Engineer | Complex code | Complex functions |
 | **4** | Implementation Engineer | Standard code | Standard functions |
 | **4** | Test Engineer | Test implementation | Unit/integration tests |
-| **4** | Documentation Writer | Documentation writing | API docs, examples |
+| **4** | Documentation Engineer | Documentation writing | API docs, examples |
 | **4** | Performance Engineer | Performance tuning | Benchmarks, profiling |
+| **4** | Log Analyzer | Log parsing & analysis | Diagnostic info |
 | **5** | Junior Implementation Engineer | Simple code | Boilerplate, simple functions |
 | **5** | Junior Test Engineer | Simple tests | Test boilerplate |
 | **5** | Junior Documentation Engineer | Simple docs | Docstrings, formatting |
@@ -1276,6 +1284,6 @@ cat .claude/agents/architecture-design.md
 
 ---
 
-**Total Agent Types**: 23 across 6 levels
+**Total Agent Types**: 44 across 6 levels (1 L0 + 6 L1 + 4 L2 + 24 L3 + 6 L4 + 3 L5)
 
 **Remember**: Trust the hierarchy, communicate clearly, and let agents work at their appropriate level!

--- a/agents/docs/onboarding.md
+++ b/agents/docs/onboarding.md
@@ -1449,7 +1449,7 @@ For security-critical components:
 ### Immediate Actions
 
 1. **Try the tutorial**: Implement a simple function end-to-end
-1. **Browse agent catalog**: See all 23 agents in [agent-catalog.md](agent-catalog.md)
+1. **Browse agent catalog**: See all 44 agents in [agent-catalog.md](agent-catalog.md)
 1. **Study real examples**: Check `.claude/agents/` for actual configurations
 
 ### Deepening Understanding

--- a/agents/docs/quick-start.md
+++ b/agents/docs/quick-start.md
@@ -255,7 +255,7 @@ cat .claude/agents/chief-architect.md
 ### Learn More
 
 1. **Complete System Overview**: Read [onboarding.md](onboarding.md) for comprehensive introduction
-1. **Agent Catalog**: Browse [agent-catalog.md](agent-catalog.md) to see all 23 agent types
+1. **Agent Catalog**: Browse [agent-catalog.md](agent-catalog.md) to see all 44 agent types
 1. **Troubleshooting**: Check [troubleshooting.md](troubleshooting.md) for detailed problem solving
 1. **Visual Hierarchy**: See [../hierarchy.md](../hierarchy.md) for the complete visual diagram
 

--- a/agents/hierarchy.md
+++ b/agents/hierarchy.md
@@ -26,33 +26,37 @@
          └────────────────────┼─────────────────────┘
                               ▼
             ┌─────────────────────────────────────┐
-            │      Level 2: Module Design Agents  │
+            │   Level 2: Design & Review Agents   │
             ├─────────────────────────────────────┤
             │  • Architecture Design Agent        │
             │  • Integration Design Agent         │
             │  • Security Design Agent            │
+            │  • Code Review Orchestrator         │
             └──────────────────┬──────────────────┘
                                │
                                ▼
             ┌─────────────────────────────────────┐
-            │   Level 3: Component Specialists     │
+            │   Level 3: Specialists (24 agents)   │
             ├──────────────────────────────────────┤
-            │  • Senior Implementation Specialist  │
-            │  • Test Design Specialist            │
+            │  • Implementation Specialist         │
+            │  • Test Specialist                   │
             │  • Documentation Specialist          │
             │  • Performance Specialist            │
-            │  • Security Implementation Specialist│
+            │  • Blog Writer Specialist            │
+            │  • 13 Code Review Specialists        │
+            │  • 4 Additional Specialists          │
             └──────────────────┬──────────────────┘
                                │
                                ▼
             ┌─────────────────────────────────────┐
-            │   Level 4: Implementation Engineers  │
+            │   Level 4: Engineers (6 agents)      │
             ├──────────────────────────────────────┤
             │  • Senior Implementation Engineer    │
             │  • Implementation Engineer           │
             │  • Test Engineer                     │
-            │  • Documentation Writer              │
+            │  • Documentation Engineer            │
             │  • Performance Engineer              │
+            │  • Log Analyzer                      │
             └──────────────────┬──────────────────┘
                                │
                                ▼
@@ -83,26 +87,29 @@
 - **Phase**: Plan
 - **Language Context**: Coordinates Mojo implementation across sections
 
-### Level 2: Module Design Agents
+### Level 2: Module Design & Review Agents
 
-- **Agents**: 3 core types (Architecture, Integration, Security)
-- **Scope**: Modules within sections
-- **Decisions**: Module structure, interfaces, security
-- **Phase**: Plan
-- **Language Context**: Designs Mojo module structures, leverages Mojo features (SIMD, traits, structs)
+- **Agents**: 4 total (3 design agents + 1 review orchestrator)
+  - Design Agents: Architecture, Integration, Security
+  - Code Review Orchestrator: Routes PR changes to 13 specialist reviewers
+- **Scope**: Modules within sections and overall PR review coordination
+- **Decisions**: Module structure, interfaces, security, and code review routing
+- **Phase**: Plan (design) and Cleanup (code review)
+- **Language Context**: Designs Mojo module structures, leverages Mojo features (SIMD, traits, structs); coordinates review across all code dimensions
 
-### Level 3: Component Specialists
+### Level 3: Specialists & Review Specialists
 
-- **Agents**: 5 types (Implementation, Test, Docs, Performance, Security)
-- **Scope**: Components within modules
-- **Decisions**: Component implementation approach
-- **Phase**: Plan, Test, Implementation, Package
-- **Language Context**: Chooses Mojo patterns (fn vs def, struct vs class, SIMD usage)
+- **Agents**: 24 total (11 implementation/execution specialists + 13 code review specialists)
+- **Scope**: Components within modules and PR review dimensions
+- **Decisions**: Component implementation approach and code review assessment
+- **Phase**: Plan, Test, Implementation, Package, Cleanup
+- **Language Context**: Chooses Mojo patterns (fn vs def, struct vs class, SIMD usage); reviews for language correctness, safety, and idioms
 - **Package Phase**: Design packaging strategy, specify .mojopkg requirements, plan CI/CD workflows
+- **Review Specialties**: Implementation, documentation, test, security, safety, Mojo language, performance, algorithm, architecture, data engineering, paper, research, dependency review
 
 ### Level 4: Implementation Engineers
 
-- **Agents**: 5 types (Senior, Standard, Test, Docs, Performance)
+- **Agents**: 6 (Senior Implementation, Implementation, Test, Documentation, Performance, Log Analyzer)
 - **Scope**: Functions and classes
 - **Decisions**: Implementation details
 - **Phase**: Test, Implementation, Package
@@ -193,19 +200,23 @@ Project Health (Level 1)
 Strategic Alignment (Level 0)
 ```text
 
-## Agent Count Estimates
+## Agent Count
 
-| Level | Types | Per Paper | Total (6 sections) |
-|-------|-------|-----------|-------------------|
-| 0     | 1     | 1         | 1                 |
-| 1     | 6     | 6         | 6                 |
-| 2     | 3     | 18        | 18                |
-| 3     | 5     | 30        | 30                |
-| 4     | 5     | 50        | 50                |
-| 5     | 3     | 30        | 30                |
-| **Total** | **23 types** | **135** | **135** |
+| Level | Name | Current Count |
+|-------|------|---|
+| 0     | Meta-Orchestrator | 1 |
+| 1     | Section Orchestrators | 6 |
+| 2     | Module Design & Review Orchestrators | 4 |
+| 3     | Specialists (Implementation + Code Review) | 24 |
+| 4     | Implementation Engineers | 6 |
+| 5     | Junior Engineers | 3 |
+| **Total** | **All Agents** | **44** |
 
-*Note: These are estimates. Actual count depends on project complexity.*
+**Level 3 Breakdown:**
+- Implementation/Execution Specialists: 11 (implementation, test, documentation, performance, security, blog writer, numerical stability, test flakiness, PR cleanup, mojo syntax validator, CI failure analyzer)
+- Code Review Specialists: 13 (implementation, documentation, test, security, safety, mojo language, performance, algorithm, architecture, data engineering, paper, research, dependency)
+
+*Historical Note: Initial planning estimated 23 agent types. Actual implementation has expanded to 44 specialized agents to handle emerging needs (blog writing, CI analysis, numerical stability, test flakiness, PR cleanup, mojo validation).*
 
 ## Quick Reference
 


### PR DESCRIPTION
## Summary
- Updated agent count from 23 to 44 across all documentation
- Added new Level 3 specialists to documentation
- Added Level 4 log-analyzer agent
- Updated hierarchy diagram with accurate breakdown
- Fixed agent counts in README, hierarchy.md, and catalog

## Test plan
- [ ] Verify documentation accuracy against .claude/agents/

🤖 Generated with [Claude Code](https://claude.com/claude-code)