### PR TITLE
feat(shared/core): Add attention module with scaled dot-product attention

### DIFF
--- a/shared/core/__init__.mojo
+++ b/shared/core/__init__.mojo
@@ -228,6 +228,11 @@ from .attention import (
     scaled_dot_product_attention_backward,
     ScaledDotProductAttentionBackwardResult,
     create_causal_mask,
+    multi_head_attention,
+    multi_head_attention_backward,
+    MultiHeadAttentionWeights,
+    MultiHeadAttentionResult,
+    MultiHeadAttentionBackwardResult,
 )
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Implements complete attention module for transformer architectures:

**Scaled Dot-Product Attention (Issue #2229):**
- `scaled_dot_product_attention`: Attention(Q, K, V) = softmax(QK^T / sqrt(d_k)) * V
- `scaled_dot_product_attention_backward`: gradient computation
- `ScaledDotProductAttentionBackwardResult`: result struct
- `create_causal_mask`: helper for autoregressive attention

**Multi-Head Attention (Issue #2230):**
- `multi_head_attention`: projects Q/K/V through multiple heads in parallel
- `multi_head_attention_backward`: gradient computation  
- `MultiHeadAttentionWeights`: container for Wq, Wk, Wv, Wo
- `MultiHeadAttentionResult`: output and attention weights
- `MultiHeadAttentionBackwardResult`: gradients for all inputs/weights

Supports both 3D (batch, seq, dim) and 4D (batch, heads, seq, dim) inputs.

Closes #2229
Closes #2230

## Test plan

- [ ] Verify scaled_dot_product_attention produces correct output shapes
- [ ] Verify attention weights sum to 1 along key dimension
- [ ] Test with and without causal mask
- [ ] Verify multi_head_attention with various num_heads
- [ ] Verify backward passes compute correct gradients

🤖 Generated with [Claude Code](https://claude.com/claude-code)