### PR TITLE
fix(examples): Resolve conflict markers accidentally merged to main

### DIFF
--- a/examples/lenet-emnist/inference.mojo
+++ b/examples/lenet-emnist/inference.mojo
@@ -71,16 +71,11 @@ struct EvaluationResult:
 
 
 fn parse_args() raises -> InferenceConfig:
-<<<<<<< HEAD
     """Parse command line arguments using enhanced argument parser.
-=======
-    """Parse command line arguments using shared ArgumentParser.
->>>>>>> 27c604ca (refactor(lenet-emnist): Final integration with all shared modules)
 
     Returns:
         InferenceConfig with parsed arguments.
     """
-<<<<<<< HEAD
     var parser = ArgumentParser()
     parser.add_argument("weights-dir", "string", "lenet5_weights")
     parser.add_argument("data-dir", "string", "datasets/emnist")
@@ -89,18 +84,6 @@ fn parse_args() raises -> InferenceConfig:
 
     var weights_dir = args.get_string("weights-dir", "lenet5_weights")
     var data_dir = args.get_string("data-dir", "datasets/emnist")
-=======
-    # Create argument parser with shared utilities
-    var parser = ArgumentParser()
-
-    # Set up standard arguments with types and defaults
-    parser.add_argument("weights-dir", "string", "lenet5_weights")
-    parser.add_argument("data-dir", "string", "datasets/emnist")
-
-    var parsed = parser.parse()
-    var weights_dir = parsed.get_string("weights-dir")
-    var data_dir = parsed.get_string("data-dir")
->>>>>>> 27c604ca (refactor(lenet-emnist): Final integration with all shared modules)
 
     return InferenceConfig(weights_dir, data_dir)
 

--- a/examples/lenet-emnist/run_infer.mojo
+++ b/examples/lenet-emnist/run_infer.mojo
@@ -76,7 +76,6 @@ struct InferConfig(Movable):
 
 
 fn parse_args() raises -> InferConfig:
-<<<<<<< HEAD
     """Parse command line arguments using enhanced argument parser."""
     var parser = ArgumentParser()
     parser.add_argument("checkpoint", "string", "")
@@ -93,27 +92,6 @@ fn parse_args() raises -> InferConfig:
     config.run_test_set = args.get_bool("test-set")
     config.data_dir = args.get_string("data-dir", "datasets/emnist")
     config.top_k = args.get_int("top-k", 5)
-=======
-    """Parse command line arguments using shared ArgumentParser."""
-    # Create argument parser with shared utilities
-    var parser = ArgumentParser()
-
-    # Set up standard arguments with types and defaults
-    parser.add_argument("checkpoint", "string", "")
-    parser.add_argument("image", "string", "")
-    parser.add_flag("test-set")
-    parser.add_argument("data-dir", "string", "datasets/emnist")
-    parser.add_argument("top-k", "int", "5")
-
-    var parsed = parser.parse()
-
-    var config = InferConfig()
-    config.checkpoint_dir = parsed.get_string("checkpoint")
-    config.image_path = parsed.get_string("image")
-    config.run_test_set = parsed.get_bool("test-set")
-    config.data_dir = parsed.get_string("data-dir")
-    config.top_k = parsed.get_int("top-k")
->>>>>>> 27c604ca (refactor(lenet-emnist): Final integration with all shared modules)
 
     return config^
 

--- a/examples/lenet-emnist/train.mojo
+++ b/examples/lenet-emnist/train.mojo
@@ -58,16 +58,11 @@ struct TrainConfig:
 
 
 fn parse_args() raises -> TrainConfig:
-<<<<<<< HEAD
     """Parse command line arguments using enhanced argument parser.
-=======
-    """Parse command line arguments using shared ArgumentParser.
->>>>>>> 27c604ca (refactor(lenet-emnist): Final integration with all shared modules)
 
     Returns:
         TrainConfig with parsed arguments.
     """
