### PR TITLE
feat(shared/autograd): Implement tape-based automatic differentiation

### DIFF
--- a/shared/autograd/tape.mojo
+++ b/shared/autograd/tape.mojo
@@ -19,12 +19,12 @@ Key Components:
 Architecture:
     Forward Pass:
         x = Variable(...)  # No recording
-        y = x + 2          # Records: TapeNode(op="add", inputs=[x], output=y, backward_fn=add_backward)
-        z = y * 3          # Records: TapeNode(op="mul", inputs=[y], output=z, backward_fn=mul_backward)
+        y = x + 2          # Records: TapeNode(op="add", inputs=[x], output=y)
+        z = y * 3          # Records: TapeNode(op="mul", inputs=[y], output=z)
 
     Backward Pass:
         z.backward()       # Traverse tape in reverse:
-                          # 1. grad_z = ones_like(z)  # ∂z/∂z = 1
+                          # 1. grad_z = ones_like(z)  # dz/dz = 1
                           # 2. grad_y = mul_backward(grad_z, y, 3)  # Chain rule
                           # 3. grad_x = add_backward(grad_y, x, 2)  # Chain rule
                           # 4. x.grad = grad_x
@@ -44,10 +44,29 @@ Examples:
     tape.backward(loss)
 
     # Access gradients
-    print(x.grad)  # Chain rule: ∂loss/∂x = ∂loss/∂z * ∂z/∂y * ∂y/∂x
+    print(x.grad)  # Chain rule: dLoss/dx
 """
 
-from ..core.extensor import ExTensor
+from ..core.extensor import ExTensor, ones_like, zeros_like
+from ..core.arithmetic import (
+    add_backward,
+    subtract_backward,
+    multiply_backward,
+    divide_backward,
+)
+from ..core.reduction import (
+    sum_backward,
+    mean_backward,
+)
+from ..core.matrix import (
+    matmul_backward,
+)
+from ..core.activation import (
+    relu_backward,
+    sigmoid_backward,
+    tanh_backward,
+    softmax_backward,
+)
 
 
 # Operation types supported by the gradient tape
@@ -63,16 +82,66 @@ alias OP_RELU = "relu"
 alias OP_SIGMOID = "sigmoid"
 alias OP_TANH = "tanh"
 alias OP_SOFTMAX = "softmax"
+alias OP_NEG = "neg"
+alias OP_EXP = "exp"
+alias OP_LOG = "log"
+alias OP_SQRT = "sqrt"
 
 
-struct TapeNode(Copyable, Movable):
+struct SavedTensors(Movable):
+    """Container for tensors saved during forward pass for backward computation.
+
+    Different operations need different tensors saved:
+    - Binary ops (add, mul): Need both inputs and output
+    - Unary ops (relu, exp): Need input and output
+    - Reductions (sum, mean): Need input shape for broadcasting back
+    """
+
+    var tensors: List[ExTensor]
+    var shapes: List[List[Int]]
+    var scalars: List[Float64]
+
+    fn __init__(out self):
+        """Initialize empty saved tensors."""
+        self.tensors = List[ExTensor]()
+        self.shapes = List[List[Int]]()
+        self.scalars = List[Float64]()
+
+    fn __moveinit__(out self, owned existing: Self):
+        """Move constructor."""
+        self.tensors = existing.tensors^
+        self.shapes = existing.shapes^
+        self.scalars = existing.scalars^
+
+    fn add_tensor(mut self, tensor: ExTensor) raises:
+        """Save a tensor for backward pass."""
+        # Create a copy of the tensor
+        var copy = zeros_like(tensor)
+        var size = tensor.numel()
+        for i in range(size):
+            copy._data[i] = tensor._data[i]
+        self.tensors.append(copy^)
+
+    fn add_shape(mut self, shape: List[Int]):
+        """Save a shape for backward pass."""
+        var shape_copy = List[Int]()
+        for i in range(len(shape)):
+            shape_copy.append(shape[i])
+        self.shapes.append(shape_copy^)
+
+    fn add_scalar(mut self, value: Float64):
+        """Save a scalar for backward pass."""
+        self.scalars.append(value)
+
+
+struct TapeNode(Movable):
     """Represents a single operation in the computation graph.
 
     Each node records:
     - The operation type (e.g., "add", "multiply", "matmul")
-    - Input tensors that were used
-    - Output tensor that was produced
-    - Metadata needed for the backward pass
+    - Input variable IDs that were used
+    - Output variable ID that was produced
+    - Saved tensors needed for the backward pass
 
     During backward propagation, nodes are traversed in reverse topological
     order, and each node's backward function is called to compute gradients.
@@ -81,21 +150,13 @@ struct TapeNode(Copyable, Movable):
         op_type: String identifier for the operation (e.g., "add", "matmul")
         input_ids: IDs of input Variables (for tracking dependencies)
         output_id: ID of output Variable
-        saved_tensors: Tensors saved for backward pass (e.g., input shapes, values)
-
-    Note:
-        This is a simplified implementation. A full production system would need:
-        - Memory-efficient tensor storage (weak references, tensor recomputation)
-        - Support for in-place operations
-        - Gradient checkpointing for memory/compute tradeoffs
+        saved_tensors: Tensors saved for backward pass
     """
 
     var op_type: String
     var input_ids: List[Int]
     var output_id: Int
-    # TODO: Add saved_tensors field for storing metadata needed in backward pass
-    # For now, we'll rely on the backward functions in shared/core/ which take
-    # the necessary inputs directly
+    var saved: SavedTensors
 
     fn __init__(out self, op_type: String, input_ids: List[Int], output_id: Int):
         """Initialize a tape node.
