### PR TITLE
feat(examples): Use enhanced arg_parser for CLI configuration

### DIFF
--- a/examples/alexnet-cifar10/inference.mojo
+++ b/examples/alexnet-cifar10/inference.mojo
@@ -18,26 +18,25 @@ References:
 from model import AlexNet
 from shared.data.datasets import load_cifar10_test
 from shared.core import ExTensor
-from sys import argv
+from shared.utils.arg_parser import ArgumentParser
 
 
 fn parse_args() raises -> Tuple[String, String]:
-    """Parse command line arguments.
+    """Parse command line arguments using enhanced argument parser.
 
     Returns:
         Tuple of (weights_dir, data_dir)
     """
-    var weights_dir = "alexnet_weights"
-    var data_dir = "datasets/cifar10"
+    var parser = ArgumentParser()
+    parser.add_argument("weights-dir", "string", "alexnet_weights")
+    parser.add_argument("data-dir", "string", "datasets/cifar10")
 
-    var args = argv()
-    for i in range(len(args)):
-        if args[i] == "--weights-dir" and i + 1 < len(args):
-            weights_dir = args[i + 1]
-        elif args[i] == "--data-dir" and i + 1 < len(args):
-            data_dir = args[i + 1]
+    var args = parser.parse()
 
-    return (weights_dir, data_dir)
+    var weights_dir = args.get_string("weights-dir", "alexnet_weights")
+    var data_dir = args.get_string("data-dir", "datasets/cifar10")
+
+    return Tuple[String, String](weights_dir, data_dir)
 
 
 fn evaluate_model(

--- a/examples/alexnet-cifar10/train.mojo
+++ b/examples/alexnet-cifar10/train.mojo
@@ -26,36 +26,26 @@ from shared.core.activation import relu, relu_backward
 from shared.core.dropout import dropout, dropout_backward
 from shared.core.loss import cross_entropy, cross_entropy_backward
 from shared.training.schedulers import step_lr
-from sys import argv
+from shared.utils.arg_parser import create_training_parser
 
 
 fn parse_args() raises -> Tuple[Int, Int, Float32, Float32, String, String]:
-    """Parse command line arguments.
+    """Parse command line arguments using enhanced argument parser.
 
     Returns:
         Tuple of (epochs, batch_size, learning_rate, momentum, data_dir, weights_dir)
     """
-    var epochs = 100
-    var batch_size = 128
-    var learning_rate = Float32(0.01)
-    var momentum = Float32(0.9)
-    var data_dir = "datasets/cifar10"
-    var weights_dir = "alexnet_weights"
+    var parser = create_training_parser()
+    parser.add_argument("weights-dir", "string", "alexnet_weights")
 
-    var args = argv()
-    for i in range(len(args)):
-        if args[i] == "--epochs" and i + 1 < len(args):
-            epochs = int(args[i + 1])
-        elif args[i] == "--batch-size" and i + 1 < len(args):
-            batch_size = int(args[i + 1])
-        elif args[i] == "--lr" and i + 1 < len(args):
-            learning_rate = Float32(float(args[i + 1]))
-        elif args[i] == "--momentum" and i + 1 < len(args):
-            momentum = Float32(float(args[i + 1]))
-        elif args[i] == "--data-dir" and i + 1 < len(args):
-            data_dir = args[i + 1]
-        elif args[i] == "--weights-dir" and i + 1 < len(args):
-            weights_dir = args[i + 1]
+    var args = parser.parse()
+
+    var epochs = args.get_int("epochs", 100)
+    var batch_size = args.get_int("batch-size", 128)
+    var learning_rate = Float32(args.get_float("lr", 0.01))
+    var momentum = Float32(args.get_float("momentum", 0.9))
+    var data_dir = args.get_string("data-dir", "datasets/cifar10")
+    var weights_dir = args.get_string("weights-dir", "alexnet_weights")
 
     return (epochs, batch_size, learning_rate, momentum, data_dir, weights_dir)
 

--- a/examples/lenet-emnist/inference.mojo
+++ b/examples/lenet-emnist/inference.mojo
@@ -19,7 +19,7 @@ References:
 from model import LeNet5
 from shared.data import load_idx_labels, load_idx_images, normalize_images
 from shared.core import ExTensor, zeros
-from sys import argv
+from shared.utils.arg_parser import ArgumentParser
 from collections import List
 from math import exp
 
@@ -70,20 +70,19 @@ struct EvaluationResult:
 
 
 fn parse_args() raises -> InferenceConfig:
