### PR TITLE
fix(core): Add transfer operator for List[ExTensor] return

### DIFF
--- a/shared/core/layers/linear.mojo
+++ b/shared/core/layers/linear.mojo
@@ -111,4 +111,4 @@ struct Linear:
         var params = List[ExTensor]()
         params.append(self.weight)
         params.append(self.bias)
-        return params
+        return params^


### PR DESCRIPTION
## Summary

Add `^` transfer operator to return statement in Linear.parameters() to fix ImplicitlyCopyable violation.

**Note:** Files mentioned in issue (integer.mojo, unsigned.mojo) don't exist in the codebase.
Other files mentioned (broadcasting.mojo, traits.mojo) compile without errors.

Closes #2271

## Test plan

- [x] `mojo build` compiles linear.mojo without errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)