### PR TITLE
fix(alexnet): Add missing evaluate_with_predict import

### DIFF
--- a/examples/alexnet-cifar10/train.mojo
+++ b/examples/alexnet-cifar10/train.mojo
@@ -27,6 +27,8 @@ from shared.core.dropout import dropout, dropout_backward
 from shared.core.loss import cross_entropy, cross_entropy_backward
 from shared.training.schedulers import step_lr
 from shared.utils.arg_parser import create_training_parser
+from shared.training.metrics import evaluate_with_predict
+from collections import List
 
 
 fn parse_args() raises -> Tuple[Int, Int, Float32, Float32, String, String]:


### PR DESCRIPTION
## Summary
- Add missing import for evaluate_with_predict from shared.training.metrics
- Add List import from collections
- Fixes compilation error in alexnet-cifar10/train.mojo

The evaluate function was using evaluate_with_predict but missing the import.

Closes #2292

🤖 Generated with [Claude Code](https://claude.com/claude-code)