### PR TITLE
fix(autograd): Remove invalid __all__ Python syntax

### DIFF
--- a/shared/autograd/__init__.mojo
+++ b/shared/autograd/__init__.mojo
@@ -177,25 +177,5 @@ from ..core.dropout import (
     dropout2d_backward,
 )
 
-__all__ = [
-    # Foundation components
-    "Variable",
-    "GradientTape",
-    "TapeNode",
-    "SGD",
-    # Functional helpers
-    "LossAndGrad",
-    "mse_loss_and_grad",
-    "bce_loss_and_grad",
-    "ce_loss_and_grad",
-    "compute_gradient",
-    "multiply_scalar",
-    "add_scalar",
-    "subtract_scalar",
-    "divide_scalar",
-    "apply_gradient",
-    "apply_gradients",
-    # Backward passes from shared.core
-    "dropout_backward",
-    "dropout2d_backward",
-]
+# Note: In Mojo, all imported symbols are automatically available
+# to package consumers. No __all__ equivalent is needed.


### PR DESCRIPTION
## Summary

Removes invalid Python-style `__all__` export list from `shared/autograd/__init__.mojo`.

Mojo doesn't support `__all__` like Python. All imported symbols are automatically available to package consumers.

This fixes the compilation error on main:
- `error: expressions are not supported at the file scope`

## Test plan

- [x] Tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)