### PR TITLE
fix(examples): Replace cross_entropy_loss with cross_entropy in training scripts

### DIFF
--- a/examples/vgg16-cifar10/train.mojo
+++ b/examples/vgg16-cifar10/train.mojo
@@ -24,7 +24,7 @@ from shared.core.pooling import maxpool2d, maxpool2d_backward
 from shared.core.linear import linear, linear_backward
 from shared.core.activation import relu, relu_backward
 from shared.core.dropout import dropout, dropout_backward
-from shared.core.loss import cross_entropy_loss, cross_entropy_loss_backward
+from shared.core.loss import cross_entropy, cross_entropy_backward
 from shared.training.schedulers import step_lr
 from shared.data import extract_batch_pair, compute_num_batches, get_batch_indices
 from sys import argv
@@ -154,12 +154,18 @@ fn compute_gradients(
     var logits = linear(drop2_out, model.fc3_weights, model.fc3_bias)
 
     # Compute loss
-    var loss = cross_entropy_loss(logits, labels)
+    var loss_tensor = cross_entropy(logits, labels)
+    var loss = loss_tensor._data.bitcast[Float32]()[0]
 
     # ========== Backward Pass (through all 16 layers) ==========
 
     # Start with gradient from loss
-    var grad_logits = cross_entropy_loss_backward(logits, labels)
+    # For cross-entropy, the initial gradient is 1.0
+    var grad_output_shape = List[Int]()
+    grad_output_shape.append(1)
+    var grad_output = zeros(grad_output_shape, logits.dtype())
+    grad_output._data.bitcast[Float32]()[0] = Float32(1.0)
+    var grad_logits = cross_entropy_backward(grad_output, logits, labels)
 
     # FC3 backward
     var fc3_grads = linear_backward(grad_logits, drop2_out, model.fc3_weights)


### PR DESCRIPTION
## Summary
- Fix API mismatch where AlexNet and VGG16 training scripts were importing `cross_entropy_loss` and `cross_entropy_loss_backward` which don't exist
- The correct functions in `shared/core/loss.mojo` are `cross_entropy` and `cross_entropy_backward`

## Changes
- `examples/alexnet-cifar10/train.mojo`: Update imports and function calls
- `examples/vgg16-cifar10/train.mojo`: Update imports and function calls
- Add `grad_output` tensor for backward pass (required parameter)
- Extract scalar loss from loss tensor for compatibility

## Priority
**CRITICAL** - This was preventing AlexNet and VGG16 examples from compiling.

Closes #2242

🤖 Generated with [Claude Code](https://claude.com/claude-code)