### PR TITLE
feat(shared): Add training argument parsing and velocity initialization utilities

### DIFF
--- a/shared/training/optimizers/__init__.mojo
+++ b/shared/training/optimizers/__init__.mojo
@@ -15,7 +15,13 @@ All optimizers follow pure functional design - caller manages state.
 # Export optimizer implementations
 
 # SGD optimizer (functional implementation and in-place mutation)
-from .sgd import sgd_step, sgd_step_simple, sgd_momentum_update_inplace
+from .sgd import (
+    sgd_step,
+    sgd_step_simple,
+    sgd_momentum_update_inplace,
+    initialize_velocities,
+    initialize_velocities_from_params,
+)
 
 # Adam optimizer (functional implementation)
 from .adam import adam_step, adam_step_simple

--- a/shared/utils/__init__.mojo
+++ b/shared/utils/__init__.mojo
@@ -135,6 +135,13 @@ from .arg_parser import (
     create_parser,  # Create new parser
 )
 
+# Training argument utilities
+from .training_args import (
+    TrainingArgs,  # Training hyperparameters container
+    parse_training_args,  # Parse common training arguments
+    parse_training_args_with_defaults,  # Parse with custom defaults
+)
+
 # ============================================================================
 # Public API
 # ============================================================================

--- a/shared/utils/training_args.mojo
+++ b/shared/utils/training_args.mojo
@@ -1,0 +1,189 @@
+"""Training argument utilities for common training script configuration.
+
+This module provides a standardized TrainingArgs struct and parse_training_args()
+function for consistent command-line argument handling across training scripts.
+
+Example:
+    from shared.utils.training_args import TrainingArgs, parse_training_args
+
+    fn main() raises:
+        var args = parse_training_args()
+        print("Epochs:", args.epochs)
+        print("Batch size:", args.batch_size)
+        print("Learning rate:", args.learning_rate)
+"""
+
+from sys import argv
+
+
+# ============================================================================
+# Training Arguments Struct
+# ============================================================================
+
+
+@fieldwise_init
+struct TrainingArgs(Copyable, Movable):
+    """Container for common training hyperparameters and paths.
+
+    Attributes:
+        epochs: Number of training epochs.
+        batch_size: Batch size for training.
+        learning_rate: Learning rate for optimizer.
+        momentum: Momentum factor for SGD.
+        data_dir: Path to dataset directory.
+        weights_dir: Path to save/load model weights.
+        verbose: Whether to print verbose output.
+    """
+
+    var epochs: Int
+    var batch_size: Int
+    var learning_rate: Float64
+    var momentum: Float64
+    var data_dir: String
+    var weights_dir: String
+    var verbose: Bool
+
+    fn __init__(out self):
+        """Initialize with default training arguments."""
+        self.epochs = 10
+        self.batch_size = 32
+        self.learning_rate = 0.01
+        self.momentum = 0.9
+        self.data_dir = "datasets"
+        self.weights_dir = "weights"
+        self.verbose = False
+
+
+# ============================================================================
+# Argument Parsing Functions
+# ============================================================================
+
+
+fn parse_training_args() raises -> TrainingArgs:
+    """Parse common training arguments from command line.
+
+    Supported arguments:
+        --epochs <int>: Number of training epochs (default: 10).
+        --batch-size <int>: Batch size (default: 32).
+        --lr <float>: Learning rate (default: 0.01).
+        --momentum <float>: Momentum for SGD (default: 0.9).
+        --data-dir <str>: Dataset directory (default: "datasets").
+        --weights-dir <str>: Weights directory (default: "weights").
+        --verbose: Enable verbose output.
+
+    Returns:
+        TrainingArgs struct with parsed values.
+
+    Example:
+        # Command line: python train.py --epochs 100 --lr 0.001 --verbose
+        var args = parse_training_args()
+        # args.epochs == 100, args.learning_rate == 0.001, args.verbose == True
+    """
+    var result = TrainingArgs()
+
+    var args = argv()
+    var i = 1  # Skip program name
+    while i < len(args):
+        var arg = args[i]
+
+        if arg == "--epochs" and i + 1 < len(args):
+            result.epochs = Int(args[i + 1])
+            i += 2
+        elif arg == "--batch-size" and i + 1 < len(args):
+            result.batch_size = Int(args[i + 1])
+            i += 2
+        elif arg == "--lr" and i + 1 < len(args):
+            result.learning_rate = Float64(args[i + 1])
+            i += 2
+        elif arg == "--momentum" and i + 1 < len(args):
+            result.momentum = Float64(args[i + 1])
+            i += 2
+        elif arg == "--data-dir" and i + 1 < len(args):
+            result.data_dir = args[i + 1]
+            i += 2
+        elif arg == "--weights-dir" and i + 1 < len(args):
+            result.weights_dir = args[i + 1]
+            i += 2
+        elif arg == "--verbose":
+            result.verbose = True
+            i += 1
+        else:
+            # Skip unknown arguments (allows model-specific args)
+            i += 1
+
+    return result^
+
+
+fn parse_training_args_with_defaults(
+    default_epochs: Int = 10,
+    default_batch_size: Int = 32,
+    default_lr: Float64 = 0.01,
+    default_momentum: Float64 = 0.9,
+    default_data_dir: String = "datasets",
+    default_weights_dir: String = "weights",
+) raises -> TrainingArgs:
+    """Parse training arguments with custom defaults.
+
+    Allows each training script to specify model-appropriate defaults
+    while still using shared parsing logic.
+
+    Args:
+        default_epochs: Default number of epochs.
+        default_batch_size: Default batch size.
+        default_lr: Default learning rate.
+        default_momentum: Default momentum.
+        default_data_dir: Default dataset directory.
+        default_weights_dir: Default weights directory.
+
+    Returns:
+        TrainingArgs struct with parsed values.
+
+    Example:
+        # AlexNet with custom defaults
+        var args = parse_training_args_with_defaults(
+            default_epochs=100,
+            default_batch_size=128,
+            default_lr=0.01,
+            default_data_dir="datasets/cifar10",
+            default_weights_dir="alexnet_weights"
+        )
+    """
+    var result = TrainingArgs()
+    result.epochs = default_epochs
+    result.batch_size = default_batch_size
+    result.learning_rate = default_lr
+    result.momentum = default_momentum
+    result.data_dir = default_data_dir
+    result.weights_dir = default_weights_dir
+    result.verbose = False
+
+    var args = argv()
+    var i = 1
+    while i < len(args):
+        var arg = args[i]
+
+        if arg == "--epochs" and i + 1 < len(args):
+            result.epochs = Int(args[i + 1])
+            i += 2
+        elif arg == "--batch-size" and i + 1 < len(args):
+            result.batch_size = Int(args[i + 1])
+            i += 2
+        elif arg == "--lr" and i + 1 < len(args):
+            result.learning_rate = Float64(args[i + 1])
+            i += 2
+        elif arg == "--momentum" and i + 1 < len(args):
+            result.momentum = Float64(args[i + 1])
+            i += 2
+        elif arg == "--data-dir" and i + 1 < len(args):
+            result.data_dir = args[i + 1]
+            i += 2
+        elif arg == "--weights-dir" and i + 1 < len(args):
+            result.weights_dir = args[i + 1]
+            i += 2
+        elif arg == "--verbose":
+            result.verbose = True
+            i += 1
+        else:
+            i += 1
+
+    return result^