@@ -108,6 +169,137 @@ struct TapeNode(Copyable, Movable):
         self.op_type = op_type
         self.input_ids = input_ids
         self.output_id = output_id
+        self.saved = SavedTensors()
+
+    fn __init__(
+        out self,
+        op_type: String,
+        input_ids: List[Int],
+        output_id: Int,
+        owned saved: SavedTensors,
+    ):
+        """Initialize a tape node with saved tensors.
+
+        Args:
+            op_type: String identifier for the operation
+            input_ids: IDs of input Variables
+            output_id: ID of output Variable
+            saved: Saved tensors for backward pass
+        """
+        self.op_type = op_type
+        self.input_ids = input_ids
+        self.output_id = output_id
+        self.saved = saved^
+
+    fn __moveinit__(out self, owned existing: Self):
+        """Move constructor."""
+        self.op_type = existing.op_type
+        self.input_ids = existing.input_ids^
+        self.output_id = existing.output_id
+        self.saved = existing.saved^
+
+
+struct VariableRegistry:
+    """Registry mapping variable IDs to their gradient tensors.
+
+    This allows the backward pass to look up and accumulate gradients
+    for variables by their ID.
+    """
+
+    var grads: List[ExTensor]
+    var has_grad: List[Bool]
+    var requires_grad: List[Bool]
+    var next_id: Int
+
+    fn __init__(out self):
+        """Initialize empty registry."""
+        self.grads = List[ExTensor]()
+        self.has_grad = List[Bool]()
+        self.requires_grad = List[Bool]()
+        self.next_id = 0
+
+    fn register(mut self, requires_grad: Bool) -> Int:
+        """Register a new variable and return its ID.
+
+        Args:
+            requires_grad: Whether this variable requires gradients
+
+        Returns:
+            The unique ID assigned to this variable
+        """
+        var id = self.next_id
+        self.next_id += 1
+
+        # Extend lists to accommodate new ID
+        # Create a placeholder tensor (will be replaced when gradient is computed)
+        var placeholder_shape = List[Int]()
+        placeholder_shape.append(1)
+        var placeholder = ExTensor(placeholder_shape, DType.float32)
+        self.grads.append(placeholder^)
+        self.has_grad.append(False)
+        self.requires_grad.append(requires_grad)
+
+        return id
+
+    fn set_grad(mut self, id: Int, grad: ExTensor) raises:
+        """Set or accumulate gradient for a variable.
+
+        Args:
+            id: Variable ID
+            grad: Gradient tensor to set/accumulate
+        """
+        if id >= len(self.grads):
+            return
+
+        if self.has_grad[id]:
+            # Accumulate gradients
+            var existing = self.grads[id]
+            var size = grad.numel()
+            for i in range(size):
+                existing._data[i] = existing._data[i] + grad._data[i]
+            self.grads[id] = existing^
+        else:
+            # First gradient - copy it
+            var grad_copy = zeros_like(grad)
+            var size = grad.numel()
+            for i in range(size):
+                grad_copy._data[i] = grad._data[i]
+            self.grads[id] = grad_copy^
+            self.has_grad[id] = True
+
+    fn get_grad(self, id: Int) -> ExTensor:
+        """Get gradient for a variable.
+
+        Args:
+            id: Variable ID
+
+        Returns:
+            The gradient tensor (or placeholder if not computed)
+        """
+        if id < len(self.grads):
+            return self.grads[id]
+        # Return empty placeholder
+        var placeholder_shape = List[Int]()
+        placeholder_shape.append(1)
+        return ExTensor(placeholder_shape, DType.float32)
+
+    fn has_gradient(self, id: Int) -> Bool:
+        """Check if a variable has a computed gradient.
+
+        Args:
+            id: Variable ID
+
+        Returns:
+            True if gradient has been computed
+        """
+        if id < len(self.has_grad):
+            return self.has_grad[id]
+        return False
+
+    fn clear(mut self):
+        """Clear all gradients but keep variable registrations."""
+        for i in range(len(self.has_grad)):
+            self.has_grad[i] = False
 
 
 struct GradientTape:
@@ -120,6 +312,7 @@ struct GradientTape:
     Attributes:
         nodes: Chronological list of recorded operations
         enabled: Whether the tape is currently recording
