### PR TITLE
[E1.2] Add AdamW optimizer to shared/training/optimizers/

### DIFF
--- a/shared/training/optimizers/__init__.mojo
+++ b/shared/training/optimizers/__init__.mojo
@@ -26,8 +26,8 @@ from .sgd import (
 # Adam optimizer (functional implementation)
 from .adam import adam_step, adam_step_simple
 
+# AdamW optimizer (functional implementation with decoupled weight decay)
+from .adamw import adamw_step, adamw_step_simple
+
 # RMSprop optimizer (functional implementation)
 from .rmsprop import rmsprop_step, rmsprop_step_simple
-
-# TODO(#2397): Implement remaining optimizers
-# from .adamw import adamw_step

--- a/shared/training/optimizers/adamw.mojo
+++ b/shared/training/optimizers/adamw.mojo
@@ -1,0 +1,224 @@
+"""AdamW optimizer (Adam with decoupled Weight Decay).
+
+This module provides the AdamW optimizer for updating model parameters
+during training using adaptive learning rates with decoupled weight decay.
+
+AdamW is a variant of Adam that decouples weight decay from the gradient-based
+update. This means weight decay is applied directly to the parameters, not to
+the gradients. This leads to better generalization and is the recommended
+approach for modern deep learning.
+
+Standard AdamW update rule:
+    m = beta1 * m + (1 - beta1) * gradients
+    v = beta2 * v + (1 - beta2) * gradients^2
+    m_hat = m / (1 - beta1^t)  # Bias correction
+    v_hat = v / (1 - beta2^t)  # Bias correction
+    params = params - learning_rate * m_hat / (sqrt(v_hat) + epsilon)
+    params = params - weight_decay * learning_rate * params  # Decoupled WD
+
+The key difference from standard Adam:
+    - Weight decay is applied AFTER the adaptive update
+    - Weight decay is NOT added to the gradients
+    - Weight decay is applied directly to parameters
+
+Reference:
+    Loshchilov, I., & Hutter, F. (2019). Decoupled Weight Decay Regularization.
+    arXiv preprint arXiv:1711.05101.
+"""
+
+from shared.core.extensor import ExTensor
+from shared.core.arithmetic import subtract, multiply, add, divide, power
+from shared.core.arithmetic_simd import (
+    subtract_simd,
+    multiply_simd,
+    add_simd,
+    divide_simd,
+)
+from shared.core.elementwise import sqrt
+from shared.core.extensor import full_like, ones_like
+
+
+fn adamw_step(
+    params: ExTensor,
+    gradients: ExTensor,
+    m: ExTensor,
+    v: ExTensor,
+    t: Int,
+    learning_rate: Float64,
+    beta1: Float64 = 0.9,
+    beta2: Float64 = 0.999,
+    epsilon: Float64 = 1e-8,
+    weight_decay: Float64 = 0.01,
+) raises -> Tuple[ExTensor, ExTensor, ExTensor]:
+    """Perform a single AdamW optimization step - pure functional.
+
+    Returns new parameters, new first moment (m), and new second moment (v).
+    Caller manages all state including timestep tracking.
+
+    Key difference from Adam:
+        Weight decay is applied directly to parameters AFTER the adaptive update,
+        not added to the gradients. This is "decoupled" weight decay.
+
+    Args:
+        `params`: Model parameters to update.
+        `gradients`: Gradients of loss with respect to params.
+        `m`: First moment estimates (exponential moving average of gradients)
+        `v`: Second moment estimates (exponential moving average of squared gradients)
+        `t`: Current timestep (starts at 1, increments each step)
+        `learning_rate`: Step size for parameter updates.
+        `beta1`: Exponential decay rate for first moment (default: 0.9)
+        `beta2`: Exponential decay rate for second moment (default: 0.999)
+        `epsilon`: Small constant for numerical stability (default: 1e-8)
+        `weight_decay`: Decoupled weight decay factor (default: 0.01)
+
+    Returns:
+        Tuple of (new_params, new_m, new_v)
+
+    Example (basic AdamW):
+        ```mojo
+        from shared.core import ExTensor, zeros_like
+        from shared.training.optimizers import adamw_step
+
+        var W = xavier_uniform(784, 128, DType.float32)
+        var m = zeros_like(W)
+        var v = zeros_like(W)
+        var t = 1
+
+        # Training loop
+        for epoch in range(100):
+            var grad_W = ...  # Compute gradients
+            (W, m, v) = adamw_step(W, grad_W, m, v, t, lr=0.001, weight_decay=0.01)
+            t += 1
+        ```
+
+    Note:
+        This is a pure function - it returns new state rather than mutating.
+        Caller must capture all three return values and update their variables.
+        Timestep t must be tracked by caller and incremented after each step.
+        Weight decay is applied AFTER the adaptive update (decoupled).
+    """
+    if params.shape() != gradients.shape():
+        raise Error("Parameters and gradients must have the same shape")
+
+    if params.dtype() != gradients.dtype():
+        raise Error("Parameters and gradients must have the same dtype")
+
+    if m.numel() == 0 or v.numel() == 0:
+        raise Error(
+            "Moment buffers (m and v) must be initialized (use zeros_like(params))"
+        )
+
+    if t <= 0:
+        raise Error("Timestep t must be positive (starts at 1)")
+
+    # Update biased first moment estimate (SIMD optimized)
+    # m = beta1 * m + (1 - beta1) * grad
+    var beta1_tensor = full_like(m, beta1)
+    var one_minus_beta1 = full_like(m, 1.0 - beta1)
+
+    var m_decay = multiply_simd(beta1_tensor, m)
+    var grad_term = multiply_simd(one_minus_beta1, gradients)
+    var new_m = add_simd(m_decay, grad_term)
+
+    # Update biased second moment estimate (SIMD optimized)
+    # v = beta2 * v + (1 - beta2) * grad^2
+    var beta2_tensor = full_like(v, beta2)
+    var one_minus_beta2 = full_like(v, 1.0 - beta2)
+
+    var v_decay = multiply_simd(beta2_tensor, v)
+    var grad_squared = multiply_simd(gradients, gradients)
+    var grad_squared_term = multiply_simd(one_minus_beta2, grad_squared)
+    var new_v = add_simd(v_decay, grad_squared_term)
+
+    # Compute bias-corrected first moment (SIMD optimized)
+    # m_hat = m / (1 - beta1^t)
+    var bias_correction1 = 1.0 - pow(beta1, Float64(t))
+    var bc1_tensor = full_like(new_m, bias_correction1)
+    var m_hat = divide_simd(new_m, bc1_tensor)
+
+    # Compute bias-corrected second moment (SIMD optimized)
+    # v_hat = v / (1 - beta2^t)
+    var bias_correction2 = 1.0 - pow(beta2, Float64(t))
+    var bc2_tensor = full_like(new_v, bias_correction2)
+    var v_hat = divide_simd(new_v, bc2_tensor)
+
+    # Compute parameter update (SIMD optimized)
+    # params = params - lr * m_hat / (sqrt(v_hat) + epsilon)
+    var v_hat_sqrt = sqrt(v_hat)
+    var epsilon_tensor = full_like(v_hat_sqrt, epsilon)
+    var denominator = add_simd(v_hat_sqrt, epsilon_tensor)
+    var update_direction = divide_simd(m_hat, denominator)
+
+    var lr_tensor = full_like(params, learning_rate)
+    var update = multiply_simd(lr_tensor, update_direction)
+    var new_params = subtract_simd(params, update)
+
+    # Apply decoupled weight decay (SIMD optimized)
+    # params = params - weight_decay * learning_rate * params
+    # Note: This is different from standard Adam where weight decay is added to gradients
+    if weight_decay > 0.0:
+        var wd_factor = weight_decay * learning_rate
+        var wd_tensor = full_like(new_params, wd_factor)
+        var wd_term = multiply_simd(wd_tensor, new_params)
+        new_params = subtract_simd(new_params, wd_term)
+
+    # Return new state (pure functional)
+    return (new_params, new_m, new_v)
+
+
+fn adamw_step_simple(
+    params: ExTensor,
+    gradients: ExTensor,
+    m: ExTensor,
+    v: ExTensor,
+    t: Int,
+    learning_rate: Float64,
+) raises -> Tuple[ExTensor, ExTensor, ExTensor]:
+    """Simplified AdamW step with default hyperparameters.
+
+    This is a convenience function for basic AdamW optimization.
+
+    Formula:
+        m = 0.9 * m + 0.1 * grad
+        v = 0.999 * v + 0.001 * grad^2
+        m_hat = m / (1 - 0.9^t)
+        v_hat = v / (1 - 0.999^t)
+        params = params - lr * m_hat / (sqrt(v_hat) + 1e-8)
+        params = params - 0.01 * lr * params  # Decoupled weight decay
+
+    Args:
+        `params`: Model parameters to update.
+        `gradients`: Gradients of loss with respect to params.
+        `m`: First moment estimate.
+        `v`: Second moment estimate.
+        `t`: Current timestep (starts at 1)
+        `learning_rate`: Step size for parameter updates.
+
+    Returns:
+        Tuple of (new_params, new_m, new_v)
+
+    Example:
+        ```mojo
+        var W = xavier_uniform(784, 128, shape, DType.float32)
+        var m = zeros_like(W)
+        var v = zeros_like(W)
+        var t = 1
+
+        for epoch in range(100):
+            var grad_W = ... # Computed gradients
+            (W, m, v) = adamw_step_simple(W, grad_W, m, v, t, 0.001)
+            t += 1
+        ```
+    """
+    return adamw_step(
+        params,
+        gradients,
+        m,
+        v,
+        t,
+        learning_rate=learning_rate,
+        beta1=0.9,
+        beta2=0.999,
+        epsilon=1e-8,
+        weight_decay=0.01,
+    )

--- a/tests/shared/training/test_adamw.mojo
+++ b/tests/shared/training/test_adamw.mojo
@@ -1,0 +1,438 @@
+"""Unit tests for AdamW (Adam with Weight Decay) optimizer implementation.
+
+Tests cover:
+- AdamW initialization and API contract
+- Parameter updates with adaptive learning rates
+- Bias correction in early training steps
+- Decoupled weight decay application
+- Comparison with standard Adam (weight decay behavior)
+- Edge cases and numerical stability
+
+Following TDD principles - these tests define the expected API
+and numerical behavior for AdamW optimizer.
+"""
+
+from tests.shared.conftest import (
+    assert_true,
+    assert_equal,
+    assert_almost_equal,
+    assert_less,
+    assert_greater,
+)
+from shared.core.extensor import ExTensor, zeros, ones, zeros_like
+from shared.training.optimizers.adamw import adamw_step, adamw_step_simple
+
+
+# ============================================================================
+# AdamW Initialization Tests
+# ============================================================================
+
+
+fn test_adamw_initialization() raises:
+    """Test AdamW optimizer initialization with hyperparameters.
+
+    Functional API Note:
+        Pure functional design - no class initialization.
+        Hyperparameters are passed as function arguments to adamw_step().
+        This test verifies that the function accepts all expected parameters.
+    """
+    # Test that adamw_step accepts all hyperparameters
+    var shape = List[Int]()
+    shape.append(3)
+    var params = ones(shape, DType.float32)
+    var grads = zeros(shape, DType.float32)
+    var m = zeros(shape, DType.float32)
+    var v = zeros(shape, DType.float32)
+
+    # Should accept all hyperparameters without error
+    var result = adamw_step(
+        params,
+        grads,
+        m,
+        v,
+        t=1,
+        learning_rate=0.001,
+        beta1=0.9,
+        beta2=0.999,
+        epsilon=1e-8,
+        weight_decay=0.01,
+    )
+
+    # If we got here without error, the API contract is satisfied
+    assert_true(True)  # Placeholder to mark test as passing
+
+
+fn test_adamw_parameter_update() raises:
+    """Test AdamW performs correct parameter update.
+
+    Functional API:
+        AdamW maintains two moments:
+        - m (first moment, momentum)
+        - v (second moment, RMSprop)
+
+        Update formulas (same as Adam):
+        - m = beta1 * m + (1 - beta1) * grad
+        - v = beta2 * v + (1 - beta2) * grad^2
+        - m_hat = m / (1 - beta1^t)  # Bias correction
+        - v_hat = v / (1 - beta2^t)  # Bias correction
+        - params = params - lr * m_hat / (sqrt(v_hat) + epsilon)
+
+        Weight decay (DIFFERENT from Adam):
+        - params = params - weight_decay * lr * params  # Decoupled WD
+
+    This is a CRITICAL test for AdamW correctness.
+    """
+    var shape = List[Int]()
+    shape.append(1)
+    var params = ones(shape, DType.float32)
+    params._data.bitcast[Float32]()[0] = 1.0
+
+    var grads = zeros(shape, DType.float32)
+    grads._data.bitcast[Float32]()[0] = 0.1
+
+    var m = zeros(shape, DType.float32)
+    var v = zeros(shape, DType.float32)
+
+    # First step (t=1):
+    # m = 0.9 * 0 + 0.1 * 0.1 = 0.01
+    # v = 0.999 * 0 + 0.001 * 0.01 = 0.00001
+    # m_hat = 0.01 / (1 - 0.9) = 0.1
+    # v_hat = 0.00001 / (1 - 0.999) = 0.01
+    # update = 0.001 * 0.1 / (sqrt(0.01) + 1e-8) ≈ 0.001
+    # params_after_update ≈ 0.999
+    # Then weight decay: params = 0.999 - 0.01 * 0.001 * 0.999 ≈ 0.9990001
+    var result = adamw_step(
+        params,
+        grads,
+        m,
+        v,
+        t=1,
+        learning_rate=0.001,
+        beta1=0.9,
+        beta2=0.999,
+        epsilon=1e-8,
+        weight_decay=0.01,
+    )
+    params = result[0]
+    m = result[1]
+    v = result[2]
+
+    # Parameter should decrease from 1.0
+    # Should be less than standard Adam due to weight decay
+    assert_less(params._data.bitcast[Float32]()[0], 1.0)
+    assert_almost_equal(Float64(params._data.bitcast[Float32]()[0]), 0.999, tolerance=1e-3)
+
+
+fn test_adamw_bias_correction() raises:
+    """Test AdamW applies bias correction in early steps.
+
+    Functional API:
+        Bias correction factors:
+        - m_hat = m / (1 - beta1^t)
+        - v_hat = v / (1 - beta2^t)
+        Where t is the step number (1, 2, 3, ...)
+
+    This is CRITICAL for AdamW's fast convergence in early training.
+    """
+    var shape = List[Int]()
+    shape.append(1)
+    var params = ones(shape, DType.float32)
+    params._data.bitcast[Float32]()[0] = 1.0
+
+    var grads = zeros(shape, DType.float32)
+    grads._data.bitcast[Float32]()[0] = 0.1
+
+    var m = zeros(shape, DType.float32)
+    var v = zeros(shape, DType.float32)
+
+    # First few steps should have larger effective learning rate
+    # due to bias correction
+    var prev_param = Float32(1.0)
+
+    # Run 5 steps
+    for t in range(1, 6):
+        var result = adamw_step(
+            params, grads, m, v, t=t, learning_rate=0.001, weight_decay=0.0
+        )
+        params = result[0]
+        m = result[1]
+        v = result[2]
+
+    # Should decrease consistently
+    assert_less(params._data.bitcast[Float32]()[0], 1.0)
+
+
+fn test_adamw_weight_decay_decoupled() raises:
+    """Test AdamW applies weight decay in decoupled manner.
+
+    Key difference from standard Adam:
+        Adam: grad_effective = grad + weight_decay * params
+              Then do adaptive update
+
+        AdamW: Do adaptive update first
+               THEN apply: params = params - weight_decay * lr * params
+
+    This test verifies the decoupled weight decay behavior.
+    """
+    var shape = List[Int]()
+    shape.append(1)
+    var params = ones(shape, DType.float32)
+    params._data.bitcast[Float32]()[0] = 1.0
+
+    var grads = zeros(shape, DType.float32)
+    grads._data.bitcast[Float32]()[0] = 0.1
+
+    var m = zeros(shape, DType.float32)
+    var v = zeros(shape, DType.float32)
+
+    # Run with no weight decay
+    var result_no_wd = adamw_step(
+        params, grads, m, v, t=1, learning_rate=0.001, weight_decay=0.0
+    )
+    var params_no_wd = result_no_wd[0]
+
+    # Reset
+    params._data.bitcast[Float32]()[0] = 1.0
+    m = zeros_like(m)
+    v = zeros_like(v)
+
+    # Run with weight decay
+    result_no_wd = adamw_step(
+        params, grads, m, v, t=1, learning_rate=0.001, weight_decay=0.01
+    )
+    var params_with_wd = result_no_wd[0]
+
+    # With weight decay, final params should be less than without
+    assert_less(
+        Float64(params_with_wd._data.bitcast[Float32]()[0]),
+        Float64(params_no_wd._data.bitcast[Float32]()[0]),
+        "Weight decay should reduce parameters",
+    )
+
+
+fn test_adamw_zero_weight_decay() raises:
+    """Test AdamW behaves like Adam when weight_decay=0.
+
+    When weight_decay=0, AdamW should be equivalent to Adam.
+    """
+    var shape = List[Int]()
+    shape.append(1)
+    var params = ones(shape, DType.float32)
+    params._data.bitcast[Float32]()[0] = 1.0
+
+    var grads = zeros(shape, DType.float32)
+    grads._data.bitcast[Float32]()[0] = 0.1
+
+    var m = zeros(shape, DType.float32)
+    var v = zeros(shape, DType.float32)
+
+    # With weight_decay=0, should work without error
+    var result = adamw_step(
+        params, grads, m, v, t=1, learning_rate=0.001, weight_decay=0.0
+    )
+
+    # Should have reduced parameters
+    assert_less(result[0]._data.bitcast[Float32]()[0], 1.0)
+
+
+fn test_adamw_step_simple() raises:
+    """Test simplified AdamW step with default hyperparameters.
+
+    adamw_step_simple uses:
+        - beta1 = 0.9
+        - beta2 = 0.999
+        - epsilon = 1e-8
+        - weight_decay = 0.01
+    """
+    var shape = List[Int]()
+    shape.append(1)
+    var params = ones(shape, DType.float32)
+    params._data.bitcast[Float32]()[0] = 1.0
+
+    var grads = zeros(shape, DType.float32)
+    grads._data.bitcast[Float32]()[0] = 0.1
+
+    var m = zeros(shape, DType.float32)
+    var v = zeros(shape, DType.float32)
+
+    # Should work with just basic parameters
+    var result = adamw_step_simple(params, grads, m, v, t=1, learning_rate=0.001)
+
+    # Should have reduced parameters
+    assert_less(result[0]._data.bitcast[Float32]()[0], 1.0)
+
+
+fn test_adamw_multiple_steps() raises:
+    """Test AdamW over multiple optimization steps.
+
+    Verifies that:
+    - Multiple steps converge (loss decreases)
+    - State accumulation works correctly
+    - No numerical instability
+    """
+    var shape = List[Int]()
+    shape.append(1)
+    var params = ones(shape, DType.float32)
+    params._data.bitcast[Float32]()[0] = 10.0
+
+    var grads = zeros(shape, DType.float32)
+    grads._data.bitcast[Float32]()[0] = 1.0  # Positive gradient, so decrease params
+
+    var m = zeros(shape, DType.float32)
+    var v = zeros(shape, DType.float32)
+
+    # Run 10 steps
+    for t in range(1, 11):
+        var result = adamw_step(
+            params, grads, m, v, t=t, learning_rate=0.1, weight_decay=0.01
+        )
+        params = result[0]
+        m = result[1]
+        v = result[2]
+
+    # Should have decreased significantly
+    assert_less(params._data.bitcast[Float32]()[0], 10.0)
+    assert_less(params._data.bitcast[Float32]()[0], 5.0)
+
+
+fn test_adamw_shape_mismatch() raises:
+    """Test AdamW raises error on shape mismatch.
+
+    Should validate that params and gradients have same shape.
+    """
+    var shape1 = List[Int]()
+    shape1.append(3)
+    var shape2 = List[Int]()
+    shape2.append(5)
+
+    var params = ones(shape1, DType.float32)
+    var grads = zeros(shape2, DType.float32)
+    var m = zeros(shape1, DType.float32)
+    var v = zeros(shape1, DType.float32)
+
+    try:
+        var _ = adamw_step(params, grads, m, v, t=1)
+        # Should not reach here
+        assert_true(False, "Should have raised error on shape mismatch")
+    except:
+        # Expected error
+        assert_true(True)
+
+
+fn test_adamw_dtype_mismatch() raises:
+    """Test AdamW raises error on dtype mismatch.
+
+    Should validate that params and gradients have same dtype.
+    """
+    var shape = List[Int]()
+    shape.append(3)
+
+    var params = ones(shape, DType.float32)
+    var grads = zeros(shape, DType.float32)
+    var m = zeros(shape, DType.float32)
+    var v = zeros(shape, DType.float32)
+
+    # If different dtypes were supported, this would test that
+    # For now, just verify dtypes match in valid case
+    var result = adamw_step(params, grads, m, v, t=1)
+    assert_true(True)
+
+
+fn test_adamw_large_parameters() raises:
+    """Test AdamW with larger parameter tensor.
+
+    Verifies SIMD operations work correctly on realistic tensor sizes.
+    """
+    var shape = List[Int]()
+    shape.append(100)
+    var params = ones(shape, DType.float32)
+    var grads = zeros(shape, DType.float32)
+
+    # Fill with test values
+    for i in range(100):
+        params._data.bitcast[Float32]()[i] = Float32(i) + 1.0
+        grads._data.bitcast[Float32]()[i] = 0.01
+
+    var m = zeros(shape, DType.float32)
+    var v = zeros(shape, DType.float32)
+
+    var result = adamw_step(params, grads, m, v, t=1, learning_rate=0.001)
+
+    # All parameters should decrease due to positive gradient
+    for i in range(100):
+        assert_less(
+            Float64(result[0]._data.bitcast[Float32]()[i]),
+            Float64(params._data.bitcast[Float32]()[i]),
+        )
+
+
+fn test_adamw_timestep_validation() raises:
+    """Test AdamW validates positive timestep.
+
+    Timestep must be >= 1 for bias correction to work.
+    """
+    var shape = List[Int]()
+    shape.append(1)
+    var params = ones(shape, DType.float32)
+    var grads = zeros(shape, DType.float32)
+    var m = zeros(shape, DType.float32)
+    var v = zeros(shape, DType.float32)
+
+    try:
+        # t=0 should fail
+        var _ = adamw_step(params, grads, m, v, t=0)
+        assert_true(False, "Should have raised error for t=0")
+    except:
+        # Expected error
+        assert_true(True)
+
+    try:
+        # t=-1 should fail
+        var _ = adamw_step(params, grads, m, v, t=-1)
+        assert_true(False, "Should have raised error for t=-1")
+    except:
+        # Expected error
+        assert_true(True)
+
+
+# ============================================================================
+# Test Main
+# ============================================================================
+
+
+fn main() raises:
+    """Run all AdamW optimizer tests."""
+    print("Testing AdamW initialization...")
+    test_adamw_initialization()
+
+    print("Testing AdamW parameter update...")
+    test_adamw_parameter_update()
+
+    print("Testing AdamW bias correction...")
+    test_adamw_bias_correction()
+
+    print("Testing AdamW decoupled weight decay...")
+    test_adamw_weight_decay_decoupled()
+
+    print("Testing AdamW zero weight decay...")
+    test_adamw_zero_weight_decay()
+
+    print("Testing AdamW step simple...")
+    test_adamw_step_simple()
+
+    print("Testing AdamW multiple steps...")
+    test_adamw_multiple_steps()
+
+    print("Testing AdamW shape mismatch...")
+    test_adamw_shape_mismatch()
+
+    print("Testing AdamW dtype mismatch...")
+    test_adamw_dtype_mismatch()
+
+    print("Testing AdamW large parameters...")
+    test_adamw_large_parameters()
+
+    print("Testing AdamW timestep validation...")
+    test_adamw_timestep_validation()
+
+    print("\nAll AdamW optimizer tests passed! ✓")


### PR DESCRIPTION
## Summary
Add AdamW optimizer (Adam with decoupled weight decay) to shared/training/optimizers/.

## Changes
- **shared/training/optimizers/adamw.mojo** (NEW) - AdamW implementation
- **tests/shared/training/test_adamw.mojo** (NEW) - Test cases
- **shared/training/optimizers/__init__.mojo** (MODIFIED) - Added exports

Closes #2363

(Replaces closed PR #2381, rebased against main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)