### PR TITLE
refactor(examples): Use List constructor shorthand instead of append chains

### DIFF
--- a/examples/alexnet-cifar10/model.mojo
+++ b/examples/alexnet-cifar10/model.mojo
@@ -90,49 +90,24 @@ struct AlexNet:
         self.dropout_rate = dropout_rate
 
         # Conv1: 3 input channels (RGB), 96 output channels, 11x11 kernel
-        var conv1_shape = List[Int]()
-        conv1_shape.append(96)  # out_channels
-        conv1_shape.append(3)   # in_channels (RGB)
-        conv1_shape.append(11)  # kernel_height
-        conv1_shape.append(11)  # kernel_width
-        self.conv1_kernel = he_uniform(conv1_shape, DType.float32)
-        self.conv1_bias = zeros(List[Int]().append(96), DType.float32)
+        self.conv1_kernel = he_uniform(List[Int](96, 3, 11, 11), DType.float32)
+        self.conv1_bias = zeros(List[Int](96), DType.float32)
 
         # Conv2: 96 input channels, 256 output channels, 5x5 kernel
-        var conv2_shape = List[Int]()
-        conv2_shape.append(256)  # out_channels
-        conv2_shape.append(96)   # in_channels
-        conv2_shape.append(5)    # kernel_height
-        conv2_shape.append(5)    # kernel_width
-        self.conv2_kernel = he_uniform(conv2_shape, DType.float32)
-        self.conv2_bias = zeros(List[Int]().append(256), DType.float32)
+        self.conv2_kernel = he_uniform(List[Int](256, 96, 5, 5), DType.float32)
+        self.conv2_bias = zeros(List[Int](256), DType.float32)
 
         # Conv3: 256 input channels, 384 output channels, 3x3 kernel
-        var conv3_shape = List[Int]()
-        conv3_shape.append(384)  # out_channels
-        conv3_shape.append(256)  # in_channels
-        conv3_shape.append(3)    # kernel_height
-        conv3_shape.append(3)    # kernel_width
-        self.conv3_kernel = he_uniform(conv3_shape, DType.float32)
-        self.conv3_bias = zeros(List[Int]().append(384), DType.float32)
+        self.conv3_kernel = he_uniform(List[Int](384, 256, 3, 3), DType.float32)
+        self.conv3_bias = zeros(List[Int](384), DType.float32)
 
         # Conv4: 384 input channels, 384 output channels, 3x3 kernel
-        var conv4_shape = List[Int]()
-        conv4_shape.append(384)  # out_channels
-        conv4_shape.append(384)  # in_channels
-        conv4_shape.append(3)    # kernel_height
-        conv4_shape.append(3)    # kernel_width
-        self.conv4_kernel = he_uniform(conv4_shape, DType.float32)
-        self.conv4_bias = zeros(List[Int]().append(384), DType.float32)
+        self.conv4_kernel = he_uniform(List[Int](384, 384, 3, 3), DType.float32)
+        self.conv4_bias = zeros(List[Int](384), DType.float32)
 
         # Conv5: 384 input channels, 256 output channels, 3x3 kernel
-        var conv5_shape = List[Int]()
-        conv5_shape.append(256)  # out_channels
-        conv5_shape.append(384)  # in_channels
-        conv5_shape.append(3)    # kernel_height
-        conv5_shape.append(3)    # kernel_width
-        self.conv5_kernel = he_uniform(conv5_shape, DType.float32)
-        self.conv5_bias = zeros(List[Int]().append(256), DType.float32)
+        self.conv5_kernel = he_uniform(List[Int](256, 384, 3, 3), DType.float32)
+        self.conv5_bias = zeros(List[Int](256), DType.float32)
 
         # After conv1 (32x32 -> 5x5 with stride=4, padding=2) -> pool1 (5x5 -> 2x2 with stride=2)
         # After conv2 (2x2 -> 2x2 with padding=2) -> pool2 (2x2 -> 1x1 with stride=2)
@@ -140,25 +115,16 @@ struct AlexNet:
         # Flattened size: 256 * 1 * 1 = 256
 
         # FC1: 256 -> 4096
-        var fc1_shape = List[Int]()
-        fc1_shape.append(4096)  # out_features
-        fc1_shape.append(256)   # in_features
-        self.fc1_weights = xavier_uniform(fc1_shape, DType.float32)
-        self.fc1_bias = zeros(List[Int]().append(4096), DType.float32)
+        self.fc1_weights = xavier_uniform(List[Int](4096, 256), DType.float32)
+        self.fc1_bias = zeros(List[Int](4096), DType.float32)
 
         # FC2: 4096 -> 4096
