### PR TITLE
fix(tests): Use correct tolerance= parameter for assert_almost_equal

### DIFF
--- a/tests/core/types/test_fp4_tensor.mojo
+++ b/tests/core/types/test_fp4_tensor.mojo
@@ -89,7 +89,7 @@ fn test_mxfp4_tensor_conversion_padding() raises:
     # Verify padding values (last 14) are zeros
     for i in range(50, 64):
         var decoded = restored._data.bitcast[Float32]()[i]
-        assert_almost_equal(decoded, 0.0, rtol=1e-5, atol=0.1)
+        assert_almost_equal(decoded, 0.0, tolerance=0.1)
 
 
 fn test_mxfp4_tensor_conversion_multidim() raises:
@@ -186,7 +186,7 @@ fn test_nvfp4_tensor_conversion_padding() raises:
     # Verify padding values (last 14) are zeros
     for i in range(50, 64):
         var decoded = restored._data.bitcast[Float32]()[i]
-        assert_almost_equal(decoded, 0.0, rtol=1e-5, atol=0.1)
+        assert_almost_equal(decoded, 0.0, tolerance=0.1)
 
 
 fn test_nvfp4_tensor_conversion_multidim() raises:

--- a/tests/shared/benchmarking/test_result.mojo
+++ b/tests/shared/benchmarking/test_result.mojo
@@ -34,7 +34,7 @@ fn test_record_single_iteration():
     assert_true(result.total_time_ns == 5000, "Total should be 5000")
     assert_true(result.min_time_ns == 5000, "Min should be 5000")
     assert_true(result.max_time_ns == 5000, "Max should be 5000")
-    assert_almost_equal(Float64(result.mean()), 5000.0, rtol=1e-6, atol=1e-6)
+    assert_almost_equal(Float64(result.mean()), 5000.0, tolerance=1e-6)
 
 
 fn test_record_multiple_iterations():
@@ -49,8 +49,8 @@ fn test_record_multiple_iterations():
     assert_true(result.total_time_ns == 10000, "Total should be 10000")
     assert_true(result.min_time_ns == 1000, "Min should be 1000")
     assert_true(result.max_time_ns == 1000, "Max should be 1000")
-    assert_almost_equal(Float64(result.mean()), 1000.0, rtol=1e-6, atol=1e-6)
-    assert_almost_equal(Float64(result.std()), 0.0, rtol=1e-6, atol=1e-6)
+    assert_almost_equal(Float64(result.mean()), 1000.0, tolerance=1e-6)
+    assert_almost_equal(Float64(result.std()), 0.0, tolerance=1e-6)
 
 
 fn test_mean_calculation():
@@ -64,7 +64,7 @@ fn test_mean_calculation():
 
     assert_true(result.iterations == 3, "Should have 3 iterations")
     # Mean = (1000 + 2000 + 3000) / 3 = 2000
-    assert_almost_equal(Float64(result.mean()), 2000.0, rtol=1e-6, atol=1e-6)
+    assert_almost_equal(Float64(result.mean()), 2000.0, tolerance=1e-6)
 
 
 fn test_std_dev_calculation():
@@ -85,20 +85,20 @@ fn test_std_dev_calculation():
 
     # Expected std dev = 1000.0
     var std = result.std()
-    assert_almost_equal(std, 1000.0, rtol=1e-5, atol=1e-5)
+    assert_almost_equal(std, 1000.0, tolerance=1e-5)
 
 
 fn test_std_dev_zero_iterations():
     """Test std dev returns 0 with no iterations."""
     var result = BenchmarkResult("empty_test", iterations=0)
-    assert_almost_equal(Float64(result.std()), 0.0, rtol=1e-6, atol=1e-6)
+    assert_almost_equal(Float64(result.std()), 0.0, tolerance=1e-6)
 
 
 fn test_std_dev_single_iteration():
     """Test std dev returns 0 with single iteration."""
     var result = BenchmarkResult("single_iter_test", iterations=0)
     result.record(5000)
-    assert_almost_equal(Float64(result.std()), 0.0, rtol=1e-6, atol=1e-6)
+    assert_almost_equal(Float64(result.std()), 0.0, tolerance=1e-6)
 
 
 fn test_min_max_tracking():
