### PR TITLE
fix(pooling): Add missing transfer operators in backward passes

### DIFF
--- a/shared/core/pooling.mojo
+++ b/shared/core/pooling.mojo
@@ -463,7 +463,7 @@ fn avgpool2d_backward(
                                 var grad_in_idx = b * (channels * in_height * in_width) + c * (in_height * in_width) + in_h * in_width + in_w
                                 grad_input._data.bitcast[Float32]()[grad_in_idx] += grad_per_position
 
-    return grad_input
+    return grad_input^
 
 
 fn global_avgpool2d_backward(
@@ -528,4 +528,4 @@ fn global_avgpool2d_backward(
                     var grad_in_idx = b * (channels * height * width) + c * (height * width) + h * width + w
                     grad_input._data.bitcast[Float32]()[grad_in_idx] = grad_per_position
 
-    return grad_input
+    return grad_input^


### PR DESCRIPTION
## Summary
- Add `^` transfer operators to `avgpool2d_backward` and `global_avgpool2d_backward` return statements
- Fixes potential ownership issues when these backward functions are called

## Changes
- `shared/core/pooling.mojo:466`: `return grad_input` → `return grad_input^`
- `shared/core/pooling.mojo:531`: `return grad_input` → `return grad_input^`

## Context
Found during subagent code review of consolidated backward pass implementations. The missing transfer operators could cause ownership issues in calling code.

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)