### PR TITLE
refactor(agents): Update docs to use GitHub issues instead of notes/issues

### DIFF
--- a/agents/docs/examples.md
+++ b/agents/docs/examples.md
@@ -100,8 +100,8 @@ Before creating the issue, can you show me the proposed API and file structure?
 ### Expected Outputs
 
 1. **GitHub Issue Created**: Issue #XXX with full specification
-1. **Plan Document**: `/notes/issues/XXX/README.md` with objectives, deliverables, success criteria
-1. **Design Spec**: Component architecture from Architecture Design Agent
+1. **Plan Document**: Posted as comments on GitHub issue #XXX with objectives, deliverables, success criteria
+1. **Design Spec**: Component architecture from Architecture Design Agent (posted to issue)
 1. **Child Issues**: Test (#XXX+1), Implementation (#XXX+2), Package (#XXX+3), Cleanup (#XXX+4)
 
 ### Common Pitfalls

--- a/agents/docs/git-worktree-guide.md
+++ b/agents/docs/git-worktree-guide.md
@@ -151,7 +151,7 @@ cd worktrees/issue-62-plan-agents
 # ... create component specs, interface definitions, etc
 
 # Commit and push
-git add agents/ notes/issues/62/
+git add agents/
 git commit -m "feat(agents): complete agent architecture design"
 git push -u origin 62-plan-agents
 
@@ -196,7 +196,6 @@ ml-odyssey/                          # Main repository
 │   ├── issue-62-plan-agents/        # Plan phase
 │   │   ├── .git                     # Worktree git link
 │   │   ├── agents/                  # Agent docs being created
-│   │   ├── notes/issues/62/         # Issue-specific docs
 │   │   └── ... (full repo contents)
 │   ├── issue-63-test-agents/        # Test phase (parallel)
 │   │   ├── .git
@@ -240,8 +239,8 @@ Parallel Phases (issue-63, 64, 65):
 # In issue-64-impl-agents worktree
 cd worktrees/issue-64-impl-agents
 
-# Read specification from Plan phase (now in main)
-cat notes/issues/62/README.md
+# Read specification from Plan phase (posted on GitHub issue)
+gh issue view 62 --comments
 
 # Implement based on spec
 # No need to access issue-63 or issue-65 worktrees
@@ -312,9 +311,8 @@ git merge --abort
 **Use Case**: Agents communicate progress without file sharing
 
 ```bash
-# Test Engineer posts status
-cd worktrees/issue-63-test-agents
-cat > notes/issues/63/STATUS.md << 'EOF'
+# Test Engineer posts status to GitHub issue
+gh issue comment 63 --body "$(cat <<'EOF'
 ## Status Update - 2025-11-08
 
 **Agent**: Test Engineer
@@ -335,22 +333,17 @@ cat > notes/issues/63/STATUS.md << 'EOF'
 - Test fixtures in tests/fixtures/ ready to use
 - Gradient test will need backward() method implemented
 EOF
+)"
 
-git add notes/issues/63/STATUS.md
-git commit -m "Update status: 60% complete"
-git push
-
-# Implementation Engineer reads status
-cd ../issue-64-impl-agents
-git fetch origin
-git show origin/63-test-agents:notes/issues/63/STATUS.md
+# Implementation Engineer reads status from GitHub issue
+gh issue view 63 --comments
 ```text
 
 ### Cross-Worktree Communication Protocol
 
 #### Daily Status Updates
 
-Each agent posts status to their issue notes:
+Each agent posts status as comments on their GitHub issue:
 
 ```markdown
 ## Status Update - YYYY-MM-DD
@@ -405,10 +398,8 @@ When one phase depends on another:
 ### Individual Agent Status
 
 ```bash
-# Each agent maintains status in their worktree
-cd worktrees/issue-64-impl-agents
-
-cat > notes/issues/64/PROGRESS.md << 'EOF'
+# Each agent posts status to their GitHub issue
+gh issue comment 64 --body "$(cat <<'EOF'
 # Implementation Progress - Issue #64
 
 ## Overall: 75% Complete
@@ -433,31 +424,26 @@ cat > notes/issues/64/PROGRESS.md << 'EOF'
 - Review all agent descriptions for auto-invocation
 - Test agent loading with Claude Code
 EOF
-
-git add notes/issues/64/PROGRESS.md
-git commit -m "Update progress: 75% complete"
-git push
+)"
 ```text
 
 ### Aggregate Status (Section Orchestrator)
 
-Section Orchestrators aggregate status from all worktrees:
+Section Orchestrators aggregate status from all GitHub issues:
 
 ```bash
-# Section Orchestrator checks all parallel worktrees
-cd /home/user/ml-odyssey
-
+# Section Orchestrator checks all parallel issues
 # Check Test status
-git show origin/63-test-agents:notes/issues/63/PROGRESS.md
+gh issue view 63 --comments | tail -50
 
 # Check Implementation status
-git show origin/64-impl-agents:notes/issues/64/PROGRESS.md
+gh issue view 64 --comments | tail -50
 
 # Check Packaging status
-git show origin/65-pkg-agents:notes/issues/65/PROGRESS.md
+gh issue view 65 --comments | tail -50
 
