### PR TITLE
feat(core): Implement layer_norm_backward for backpropagation

### DIFF
--- a/shared/core/__init__.mojo
+++ b/shared/core/__init__.mojo
@@ -202,6 +202,7 @@ from .normalization import (
     batch_norm2d,
     batch_norm2d_backward,
     layer_norm,
+    layer_norm_backward,
 )
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Adds `layer_norm_backward` function to `shared/core/normalization.mojo`
- Supports both 2D (batch, features) and 4D (batch, channels, height, width) inputs
- Computes gradients with respect to input, gamma, and beta parameters
- Implements mathematical formulation from Ba et al. (2016) Layer Normalization paper
- Supports float32 and float64 dtypes with epsilon for numerical stability

## Changes

- `shared/core/normalization.mojo`: Added ~450 lines implementing `layer_norm_backward`
- `shared/core/__init__.mojo`: Exported `layer_norm_backward`
- `tests/shared/core/test_normalization.mojo`: Added 4 tests for shape validation and edge cases

## Test plan

- [x] Tests pass locally: `pixi run mojo run -I . tests/shared/core/test_normalization.mojo`
- [x] Shape validation for 2D and 4D inputs
- [x] Gradient accumulation for grad_beta verified
- [x] Zero variance edge case handled correctly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)