### PR DESCRIPTION
## Summary
Adds two shared utilities for training scripts to reduce code duplication:

1. **TrainingArgs** (Issue #2244) - Standardized training argument parsing
2. **Velocity Initialization** (Issue #2246) - SGD momentum buffer creation

## Changes

### shared/utils/training_args.mojo (new file)
- `TrainingArgs` struct with common hyperparameters:
  - `epochs`, `batch_size`, `learning_rate`, `momentum`
  - `data_dir`, `weights_dir`, `verbose`
- `parse_training_args()` - Parse standard training arguments
- `parse_training_args_with_defaults()` - Parse with model-specific defaults

### shared/training/optimizers/sgd.mojo
- `initialize_velocities(param_shapes, dtype)` - Create zero-initialized velocity tensors from shapes
- `initialize_velocities_from_params(params)` - Convenience function using parameter tensors

### Export updates
- `shared/utils/__init__.mojo` - Export TrainingArgs and parsing functions
- `shared/training/optimizers/__init__.mojo` - Export velocity initialization functions

## Usage Examples

```mojo
# Training arguments (Issue #2244)
from shared.utils import parse_training_args_with_defaults

var args = parse_training_args_with_defaults(
    default_epochs=100,
    default_batch_size=128,
    default_data_dir="datasets/cifar10"
)
print("Epochs:", args.epochs)
print("Learning rate:", args.learning_rate)
```

```mojo
# Velocity initialization (Issue #2246)
from shared.training.optimizers import initialize_velocities

var shapes = List[List[Int]]()
shapes.append(model.conv1_kernel.shape())
shapes.append(model.conv1_bias.shape())

var velocities = initialize_velocities(shapes)
```

## Test plan
- [x] `shared/utils/training_args.mojo` compiles
- [x] `shared/training/optimizers/sgd.mojo` compiles
- [x] Pre-commit hooks pass

Closes #2244
Closes #2246

🤖 Generated with [Claude Code](https://claude.com/claude-code)