-# Create aggregate report
-cat > notes/issues/62/AGGREGATE_STATUS.md << 'EOF'
+# Post aggregate report to parent issue
+gh issue comment 62 --body "$(cat <<'EOF'
 # Agents Implementation - Aggregate Status
 
 **Date**: 2025-11-08
@@ -487,6 +473,7 @@ cat > notes/issues/62/AGGREGATE_STATUS.md << 'EOF'
 - Test: Add validation tests for agent configs
 - Packaging: Finalize integration documentation
 EOF
+)"
 ```text
 
 ## Common Workflows
@@ -499,8 +486,8 @@ git worktree add worktrees/issue-62-plan-agents -b 62-plan-agents
 cd worktrees/issue-62-plan-agents
 
 # Architecture Design Agent creates specs
-# ... design work
-git add notes/issues/62/
+# ... design work, post specs to GitHub issue #62
+git add agents/
 git commit -m "feat(agents): design agent architecture"
 git push -u origin 62-plan-agents
 

--- a/agents/docs/workflows.md
+++ b/agents/docs/workflows.md
@@ -91,13 +91,13 @@ Architecture Design Agent:
   - Documents dependencies:
     * Requires: Tensor operations from core_ops
     * Integration: Will be used by LeNet-5 and future papers
-  - Creates detailed specification in notes/issues/150/
+  - Posts detailed specification as comment on GitHub issue #150
 ```text
 
 ### Artifacts
 
-- Component specification: `notes/issues/150/component-spec.md`
-- Interface definitions: `notes/issues/150/interfaces.md`
+- Component specification: Posted as comment on GitHub issue #150
+- Interface definitions: Posted as comment on GitHub issue #150
 - Dependency graph
 
 ##### Step 3: Component Planning (Level 3)
@@ -144,9 +144,9 @@ Documentation Specialist:
 
 ### Artifacts
 
-- Implementation plan: `notes/issues/150/implementation-plan.md`
-- Test plan: `notes/issues/150/test-plan.md`
-- Documentation outline: `notes/issues/150/docs-outline.md`
+- Implementation plan: Posted as comment on GitHub issue #150
+- Test plan: Posted as comment on GitHub issue #150
+- Documentation outline: Posted as comment on GitHub issue #150
 
 **Plan Phase Complete**: Specifications approved, ready for parallel execution
 
@@ -700,7 +700,7 @@ Implementation Specialist:
   - Creates brief fix specification:
     * Update _apply_kernel_simd to handle rectangular kernels
     * Fix: Use kernel_height and kernel_width separately
-  - Documents in notes/issues/200/fix-plan.md
+  - Posts fix plan as comment on GitHub issue #200
 
 Test Specialist:
   - Plans test:
@@ -1089,7 +1089,7 @@ Component Specialists (Level 3):
 
 ### Plan Phase Artifacts
 
-- Module specifications: `notes/issues/400-403/`
+- Module specifications: Posted as comments on GitHub issues #400-403
 - Interface definitions
 - Integration plan
 - Timeline: 8-12 weeks for full implementation

--- a/agents/guides/package-phase-guide.md
+++ b/agents/guides/package-phase-guide.md
@@ -109,7 +109,7 @@ dist/
 
 ❌ **Just Documenting Structure**:
 
-- Package phase is NOT about writing notes/issues/XX/README.md
+- Package phase is NOT about writing documentation comments on GitHub issues
 - NOT about documenting that `__init__.mojo` exists
 - NOT about verifying directory structure
 
@@ -130,7 +130,7 @@ dist/
 These activities, while useful, do NOT constitute Package phase completion:
 
 - ❌ Writing comprehensive README.md files
-- ❌ Creating notes/issues/XX/README.md documentation
+- ❌ Creating documentation comments on GitHub issues
 - ❌ Verifying `__init__.mojo` exports are correct
 - ❌ Documenting that "package structure is ready"
 - ❌ Listing files that exist in the module
@@ -142,7 +142,7 @@ These activities, while useful, do NOT constitute Package phase completion:
 Issue #40: [Package] Data Module
 
 Deliverables:
-✅ Created notes/issues/40/README.md documenting structure
+✅ Posted documentation comment on GitHub issue #40
 ✅ Verified shared/data/__init__.mojo has 19 exports
 ✅ Confirmed README.md is comprehensive (546 lines)
 ✅ Documented that module is "production-ready"
@@ -394,7 +394,7 @@ PR Title: "docs(training): complete package phase verification"
 
 Changes:
 
-- Added notes/issues/35/README.md
+- Posted documentation to GitHub issue #35
 - Updated README to say "package is ready"
 - Verified __init__.mojo exports
 


### PR DESCRIPTION
## Summary

- Replace all references to local `notes/issues/` directories with GitHub issue-based workflows
- Update examples to use `gh issue view` and `gh issue comment` commands
- Align with migration from PR #2238

## Files Updated

- `agents/guides/package-phase-guide.md` - Update anti-patterns to reference GitHub issues
- `agents/docs/workflows.md` - Update artifact locations to GitHub issue comments
- `agents/docs/git-worktree-guide.md` - Update status reporting to use `gh issue comment`
- `agents/docs/examples.md` - Update expected outputs to reference issue comments

## Test Plan

- [x] All `notes/issues` references removed from agents directory
- [x] Pre-commit checks pass
- [ ] Verify documentation is coherent and examples work

🤖 Generated with [Claude Code](https://claude.com/claude-code)