### PR TITLE
[Refactor] Migrate CIFAR-10 examples to use shared data loaders

### DIFF
--- a/examples/alexnet-cifar10/inference.mojo
+++ b/examples/alexnet-cifar10/inference.mojo
@@ -16,7 +16,7 @@ References:
 """
 
 from model import AlexNet
-from data_loader import load_cifar10_test
+from shared.data.datasets import load_cifar10_test
 from shared.core import ExTensor
 from sys import argv
 

--- a/examples/alexnet-cifar10/train.mojo
+++ b/examples/alexnet-cifar10/train.mojo
@@ -17,7 +17,7 @@ References:
 """
 
 from model import AlexNet
-from data_loader import load_cifar10_train, load_cifar10_test
+from shared.data.datasets import load_cifar10_train, load_cifar10_test
 from shared.core import ExTensor, zeros
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import maxpool2d, maxpool2d_backward

--- a/examples/densenet121-cifar10/inference.mojo
+++ b/examples/densenet121-cifar10/inference.mojo
@@ -2,8 +2,8 @@
 
 from shared.core import ExTensor, zeros
 from shared.data import extract_batch_pair, compute_num_batches
+from shared.data.datasets import load_cifar10_test
 from model import DenseNet121
-from data_loader import load_cifar10_test
 
 alias CLASS_NAMES = ["airplane", "automobile", "bird", "cat", "deer", "dog", "frog", "horse", "ship", "truck"]
 

--- a/examples/densenet121-cifar10/train.mojo
+++ b/examples/densenet121-cifar10/train.mojo
@@ -13,8 +13,8 @@ Full implementation would require ~3000 lines. Consider automatic differentiatio
 
 from shared.core import ExTensor, zeros, cross_entropy
 from shared.data import extract_batch_pair, compute_num_batches
+from shared.data.datasets import load_cifar10_train
 from model import DenseNet121
-from data_loader import load_cifar10_train
 
 fn main() raises:
     print("=" * 60)

--- a/examples/googlenet-cifar10/inference.mojo
+++ b/examples/googlenet-cifar10/inference.mojo
@@ -18,8 +18,8 @@ Features:
 
 from shared.core import ExTensor, zeros
 from shared.data import extract_batch_pair, compute_num_batches
+from shared.data.datasets import load_cifar10_test
 from model import GoogLeNet
-from data_loader import load_cifar10_test
 
 
 # CIFAR-10 class names

--- a/examples/googlenet-cifar10/train.mojo
+++ b/examples/googlenet-cifar10/train.mojo
@@ -58,8 +58,8 @@ from shared.data import (
     extract_batch_pair,
     compute_num_batches,
 )
+from shared.data.datasets import load_cifar10_train
 from model import GoogLeNet, InceptionModule
-from data_loader import load_cifar10_train
 
 
 fn compute_learning_rate(initial_lr: Float32, epoch: Int) -> Float32:

--- a/examples/mobilenetv1-cifar10/inference.mojo
+++ b/examples/mobilenetv1-cifar10/inference.mojo
@@ -14,8 +14,8 @@ Features:
 
 from shared.core import ExTensor, zeros
 from shared.data import extract_batch_pair, compute_num_batches
+from shared.data.datasets import load_cifar10_test
 from model import MobileNetV1
-from data_loader import load_cifar10_test
 
 
 # CIFAR-10 class names

--- a/examples/mobilenetv1-cifar10/train.mojo
+++ b/examples/mobilenetv1-cifar10/train.mojo
@@ -44,8 +44,8 @@ from shared.core import (
     cross_entropy_backward,
 )
 from shared.data import extract_batch_pair, compute_num_batches
+from shared.data.datasets import load_cifar10_train
 from model import MobileNetV1
-from data_loader import load_cifar10_train
 
 
 fn compute_learning_rate(initial_lr: Float32, epoch: Int) -> Float32:

--- a/examples/resnet18-cifar10/inference.mojo
+++ b/examples/resnet18-cifar10/inference.mojo
@@ -18,8 +18,8 @@ Features:
 
 from shared.core import ExTensor, zeros
 from shared.data import extract_batch_pair, compute_num_batches
+from shared.data.datasets import load_cifar10_test
 from model import ResNet18
-from data_loader import load_cifar10_test
 
 
 # CIFAR-10 class names

--- a/examples/resnet18-cifar10/train.mojo
+++ b/examples/resnet18-cifar10/train.mojo
@@ -29,9 +29,9 @@ from shared.core.activation import relu, relu_backward
 from shared.core.normalization import batch_norm2d, batch_norm2d_backward
 from shared.core.arithmetic import add, add_backward
 from shared.data import extract_batch_pair, compute_num_batches
+from shared.data.datasets import load_cifar10_train, load_cifar10_test
 from shared.training.optimizers import sgd_momentum_update_inplace
 from model import ResNet18
-from data_loader import load_cifar10_train, load_cifar10_test
 
 
 fn compute_accuracy(model: mut ResNet18, images: ExTensor, labels: ExTensor) raises -> Float32:

--- a/examples/vgg16-cifar10/inference.mojo
+++ b/examples/vgg16-cifar10/inference.mojo
@@ -7,7 +7,7 @@ Usage:
 """
 
 from shared.core import ExTensor, zeros
-from data_loader import load_cifar10_batch
+from shared.data.formats import load_cifar10_batch
 from model import VGG16
 
 

--- a/examples/vgg16-cifar10/train.mojo
+++ b/examples/vgg16-cifar10/train.mojo
@@ -17,7 +17,7 @@ References:
 """
 
 from model import VGG16
-from data_loader import load_cifar10_train, load_cifar10_test
+from shared.data.datasets import load_cifar10_train, load_cifar10_test
 from shared.core import ExTensor, zeros
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import maxpool2d, maxpool2d_backward

--- a/shared/data/datasets/__init__.mojo
+++ b/shared/data/datasets/__init__.mojo
@@ -32,3 +32,4 @@ from .._datasets_core import (
 
 # CIFAR-10 dataset
 from .cifar10 import CIFAR10Dataset, CIFAR10_CLASSES
+from .cifar10_loaders import load_cifar10_train, load_cifar10_test


### PR DESCRIPTION
## Summary

- Updated all 6 CIFAR-10 examples (AlexNet, ResNet-18, DenseNet-121, GoogLeNet, MobileNetV1, VGG-16)
- Changed imports from local `data_loader` to `shared.data.datasets`
- Updated `datasets/__init__.mojo` to export CIFAR-10 loaders

Closes #2203

## Test plan

- [x] Examples updated to use shared imports
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)