### PR TITLE
fix(lenet): Fix compilation errors and add LeNet-5 tests to CI

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -60,6 +60,12 @@ jobs:
           - name: "Debug"
             path: "tests/debug"
             pattern: "test_*.mojo"
+          - name: "LeNet-5 Examples"
+            path: "examples/lenet-emnist"
+            # Only run tests that don't require EMNIST dataset (test_lenet5.mojo, test_model.mojo)
+            # Other tests (test_gradients, test_loss_decrease, test_predictions, etc.) require:
+            #   datasets/emnist/ which must be downloaded separately
+            pattern: "test_lenet5.mojo test_model.mojo"
 
     name: "${{ matrix.test-group.name }}"
 

--- a/examples/lenet-emnist/run_infer.mojo
+++ b/examples/lenet-emnist/run_infer.mojo
@@ -51,7 +51,7 @@ fn get_class_label(class_idx: Int) -> String:
             return "?"
 
 
-struct InferConfig:
+struct InferConfig(Movable):
     """Inference configuration."""
     var checkpoint_dir: String
     var image_path: String
@@ -65,6 +65,13 @@ struct InferConfig:
         self.run_test_set = False
         self.data_dir = "datasets/emnist"
         self.top_k = 5
+
+    fn __moveinit__(out self, owned other: Self):
+        self.checkpoint_dir = other.checkpoint_dir^
+        self.image_path = other.image_path^
+        self.run_test_set = other.run_test_set
+        self.data_dir = other.data_dir^
+        self.top_k = other.top_k
 
 
 fn parse_args() raises -> InferConfig:
@@ -92,7 +99,7 @@ fn parse_args() raises -> InferConfig:
         else:
             i += 1
 
-    return config
+    return config^
 
 
 fn get_top_k_predictions(logits: ExTensor, k: Int) raises -> List[Tuple[Int, Float32]]:

--- a/examples/lenet-emnist/train.mojo
+++ b/examples/lenet-emnist/train.mojo
@@ -180,11 +180,11 @@ fn compute_gradients(
         conv1_grads.grad_bias^,
         conv2_grads.grad_kernel^,
         conv2_grads.grad_bias^,
-        fc1_grads.grad_weights^,
+        fc1_grads.grad_kernel^,
         fc1_grads.grad_bias^,
-        fc2_grads.grad_weights^,
+        fc2_grads.grad_kernel^,
         fc2_grads.grad_bias^,
-        fc3_grads.grad_weights^,
+        fc3_grads.grad_kernel^,
         fc3_grads.grad_bias^
     )
 


### PR DESCRIPTION
## Summary

- Fix compilation errors in LeNet-5 example files that prevented all files from compiling
- Add LeNet-5 tests to CI/CD comprehensive tests workflow

## Changes

### Bug Fixes

**weights.mojo** - Fix UnsafePointer write bug
- Changed `hex_to_bytes()` function to `hex_to_bytes_into_tensor()` that accepts `mut tensor: ExTensor`
- Writes directly via `tensor._data.bitcast[UInt8]()[offset]` to avoid UnsafePointer mutability issues

**train.mojo** - Fix LinearBackwardResult field name
- Changed `grad_weights` to `grad_kernel` (correct field name for LinearBackwardResult struct)

**run_infer.mojo** - Fix struct ownership for return
- Added `Movable` trait and `__moveinit__` to `InferConfig` struct
- Use `return config^` to properly transfer ownership

### CI/CD

**comprehensive-tests.yml**
- Added "LeNet-5 Examples" test group to run LeNet-5 tests in CI
- Only includes dataset-independent tests (`test_lenet5.mojo`, `test_model.mojo`)
- Other tests require EMNIST dataset download (noted in comments)

## Test Plan

- [x] All 11 LeNet-5 .mojo files compile successfully
- [x] `test_lenet5.mojo` passes (10/10 tests)
- [x] `test_model.mojo` passes
- [x] CI workflow includes new test group

🤖 Generated with [Claude Code](https://claude.com/claude-code)