@@ -112,8 +112,8 @@ fn test_min_max_tracking():
 
     assert_true(result.min_time_ns == 1000, "Min should be 1000")
     assert_true(result.max_time_ns == 8000, "Max should be 8000")
-    assert_almost_equal(Float64(result.min_time()), 1000.0, rtol=1e-6, atol=1e-6)
-    assert_almost_equal(Float64(result.max_time()), 8000.0, rtol=1e-6, atol=1e-6)
+    assert_almost_equal(Float64(result.min_time()), 1000.0, tolerance=1e-6)
+    assert_almost_equal(Float64(result.max_time()), 8000.0, tolerance=1e-6)
 
 
 fn test_large_iteration_count():
@@ -129,7 +129,7 @@ fn test_large_iteration_count():
 
     # Mean should be around 10049.5
     var mean = result.mean()
-    assert_almost_equal(mean, 10049.5, rtol=1.0, atol=1.0)
+    assert_almost_equal(mean, 10049.5, tolerance=1.0)
 
     # Min should be 10000, max should be 10099
     assert_true(result.min_time_ns == 10000, "Min should be 10000")
@@ -210,7 +210,7 @@ fn test_welford_numerical_stability():
     var expected_mean = Float64(30000) / 201.0
     var actual_mean = result.mean()
 
-    assert_almost_equal(actual_mean, expected_mean, rtol=0.1, atol=0.1)
+    assert_almost_equal(actual_mean, expected_mean, tolerance=0.1)
 
 
 fn test_sequential_recording():
@@ -222,7 +222,7 @@ fn test_sequential_recording():
         result.record(i * 1000)
 
     # Mean of 1000..10000 = 5500
-    assert_almost_equal(Float64(result.mean()), 5500.0, rtol=1e-5, atol=1e-5)
+    assert_almost_equal(Float64(result.mean()), 5500.0, tolerance=1e-5)
 
     # Sample std dev calculation:
     # Deviations from mean: -4500, -3500, -2500, -1500, -500, 500, 1500, 2500, 3500, 4500
@@ -233,25 +233,25 @@ fn test_sequential_recording():
     // Sample std = sqrt(9166666.67) ≈ 3027.65
     var expected_std = 3027.65
     var actual_std = result.std()
-    assert_almost_equal(actual_std, expected_std, rtol=50.0, atol=50.0)
+    assert_almost_equal(actual_std, expected_std, tolerance=50.0)
 
 
 fn test_mean_getter_with_no_records():
     """Test mean() returns 0 when no iterations recorded."""
     var result = BenchmarkResult("empty_mean_test", iterations=0)
-    assert_almost_equal(Float64(result.mean()), 0.0, rtol=1e-6, atol=1e-6)
+    assert_almost_equal(Float64(result.mean()), 0.0, tolerance=1e-6)
 
 
 fn test_min_getter_with_no_records():
     """Test min_time() returns 0 when no iterations recorded."""
     var result = BenchmarkResult("empty_min_test", iterations=0)
-    assert_almost_equal(Float64(result.min_time()), 0.0, rtol=1e-6, atol=1e-6)
+    assert_almost_equal(Float64(result.min_time()), 0.0, tolerance=1e-6)
 
 
 fn test_max_getter_with_no_records():
     """Test max_time() returns 0 when no iterations recorded."""
     var result = BenchmarkResult("empty_max_test", iterations=0)
-    assert_almost_equal(Float64(result.max_time()), 0.0, rtol=1e-6, atol=1e-6)
+    assert_almost_equal(Float64(result.max_time()), 0.0, tolerance=1e-6)
 
 
 fn main():


### PR DESCRIPTION
## Summary

Fix compilation error in CI caused by using incorrect parameter names for `assert_almost_equal` function.

- The `assert_almost_equal` function in `conftest.mojo` uses `tolerance=` parameter
- Previous fix (PR #2326) incorrectly changed to `rtol=`/`atol=` which don't exist
- This caused compilation errors in Main Branch Quality workflow

## Changes

- `tests/core/types/test_fp4_tensor.mojo`: 2 occurrences fixed
- `tests/shared/benchmarking/test_result.mojo`: 16 occurrences fixed

## Test plan

- [x] Changed `rtol=X, atol=Y` to `tolerance=max(X,Y)`
- [ ] CI should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)