-        var fc2_shape = List[Int]()
-        fc2_shape.append(4096)  # out_features
-        fc2_shape.append(4096)  # in_features
-        self.fc2_weights = xavier_uniform(fc2_shape, DType.float32)
-        self.fc2_bias = zeros(List[Int]().append(4096), DType.float32)
+        self.fc2_weights = xavier_uniform(List[Int](4096, 4096), DType.float32)
+        self.fc2_bias = zeros(List[Int](4096), DType.float32)
 
         # FC3: 4096 -> num_classes
-        var fc3_shape = List[Int]()
-        fc3_shape.append(num_classes)  # out_features
-        fc3_shape.append(4096)         # in_features
-        self.fc3_weights = xavier_uniform(fc3_shape, DType.float32)
-        self.fc3_bias = zeros(List[Int]().append(num_classes), DType.float32)
+        self.fc3_weights = xavier_uniform(List[Int](num_classes, 4096), DType.float32)
+        self.fc3_bias = zeros(List[Int](num_classes), DType.float32)
 
     fn forward(mut self, input: ExTensor, training: Bool = True) raises -> ExTensor:
         """Forward pass through AlexNet.

--- a/examples/vgg16-cifar10/model.mojo
+++ b/examples/vgg16-cifar10/model.mojo
@@ -159,150 +159,55 @@ struct VGG16:
         self.dropout_rate = dropout_rate
 
         # Block 1: Input channels=3 (RGB), output channels=64
-        # Conv1_1: (64, 3, 3, 3)
-        var conv1_1_shape = List[Int]()
-        conv1_1_shape.append(64)   # out_channels
-        conv1_1_shape.append(3)    # in_channels (RGB)
-        conv1_1_shape.append(3)    # kernel_height
-        conv1_1_shape.append(3)    # kernel_width
-        self.conv1_1_kernel = he_uniform(conv1_1_shape, DType.float32)
-        self.conv1_1_bias = zeros(List[Int]().append(64), DType.float32)
-
-        # Conv1_2: (64, 64, 3, 3)
-        var conv1_2_shape = List[Int]()
-        conv1_2_shape.append(64)   # out_channels
-        conv1_2_shape.append(64)   # in_channels
-        conv1_2_shape.append(3)    # kernel_height
-        conv1_2_shape.append(3)    # kernel_width
-        self.conv1_2_kernel = he_uniform(conv1_2_shape, DType.float32)
-        self.conv1_2_bias = zeros(List[Int]().append(64), DType.float32)
+        self.conv1_1_kernel = he_uniform(List[Int](64, 3, 3, 3), DType.float32)
+        self.conv1_1_bias = zeros(List[Int](64), DType.float32)
+        self.conv1_2_kernel = he_uniform(List[Int](64, 64, 3, 3), DType.float32)
+        self.conv1_2_bias = zeros(List[Int](64), DType.float32)
 
         # Block 2: Input channels=64, output channels=128
-        # Conv2_1: (128, 64, 3, 3)
-        var conv2_1_shape = List[Int]()
-        conv2_1_shape.append(128)
-        conv2_1_shape.append(64)
-        conv2_1_shape.append(3)
-        conv2_1_shape.append(3)
-        self.conv2_1_kernel = he_uniform(conv2_1_shape, DType.float32)
-        self.conv2_1_bias = zeros(List[Int]().append(128), DType.float32)
-
-        # Conv2_2: (128, 128, 3, 3)
-        var conv2_2_shape = List[Int]()
-        conv2_2_shape.append(128)
-        conv2_2_shape.append(128)
-        conv2_2_shape.append(3)
-        conv2_2_shape.append(3)
-        self.conv2_2_kernel = he_uniform(conv2_2_shape, DType.float32)
-        self.conv2_2_bias = zeros(List[Int]().append(128), DType.float32)
+        self.conv2_1_kernel = he_uniform(List[Int](128, 64, 3, 3), DType.float32)
+        self.conv2_1_bias = zeros(List[Int](128), DType.float32)
+        self.conv2_2_kernel = he_uniform(List[Int](128, 128, 3, 3), DType.float32)
+        self.conv2_2_bias = zeros(List[Int](128), DType.float32)
 
         # Block 3: Input channels=128, output channels=256
-        # Conv3_1: (256, 128, 3, 3)
-        var conv3_1_shape = List[Int]()
-        conv3_1_shape.append(256)
-        conv3_1_shape.append(128)
-        conv3_1_shape.append(3)
-        conv3_1_shape.append(3)
-        self.conv3_1_kernel = he_uniform(conv3_1_shape, DType.float32)
-        self.conv3_1_bias = zeros(List[Int]().append(256), DType.float32)
-
-        # Conv3_2: (256, 256, 3, 3)
-        var conv3_2_shape = List[Int]()
-        conv3_2_shape.append(256)
-        conv3_2_shape.append(256)
-        conv3_2_shape.append(3)
-        conv3_2_shape.append(3)
-        self.conv3_2_kernel = he_uniform(conv3_2_shape, DType.float32)
-        self.conv3_2_bias = zeros(List[Int]().append(256), DType.float32)
-
-        # Conv3_3: (256, 256, 3, 3)
-        var conv3_3_shape = List[Int]()
-        conv3_3_shape.append(256)
-        conv3_3_shape.append(256)
-        conv3_3_shape.append(3)
-        conv3_3_shape.append(3)
-        self.conv3_3_kernel = he_uniform(conv3_3_shape, DType.float32)
-        self.conv3_3_bias = zeros(List[Int]().append(256), DType.float32)
+        self.conv3_1_kernel = he_uniform(List[Int](256, 128, 3, 3), DType.float32)
+        self.conv3_1_bias = zeros(List[Int](256), DType.float32)
+        self.conv3_2_kernel = he_uniform(List[Int](256, 256, 3, 3), DType.float32)
+        self.conv3_2_bias = zeros(List[Int](256), DType.float32)
+        self.conv3_3_kernel = he_uniform(List[Int](256, 256, 3, 3), DType.float32)
+        self.conv3_3_bias = zeros(List[Int](256), DType.float32)
 
         # Block 4: Input channels=256, output channels=512
-        # Conv4_1: (512, 256, 3, 3)
-        var conv4_1_shape = List[Int]()
-        conv4_1_shape.append(512)
-        conv4_1_shape.append(256)
-        conv4_1_shape.append(3)
-        conv4_1_shape.append(3)
-        self.conv4_1_kernel = he_uniform(conv4_1_shape, DType.float32)
-        self.conv4_1_bias = zeros(List[Int]().append(512), DType.float32)
-
-        # Conv4_2: (512, 512, 3, 3)
-        var conv4_2_shape = List[Int]()
-        conv4_2_shape.append(512)
-        conv4_2_shape.append(512)
-        conv4_2_shape.append(3)
-        conv4_2_shape.append(3)
-        self.conv4_2_kernel = he_uniform(conv4_2_shape, DType.float32)
-        self.conv4_2_bias = zeros(List[Int]().append(512), DType.float32)
-
-        # Conv4_3: (512, 512, 3, 3)
-        var conv4_3_shape = List[Int]()
-        conv4_3_shape.append(512)
-        conv4_3_shape.append(512)
-        conv4_3_shape.append(3)
-        conv4_3_shape.append(3)
-        self.conv4_3_kernel = he_uniform(conv4_3_shape, DType.float32)
-        self.conv4_3_bias = zeros(List[Int]().append(512), DType.float32)
+        self.conv4_1_kernel = he_uniform(List[Int](512, 256, 3, 3), DType.float32)
+        self.conv4_1_bias = zeros(List[Int](512), DType.float32)
+        self.conv4_2_kernel = he_uniform(List[Int](512, 512, 3, 3), DType.float32)
+        self.conv4_2_bias = zeros(List[Int](512), DType.float32)
+        self.conv4_3_kernel = he_uniform(List[Int](512, 512, 3, 3), DType.float32)
+        self.conv4_3_bias = zeros(List[Int](512), DType.float32)
 
         # Block 5: Input channels=512, output channels=512
-        # Conv5_1: (512, 512, 3, 3)
-        var conv5_1_shape = List[Int]()
-        conv5_1_shape.append(512)
-        conv5_1_shape.append(512)
-        conv5_1_shape.append(3)
-        conv5_1_shape.append(3)
-        self.conv5_1_kernel = he_uniform(conv5_1_shape, DType.float32)
-        self.conv5_1_bias = zeros(List[Int]().append(512), DType.float32)
-
-        # Conv5_2: (512, 512, 3, 3)
-        var conv5_2_shape = List[Int]()
-        conv5_2_shape.append(512)
-        conv5_2_shape.append(512)
-        conv5_2_shape.append(3)
-        conv5_2_shape.append(3)
-        self.conv5_2_kernel = he_uniform(conv5_2_shape, DType.float32)
-        self.conv5_2_bias = zeros(List[Int]().append(512), DType.float32)
-
-        # Conv5_3: (512, 512, 3, 3)
-        var conv5_3_shape = List[Int]()
-        conv5_3_shape.append(512)
-        conv5_3_shape.append(512)
-        conv5_3_shape.append(3)
-        conv5_3_shape.append(3)
-        self.conv5_3_kernel = he_uniform(conv5_3_shape, DType.float32)
-        self.conv5_3_bias = zeros(List[Int]().append(512), DType.float32)
+        self.conv5_1_kernel = he_uniform(List[Int](512, 512, 3, 3), DType.float32)
+        self.conv5_1_bias = zeros(List[Int](512), DType.float32)
+        self.conv5_2_kernel = he_uniform(List[Int](512, 512, 3, 3), DType.float32)
+        self.conv5_2_bias = zeros(List[Int](512), DType.float32)
+        self.conv5_3_kernel = he_uniform(List[Int](512, 512, 3, 3), DType.float32)
+        self.conv5_3_bias = zeros(List[Int](512), DType.float32)
 
         # After all conv blocks + pools: 32 -> 16 -> 8 -> 4 -> 2 -> 1
         # Flattened size: 512 * 1 * 1 = 512
 
         # FC1: 512 -> 512
-        var fc1_shape = List[Int]()
-        fc1_shape.append(512)   # out_features
-        fc1_shape.append(512)   # in_features
-        self.fc1_weights = he_uniform(fc1_shape, DType.float32)
-        self.fc1_bias = zeros(List[Int]().append(512), DType.float32)
+        self.fc1_weights = he_uniform(List[Int](512, 512), DType.float32)
+        self.fc1_bias = zeros(List[Int](512), DType.float32)
 
         # FC2: 512 -> 512
-        var fc2_shape = List[Int]()
-        fc2_shape.append(512)   # out_features
-        fc2_shape.append(512)   # in_features
-        self.fc2_weights = he_uniform(fc2_shape, DType.float32)
-        self.fc2_bias = zeros(List[Int]().append(512), DType.float32)
+        self.fc2_weights = he_uniform(List[Int](512, 512), DType.float32)
+        self.fc2_bias = zeros(List[Int](512), DType.float32)
 
         # FC3: 512 -> num_classes
-        var fc3_shape = List[Int]()
-        fc3_shape.append(num_classes)  # out_features
-        fc3_shape.append(512)          # in_features
-        self.fc3_weights = he_uniform(fc3_shape, DType.float32)
-        self.fc3_bias = zeros(List[Int]().append(num_classes), DType.float32)
+        self.fc3_weights = he_uniform(List[Int](num_classes, 512), DType.float32)
+        self.fc3_bias = zeros(List[Int](num_classes), DType.float32)
 
     fn forward(mut self, input: ExTensor, training: Bool = True) raises -> ExTensor:
         """Forward pass through VGG-16.


### PR DESCRIPTION
## Summary
Replace verbose List initialization patterns with concise constructor syntax.

## Before (verbose)
```mojo
var conv1_shape = List[Int]()
conv1_shape.append(96)   # out_channels
conv1_shape.append(3)    # in_channels
conv1_shape.append(11)   # kernel_height
conv1_shape.append(11)   # kernel_width
self.conv1_kernel = he_uniform(conv1_shape, DType.float32)
self.conv1_bias = zeros(List[Int]().append(96), DType.float32)
```

## After (concise)
```mojo
self.conv1_kernel = he_uniform(List[Int](96, 3, 11, 11), DType.float32)
self.conv1_bias = zeros(List[Int](96), DType.float32)
```

## Files Refactored
- `examples/alexnet-cifar10/model.mojo`: 5 conv + 3 FC layers
- `examples/vgg16-cifar10/model.mojo`: 13 conv + 3 FC layers

## Impact
**Removes 129 lines of boilerplate code** while maintaining identical functionality.

Closes #2247

🤖 Generated with [Claude Code](https://claude.com/claude-code)