-    """Parse command line arguments.
+    """Parse command line arguments using enhanced argument parser.
 
     Returns:
         InferenceConfig with parsed arguments.
     """
-    var weights_dir = String("lenet5_weights")
-    var data_dir = String("datasets/emnist")
+    var parser = ArgumentParser()
+    parser.add_argument("weights-dir", "string", "lenet5_weights")
+    parser.add_argument("data-dir", "string", "datasets/emnist")
 
-    var args = argv()
-    for i in range(len(args)):
-        if args[i] == "--weights-dir" and i + 1 < len(args):
-            weights_dir = args[i + 1]
-        elif args[i] == "--data-dir" and i + 1 < len(args):
-            data_dir = args[i + 1]
+    var args = parser.parse()
+
+    var weights_dir = args.get_string("weights-dir", "lenet5_weights")
+    var data_dir = args.get_string("data-dir", "datasets/emnist")
 
     return InferenceConfig(weights_dir, data_dir)
 

--- a/examples/lenet-emnist/run_infer.mojo
+++ b/examples/lenet-emnist/run_infer.mojo
@@ -17,7 +17,7 @@ Arguments:
 from model import LeNet5
 from shared.data import load_idx_labels, load_idx_images, normalize_images
 from shared.core import ExTensor, zeros
-from sys import argv
+from shared.utils.arg_parser import ArgumentParser
 from collections import List
 
 
@@ -75,29 +75,22 @@ struct InferConfig(Movable):
 
 
 fn parse_args() raises -> InferConfig:
-    """Parse command line arguments."""
-    var config = InferConfig()
+    """Parse command line arguments using enhanced argument parser."""
+    var parser = ArgumentParser()
+    parser.add_argument("checkpoint", "string", "")
+    parser.add_argument("image", "string", "")
+    parser.add_flag("test-set")
+    parser.add_argument("data-dir", "string", "datasets/emnist")
+    parser.add_argument("top-k", "int", "5")
 
-    var args = argv()
-    var i = 0
-    while i < len(args):
-        if args[i] == "--checkpoint" and i + 1 < len(args):
-            config.checkpoint_dir = args[i + 1]
-            i += 2
-        elif args[i] == "--image" and i + 1 < len(args):
-            config.image_path = args[i + 1]
-            i += 2
-        elif args[i] == "--test-set":
-            config.run_test_set = True
-            i += 1
-        elif args[i] == "--data-dir" and i + 1 < len(args):
-            config.data_dir = args[i + 1]
-            i += 2
-        elif args[i] == "--top-k" and i + 1 < len(args):
-            config.top_k = Int(args[i + 1])
-            i += 2
-        else:
-            i += 1
+    var args = parser.parse()
+
+    var config = InferConfig()
+    config.checkpoint_dir = args.get_string("checkpoint", "")
+    config.image_path = args.get_string("image", "")
+    config.run_test_set = args.get_bool("test-set")
+    config.data_dir = args.get_string("data-dir", "datasets/emnist")
+    config.top_k = args.get_int("top-k", 5)
 
     return config^
 

--- a/examples/lenet-emnist/train.mojo
+++ b/examples/lenet-emnist/train.mojo
@@ -31,7 +31,7 @@ from shared.core.pooling import maxpool2d, maxpool2d_backward
 from shared.core.linear import linear, linear_backward
 from shared.core.activation import relu, relu_backward
 from shared.core.loss import cross_entropy, cross_entropy_backward
-from sys import argv
+from shared.utils.arg_parser import create_training_parser
 from collections import List
 
 # Default number of classes for EMNIST Balanced dataset
@@ -55,29 +55,21 @@ struct TrainConfig:
 
 
 fn parse_args() raises -> TrainConfig:
-    """Parse command line arguments.
+    """Parse command line arguments using enhanced argument parser.
 
     Returns:
         TrainConfig with parsed arguments.
     """
-    var epochs = 10
-    var batch_size = 32
-    var learning_rate = Float32(0.001)
-    var data_dir = String("datasets/emnist")
-    var weights_dir = String("lenet5_weights")
+    var parser = create_training_parser()
+    parser.add_argument("weights-dir", "string", "lenet5_weights")
 
-    var args = argv()
-    for i in range(len(args)):
-        if args[i] == "--epochs" and i + 1 < len(args):
-            epochs = Int(args[i + 1])
-        elif args[i] == "--batch-size" and i + 1 < len(args):
-            batch_size = Int(args[i + 1])
-        elif args[i] == "--lr" and i + 1 < len(args):
-            learning_rate = Float32(Float64(args[i + 1]))
-        elif args[i] == "--data-dir" and i + 1 < len(args):
-            data_dir = args[i + 1]
-        elif args[i] == "--weights-dir" and i + 1 < len(args):
-            weights_dir = args[i + 1]
+    var args = parser.parse()
+
+    var epochs = args.get_int("epochs", 10)
+    var batch_size = args.get_int("batch-size", 32)
+    var learning_rate = Float32(args.get_float("lr", 0.001))
+    var data_dir = args.get_string("data-dir", "datasets/emnist")
+    var weights_dir = args.get_string("weights-dir", "lenet5_weights")
 
     return TrainConfig(epochs, batch_size, learning_rate, data_dir, weights_dir)
 

--- a/examples/vgg16-cifar10/inference.mojo
+++ b/examples/vgg16-cifar10/inference.mojo
@@ -3,12 +3,32 @@
 Loads trained weights and evaluates on test set.
 
 Usage:
-    mojo run examples/vgg16-cifar10/inference.mojo --weights-dir vgg16_weights
+    mojo run examples/vgg16-cifar10/inference.mojo --weights-dir vgg16_weights --data-dir datasets/cifar10
 """
 
 from shared.core import ExTensor, zeros
 from shared.data.formats import load_cifar10_batch
 from model import VGG16
+from shared.utils.arg_parser import ArgumentParser
+from collections import List
+
+
+fn parse_args() raises -> Tuple[String, String]:
+    """Parse command line arguments using enhanced argument parser.
+
+    Returns:
+        Tuple of (weights_dir, data_dir)
+    """
+    var parser = ArgumentParser()
+    parser.add_argument("weights-dir", "string", "vgg16_weights")
+    parser.add_argument("data-dir", "string", "datasets/cifar10")
+
+    var args = parser.parse()
+
+    var weights_dir = args.get_string("weights-dir", "vgg16_weights")
+    var data_dir = args.get_string("data-dir", "datasets/cifar10")
+
+    return Tuple[String, String](weights_dir, data_dir)
 
 
 fn compute_test_accuracy(mut model: VGG16, test_images: ExTensor, test_labels: ExTensor) raises -> Float32:
@@ -61,9 +81,10 @@ fn main() raises:
     print("=== VGG-16 Inference on CIFAR-10 ===")
     print()
 
-    # Configuration
-    var weights_dir = "vgg16_weights"
-    var data_dir = "datasets/cifar10"
+    # Parse command-line arguments
+    var parsed = parse_args()
+    var weights_dir = parsed[0]
+    var data_dir = parsed[1]
 
     # Load test set
     print("Loading CIFAR-10 test set...")

--- a/examples/vgg16-cifar10/train.mojo
+++ b/examples/vgg16-cifar10/train.mojo
@@ -27,38 +27,28 @@ from shared.core.dropout import dropout, dropout_backward
 from shared.core.loss import cross_entropy, cross_entropy_backward
 from shared.training.schedulers import step_lr
 from shared.data import extract_batch_pair, compute_num_batches, get_batch_indices
-from sys import argv
+from shared.utils.arg_parser import create_training_parser
 
 
-fn parse_args() raises -> (Int, Int, Float32, Float32, String, String):
-    """Parse command line arguments.
+fn parse_args() raises -> Tuple[Int, Int, Float32, Float32, String, String]:
+    """Parse command line arguments using enhanced argument parser.
 
     Returns:
         Tuple of (epochs, batch_size, learning_rate, momentum, data_dir, weights_dir)
     """
-    var epochs = 200
-    var batch_size = 128
-    var learning_rate = Float32(0.01)
-    var momentum = Float32(0.9)
-    var data_dir = "datasets/cifar10"
-    var weights_dir = "vgg16_weights"
+    var parser = create_training_parser()
+    parser.add_argument("weights-dir", "string", "vgg16_weights")
 
-    var args = argv()
-    for i in range(len(args)):
-        if args[i] == "--epochs" and i + 1 < len(args):
-            epochs = int(args[i + 1])
-        elif args[i] == "--batch-size" and i + 1 < len(args):
-            batch_size = int(args[i + 1])
-        elif args[i] == "--lr" and i + 1 < len(args):
-            learning_rate = Float32(float(args[i + 1]))
-        elif args[i] == "--momentum" and i + 1 < len(args):
-            momentum = Float32(float(args[i + 1]))
-        elif args[i] == "--data-dir" and i + 1 < len(args):
-            data_dir = args[i + 1]
-        elif args[i] == "--weights-dir" and i + 1 < len(args):
-            weights_dir = args[i + 1]
+    var args = parser.parse()
 
-    return (epochs, batch_size, learning_rate, momentum, data_dir, weights_dir)
+    var epochs = args.get_int("epochs", 200)
+    var batch_size = args.get_int("batch-size", 128)
+    var learning_rate = Float32(args.get_float("lr", 0.01))
+    var momentum = Float32(args.get_float("momentum", 0.9))
+    var data_dir = args.get_string("data-dir", "datasets/cifar10")
+    var weights_dir = args.get_string("weights-dir", "vgg16_weights")
+
+    return Tuple[Int, Int, Float32, Float32, String, String](epochs, batch_size, learning_rate, momentum, data_dir, weights_dir)
 
 
 fn compute_gradients(


### PR DESCRIPTION
## Summary
- Update lenet-emnist, alexnet-cifar10, vgg16-cifar10 train/inference scripts
- Use create_training_parser() from shared.utils.arg_parser
- Replace hardcoded hyperparameters with parsed arguments
- Add standard CLI options: --epochs, --batch-size, --lr, etc.

Files updated:
- examples/lenet-emnist/run_train.mojo, train.mojo, inference.mojo, run_infer.mojo
- examples/alexnet-cifar10/train.mojo, inference.mojo
- examples/vgg16-cifar10/train.mojo, inference.mojo

Closes #2297

🤖 Generated with [Claude Code](https://claude.com/claude-code)