### PR TITLE
fix(tests): Add raises keyword to benchmarking test functions

### DIFF
--- a/tests/shared/benchmarking/test_runner.mojo
+++ b/tests/shared/benchmarking/test_runner.mojo
@@ -15,10 +15,11 @@ from shared.benchmarking import (
     BenchmarkConfig,
     benchmark_function,
     create_benchmark_config,
+    print_benchmark_report,
 )
 
 
-fn test_benchmark_config_creation():
+fn test_benchmark_config_creation() raises:
     """Test creating benchmark configurations."""
     var config = BenchmarkConfig(
         warmup_iters=5, measure_iters=50, compute_percentiles=True, report_throughput=True
@@ -30,7 +31,7 @@ fn test_benchmark_config_creation():
     print("PASS: test_benchmark_config_creation")
 
 
-fn test_create_benchmark_config():
+fn test_create_benchmark_config() raises:
     """Test helper function to create config."""
     var config = create_benchmark_config(warmup_iters=10, measure_iters=100)
     assert_equal(config.warmup_iters, 10)
@@ -40,7 +41,7 @@ fn test_create_benchmark_config():
     print("PASS: test_create_benchmark_config")
 
 
-fn test_create_benchmark_config_defaults():
+fn test_create_benchmark_config_defaults() raises:
     """Test default values in config creation."""
     var config = create_benchmark_config()
     assert_equal(config.warmup_iters, 10)
@@ -50,7 +51,7 @@ fn test_create_benchmark_config_defaults():
     print("PASS: test_create_benchmark_config_defaults")
 
 
-fn test_benchmark_result_creation():
+fn test_benchmark_result_creation() raises:
     """Test creating benchmark result."""
     var result = BenchmarkResult(
         mean_latency_ms=10.5,
@@ -81,7 +82,7 @@ fn test_benchmark_result_creation():
 fn test_benchmark_simple_operation() raises:
     """Test benchmarking a simple operation."""
 
-    fn simple_operation():
+    fn simple_operation() raises:
         # Just do some basic computation
         var x = 0
         for i in range(100):
@@ -103,7 +104,7 @@ fn test_benchmark_simple_operation() raises:
 fn test_benchmark_with_percentiles() raises:
     """Test benchmarking with percentile computation."""
 
-    fn simple_operation():
+    fn simple_operation() raises:
         var x = 0
         for i in range(50):
             x += i
@@ -121,7 +122,7 @@ fn test_benchmark_with_percentiles() raises:
     print("PASS: test_benchmark_with_percentiles")
 
 
-fn test_print_benchmark_report():
+fn test_print_benchmark_report() raises:
     """Test printing benchmark report."""
     var result = BenchmarkResult(
         mean_latency_ms=10.5,
@@ -141,7 +142,7 @@ fn test_print_benchmark_report():
     print("PASS: test_print_benchmark_report")
 
 
-fn test_benchmark_config_custom_values():
+fn test_benchmark_config_custom_values() raises:
     """Test creating config with custom values."""
     var config = BenchmarkConfig(
         warmup_iters=20,
@@ -156,7 +157,7 @@ fn test_benchmark_config_custom_values():
     print("PASS: test_benchmark_config_custom_values")
 
 
-fn test_benchmark_result_statistics():
+fn test_benchmark_result_statistics() raises:
     """Test that benchmark results contain reasonable statistics."""
     # Create a result with realistic values
     var result = BenchmarkResult(
@@ -184,7 +185,7 @@ fn test_benchmark_result_statistics():
 fn test_benchmark_multiple_iterations() raises:
     """Test benchmarking with different iteration counts."""
 
-    fn operation():
+    fn operation() raises:
         var sum = 0
         for i in range(10):
             sum += i


### PR DESCRIPTION
## Summary

- Add `raises` to test functions calling assert_equal/assert_true
- Add `raises` to nested functions passed to benchmark_function
- Add missing print_benchmark_report import

Closes #2270

## Test plan

- [x] `mojo build` compiles test_runner.mojo without errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)