### PR TITLE
feat(shared/core/activation): Add hard_sigmoid, hard_swish, hard_tanh

### DIFF
--- a/shared/core/__init__.mojo
+++ b/shared/core/__init__.mojo
@@ -153,6 +153,9 @@ from .activation import (
     swish,
     mish,
     elu,
+    hard_sigmoid,
+    hard_swish,
+    hard_tanh,
     relu_backward,
     leaky_relu_backward,
     prelu_backward,
@@ -163,6 +166,9 @@ from .activation import (
     swish_backward,
     mish_backward,
     elu_backward,
+    hard_sigmoid_backward,
+    hard_swish_backward,
+    hard_tanh_backward,
 )
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Add piecewise linear activation functions for efficient inference, commonly used in MobileNetV3 and similar efficient architectures.

### New Functions

| Function | Formula | Description |
|----------|---------|-------------|
| `hard_sigmoid` | `clip((x + 3) / 6, 0, 1)` | Faster sigmoid approximation |
| `hard_swish` | `x * hard_sigmoid(x)` | Faster swish approximation |
| `hard_tanh` | `clip(x, min, max)` | Faster tanh approximation |

Each function includes:
- Forward pass implementation
- Backward pass for gradient computation
- Support for float16, float32, float64 dtypes
- Comprehensive docstrings with formulas and examples

### Bug Fixes
Also fixes missing imports in activation.mojo (add, subtract, multiply from arithmetic module).

## Test Plan
- [x] Hard activation functions compile and run correctly
- [x] Pre-commit hooks pass
- [ ] CI passes

Closes #2234

🤖 Generated with [Claude Code](https://claude.com/claude-code)