-<<<<<<< HEAD
     var parser = create_training_parser()
     parser.add_argument("weights-dir", "string", "lenet5_weights")
 
@@ -78,25 +73,6 @@ fn parse_args() raises -> TrainConfig:
     var learning_rate = Float32(args.get_float("lr", 0.001))
     var data_dir = args.get_string("data-dir", "datasets/emnist")
     var weights_dir = args.get_string("weights-dir", "lenet5_weights")
-=======
-    # Create argument parser with shared utilities
-    var parser = ArgumentParser()
-
-    # Set up standard arguments with types and defaults
-    parser.add_argument("epochs", "int", "10")
-    parser.add_argument("batch-size", "int", "32")
-    parser.add_argument("lr", "float", "0.001")
-    parser.add_argument("data-dir", "string", "datasets/emnist")
-    parser.add_argument("weights-dir", "string", "lenet5_weights")
-
-    var args = parser.parse()
-
-    var epochs = args.get_int("epochs")
-    var batch_size = args.get_int("batch-size")
-    var learning_rate = Float32(args.get_float("lr"))
-    var data_dir = args.get_string("data-dir")
-    var weights_dir = args.get_string("weights-dir")
->>>>>>> 27c604ca (refactor(lenet-emnist): Final integration with all shared modules)
 
     return TrainConfig(epochs, batch_size, learning_rate, data_dir, weights_dir)
 

--- a/examples/vgg16-cifar10/inference.mojo
+++ b/examples/vgg16-cifar10/inference.mojo
@@ -51,7 +51,6 @@ fn compute_test_accuracy(mut model: VGG16, test_images: ExTensor, test_labels: E
     var test_shape = test_images.shape()
     var num_test_samples = test_shape[0]
 
-<<<<<<< HEAD
     print("Evaluating on " + str(num_test_samples) + " test samples...")
 
     # Collect predictions using model.predict()
@@ -64,36 +63,16 @@ fn compute_test_accuracy(mut model: VGG16, test_images: ExTensor, test_labels: E
 
         # Forward pass (inference mode)
         var pred_class = model.predict(sample)
-=======
-    var predictions = List[Int]()
-
-    print("Evaluating on " + str(num_test_samples) + " test samples...")
-
-    # Process each test sample and collect predictions
-    for i in range(num_test_samples):
-        # Extract single sample using shared batch utilities
-        var batch_pair = extract_batch_pair(test_images, test_labels, i, 1)
-        var sample_image = batch_pair[0]
-
-        # Forward pass (inference mode)
-        var pred_class = model.predict(sample_image)
->>>>>>> ac757af4 (refactor(vgg16): Final integration with all shared modules)
         predictions.append(pred_class)
 
         # Print progress every 1000 samples
         if (i + 1) % 1000 == 0:
             print("  Processed " + str(i + 1) + "/" + str(num_test_samples))
 
-<<<<<<< HEAD
     # Use shared evaluate function
     var accuracy_fraction = evaluate_with_predict(predictions, test_labels)
     var accuracy = accuracy_fraction * 100.0
     return accuracy
-=======
-    # Use shared evaluate function from shared.training.metrics
-    var accuracy = evaluate_with_predict(predictions, test_labels)
-    return accuracy * 100.0
->>>>>>> ac757af4 (refactor(vgg16): Final integration with all shared modules)
 
 
 fn main() raises:


### PR DESCRIPTION
## Summary

This PR fixes unresolved git conflict markers that were accidentally merged to main in commit 0bf6beb0.

**Affected files:**
- `examples/lenet-emnist/train.mojo`
- `examples/lenet-emnist/inference.mojo`
- `examples/lenet-emnist/run_infer.mojo`
- `examples/vgg16-cifar10/inference.mojo`

**Resolution:**
- Used the correct version with `create_training_parser()` and default values for argument parsing
- Removed duplicate conflict marker blocks

## Test plan
- [ ] Verify no `<<<<<<` markers remain in codebase
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)