### PR TITLE
feat(shared/core): Implement depthwise_separable_conv2d

### DIFF
--- a/shared/core/__init__.mojo
+++ b/shared/core/__init__.mojo
@@ -196,6 +196,12 @@ from .conv import (
     depthwise_conv2d_no_bias_backward,
     DepthwiseConv2dBackwardResult,
     DepthwiseConv2dNoBiasBackwardResult,
+    depthwise_separable_conv2d,
+    depthwise_separable_conv2d_no_bias,
+    depthwise_separable_conv2d_backward,
+    depthwise_separable_conv2d_no_bias_backward,
+    DepthwiseSeparableConv2dBackwardResult,
+    DepthwiseSeparableConv2dNoBiasBackwardResult,
 )
 
 from .pooling import (


### PR DESCRIPTION
## Summary

Implements depthwise separable convolution operations for efficient mobile-style convolutions (used in MobileNet, EfficientNet, etc.):

- **depthwise_separable_conv2d**: Full operation with bias
- **depthwise_separable_conv2d_no_bias**: No bias variant  
- **depthwise_separable_conv2d_backward**: Computes gradients for input, depthwise kernel, pointwise kernel, and bias
- **depthwise_separable_conv2d_no_bias_backward**: No bias variant
- **DepthwiseSeparableConv2dBackwardResult**: Result struct for backward pass
- **DepthwiseSeparableConv2dNoBiasBackwardResult**: No bias result struct

The implementation follows the pure functional API design and properly chains gradients through both the depthwise and pointwise convolution stages.

Closes #2228

## Test plan

- [ ] Verify forward pass produces correct output shapes
- [ ] Verify backward pass computes correct gradients
- [ ] Verify exports in `__init__.mojo` are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)