### PR TITLE
feat(shared/core): Implement depthwise_conv2d and backward passes

### DIFF
--- a/shared/core/__init__.mojo
+++ b/shared/core/__init__.mojo
@@ -190,6 +190,12 @@ from .conv import (
     conv2d_no_bias,
     conv2d_backward,
     conv2d_no_bias_backward,
+    depthwise_conv2d,
+    depthwise_conv2d_no_bias,
+    depthwise_conv2d_backward,
+    depthwise_conv2d_no_bias_backward,
+    DepthwiseConv2dBackwardResult,
+    DepthwiseConv2dNoBiasBackwardResult,
 )
 
 from .pooling import (

--- a/shared/core/conv.mojo
+++ b/shared/core/conv.mojo
@@ -383,3 +383,353 @@ fn conv2d_no_bias_backward(
     """
     var result = conv2d_backward(grad_output, x, kernel, stride, padding)
     return Conv2dNoBiasBackwardResult(result.grad_input^, result.grad_kernel^)
+
+
+struct DepthwiseConv2dBackwardResult(Movable):
+    """Result struct for depthwise_conv2d_backward function.
+
+    Holds the three gradient tensors returned by the backward pass.
+    """
+    var grad_input: ExTensor
+    var grad_kernel: ExTensor
+    var grad_bias: ExTensor
+
+    fn __init__(out self, var grad_input: ExTensor, var grad_kernel: ExTensor, var grad_bias: ExTensor):
+        """Initialize the result struct with the three gradients."""
+        self.grad_input = grad_input^
+        self.grad_kernel = grad_kernel^
+        self.grad_bias = grad_bias^
+
+    fn __moveinit__(out self, deinit existing: Self):
+        """Move constructor."""
+        self.grad_input = existing.grad_input^
+        self.grad_kernel = existing.grad_kernel^
+        self.grad_bias = existing.grad_bias^
+
+
+fn depthwise_conv2d(
+    x: ExTensor,
+    kernel: ExTensor,
+    bias: ExTensor,
+    stride: Int = 1,
+    padding: Int = 0
+) raises -> ExTensor:
+    """Functional depthwise 2D convolution: y = depthwise_conv2d(x, kernel) + bias
+
+    Each input channel is convolved with its own filter (no cross-channel mixing).
+    Used in efficient architectures like MobileNet and EfficientNet.
+
+    Args:
+        `x`: Input tensor of shape (batch, channels, height, width)
+        `kernel`: Depthwise kernels of shape (channels, 1, kH, kW)
+        `bias`: Bias vector of shape (channels,)
+        `stride`: Stride for convolution (default: 1)
+        `padding`: Zero-padding added to input (default: 0)
+
+    Returns:
+        Output tensor of shape (batch, channels, out_height, out_width)
+        where:
+            out_height = (height + 2*padding - kH) // stride + 1
+            out_width = (width + 2*padding - kW) // stride + 1
+
+    Example:
+        ```mojo
+        from shared.core import depthwise_conv2d, zeros, he_uniform
+
+        # Depthwise kernel: one 3x3 filter per channel
+        var kernel = he_uniform((32, 1, 3, 3), DType.float32)  # 32 channels
+        var bias = zeros(32, DType.float32)
+
+        var output = depthwise_conv2d(input, kernel, bias, stride=1, padding=1)
+        ```
+
+    Raises:
+        Error: If tensor shapes are incompatible.
+    """
+    # Get input dimensions
+    var x_shape = x.shape()
+    if len(x_shape) != 4:
+        raise Error("depthwise_conv2d: Input must be 4D tensor (batch, channels, height, width)")
+
+    var batch = x_shape[0]
+    var channels = x_shape[1]
+    var in_height = x_shape[2]
+    var in_width = x_shape[3]
+
+    # Get kernel dimensions
+    var k_shape = kernel.shape()
+    if len(k_shape) != 4:
+        raise Error("depthwise_conv2d: Kernel must be 4D tensor (channels, 1, kH, kW)")
+
+    var kernel_channels = k_shape[0]
+    var kernel_depth = k_shape[1]
+    var kH = k_shape[2]
+    var kW = k_shape[3]
+
+    if kernel_channels != channels:
+        raise Error("depthwise_conv2d: Kernel channels must match input channels")
+
+    if kernel_depth != 1:
+        raise Error("depthwise_conv2d: Kernel depth must be 1 for depthwise convolution")
+
+    # Compute output dimensions
+    var out_h, var out_w = conv2d_output_shape(in_height, in_width, kH, kW, stride, padding)
+    var out_height = out_h
+    var out_width = out_w
+
+    # Create output tensor
+    var out_shape = List[Int]()
+    out_shape.append(batch)
+    out_shape.append(channels)
+    out_shape.append(out_height)
+    out_shape.append(out_width)
+    var output = zeros(out_shape, x.dtype())
+
+    # Depthwise convolution: each channel convolved independently
+    for b in range(batch):
+        for c in range(channels):
+            for oh in range(out_height):
+                for ow in range(out_width):
+                    var sum_val = Float32(0.0)
+
+                    # Compute input position
+                    var in_h_start = oh * stride - padding
+                    var in_w_start = ow * stride - padding
+
+                    # Convolve with this channel's kernel only
+                    for kh in range(kH):
+                        for kw in range(kW):
+                            var in_h = in_h_start + kh
+                            var in_w = in_w_start + kw
+
+                            # Check bounds (zero padding)
+                            if in_h >= 0 and in_h < in_height and in_w >= 0 and in_w < in_width:
+                                # Get input value
+                                var in_idx = b * (channels * in_height * in_width) + c * (in_height * in_width) + in_h * in_width + in_w
+                                # Get kernel value (kernel shape is [channels, 1, kH, kW])
+                                var k_idx = c * (1 * kH * kW) + kh * kW + kw
+
+                                var in_val = x._data.bitcast[Float32]()[in_idx]
+                                var k_val = kernel._data.bitcast[Float32]()[k_idx]
+
+                                sum_val += in_val * k_val
+
+                    # Add bias
+                    var b_val = bias._data.bitcast[Float32]()[c]
+                    sum_val += b_val
+
+                    # Write to output
+                    var out_idx = b * (channels * out_height * out_width) + c * (out_height * out_width) + oh * out_width + ow
+                    output._data.bitcast[Float32]()[out_idx] = sum_val
+
+    return output^
+
+
+fn depthwise_conv2d_no_bias(
+    x: ExTensor,
+    kernel: ExTensor,
+    stride: Int = 1,
+    padding: Int = 0
+) raises -> ExTensor:
+    """Functional depthwise 2D convolution without bias.
+
+    Args:
+        `x`: Input tensor of shape (batch, channels, height, width)
+        `kernel`: Depthwise kernels of shape (channels, 1, kH, kW)
+        `stride`: Stride for convolution (default: 1)
+        `padding`: Zero-padding added to input (default: 0)
+
+    Returns:
+        Output tensor of shape (batch, channels, out_height, out_width)
+
+    Raises:
+        Error: If tensor shapes are incompatible.
+    """
+    var x_shape = x.shape()
+    var channels = x_shape[1]
+    var bias_shape = List[Int]()
+    bias_shape.append(channels)
+    var bias = zeros(bias_shape, x.dtype())
+
+    return depthwise_conv2d(x, kernel, bias, stride, padding)
+
+
+fn depthwise_conv2d_backward(
+    grad_output: ExTensor,
+    x: ExTensor,
+    kernel: ExTensor,
+    stride: Int = 1,
+    padding: Int = 0
+) raises -> DepthwiseConv2dBackwardResult:
+    """Backward pass for depthwise 2D convolution.
+
+    Computes gradients with respect to input, kernel, and bias.
+
+    Args:
+        `grad_output`: Gradient w.r.t. output, shape (batch, channels, out_H, out_W)
+        `x`: Input from forward pass, shape (batch, channels, in_H, in_W)
+        `kernel`: Kernel from forward pass, shape (channels, 1, kH, kW)
+        `stride`: Stride used in forward pass.
+        `padding`: Padding used in forward pass.
+
+    Returns:
+        DepthwiseConv2dBackwardResult containing:
+            - grad_input: Gradient w.r.t. input, shape (batch, channels, in_H, in_W)
+            - grad_kernel: Gradient w.r.t. kernel, shape (channels, 1, kH, kW)
+            - grad_bias: Gradient w.r.t. bias, shape (channels,)
+
+    Example:
+        ```mojo
+        from shared.core import depthwise_conv2d, depthwise_conv2d_backward
+
+        # Forward pass
+        var output = depthwise_conv2d(x, kernel, bias, stride, padding)
+        # ... compute loss and grad_output ...
+
+        # Backward pass
+        var result = depthwise_conv2d_backward(grad_output, x, kernel, stride, padding)
+        var grad_x = result.grad_input
+        var grad_k = result.grad_kernel
+        var grad_b = result.grad_bias
+        ```
+
+    Raises:
+        Error if tensor shapes are incompatible.
+    """
+    # Get dimensions
+    var x_shape = x.shape()
+    var k_shape = kernel.shape()
+    var grad_out_shape = grad_output.shape()
+
+    var batch = x_shape[0]
+    var channels = x_shape[1]
+    var in_height = x_shape[2]
+    var in_width = x_shape[3]
+
+    var kH = k_shape[2]
+    var kW = k_shape[3]
+
+    var out_height = grad_out_shape[2]
+    var out_width = grad_out_shape[3]
+
+    # Initialize gradients
+    var grad_input = zeros(x_shape, x.dtype())
+    var grad_kernel = zeros(k_shape, kernel.dtype())
+
+    # Compute grad_input
+    # For depthwise conv, each channel's gradient only depends on its own kernel
+    for b in range(batch):
+        for c in range(channels):
+            for ih in range(in_height):
+                for iw in range(in_width):
+                    var grad_sum = Float32(0.0)
+
+                    for oh in range(out_height):
+                        for ow in range(out_width):
+                            # Compute kernel offset
+                            var kh = ih - oh * stride + padding
+                            var kw = iw - ow * stride + padding
+
+                            # Check if kernel offset is valid
+                            if kh >= 0 and kh < kH and kw >= 0 and kw < kW:
+                                # Get grad_output value
+                                var grad_out_idx = b * (channels * out_height * out_width) + c * (out_height * out_width) + oh * out_width + ow
+                                var grad_out_val = grad_output._data.bitcast[Float32]()[grad_out_idx]
+
+                                # Get kernel value (shape: [channels, 1, kH, kW])
+                                var k_idx = c * (1 * kH * kW) + kh * kW + kw
+                                var k_val = kernel._data.bitcast[Float32]()[k_idx]
+
+                                grad_sum += grad_out_val * k_val
+
+                    # Write to grad_input
+                    var grad_in_idx = b * (channels * in_height * in_width) + c * (in_height * in_width) + ih * in_width + iw
+                    grad_input._data.bitcast[Float32]()[grad_in_idx] = grad_sum
+
+    # Compute grad_kernel
+    for c in range(channels):
+        for kh in range(kH):
+            for kw in range(kW):
+                var grad_sum = Float32(0.0)
+
+                for b in range(batch):
+                    for oh in range(out_height):
+                        for ow in range(out_width):
+                            # Compute input position
+                            var in_h = oh * stride - padding + kh
+                            var in_w = ow * stride - padding + kw
+
+                            # Check bounds
+                            if in_h >= 0 and in_h < in_height and in_w >= 0 and in_w < in_width:
+                                # Get input value
+                                var in_idx = b * (channels * in_height * in_width) + c * (in_height * in_width) + in_h * in_width + in_w
+                                var in_val = x._data.bitcast[Float32]()[in_idx]
+
+                                # Get grad_output value
+                                var grad_out_idx = b * (channels * out_height * out_width) + c * (out_height * out_width) + oh * out_width + ow
+                                var grad_out_val = grad_output._data.bitcast[Float32]()[grad_out_idx]
+
+                                grad_sum += in_val * grad_out_val
+
+                # Write to grad_kernel (shape: [channels, 1, kH, kW])
+                var grad_k_idx = c * (1 * kH * kW) + kh * kW + kw
+                grad_kernel._data.bitcast[Float32]()[grad_k_idx] = grad_sum
+
+    # Compute grad_bias: sum over batch, height, width
+    var grad_bias_shape = List[Int]()
+    grad_bias_shape.append(channels)
+    var grad_bias = zeros(grad_bias_shape, grad_output.dtype())
+
+    for c in range(channels):
+        var bias_grad_sum = Float32(0.0)
+
+        for b in range(batch):
+            for oh in range(out_height):
+                for ow in range(out_width):
+                    var grad_out_idx = b * (channels * out_height * out_width) + c * (out_height * out_width) + oh * out_width + ow
+                    var grad_out_val = grad_output._data.bitcast[Float32]()[grad_out_idx]
+                    bias_grad_sum += grad_out_val
+
+        grad_bias._data.bitcast[Float32]()[c] = bias_grad_sum
+
+    return DepthwiseConv2dBackwardResult(grad_input^, grad_kernel^, grad_bias^)
+
+
+struct DepthwiseConv2dNoBiasBackwardResult(Movable):
+    """Result struct for depthwise_conv2d_no_bias_backward function."""
+    var grad_input: ExTensor
+    var grad_kernel: ExTensor
+
+    fn __init__(out self, var grad_input: ExTensor, var grad_kernel: ExTensor):
+        self.grad_input = grad_input^
+        self.grad_kernel = grad_kernel^
+
+    fn __moveinit__(out self, deinit existing: Self):
+        self.grad_input = existing.grad_input^
+        self.grad_kernel = existing.grad_kernel^
+
+
+fn depthwise_conv2d_no_bias_backward(
+    grad_output: ExTensor,
+    x: ExTensor,
+    kernel: ExTensor,
+    stride: Int = 1,
+    padding: Int = 0
+) raises -> DepthwiseConv2dNoBiasBackwardResult:
+    """Backward pass for depthwise 2D convolution without bias.
+
+    Args:
+        `grad_output`: Gradient w.r.t. output.
+        `x`: Input from forward pass.
+        `kernel`: Kernel from forward pass.
+        `stride`: Stride used in forward pass.
+        `padding`: Padding used in forward pass.
+
+    Returns:
+        DepthwiseConv2dNoBiasBackwardResult containing grad_input and grad_kernel.
+
+    Raises:
+        Error if tensor shapes are incompatible.
+    """
+    var result = depthwise_conv2d_backward(grad_output, x, kernel, stride, padding)
+    return DepthwiseConv2dNoBiasBackwardResult(result.grad_input^, result.grad_kernel^)


### PR DESCRIPTION
## Summary

Adds depthwise convolution support for MobileNet/EfficientNet architectures:

- `depthwise_conv2d`: forward pass with groups=in_channels
- `depthwise_conv2d_no_bias`: forward pass without bias  
- `depthwise_conv2d_backward`: gradient computation with bias
- `depthwise_conv2d_no_bias_backward`: gradient computation without bias
- `DepthwiseConv2dBackwardResult`: result struct for backward pass
- `DepthwiseConv2dNoBiasBackwardResult`: result struct for no-bias backward

Kernel shape: `(channels, 1, kH, kW)` - one filter per input channel

Closes #2227

## Test plan

- [ ] Verify forward pass produces correct output shapes
- [ ] Verify backward pass computes correct gradients
- [ ] Compare against PyTorch depthwise conv implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)