### PR TITLE
feat(shared/core): Implement group_norm and group_norm_backward

### DIFF
--- a/shared/core/__init__.mojo
+++ b/shared/core/__init__.mojo
@@ -210,6 +210,8 @@ from .normalization import (
     batch_norm2d_backward,
     layer_norm,
     layer_norm_backward,
+    group_norm,
+    group_norm_backward,
 )
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- Implements group normalization which divides channels into groups and normalizes within each group
- Works well with small batch sizes where batch norm fails
- Used in detection and segmentation models

Functions added:
- `group_norm()`: Forward pass with per-group mean/variance normalization
- `group_norm_backward()`: Full backward pass with gradients for input, gamma, beta

Closes #2232

## Test plan
- [x] Supports float32 and float64 dtypes
- [x] Validates channels divisible by num_groups
- [x] Exported from `shared/core/__init__.mojo`
- [x] Documentation included

🤖 Generated with [Claude Code](https://claude.com/claude-code)