+        registry: Variable registry for gradient storage
 
     Design Note:
         This uses a global tape approach (like TensorFlow's GradientTape) rather
@@ -140,11 +333,13 @@ struct GradientTape:
 
     var nodes: List[TapeNode]
     var enabled: Bool
+    var registry: VariableRegistry
 
     fn __init__(out self):
         """Initialize an empty gradient tape."""
         self.nodes = List[TapeNode]()
         self.enabled = False
+        self.registry = VariableRegistry()
 
     fn enable(mut self):
         """Enable recording of operations.
@@ -182,8 +377,26 @@ struct GradientTape:
             tape.clear()  # Free memory
         """
         self.nodes = List[TapeNode]()
+        self.registry.clear()
 
-    fn record(mut self, op_type: String, input_ids: List[Int], output_id: Int):
+    fn register_variable(mut self, requires_grad: Bool) -> Int:
+        """Register a new variable in the tape's registry.
+
+        Args:
+            requires_grad: Whether this variable requires gradients
+
+        Returns:
+            Unique ID for the variable
+        """
+        return self.registry.register(requires_grad)
+
+    fn record(
+        mut self,
+        op_type: String,
+        input_ids: List[Int],
+        output_id: Int,
+        owned saved: SavedTensors,
+    ):
         """Record an operation in the tape.
 
         This method is called internally by Variable operations to register
@@ -193,51 +406,265 @@ struct GradientTape:
             op_type: String identifier for the operation
             input_ids: IDs of input Variables
             output_id: ID of output Variable
+            saved: Saved tensors for backward pass
 
         Note:
-            Only records if tape is enabled and at least one input requires gradients.
+            Only records if tape is enabled.
 
         Examples:
             # Internal use by Variable operations
-            if tape.enabled and (x.requires_grad or y.requires_grad):
-                tape.record("add", input_ids, output_id)
+            if tape.enabled:
+                tape.record("add", input_ids, output_id, saved)
         """
         if not self.enabled:
             return
 
-        var node = TapeNode(op_type, input_ids, output_id)
-        self.nodes.append(node)
+        var node = TapeNode(op_type, input_ids, output_id, saved^)
+        self.nodes.append(node^)
 
-    fn backward(mut self):
+    fn backward(mut self, output_id: Int, output_grad: ExTensor) raises:
         """Compute gradients by traversing tape in reverse.
 
         Applies the chain rule in reverse topological order:
-        1. Initialize gradient of final output to ones (∂L/∂L = 1)
+        1. Initialize gradient of final output with provided grad
         2. For each node in reverse:
-           a. Get upstream gradient (∂L/∂output)
-           b. Call backward function to get local gradients (∂output/∂inputs)
-           c. Apply chain rule: ∂L/∂input = ∂L/∂output * ∂output/∂input
+           a. Get upstream gradient (dL/d_output)
+           b. Call backward function to get local gradients (d_output/d_inputs)
+           c. Apply chain rule: dL/d_input = dL/d_output * d_output/d_input
            d. Accumulate gradients in input Variables
 
-        Note:
-            This is a placeholder. Full implementation requires:
-            - Mapping from Variable IDs to Variable objects
-            - Calling the appropriate backward function for each operation
-            - Handling gradient accumulation for Variables used multiple times
+        Args:
+            output_id: ID of the output variable to backprop from
+            output_grad: Gradient of the loss with respect to output
 
         Examples:
-            var x = Variable(data, requires_grad=True)
             var loss = compute_loss(x)
-            tape.backward()  # Populates x.grad
+            var ones = ones_like(loss.data)
+            tape.backward(loss.id, ones)  # Populates x.grad
         """
-        # TODO: Implement backward pass
-        # For now, this is a placeholder that will be implemented once we have:
-        # 1. Variable ID to Variable mapping
-        # 2. Dispatching to correct backward functions
-        # 3. Gradient accumulation logic
-        pass
+        # Set the gradient of the output
+        self.registry.set_grad(output_id, output_grad)
+
+        # Traverse nodes in reverse order
+        var num_nodes = len(self.nodes)
+        for rev_i in range(num_nodes):
+            var i = num_nodes - 1 - rev_i
+            var node = self.nodes[i]
+
+            # Skip if output doesn't have gradient yet
+            if not self.registry.has_gradient(node.output_id):
+                continue
+
+            var grad_output = self.registry.get_grad(node.output_id)
+
+            # Dispatch to appropriate backward function based on op_type
+            if node.op_type == OP_ADD:
+                self._backward_add(node, grad_output)
+            elif node.op_type == OP_SUBTRACT:
+                self._backward_subtract(node, grad_output)
+            elif node.op_type == OP_MULTIPLY:
+                self._backward_multiply(node, grad_output)
+            elif node.op_type == OP_DIVIDE:
+                self._backward_divide(node, grad_output)
+            elif node.op_type == OP_SUM:
+                self._backward_sum(node, grad_output)
+            elif node.op_type == OP_MEAN:
+                self._backward_mean(node, grad_output)
+            elif node.op_type == OP_MATMUL:
+                self._backward_matmul(node, grad_output)
+            elif node.op_type == OP_RELU:
+                self._backward_relu(node, grad_output)
+            elif node.op_type == OP_SIGMOID:
+                self._backward_sigmoid(node, grad_output)
+            elif node.op_type == OP_TANH:
+                self._backward_tanh(node, grad_output)
+            elif node.op_type == OP_NEG:
+                self._backward_neg(node, grad_output)
+            # Add more operations as needed
+
+    fn _backward_add(mut self, node: TapeNode, grad_output: ExTensor) raises:
+        """Backward pass for addition: d(a+b)/da = 1, d(a+b)/db = 1."""
+        # grad_input = grad_output (gradient flows unchanged)
+        # Use add_backward from shared.core
+        var result = add_backward(grad_output)
+
+        if len(node.input_ids) >= 1:
+            self.registry.set_grad(node.input_ids[0], result.grad_a)
+        if len(node.input_ids) >= 2:
+            self.registry.set_grad(node.input_ids[1], result.grad_b)
+
+    fn _backward_subtract(mut self, node: TapeNode, grad_output: ExTensor) raises:
+        """Backward pass for subtraction: d(a-b)/da = 1, d(a-b)/db = -1."""
+        var result = subtract_backward(grad_output)
+
+        if len(node.input_ids) >= 1:
+            self.registry.set_grad(node.input_ids[0], result.grad_a)
+        if len(node.input_ids) >= 2:
+            self.registry.set_grad(node.input_ids[1], result.grad_b)
+
+    fn _backward_multiply(mut self, node: TapeNode, grad_output: ExTensor) raises:
+        """Backward pass for multiplication: d(a*b)/da = b, d(a*b)/db = a."""
+        if len(node.saved.tensors) < 2:
+            return
+
+        var a = node.saved.tensors[0]
+        var b = node.saved.tensors[1]
+        var result = multiply_backward(grad_output, a, b)
+
+        if len(node.input_ids) >= 1:
+            self.registry.set_grad(node.input_ids[0], result.grad_a)
+        if len(node.input_ids) >= 2:
+            self.registry.set_grad(node.input_ids[1], result.grad_b)
+
+    fn _backward_divide(mut self, node: TapeNode, grad_output: ExTensor) raises:
+        """Backward pass for division: d(a/b)/da = 1/b, d(a/b)/db = -a/b^2."""
+        if len(node.saved.tensors) < 2:
+            return
+
+        var a = node.saved.tensors[0]
+        var b = node.saved.tensors[1]
+        var result = divide_backward(grad_output, a, b)
+
+        if len(node.input_ids) >= 1:
+            self.registry.set_grad(node.input_ids[0], result.grad_a)
+        if len(node.input_ids) >= 2:
+            self.registry.set_grad(node.input_ids[1], result.grad_b)
+
+    fn _backward_sum(mut self, node: TapeNode, grad_output: ExTensor) raises:
+        """Backward pass for sum reduction."""
+        if len(node.saved.shapes) < 1:
+            return
+
+        var input_shape = node.saved.shapes[0]
+        var axis = -1  # Default: full reduction
+        if len(node.saved.scalars) >= 1:
+            axis = Int(node.saved.scalars[0])
+
+        var grad_input = sum_backward(grad_output, input_shape, axis)
+
+        if len(node.input_ids) >= 1:
+            self.registry.set_grad(node.input_ids[0], grad_input)
+
+    fn _backward_mean(mut self, node: TapeNode, grad_output: ExTensor) raises:
+        """Backward pass for mean reduction."""
+        if len(node.saved.shapes) < 1:
+            return
+
+        var input_shape = node.saved.shapes[0]
+        var axis = -1  # Default: full reduction
+        if len(node.saved.scalars) >= 1:
+            axis = Int(node.saved.scalars[0])
+
+        var grad_input = mean_backward(grad_output, input_shape, axis)
+
+        if len(node.input_ids) >= 1:
+            self.registry.set_grad(node.input_ids[0], grad_input)
+
+    fn _backward_matmul(mut self, node: TapeNode, grad_output: ExTensor) raises:
+        """Backward pass for matrix multiplication."""
+        if len(node.saved.tensors) < 2:
+            return
+
+        var a = node.saved.tensors[0]
+        var b = node.saved.tensors[1]
+        var result = matmul_backward(grad_output, a, b)
+
+        if len(node.input_ids) >= 1:
+            self.registry.set_grad(node.input_ids[0], result.grad_a)
+        if len(node.input_ids) >= 2:
+            self.registry.set_grad(node.input_ids[1], result.grad_b)
+
+    fn _backward_relu(mut self, node: TapeNode, grad_output: ExTensor) raises:
+        """Backward pass for ReLU activation."""
+        if len(node.saved.tensors) < 1:
+            return
+
+        var x = node.saved.tensors[0]
+        var grad_input = relu_backward(grad_output, x)
+
+        if len(node.input_ids) >= 1:
+            self.registry.set_grad(node.input_ids[0], grad_input)
+
+    fn _backward_sigmoid(mut self, node: TapeNode, grad_output: ExTensor) raises:
+        """Backward pass for sigmoid activation."""
+        if len(node.saved.tensors) < 1:
+            return
+
+        # saved tensor is the output of sigmoid
+        var output = node.saved.tensors[0]
+        var grad_input = sigmoid_backward(grad_output, output)
+
+        if len(node.input_ids) >= 1:
+            self.registry.set_grad(node.input_ids[0], grad_input)
+
+    fn _backward_tanh(mut self, node: TapeNode, grad_output: ExTensor) raises:
+        """Backward pass for tanh activation."""
+        if len(node.saved.tensors) < 1:
+            return
+
+        # saved tensor is the output of tanh
+        var output = node.saved.tensors[0]
+        var grad_input = tanh_backward(grad_output, output)
+
+        if len(node.input_ids) >= 1:
+            self.registry.set_grad(node.input_ids[0], grad_input)
+
+    fn _backward_neg(mut self, node: TapeNode, grad_output: ExTensor) raises:
+        """Backward pass for negation: d(-x)/dx = -1."""
+        # Negate the gradient
+        var grad_input = zeros_like(grad_output)
+        var size = grad_output.numel()
+        for i in range(size):
+            grad_input._data[i] = -grad_output._data[i]
+
+        if len(node.input_ids) >= 1:
+            self.registry.set_grad(node.input_ids[0], grad_input^)
+
+    fn get_grad(self, var_id: Int) -> ExTensor:
+        """Get the computed gradient for a variable.
+
+        Args:
+            var_id: The variable ID
+
+        Returns:
+            The gradient tensor
+        """
+        return self.registry.get_grad(var_id)
 
 
-# Global gradient tape instance
-# TODO: Consider thread-local storage for multi-threaded training
-# var global_tape = GradientTape()
+struct NoGradContext:
+    """Context manager equivalent for disabling gradient computation.
+
+    Used for inference or when you want to temporarily disable gradient tracking.
+    Unlike Python's context manager, you must manually call exit().
+
+    Examples:
+        var ctx = NoGradContext(tape)
+        ctx.enter()  # Disable gradient tracking
+
+        # Operations here are not recorded
+        var y = model.forward(x)
+
+        ctx.exit()  # Re-enable gradient tracking
+    """
+
+    var tape: UnsafePointer[GradientTape]
+    var was_enabled: Bool
+
+    fn __init__(out self, mut tape: GradientTape):
+        """Initialize no-grad context.
+
+        Args:
+            tape: The gradient tape to manage
+        """
+        self.tape = UnsafePointer[GradientTape].address_of(tape)
+        self.was_enabled = tape.enabled
+
+    fn enter(mut self):
+        """Enter no-grad mode (disable recording)."""
+        self.tape[].disable()
+
+    fn exit(mut self):
+        """Exit no-grad mode (restore previous state)."""
+        if self.was_enabled:
+            self.tape[].enable()

--- a/shared/autograd/variable.mojo
+++ b/shared/autograd/variable.mojo
@@ -9,29 +9,54 @@ replayed in reverse during backward propagation.
 
 Key Concepts:
 - Variable wraps an ExTensor and adds requires_grad flag and grad storage
-- Operations on Variables are recorded in a global gradient tape
+- Operations on Variables are recorded in a gradient tape
 - Calling .backward() triggers automatic gradient computation via chain rule
 - Gradients accumulate across multiple backward passes (call .zero_grad() to reset)
 
 Examples:
+    from shared.autograd import Variable, GradientTape
+
+    # Create gradient tape
+    var tape = GradientTape()
+    tape.enable()
+
     # Create variables with gradient tracking
-    var x = Variable(zeros(shape, dtype), requires_grad=True)
-    var y = Variable(ones(shape, dtype), requires_grad=True)
+    var x = Variable(zeros(shape, dtype), requires_grad=True, tape)
+    var y = Variable(ones(shape, dtype), requires_grad=True, tape)
 
     # Perform operations (recorded in tape)
-    var z = x + y
-    var loss = (z * z).sum()
+    var z = variable_add(x, y, tape)
+    var loss = variable_sum(z, tape)
 
     # Compute gradients automatically
-    loss.backward()
+    loss.backward(tape)
 
     # Access gradients
-    print(x.grad)  # dLoss/dx
-    print(y.grad)  # dLoss/dy
+    print(tape.get_grad(x.id))  # dLoss/dx
+    print(tape.get_grad(y.id))  # dLoss/dy
 """
 
-from ..core.extensor import ExTensor
-from collections.optional import Optional
+from ..core.extensor import ExTensor, ones_like, zeros_like
+from ..core.arithmetic import add, subtract, multiply, divide
+from ..core.reduction import sum as tensor_sum, mean as tensor_mean
+from ..core.matrix import matmul
+from ..core.activation import relu, sigmoid, tanh
+
+from .tape import (
+    GradientTape,
+    SavedTensors,
+    OP_ADD,
+    OP_SUBTRACT,
+    OP_MULTIPLY,
+    OP_DIVIDE,
+    OP_SUM,
+    OP_MEAN,
+    OP_MATMUL,
+    OP_RELU,
+    OP_SIGMOID,
+    OP_TANH,
+    OP_NEG,
+)
 
 
 struct Variable:
@@ -40,72 +65,70 @@ struct Variable:
     Variable extends ExTensor with gradient tracking capabilities. Each Variable
     maintains:
     - data: The actual tensor values (ExTensor)
-    - grad: Accumulated gradients (Optional[ExTensor])
+    - id: Unique identifier for tape tracking
     - requires_grad: Whether to track operations for this variable
-    - grad_fn: Backward function to compute gradients (Optional)
+
+    Gradients are stored in the GradientTape's registry, not in the Variable
+    itself. This allows for gradient accumulation and cleanup via the tape.
 
     Attributes:
         data: The underlying ExTensor containing values
-        grad: Optional gradient tensor (None until backward() is called)
+        id: Unique identifier for gradient tracking
         requires_grad: Flag indicating whether this Variable participates in autograd
 
     Note:
-        Variables are immutable after creation. Operations create new Variables
-        with updated data and grad_fn, following functional programming patterns.
+        Operations on Variables create new Variables. The tape records which
+        operations were performed and on which variables, enabling automatic
+        gradient computation.
     """
 
     var data: ExTensor
-    var grad: Optional[ExTensor]
+    var id: Int
     var requires_grad: Bool
-    # TODO: Add grad_fn field once we implement backward functions
 
-    fn __init__(out self, var data: ExTensor, requires_grad: Bool = False):
-        """Initialize a Variable from an ExTensor.
+    fn __init__(
+        out self,
+        owned data: ExTensor,
+        requires_grad: Bool,
+        mut tape: GradientTape,
+    ):
+        """Initialize a Variable and register it with the tape.
 
         Args:
             data: The tensor values to wrap (ownership transferred)
-            requires_grad: Whether to track gradients for this variable (default: False)
+            requires_grad: Whether to track gradients for this variable
+            tape: The gradient tape to register with
 
         Examples:
-            var x = Variable(zeros(shape, dtype), requires_grad=True)
-            var y = Variable(ones(shape, dtype))  # requires_grad=False by default
+            var tape = GradientTape()
+            var x = Variable(zeros(shape, dtype), True, tape)
         """
         self.data = data^
-        self.grad = None
         self.requires_grad = requires_grad
+        self.id = tape.register_variable(requires_grad)
 
-    fn __init__(out self, var data: ExTensor, var grad: ExTensor, requires_grad: Bool = False):
-        """Initialize a Variable with explicit gradient.
+    fn __init__(
+        out self,
+        owned data: ExTensor,
+        requires_grad: Bool,
+        id: Int,
+    ):
+        """Initialize a Variable with explicit ID (internal use).
 
         Args:
             data: The tensor values to wrap (ownership transferred)
-            grad: The gradient tensor (ownership transferred)
             requires_grad: Whether to track gradients for this variable
+            id: Pre-assigned variable ID
 
         Note:
             This constructor is primarily for internal use when creating
-            intermediate Variables during operations.
+            output Variables from operations.
         """
         self.data = data^
-        self.grad = grad^
         self.requires_grad = requires_grad
+        self.id = id
 
-    fn zero_grad(mut self):
-        """Reset gradients to None.
-
-        Should be called before each backward pass to prevent gradient accumulation
-        from previous iterations.
-
-        Examples:
-            for epoch in range(num_epochs):
-                optimizer.zero_grad()  # Clear previous gradients
-                loss = forward(x)
-                loss.backward()
-                optimizer.step()
-        """
-        self.grad = None
-
-    fn backward(mut self):
+    fn backward(self, mut tape: GradientTape) raises:
         """Compute gradients via automatic differentiation.
 
         Triggers backward pass through the computation graph, computing gradients
@@ -113,44 +136,393 @@ struct Variable:
         Variable.
 
         The gradient of this Variable with respect to itself is initialized to
-        ones (∂self/∂self = 1), then gradients are propagated backward through
+        ones (d_self/d_self = 1), then gradients are propagated backward through
         the graph using the chain rule.
 
-        Note:
-            Currently this is a placeholder. Full implementation requires:
-            1. Gradient tape to record operations
-            2. Backward functions for each operation
-            3. Topological sort of computation graph
-            4. Chain rule application in reverse order
-
-        Raises:
-            Error if this Variable is not a scalar (backward() requires scalar output)
+        Args:
+            tape: The gradient tape that recorded operations
 
         Examples:
-            var x = Variable(data, requires_grad=True)
-            var loss = compute_loss(x)
-            loss.backward()  # Computes gradients for all inputs
-            print(x.grad)    # ∂loss/∂x
+            var x = Variable(data, True, tape)
+            var loss = compute_loss(x, tape)
+            loss.backward(tape)  # Computes gradients for all inputs
+            print(tape.get_grad(x.id))  # dLoss/dx
         """
-        # TODO: Implement backward pass
-        # For now, this is a placeholder that will be implemented once we have:
-        # 1. Gradient tape recording operations
-        # 2. Backward functions registered for each operation
-        # 3. Topological sorting of computation graph
-        pass
+        # Initialize gradient of output to ones
+        var grad = ones_like(self.data)
+        tape.backward(self.id, grad^)
 
-    fn detach(self) -> Variable:
-        """Create a new Variable with the same data but no gradient tracking.
+    fn detach(self) -> ExTensor:
+        """Get the underlying tensor without gradient tracking.
 
         Useful for breaking the computation graph when you want to use values
         without tracking gradients.
 
         Returns:
-            New Variable with requires_grad=False and no grad_fn
+            The underlying ExTensor (copy)
 
         Examples:
-            var x = Variable(data, requires_grad=True)
-            var y = x.detach()  # y shares data but doesn't track gradients
-            var z = y + 1       # Operations on y don't affect x's gradient
+            var x = Variable(data, True, tape)
+            var y = x.detach()  # y is just an ExTensor, no gradient tracking
         """
-        return Variable(self.data, requires_grad=False)
+        return self.data
+
+    fn shape(self) -> List[Int]:
+        """Get the shape of the underlying tensor.
+
+        Returns:
+            List of dimension sizes
+        """
+        return self.data.shape()
+
+    fn numel(self) -> Int:
+        """Get the number of elements in the tensor.
+
+        Returns:
+            Total number of elements
+        """
+        return self.data.numel()
+
+    fn dtype(self) -> DType:
+        """Get the data type of the underlying tensor.
+
+        Returns:
+            The DType of the tensor
+        """
+        return self.data.dtype()
+
+
+# ============================================================================
+# Variable Operations
+# ============================================================================
+# These functions perform operations on Variables and record them in the tape.
+# They follow the functional API pattern - each operation creates a new Variable.
+
+
+fn variable_add(
+    a: Variable,
+    b: Variable,
+    mut tape: GradientTape,
+) raises -> Variable:
+    """Add two Variables element-wise.
+
+    Args:
+        a: First input Variable
+        b: Second input Variable
+        tape: Gradient tape for recording
+
+    Returns:
+        New Variable containing a + b
+    """
+    var result_data = add(a.data, b.data)
+    var result_id = tape.register_variable(a.requires_grad or b.requires_grad)
+
+    # Record operation for backward pass
+    if tape.enabled and (a.requires_grad or b.requires_grad):
+        var input_ids = List[Int]()
+        input_ids.append(a.id)
+        input_ids.append(b.id)
+        var saved = SavedTensors()
+        tape.record(OP_ADD, input_ids^, result_id, saved^)
+
+    return Variable(result_data^, a.requires_grad or b.requires_grad, result_id)
+
+
+fn variable_subtract(
+    a: Variable,
+    b: Variable,
+    mut tape: GradientTape,
+) raises -> Variable:
+    """Subtract two Variables element-wise.
+
+    Args:
+        a: First input Variable
+        b: Second input Variable
+        tape: Gradient tape for recording
+
+    Returns:
+        New Variable containing a - b
+    """
+    var result_data = subtract(a.data, b.data)
+    var result_id = tape.register_variable(a.requires_grad or b.requires_grad)
+
+    if tape.enabled and (a.requires_grad or b.requires_grad):
+        var input_ids = List[Int]()
+        input_ids.append(a.id)
+        input_ids.append(b.id)
+        var saved = SavedTensors()
+        tape.record(OP_SUBTRACT, input_ids^, result_id, saved^)
+
+    return Variable(result_data^, a.requires_grad or b.requires_grad, result_id)
+
+
+fn variable_multiply(
+    a: Variable,
+    b: Variable,
+    mut tape: GradientTape,
+) raises -> Variable:
+    """Multiply two Variables element-wise.
+
+    Args:
+        a: First input Variable
+        b: Second input Variable
+        tape: Gradient tape for recording
+
+    Returns:
+        New Variable containing a * b
+    """
+    var result_data = multiply(a.data, b.data)
+    var result_id = tape.register_variable(a.requires_grad or b.requires_grad)
+
+    if tape.enabled and (a.requires_grad or b.requires_grad):
+        var input_ids = List[Int]()
+        input_ids.append(a.id)
+        input_ids.append(b.id)
+
+        # Save inputs for backward pass
+        var saved = SavedTensors()
+        saved.add_tensor(a.data)
+        saved.add_tensor(b.data)
+        tape.record(OP_MULTIPLY, input_ids^, result_id, saved^)
+
+    return Variable(result_data^, a.requires_grad or b.requires_grad, result_id)
+
+
+fn variable_divide(
+    a: Variable,
+    b: Variable,
+    mut tape: GradientTape,
+) raises -> Variable:
+    """Divide two Variables element-wise.
+
+    Args:
+        a: Numerator Variable
+        b: Denominator Variable
+        tape: Gradient tape for recording
+
+    Returns:
+        New Variable containing a / b
+    """
+    var result_data = divide(a.data, b.data)
+    var result_id = tape.register_variable(a.requires_grad or b.requires_grad)
+
+    if tape.enabled and (a.requires_grad or b.requires_grad):
+        var input_ids = List[Int]()
+        input_ids.append(a.id)
+        input_ids.append(b.id)
+
+        # Save inputs for backward pass
+        var saved = SavedTensors()
+        saved.add_tensor(a.data)
+        saved.add_tensor(b.data)
+        tape.record(OP_DIVIDE, input_ids^, result_id, saved^)
+
+    return Variable(result_data^, a.requires_grad or b.requires_grad, result_id)
+
+
+fn variable_matmul(
+    a: Variable,
+    b: Variable,
+    mut tape: GradientTape,
+) raises -> Variable:
+    """Matrix multiply two Variables.
+
+    Args:
+        a: First matrix Variable
+        b: Second matrix Variable
+        tape: Gradient tape for recording
+
+    Returns:
+        New Variable containing a @ b
+    """
+    var result_data = matmul(a.data, b.data)
+    var result_id = tape.register_variable(a.requires_grad or b.requires_grad)
+
+    if tape.enabled and (a.requires_grad or b.requires_grad):
+        var input_ids = List[Int]()
+        input_ids.append(a.id)
+        input_ids.append(b.id)
+
+        # Save inputs for backward pass
+        var saved = SavedTensors()
+        saved.add_tensor(a.data)
+        saved.add_tensor(b.data)
+        tape.record(OP_MATMUL, input_ids^, result_id, saved^)
+
+    return Variable(result_data^, a.requires_grad or b.requires_grad, result_id)
+
+
+fn variable_sum(
+    x: Variable,
+    mut tape: GradientTape,
+    axis: Int = -1,
+) raises -> Variable:
+    """Sum a Variable along an axis (or all elements if axis=-1).
+
+    Args:
+        x: Input Variable
+        tape: Gradient tape for recording
+        axis: Axis to sum along (-1 for full reduction)
+
+    Returns:
+        New Variable containing the sum
+    """
+    var result_data = tensor_sum(x.data, axis)
+    var result_id = tape.register_variable(x.requires_grad)
+
+    if tape.enabled and x.requires_grad:
+        var input_ids = List[Int]()
+        input_ids.append(x.id)
+
+        # Save input shape and axis for backward pass
+        var saved = SavedTensors()
+        saved.add_shape(x.data.shape())
+        saved.add_scalar(Float64(axis))
+        tape.record(OP_SUM, input_ids^, result_id, saved^)
+
+    return Variable(result_data^, x.requires_grad, result_id)
+
+
+fn variable_mean(
+    x: Variable,
+    mut tape: GradientTape,
+    axis: Int = -1,
+) raises -> Variable:
+    """Mean of a Variable along an axis (or all elements if axis=-1).
+
+    Args:
+        x: Input Variable
+        tape: Gradient tape for recording
+        axis: Axis to average along (-1 for full reduction)
+
+    Returns:
+        New Variable containing the mean
+    """
+    var result_data = tensor_mean(x.data, axis)
+    var result_id = tape.register_variable(x.requires_grad)
+
+    if tape.enabled and x.requires_grad:
+        var input_ids = List[Int]()
+        input_ids.append(x.id)
+
+        # Save input shape and axis for backward pass
+        var saved = SavedTensors()
+        saved.add_shape(x.data.shape())
+        saved.add_scalar(Float64(axis))
+        tape.record(OP_MEAN, input_ids^, result_id, saved^)
+
+    return Variable(result_data^, x.requires_grad, result_id)
+
+
+fn variable_relu(
+    x: Variable,
+    mut tape: GradientTape,
+) raises -> Variable:
+    """Apply ReLU activation to a Variable.
+
+    Args:
+        x: Input Variable
+        tape: Gradient tape for recording
+
+    Returns:
+        New Variable containing ReLU(x)
+    """
+    var result_data = relu(x.data)
+    var result_id = tape.register_variable(x.requires_grad)
+
+    if tape.enabled and x.requires_grad:
+        var input_ids = List[Int]()
+        input_ids.append(x.id)
+
+        # Save input for backward pass
+        var saved = SavedTensors()
+        saved.add_tensor(x.data)
+        tape.record(OP_RELU, input_ids^, result_id, saved^)
+
+    return Variable(result_data^, x.requires_grad, result_id)
+
+
+fn variable_sigmoid(
+    x: Variable,
+    mut tape: GradientTape,
+) raises -> Variable:
+    """Apply sigmoid activation to a Variable.
+
+    Args:
+        x: Input Variable
+        tape: Gradient tape for recording
+
+    Returns:
+        New Variable containing sigmoid(x)
+    """
+    var result_data = sigmoid(x.data)
+    var result_id = tape.register_variable(x.requires_grad)
+
+    if tape.enabled and x.requires_grad:
+        var input_ids = List[Int]()
+        input_ids.append(x.id)
+
+        # Save output for backward pass (sigmoid_backward uses output)
+        var saved = SavedTensors()
+        saved.add_tensor(result_data)
+        tape.record(OP_SIGMOID, input_ids^, result_id, saved^)
+
+    return Variable(result_data^, x.requires_grad, result_id)
+
+
+fn variable_tanh(
+    x: Variable,
+    mut tape: GradientTape,
+) raises -> Variable:
+    """Apply tanh activation to a Variable.
+
+    Args:
+        x: Input Variable
+        tape: Gradient tape for recording
+
+    Returns:
+        New Variable containing tanh(x)
+    """
+    var result_data = tanh(x.data)
+    var result_id = tape.register_variable(x.requires_grad)
+
+    if tape.enabled and x.requires_grad:
+        var input_ids = List[Int]()
+        input_ids.append(x.id)
+
+        # Save output for backward pass (tanh_backward uses output)
+        var saved = SavedTensors()
+        saved.add_tensor(result_data)
+        tape.record(OP_TANH, input_ids^, result_id, saved^)
+
+    return Variable(result_data^, x.requires_grad, result_id)
+
+
+fn variable_neg(
+    x: Variable,
+    mut tape: GradientTape,
+) raises -> Variable:
+    """Negate a Variable element-wise.
+
+    Args:
+        x: Input Variable
+        tape: Gradient tape for recording
+
+    Returns:
+        New Variable containing -x
+    """
+    # Create negated tensor
+    var result_data = zeros_like(x.data)
+    var size = x.data.numel()
+    for i in range(size):
+        result_data._data[i] = -x.data._data[i]
+
+    var result_id = tape.register_variable(x.requires_grad)
+
+    if tape.enabled and x.requires_grad:
+        var input_ids = List[Int]()
+        input_ids.append(x.id)
+        var saved = SavedTensors()
+        tape.record(OP_NEG, input_ids^, result_id, saved^)
+
+    return Variable(result_data^, x.requires_grad, result_id)


### PR DESCRIPTION
## Summary

Completes the tape-based automatic differentiation system in `shared/autograd/`:

**GradientTape enhancements:**
- `SavedTensors` struct for storing tensors/shapes/scalars needed in backward pass
- `VariableRegistry` for mapping variable IDs to gradient tensors
- `backward()` implementation that traverses nodes in reverse topological order
- Backward dispatchers for common operations (add, subtract, multiply, divide, matmul, sum, mean, relu, sigmoid, tanh, neg)
- `NoGradContext` for temporarily disabling gradient computation (like torch.no_grad())

**Variable enhancements:**
- `id` field for tape registration
- Constructor that automatically registers with tape
- `backward()` method that triggers tape backward pass
- Helper methods: `shape()`, `numel()`, `dtype()`, `detach()`

**Variable operations (tape-integrated):**
- `variable_add`, `variable_subtract`, `variable_multiply`, `variable_divide`
- `variable_matmul`
- `variable_sum`, `variable_mean`
- `variable_relu`, `variable_sigmoid`, `variable_tanh`
- `variable_neg`

## Usage Example

```mojo
from shared.autograd import Variable, GradientTape
from shared.autograd import variable_multiply, variable_sum

# Create gradient tape
var tape = GradientTape()
tape.enable()

# Create variables with gradient tracking
var x = Variable(data, requires_grad=True, tape)
var y = Variable(weights, requires_grad=True, tape)

# Perform operations (automatically recorded)
var z = variable_multiply(x, y, tape)
var loss = variable_sum(z, tape)

# Compute gradients automatically
loss.backward(tape)

# Access gradients
var grad_x = tape.get_grad(x.id)
var grad_y = tape.get_grad(y.id)
```

Closes #2235

## Test plan

- [ ] Verify GradientTape records operations when enabled
- [ ] Verify backward() computes correct gradients for basic operations
- [ ] Verify NoGradContext properly disables/enables recording
- [ ] Verify gradient accumulation works for variables used multiple times

🤖 Generated with [Claude Code](https://claude.com/claude-code)