### PR TITLE
[E1.4] Add Conv2dLayer, BatchNorm2dLayer to shared/core/layers/

### DIFF
--- a/shared/core/layers/__init__.mojo
+++ b/shared/core/layers/__init__.mojo
@@ -28,9 +28,9 @@ Example:.    from shared.core.layers import Linear, ReLU
             self.fc2 = Linear(128, 10)
 """
 
-# Layer exports will be added here as components are implemented
+# Layer exports
 from .linear import Linear
-# from .conv import Conv2D
+from .conv2d import Conv2dLayer
+from .batchnorm import BatchNorm2dLayer
 # from .activation import ReLU, Sigmoid, Tanh
-# from .normalization import BatchNorm, LayerNorm
 # from .pooling import MaxPool2D, AvgPool2D

--- a/shared/core/layers/batchnorm.mojo
+++ b/shared/core/layers/batchnorm.mojo
@@ -1,0 +1,270 @@
+"""BatchNorm2D (2D batch normalization) layer with parameter management.
+
+This module provides a BatchNorm2dLayer wrapper class that manages gamma, beta,
+and running statistics for 2D batch normalization. The layer wraps the pure
+functional batch_norm2d function and maintains learnable scale/shift parameters
+along with exponential moving averages of batch statistics.
+
+Key components:
+- BatchNorm2dLayer: 2D batch normalization layer with learnable parameters
+  Implements: y = gamma * (x - mean) / sqrt(var + eps) + beta (training)
+             y = gamma * (x - running_mean) / sqrt(running_var + eps) + beta (inference)
+"""
+
+from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.normalization import batch_norm2d
+
+
+struct BatchNorm2dLayer(Copyable, Movable):
+    """2D Batch Normalization layer.
+
+    Normalizes activations across the batch dimension for each channel.
+    Maintains running statistics for use during inference.
+
+    Attributes:
+        gamma: Scale parameter of shape (channels,).
+        beta: Shift parameter of shape (channels,).
+        running_mean: Running mean of shape (channels,).
+        running_var: Running variance of shape (channels,).
+        num_channels: Number of channels to normalize.
+        momentum: Momentum for running statistics update.
+        eps: Small constant for numerical stability.
+    """
+
+    var gamma: ExTensor
+    var beta: ExTensor
+    var running_mean: ExTensor
+    var running_var: ExTensor
+    var num_channels: Int
+    var momentum: Float32
+    var eps: Float32
+
+    fn __init__(
+        out self,
+        num_channels: Int,
+        momentum: Float32 = 0.1,
+        eps: Float32 = 1e-5
+    ) raises:
+        """Initialize BatchNorm2D layer with learnable parameters and running statistics.
+
+        Gamma (scale) is initialized to 1.0 for each channel (identity transform).
+        Beta (shift) is initialized to 0.0.
+        Running mean is initialized to 0.0 and running variance to 1.0.
+
+        Args:
+            num_channels: Number of channels to normalize.
+            momentum: Momentum for exponential moving average of running statistics
+                     (default: 0.1). Higher values give more weight to current batch.
+            eps: Small constant for numerical stability to avoid division by zero
+                (default: 1e-5).
+
+        Raises:
+            Error if tensor creation fails.
+
+        Example:
+            ```mojo
+            # Normalize 16 channels from Conv2d output
+            var bn = BatchNorm2dLayer(16, momentum=0.1)
+            ```
+        """
+        self.num_channels = num_channels
+        self.momentum = momentum
+        self.eps = eps
+
+        # Initialize gamma (scale) to 1.0 for each channel
+        # Shape: (channels,)
+        var gamma_shape = List[Int]()
+        gamma_shape.append(num_channels)
+        self.gamma = ones(gamma_shape, DType.float32)
+
+        # Initialize beta (shift) to 0.0
+        # Shape: (channels,)
+        var beta_shape = List[Int]()
+        beta_shape.append(num_channels)
+        self.beta = zeros(beta_shape, DType.float32)
+
+        # Initialize running_mean to 0.0
+        # Shape: (channels,)
+        var running_mean_shape = List[Int]()
+        running_mean_shape.append(num_channels)
+        self.running_mean = zeros(running_mean_shape, DType.float32)
+
+        # Initialize running_var to 1.0
+        # Shape: (channels,)
+        var running_var_shape = List[Int]()
+        running_var_shape.append(num_channels)
+        self.running_var = ones(running_var_shape, DType.float32)
+
+    fn forward(
+        mut self,
+        input: ExTensor,
+        training: Bool = True
+    ) raises -> ExTensor:
+        """Forward pass with batch normalization.
+
+        In training mode: computes batch statistics and updates running statistics.
+        In inference mode: uses running statistics for normalization.
+
+        Args:
+            input: Input tensor of shape (batch, channels, height, width).
+            training: If True, use batch statistics and update running stats.
+                     If False, use running statistics (default: True).
+
+        Returns:
+            Output tensor of shape (batch, channels, height, width).
+
+        Raises:
+            Error if tensor operations fail.
+
+        Note:
+            This method mutates self.running_mean and self.running_var
+            when training=True to track exponential moving averages.
+
+        Formula (training):
+            mean = mean(x, axis=(0, 2, 3))  # Per channel
+            var = var(x, axis=(0, 2, 3))
+            x_norm = (x - mean) / sqrt(var + eps)
+            output = gamma * x_norm + beta
+            running_mean = (1 - momentum) * running_mean + momentum * mean
+            running_var = (1 - momentum) * running_var + momentum * var
+
+        Formula (inference):
+            x_norm = (x - running_mean) / sqrt(running_var + eps)
+            output = gamma * x_norm + beta
+
+        Example:
+            ```mojo
+            var bn = BatchNorm2dLayer(16)
+            var input = randn([2, 16, 32, 32], DType.float32)
+
+            # Training mode: updates running statistics
+            var output = bn.forward(input, training=True)
+
+            # Inference mode: uses running statistics
+            var output = bn.forward(input, training=False)
+            ```
+        """
+        var (output, new_running_mean, new_running_var) = batch_norm2d(
+            input,
+            self.gamma,
+            self.beta,
+            self.running_mean,
+            self.running_var,
+            training,
+            Float64(self.momentum),
+            Float64(self.eps)
+        )
+
+        # Update running statistics if training
+        if training:
+            self.running_mean = new_running_mean^
+            self.running_var = new_running_var^
+
+        return output^
+
+    fn parameters(self) raises -> List[ExTensor]:
+        """Get list of trainable parameters.
+
+        Returns:
+            List containing [gamma, beta] tensors that need gradients.
+            (Running statistics are not trainable parameters)
+
+        Raises:
+            Error if tensor copying fails.
+
+        Example:
+            ```mojo
+            var bn = BatchNorm2dLayer(16)
+            var params = bn.parameters()
+            # params[0] is gamma (scale), params[1] is beta (shift)
+            ```
+        """
+        var params = List[ExTensor]()
+
+        # Create copies of gamma and beta tensors
+        var gamma_copy = zeros_like(self.gamma)
+        var beta_copy = zeros_like(self.beta)
+
+        var gamma_size = self.gamma.numel()
+        var beta_size = self.beta.numel()
+
+        for i in range(gamma_size):
+            gamma_copy._data[i] = self.gamma._data[i]
+
+        for i in range(beta_size):
+            beta_copy._data[i] = self.beta._data[i]
+
+        params.append(gamma_copy^)
+        params.append(beta_copy^)
+        return params^
+
+    fn get_running_stats(self) raises -> Tuple[ExTensor, ExTensor]:
+        """Get current running statistics.
+
+        Returns:
+            Tuple of (running_mean, running_var) for use during inference
+            or checkpointing.
+
+        Raises:
+            Error if tensor copying fails.
+
+        Example:
+            ```mojo
+            var bn = BatchNorm2dLayer(16)
+            # After training...
+            var (mean, var) = bn.get_running_stats()
+            ```
+        """
+        var mean_copy = zeros_like(self.running_mean)
+        var var_copy = zeros_like(self.running_var)
+
+        var mean_size = self.running_mean.numel()
+        var var_size = self.running_var.numel()
+
+        for i in range(mean_size):
+            mean_copy._data[i] = self.running_mean._data[i]
+
+        for i in range(var_size):
+            var_copy._data[i] = self.running_var._data[i]
+
+        return Tuple[ExTensor, ExTensor](mean_copy^, var_copy^)
+
+    fn set_running_stats(
+        mut self,
+        running_mean: ExTensor,
+        running_var: ExTensor
+    ) raises:
+        """Set running statistics (for loading from checkpoint).
+
+        Args:
+            running_mean: Running mean to set, shape (channels,).
+            running_var: Running variance to set, shape (channels,).
+
+        Raises:
+            Error if tensor shapes don't match.
+
+        Example:
+            ```mojo
+            var bn = BatchNorm2dLayer(16)
+            # Load from checkpoint
+            var (saved_mean, saved_var) = load_stats()
+            bn.set_running_stats(saved_mean, saved_var)
+            ```
+        """
+        var mean_size = running_mean.numel()
+        var var_size = running_var.numel()
+
+        if mean_size != self.running_mean.numel():
+            raise Error("Running mean size mismatch")
+
+        if var_size != self.running_var.numel():
+            raise Error("Running variance size mismatch")
+
+        self.running_mean = zeros_like(self.running_mean)
+        self.running_var = zeros_like(self.running_var)
+
+        for i in range(mean_size):
+            self.running_mean._data[i] = running_mean._data[i]
+
+        for i in range(var_size):
+            self.running_var._data[i] = running_var._data[i]

--- a/shared/core/layers/conv2d.mojo
+++ b/shared/core/layers/conv2d.mojo
@@ -1,0 +1,208 @@
+"""Conv2D (2D convolutional) layer with parameter management.
+
+This module provides a Conv2dLayer wrapper class that manages weights and biases
+for 2D convolution operations. The layer wraps the pure functional conv2d function
+and maintains learnable parameters.
+
+Key components:
+- Conv2dLayer: 2D convolutional layer with learnable weights and bias
+  Implements: y = conv2d(x, weight, bias, stride, padding)
+"""
+
+from shared.core.extensor import ExTensor, zeros, randn, zeros_like
+from shared.core.initializers import kaiming_uniform
+from shared.core.conv import conv2d, conv2d_backward, Conv2dBackwardResult
+
+
+struct Conv2dLayer(Copyable, Movable):
+    """2D Convolutional layer: y = conv2d(x, weight, bias, stride, padding).
+
+    A 2D convolutional neural network layer that applies learnable filters
+    to spatially structured inputs (images).
+
+    Attributes:
+        weight: Filter weights of shape (out_channels, in_channels, kernel_h, kernel_w).
+        bias: Bias vector of shape (out_channels,).
+        in_channels: Number of input channels.
+        out_channels: Number of output channels (filters).
+        kernel_h: Kernel height.
+        kernel_w: Kernel width.
+        stride: Stride for convolution.
+        padding: Zero-padding added to input.
+    """
+
+    var weight: ExTensor
+    var bias: ExTensor
+    var in_channels: Int
+    var out_channels: Int
+    var kernel_h: Int
+    var kernel_w: Int
+    var stride: Int
+    var padding: Int
+
+    fn __init__(
+        out self,
+        in_channels: Int,
+        out_channels: Int,
+        kernel_h: Int,
+        kernel_w: Int,
+        stride: Int = 1,
+        padding: Int = 0
+    ) raises:
+        """Initialize Conv2D layer with He/Kaiming weights and zero bias.
+
+        Uses He initialization for weights (scaled by sqrt(2 / (in_channels * kH * kW))).
+        Bias is initialized to zero.
+
+        Args:
+            in_channels: Number of input channels.
+            out_channels: Number of output channels (filters).
+            kernel_h: Height of convolutional kernel.
+            kernel_w: Width of convolutional kernel.
+            stride: Stride for convolution (default: 1).
+            padding: Zero-padding added to input (default: 0).
+
+        Raises:
+            Error if tensor creation fails.
+
+        Example:
+            ```mojo
+            # 3x3 convolution: 3 input channels -> 16 output channels
+            var layer = Conv2dLayer(3, 16, 3, 3, stride=1, padding=1)
+            ```
+        """
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_h = kernel_h
+        self.kernel_w = kernel_w
+        self.stride = stride
+        self.padding = padding
+
+        # Initialize weights with Kaiming/He initialization
+        # Shape: (out_channels, in_channels, kernel_h, kernel_w)
+        var weight_shape = List[Int]()
+        weight_shape.append(out_channels)
+        weight_shape.append(in_channels)
+        weight_shape.append(kernel_h)
+        weight_shape.append(kernel_w)
+
+        # Fan-in for conv2d: in_channels * kernel_h * kernel_w
+        var fan_in = in_channels * kernel_h * kernel_w
+        # Fan-out for conv2d: out_channels * kernel_h * kernel_w
+        var fan_out = out_channels * kernel_h * kernel_w
+        self.weight = kaiming_uniform(fan_in, fan_out, weight_shape, DType.float32)
+
+        # Initialize bias to zeros
+        # Shape: (out_channels,)
+        var bias_shape = List[Int]()
+        bias_shape.append(out_channels)
+        self.bias = zeros(bias_shape, DType.float32)
+
+    fn forward(self, input: ExTensor) raises -> ExTensor:
+        """Forward pass: y = conv2d(x, weight, bias, stride, padding).
+
+        Applies the learned convolutional filters to the input.
+
+        Args:
+            input: Input tensor of shape (batch, in_channels, height, width).
+
+        Returns:
+            Output tensor of shape (batch, out_channels, out_height, out_width).
+
+        Raises:
+            Error if tensor operations fail.
+
+        Note:
+            The output spatial dimensions are computed as:
+            - out_height = (height + 2*padding - kernel_h) // stride + 1
+            - out_width = (width + 2*padding - kernel_w) // stride + 1
+
+        Example:
+            ```mojo
+            var layer = Conv2dLayer(3, 16, 3, 3, stride=1, padding=1)
+            var input = randn([1, 3, 32, 32], DType.float32)  # 32x32 RGB image
+            var output = layer.forward(input)  # Shape: [1, 16, 32, 32]
+            ```
+        """
+        return conv2d(input, self.weight, self.bias, self.stride, self.padding)
+
+    fn backward(
+        self,
+        grad_output: ExTensor,
+        input: ExTensor
+    ) raises -> Tuple[ExTensor, ExTensor, ExTensor]:
+        """Backward pass: compute gradients w.r.t. input, weight, and bias.
+
+        Computes gradients needed for training via backpropagation.
+
+        Args:
+            grad_output: Gradient w.r.t. output, shape (batch, out_channels, out_H, out_W).
+            input: Input from forward pass, shape (batch, in_channels, in_H, in_W).
+
+        Returns:
+            Tuple of (grad_input, grad_weight, grad_bias):
+            - grad_input: Gradient w.r.t. input, shape (batch, in_channels, in_H, in_W)
+            - grad_weight: Gradient w.r.t. weight, shape (out_channels, in_channels, kH, kW)
+            - grad_bias: Gradient w.r.t. bias, shape (out_channels,)
+
+        Raises:
+            Error if tensor operations fail.
+
+        Example:
+            ```mojo
+            var layer = Conv2dLayer(3, 16, 3, 3)
+            var input = randn([2, 3, 32, 32], DType.float32)
+            var output = layer.forward(input)
+
+            # Compute gradients
+            var grad_output = randn(output.shape(), DType.float32)
+            var (grad_input, grad_weight, grad_bias) = layer.backward(grad_output, input)
+            ```
+        """
+        var result = conv2d_backward(
+            grad_output,
+            input,
+            self.weight,
+            self.stride,
+            self.padding
+        )
+        return Tuple[ExTensor, ExTensor, ExTensor](
+            result.grad_input^,
+            result.grad_kernel^,
+            result.grad_bias^
+        )
+
+    fn parameters(self) raises -> List[ExTensor]:
+        """Get list of trainable parameters.
+
+        Returns:
+            List containing [weight, bias] tensors that need gradients.
+
+        Raises:
+            Error if tensor copying fails.
+
+        Example:
+            ```mojo
+            var layer = Conv2dLayer(3, 16, 3, 3)
+            var params = layer.parameters()
+            # params[0] is weight, params[1] is bias
+            ```
+        """
+        var params = List[ExTensor]()
+
+        # Create copies of weight and bias tensors
+        var weight_copy = zeros_like(self.weight)
+        var bias_copy = zeros_like(self.bias)
+
+        var weight_size = self.weight.numel()
+        var bias_size = self.bias.numel()
+
+        for i in range(weight_size):
+            weight_copy._data[i] = self.weight._data[i]
+
+        for i in range(bias_size):
+            bias_copy._data[i] = self.bias._data[i]
+
+        params.append(weight_copy^)
+        params.append(bias_copy^)
+        return params^

--- a/tests/shared/core/layers/test_batchnorm.mojo
+++ b/tests/shared/core/layers/test_batchnorm.mojo
@@ -1,0 +1,424 @@
+"""Unit tests for BatchNorm2dLayer class.
+
+Tests cover:
+- BatchNorm2dLayer initialization with correct parameter shapes
+- Forward pass in training mode (batch statistics, running stats update)
+- Forward pass in inference mode (running statistics)
+- Parameter extraction and management
+- Running statistics management
+
+Following TDD principles - these tests define the expected API for BatchNorm2dLayer.
+"""
+
+from shared.testing.assertions import (
+    assert_almost_equal,
+    assert_equal,
+    assert_equal_int,
+    assert_true,
+)
+from shared.core.extensor import ExTensor, zeros, ones, randn
+from shared.core.layers.batchnorm import BatchNorm2dLayer
+
+
+# ============================================================================
+# BatchNorm2dLayer Initialization Tests
+# ============================================================================
+
+
+fn test_batchnorm_initialization() raises:
+    """Test BatchNorm2dLayer parameter creation with correct shapes.
+
+    Verifies that gamma, beta, and running statistics are initialized correctly.
+    """
+    var num_channels = 16
+
+    var layer = BatchNorm2dLayer(num_channels)
+
+    # Check gamma shape: (channels,)
+    var gamma_shape = layer.gamma.shape()
+    assert_equal_int(len(gamma_shape), 1)
+    assert_equal(gamma_shape[0], num_channels)
+
+    # Check beta shape: (channels,)
+    var beta_shape = layer.beta.shape()
+    assert_equal_int(len(beta_shape), 1)
+    assert_equal(beta_shape[0], num_channels)
+
+    # Check running_mean shape: (channels,)
+    var running_mean_shape = layer.running_mean.shape()
+    assert_equal_int(len(running_mean_shape), 1)
+    assert_equal(running_mean_shape[0], num_channels)
+
+    # Check running_var shape: (channels,)
+    var running_var_shape = layer.running_var.shape()
+    assert_equal_int(len(running_var_shape), 1)
+    assert_equal(running_var_shape[0], num_channels)
+
+
+fn test_batchnorm_gamma_initialized_to_one() raises:
+    """Test that gamma (scale) is initialized to 1.0 for each channel.
+
+    Gamma = 1.0 means identity scaling initially.
+    """
+    var layer = BatchNorm2dLayer(16)
+
+    var gamma_data = layer.gamma._data.bitcast[Float32]()
+    for i in range(layer.gamma.numel()):
+        assert_almost_equal(gamma_data[i], 1.0, tolerance=1e-6)
+
+
+fn test_batchnorm_beta_initialized_to_zero() raises:
+    """Test that beta (shift) is initialized to 0.0 for each channel.
+
+    Beta = 0.0 means no shift initially.
+    """
+    var layer = BatchNorm2dLayer(16)
+
+    var beta_data = layer.beta._data.bitcast[Float32]()
+    for i in range(layer.beta.numel()):
+        assert_almost_equal(beta_data[i], 0.0, tolerance=1e-6)
+
+
+fn test_batchnorm_running_mean_initialized_to_zero() raises:
+    """Test that running_mean is initialized to 0.0."""
+    var layer = BatchNorm2dLayer(16)
+
+    var mean_data = layer.running_mean._data.bitcast[Float32]()
+    for i in range(layer.running_mean.numel()):
+        assert_almost_equal(mean_data[i], 0.0, tolerance=1e-6)
+
+
+fn test_batchnorm_running_var_initialized_to_one() raises:
+    """Test that running_var is initialized to 1.0."""
+    var layer = BatchNorm2dLayer(16)
+
+    var var_data = layer.running_var._data.bitcast[Float32]()
+    for i in range(layer.running_var.numel()):
+        assert_almost_equal(var_data[i], 1.0, tolerance=1e-6)
+
+
+fn test_batchnorm_initialization_with_momentum_eps() raises:
+    """Test BatchNorm2dLayer initialization with custom momentum and epsilon.
+
+    Verifies that momentum and eps parameters are stored correctly.
+    """
+    var num_channels = 32
+    var momentum = Float32(0.05)
+    var eps = Float32(1e-3)
+
+    var layer = BatchNorm2dLayer(num_channels, momentum=momentum, eps=eps)
+
+    assert_equal(layer.num_channels, num_channels)
+    assert_almost_equal(layer.momentum, momentum, tolerance=1e-6)
+    assert_almost_equal(layer.eps, eps, tolerance=1e-6)
+
+
+# ============================================================================
+# BatchNorm2dLayer Forward Pass Tests
+# ============================================================================
+
+
+fn test_batchnorm_forward_output_shape() raises:
+    """Test BatchNorm2dLayer forward pass preserves input shape.
+
+    BatchNorm should not change spatial dimensions.
+    """
+    var layer = BatchNorm2dLayer(16)
+
+    # Input: (batch=2, channels=16, height=32, width=32)
+    var input_shape = List[Int]()
+    input_shape.append(2)
+    input_shape.append(16)
+    input_shape.append(32)
+    input_shape.append(32)
+    var input = randn(input_shape, DType.float32)
+
+    var output = layer.forward(input, training=True)
+
+    # Output shape should match input shape
+    var output_shape = output.shape()
+    assert_equal(output_shape[0], 2)
+    assert_equal(output_shape[1], 16)
+    assert_equal(output_shape[2], 32)
+    assert_equal(output_shape[3], 32)
+
+
+fn test_batchnorm_forward_training_mode() raises:
+    """Test BatchNorm2dLayer forward pass in training mode.
+
+    Training mode should:
+    1. Compute batch statistics
+    2. Normalize using batch statistics
+    3. Update running statistics
+    """
+    var layer = BatchNorm2dLayer(4, momentum=0.1)
+
+    # Create input with known values
+    var input_shape = List[Int]()
+    input_shape.append(2)
+    input_shape.append(4)
+    input_shape.append(2)
+    input_shape.append(2)
+    var input = zeros(input_shape, DType.float32)
+
+    # Fill with simple values to verify normalization
+    # Batch 0: all values = 2.0
+    # Batch 1: all values = 4.0
+    for i in range(2):  # batch
+        for c in range(4):  # channels
+            for h in range(2):  # height
+                for w in range(2):  # width
+                    var idx = i * (4 * 2 * 2) + c * (2 * 2) + h * 2 + w
+                    input._data.bitcast[Float32]()[idx] = Float32(2.0 + i * 2.0)
+
+    # Forward in training mode
+    var output = layer.forward(input, training=True)
+
+    # Running statistics should be updated
+    # After first forward with momentum=0.1:
+    # running_mean = 0.9 * 0 + 0.1 * batch_mean = 0.1 * 3.0 = 0.3
+    # (batch_mean = (2.0 * 8 + 4.0 * 8) / 16 = 3.0)
+    var running_mean_data = layer.running_mean._data.bitcast[Float32]()
+    var running_var_data = layer.running_var._data.bitcast[Float32]()
+
+    # Check that running stats changed (not still initial values)
+    var mean_changed = Float32(0.0)
+    for i in range(4):
+        if running_mean_data[i] != 0.0:
+            mean_changed = 1.0
+
+    assert_true(mean_changed > 0.5, "Running mean not updated in training mode")
+
+
+fn test_batchnorm_forward_inference_mode() raises:
+    """Test BatchNorm2dLayer forward pass in inference mode.
+
+    Inference mode should:
+    1. Use running statistics (not compute batch statistics)
+    2. NOT update running statistics
+    """
+    var layer = BatchNorm2dLayer(4)
+
+    # Manually set running statistics
+    var mean_data = layer.running_mean._data.bitcast[Float32]()
+    var var_data = layer.running_var._data.bitcast[Float32]()
+    for i in range(4):
+        mean_data[i] = 0.5
+        var_data[i] = 2.0
+
+    # Create input
+    var input_shape = List[Int]()
+    input_shape.append(2)
+    input_shape.append(4)
+    input_shape.append(2)
+    input_shape.append(2)
+    var input = randn(input_shape, DType.float32)
+
+    # Forward in inference mode
+    var output = layer.forward(input, training=False)
+
+    # Verify output shape unchanged
+    var output_shape = output.shape()
+    assert_equal(output_shape[0], 2)
+    assert_equal(output_shape[1], 4)
+    assert_equal(output_shape[2], 2)
+    assert_equal(output_shape[3], 2)
+
+    # Running statistics should NOT have changed
+    for i in range(4):
+        assert_almost_equal(mean_data[i], 0.5, tolerance=1e-6)
+        assert_almost_equal(var_data[i], 2.0, tolerance=1e-6)
+
+
+fn test_batchnorm_forward_without_gamma_beta() raises:
+    """Test BatchNorm2dLayer forward pass with gamma=1, beta=0 (identity).
+
+    With gamma=1 and beta=0, output should be normalized input.
+    """
+    var layer = BatchNorm2dLayer(4)
+
+    # Input with known mean and variance
+    var input_shape = List[Int]()
+    input_shape.append(1)
+    input_shape.append(4)
+    input_shape.append(2)
+    input_shape.append(2)
+    var input = zeros(input_shape, DType.float32)
+
+    # Fill channel 0 with [1, 2, 3, 4]
+    var data = input._data.bitcast[Float32]()
+    data[0] = 1.0
+    data[1] = 2.0
+    data[2] = 3.0
+    data[3] = 4.0
+
+    # Forward pass
+    var output = layer.forward(input, training=True)
+
+    # With gamma=1, beta=0, output should be normalized
+    # mean = 2.5, std = sqrt(1.25) ≈ 1.118
+    var output_data = output._data.bitcast[Float32]()
+
+    # Check that values are roughly normalized (mean ≈ 0)
+    var sum = Float32(0.0)
+    for i in range(4):
+        sum += output_data[i]
+
+    var mean = sum / 4.0
+    assert_true(mean > -0.1 && mean < 0.1, "Normalized values should have mean near 0")
+
+
+# ============================================================================
+# BatchNorm2dLayer Parameters Tests
+# ============================================================================
+
+
+fn test_batchnorm_parameters_list() raises:
+    """Test BatchNorm2dLayer.parameters() returns gamma and beta tensors."""
+    var layer = BatchNorm2dLayer(16)
+
+    var params = layer.parameters()
+
+    # Should return [gamma, beta]
+    assert_equal(params.size(), 2)
+
+    # First parameter is gamma
+    var gamma = params[0]
+    var gamma_shape = gamma.shape()
+    assert_equal(gamma_shape[0], 16)
+
+    # Second parameter is beta
+    var beta = params[1]
+    var beta_shape = beta.shape()
+    assert_equal(beta_shape[0], 16)
+
+
+# ============================================================================
+# BatchNorm2dLayer Running Statistics Tests
+# ============================================================================
+
+
+fn test_batchnorm_get_running_stats() raises:
+    """Test BatchNorm2dLayer.get_running_stats() returns current statistics."""
+    var layer = BatchNorm2dLayer(16)
+
+    var (mean, var) = layer.get_running_stats()
+
+    # Should return copies of running_mean and running_var
+    var mean_shape = mean.shape()
+    var var_shape = var.shape()
+
+    assert_equal(mean_shape[0], 16)
+    assert_equal(var_shape[0], 16)
+
+    # Verify initial values
+    var mean_data = mean._data.bitcast[Float32]()
+    var var_data = var._data.bitcast[Float32]()
+
+    for i in range(16):
+        assert_almost_equal(mean_data[i], 0.0, tolerance=1e-6)
+        assert_almost_equal(var_data[i], 1.0, tolerance=1e-6)
+
+
+fn test_batchnorm_set_running_stats() raises:
+    """Test BatchNorm2dLayer.set_running_stats() updates statistics."""
+    var layer = BatchNorm2dLayer(16)
+
+    # Create new running statistics
+    var new_mean_shape = List[Int]()
+    new_mean_shape.append(16)
+    var new_mean = ones(new_mean_shape, DType.float32)
+
+    var new_var_shape = List[Int]()
+    new_var_shape.append(16)
+    var new_var = zeros(new_var_shape, DType.float32)
+    for i in range(16):
+        new_var._data.bitcast[Float32]()[i] = 2.0
+
+    # Set the statistics
+    layer.set_running_stats(new_mean, new_var)
+
+    # Verify they were set
+    var mean_data = layer.running_mean._data.bitcast[Float32]()
+    var var_data = layer.running_var._data.bitcast[Float32]()
+
+    for i in range(16):
+        assert_almost_equal(mean_data[i], 1.0, tolerance=1e-6)
+        assert_almost_equal(var_data[i], 2.0, tolerance=1e-6)
+
+
+fn test_batchnorm_running_stats_update_over_batches() raises:
+    """Test BatchNorm2dLayer running statistics accumulate over multiple batches.
+
+    With momentum=0.1, running_stat = 0.9 * old + 0.1 * batch_stat
+    """
+    var layer = BatchNorm2dLayer(1, momentum=0.1)
+
+    # First batch: all 1.0
+    var input1_shape = List[Int]()
+    input1_shape.append(1)
+    input1_shape.append(1)
+    input1_shape.append(2)
+    input1_shape.append(2)
+    var input1 = ones(input1_shape, DType.float32)
+
+    var output1 = layer.forward(input1, training=True)
+
+    var (mean1, var1) = layer.get_running_stats()
+    var mean_data1 = mean1._data.bitcast[Float32]()
+    var mean_after_first = mean_data1[0]
+
+    # Second batch: all 3.0
+    var input2 = zeros(input1_shape, DType.float32)
+    var data2 = input2._data.bitcast[Float32]()
+    for i in range(4):
+        data2[i] = 3.0
+
+    var output2 = layer.forward(input2, training=True)
+
+    var (mean2, var2) = layer.get_running_stats()
+    var mean_data2 = mean2._data.bitcast[Float32]()
+    var mean_after_second = mean_data2[0]
+
+    # Running mean should have changed (0.9 * 0.1 + 0.1 * 3 ≈ 0.309)
+    # But not as much as batch mean (which would be 3.0)
+    assert_true(
+        mean_after_first < mean_after_second,
+        "Running mean should increase after seeing 3.0"
+    )
+    assert_true(
+        mean_after_second < Float32(1.5),
+        "Running mean should not jump all the way to batch mean"
+    )
+
+
+# ============================================================================
+# Test Main
+# ============================================================================
+
+
+fn main() raises:
+    """Run all BatchNorm2dLayer tests."""
+    print("Running BatchNorm2dLayer initialization tests...")
+    test_batchnorm_initialization()
+    test_batchnorm_gamma_initialized_to_one()
+    test_batchnorm_beta_initialized_to_zero()
+    test_batchnorm_running_mean_initialized_to_zero()
+    test_batchnorm_running_var_initialized_to_one()
+    test_batchnorm_initialization_with_momentum_eps()
+
+    print("Running BatchNorm2dLayer forward pass tests...")
+    test_batchnorm_forward_output_shape()
+    test_batchnorm_forward_training_mode()
+    test_batchnorm_forward_inference_mode()
+    test_batchnorm_forward_without_gamma_beta()
+
+    print("Running BatchNorm2dLayer parameters tests...")
+    test_batchnorm_parameters_list()
+
+    print("Running BatchNorm2dLayer running statistics tests...")
+    test_batchnorm_get_running_stats()
+    test_batchnorm_set_running_stats()
+    test_batchnorm_running_stats_update_over_batches()
+
+    print("\nAll BatchNorm2dLayer tests passed! ✓")

--- a/tests/shared/core/layers/test_conv2d.mojo
+++ b/tests/shared/core/layers/test_conv2d.mojo
@@ -1,0 +1,388 @@
+"""Unit tests for Conv2dLayer class.
+
+Tests cover:
+- Conv2dLayer initialization with correct parameter shapes
+- Forward pass computation
+- Backward pass gradient computation
+- Parameter extraction and management
+- Different kernel sizes, strides, and padding
+
+Following TDD principles - these tests define the expected API for Conv2dLayer.
+"""
+
+from shared.testing.assertions import (
+    assert_almost_equal,
+    assert_equal,
+    assert_equal_int,
+    assert_shape,
+    assert_true,
+)
+from shared.core.extensor import ExTensor, zeros, ones, randn
+from shared.core.layers.conv2d import Conv2dLayer
+
+
+# ============================================================================
+# Conv2dLayer Initialization Tests
+# ============================================================================
+
+
+fn test_conv2d_initialization() raises:
+    """Test Conv2dLayer parameter creation with correct shapes.
+
+    Verifies that weights and biases are initialized with correct dimensions.
+    """
+    var in_channels = 3
+    var out_channels = 16
+    var kernel_h = 3
+    var kernel_w = 3
+
+    var layer = Conv2dLayer(in_channels, out_channels, kernel_h, kernel_w)
+
+    # Check weight shape: (out_channels, in_channels, kernel_h, kernel_w)
+    var weight_shape = layer.weight.shape()
+    assert_equal_int(len(weight_shape), 4)
+    assert_equal(weight_shape[0], out_channels)
+    assert_equal(weight_shape[1], in_channels)
+    assert_equal(weight_shape[2], kernel_h)
+    assert_equal(weight_shape[3], kernel_w)
+
+    # Check bias shape: (out_channels,)
+    var bias_shape = layer.bias.shape()
+    assert_equal_int(len(bias_shape), 1)
+    assert_equal(bias_shape[0], out_channels)
+
+
+fn test_conv2d_initialization_with_stride_padding() raises:
+    """Test Conv2dLayer initialization with stride and padding parameters.
+
+    Verifies that stride and padding are stored correctly.
+    """
+    var in_channels = 3
+    var out_channels = 32
+    var kernel_h = 5
+    var kernel_w = 5
+    var stride = 2
+    var padding = 2
+
+    var layer = Conv2dLayer(
+        in_channels,
+        out_channels,
+        kernel_h,
+        kernel_w,
+        stride=stride,
+        padding=padding
+    )
+
+    # Check parameters stored
+    assert_equal(layer.in_channels, in_channels)
+    assert_equal(layer.out_channels, out_channels)
+    assert_equal(layer.kernel_h, kernel_h)
+    assert_equal(layer.kernel_w, kernel_w)
+    assert_equal(layer.stride, stride)
+    assert_equal(layer.padding, padding)
+
+
+fn test_conv2d_weight_initialization_scale() raises:
+    """Test that weights are initialized with reasonable scale.
+
+    He initialization should scale weights by sqrt(2 / (in_channels * kH * kW))
+    We verify that weights are not too large or too small.
+    """
+    var in_channels = 3
+    var out_channels = 16
+    var kernel_h = 3
+    var kernel_w = 3
+
+    var layer = Conv2dLayer(in_channels, out_channels, kernel_h, kernel_w)
+
+    # He scale should be sqrt(2 / (3 * 3 * 3)) ≈ 0.264
+    # We check that weights are roughly in this scale (not zeros, not too large)
+    var weight_data = layer.weight._data.bitcast[Float32]()
+    var num_weights = layer.weight.numel()
+
+    var sum_abs = Float32(0.0)
+    for i in range(num_weights):
+        var abs_val = Float32(0.0)
+        if weight_data[i] > 0.0:
+            abs_val = weight_data[i]
+        else:
+            abs_val = -weight_data[i]
+        sum_abs += abs_val
+
+    var mean_abs = sum_abs / Float32(num_weights)
+
+    # Mean absolute value should be reasonably scaled (not 0, not > 1)
+    assert_true(mean_abs > Float32(0.01), "Weights too small - not initialized")
+    assert_true(mean_abs < Float32(1.0), "Weights too large - bad scaling")
+
+
+fn test_conv2d_bias_initialized_to_zero() raises:
+    """Test that bias is initialized to zero."""
+    var layer = Conv2dLayer(3, 16, 3, 3)
+
+    var bias_data = layer.bias._data.bitcast[Float32]()
+    for i in range(layer.bias.numel()):
+        assert_almost_equal(bias_data[i], 0.0, tolerance=1e-6)
+
+
+# ============================================================================
+# Conv2dLayer Forward Pass Tests
+# ============================================================================
+
+
+fn test_conv2d_forward_output_shape() raises:
+    """Test Conv2dLayer forward pass produces correct output shape.
+
+    Formula: out_size = (in_size + 2*padding - kernel_size) / stride + 1
+    """
+    var in_channels = 3
+    var out_channels = 16
+    var kernel_h = 3
+    var kernel_w = 3
+    var stride = 1
+    var padding = 1
+
+    var layer = Conv2dLayer(
+        in_channels,
+        out_channels,
+        kernel_h,
+        kernel_w,
+        stride=stride,
+        padding=padding
+    )
+
+    # Input: (batch=2, channels=3, height=32, width=32)
+    var input_shape = List[Int]()
+    input_shape.append(2)
+    input_shape.append(in_channels)
+    input_shape.append(32)
+    input_shape.append(32)
+    var input = randn(input_shape, DType.float32)
+
+    var output = layer.forward(input)
+
+    # Expected output shape: (2, 16, 32, 32)
+    # height: (32 + 2*1 - 3) / 1 + 1 = 32
+    # width: (32 + 2*1 - 3) / 1 + 1 = 32
+    var output_shape = output.shape()
+    assert_equal(output_shape[0], 2)  # batch
+    assert_equal(output_shape[1], out_channels)
+    assert_equal(output_shape[2], 32)  # height
+    assert_equal(output_shape[3], 32)  # width
+
+
+fn test_conv2d_forward_with_stride() raises:
+    """Test Conv2dLayer forward pass with stride > 1.
+
+    Stride downsamples spatial dimensions by stride factor.
+    """
+    var in_channels = 3
+    var out_channels = 16
+    var stride = 2
+    var padding = 0
+
+    var layer = Conv2dLayer(in_channels, out_channels, 3, 3, stride=stride, padding=padding)
+
+    # Input: (1, 3, 32, 32)
+    var input_shape = List[Int]()
+    input_shape.append(1)
+    input_shape.append(in_channels)
+    input_shape.append(32)
+    input_shape.append(32)
+    var input = randn(input_shape, DType.float32)
+
+    var output = layer.forward(input)
+
+    # Expected output shape: (1, 16, 15, 15)
+    # height: (32 + 2*0 - 3) / 2 + 1 = 15
+    # width: (32 + 2*0 - 3) / 2 + 1 = 15
+    var output_shape = output.shape()
+    assert_equal(output_shape[0], 1)
+    assert_equal(output_shape[1], out_channels)
+    assert_equal(output_shape[2], 15)
+    assert_equal(output_shape[3], 15)
+
+
+fn test_conv2d_forward_no_padding() raises:
+    """Test Conv2dLayer forward pass with no padding (valid convolution).
+
+    No padding reduces spatial dimensions by (kernel_size - 1).
+    """
+    var in_channels = 3
+    var out_channels = 16
+    var kernel_size = 5
+    var padding = 0
+
+    var layer = Conv2dLayer(
+        in_channels,
+        out_channels,
+        kernel_size,
+        kernel_size,
+        stride=1,
+        padding=padding
+    )
+
+    # Input: (1, 3, 32, 32)
+    var input_shape = List[Int]()
+    input_shape.append(1)
+    input_shape.append(in_channels)
+    input_shape.append(32)
+    input_shape.append(32)
+    var input = randn(input_shape, DType.float32)
+
+    var output = layer.forward(input)
+
+    # Expected output shape: (1, 16, 28, 28)
+    # height: (32 + 0 - 5) / 1 + 1 = 28
+    var output_shape = output.shape()
+    assert_equal(output_shape[2], 28)
+    assert_equal(output_shape[3], 28)
+
+
+fn test_conv2d_forward_batch_independence() raises:
+    """Property: Conv2dLayer processes batch elements independently.
+
+    Processing a batch should give same results as processing individually.
+    """
+    var layer = Conv2dLayer(3, 16, 3, 3, stride=1, padding=1)
+
+    # Create batch input: (2, 3, 16, 16)
+    var batch_input_shape = List[Int]()
+    batch_input_shape.append(2)
+    batch_input_shape.append(3)
+    batch_input_shape.append(16)
+    batch_input_shape.append(16)
+    var batch_input = randn(batch_input_shape, DType.float32)
+
+    # Process as batch
+    var batch_output = layer.forward(batch_input)
+
+    # Process first element individually: (1, 3, 16, 16)
+    var single_input_shape = List[Int]()
+    single_input_shape.append(1)
+    single_input_shape.append(3)
+    single_input_shape.append(16)
+    single_input_shape.append(16)
+    var single_input = zeros(single_input_shape, DType.float32)
+
+    # Copy first batch element to single input
+    var total_spatial = 3 * 16 * 16
+    for i in range(total_spatial):
+        single_input._data[i] = batch_input._data[i]
+
+    var single_output = layer.forward(single_input)
+
+    # First batch element output should match individual processing
+    var batch_out_spatial = 16 * 16 * 16  # out_channels * height * width
+    for i in range(batch_out_spatial):
+        assert_almost_equal(
+            batch_output._data.bitcast[Float32]()[i],
+            single_output._data.bitcast[Float32]()[i],
+            tolerance=1e-4
+        )
+
+
+# ============================================================================
+# Conv2dLayer Backward Pass Tests
+# ============================================================================
+
+
+fn test_conv2d_backward_gradient_shapes() raises:
+    """Test Conv2dLayer backward pass returns gradients with correct shapes.
+
+    Backward should return (grad_input, grad_weight, grad_bias) with matching
+    shapes to forward inputs/parameters.
+    """
+    var in_channels = 3
+    var out_channels = 16
+    var kernel_h = 3
+    var kernel_w = 3
+
+    var layer = Conv2dLayer(in_channels, out_channels, kernel_h, kernel_w, stride=1, padding=1)
+
+    # Input and forward pass
+    var input_shape = List[Int]()
+    input_shape.append(2)
+    input_shape.append(in_channels)
+    input_shape.append(32)
+    input_shape.append(32)
+    var input = randn(input_shape, DType.float32)
+    var output = layer.forward(input)
+
+    # Create gradient w.r.t. output
+    var grad_output = randn(output.shape(), DType.float32)
+
+    # Backward pass
+    var (grad_input, grad_weight, grad_bias) = layer.backward(grad_output, input)
+
+    # Check gradient shapes match input/parameter shapes
+    var grad_input_shape = grad_input.shape()
+    assert_equal(grad_input_shape[0], 2)
+    assert_equal(grad_input_shape[1], in_channels)
+    assert_equal(grad_input_shape[2], 32)
+    assert_equal(grad_input_shape[3], 32)
+
+    var grad_weight_shape = grad_weight.shape()
+    assert_equal(grad_weight_shape[0], out_channels)
+    assert_equal(grad_weight_shape[1], in_channels)
+    assert_equal(grad_weight_shape[2], kernel_h)
+    assert_equal(grad_weight_shape[3], kernel_w)
+
+    var grad_bias_shape = grad_bias.shape()
+    assert_equal(grad_bias_shape[0], out_channels)
+
+
+# ============================================================================
+# Conv2dLayer Parameters Tests
+# ============================================================================
+
+
+fn test_conv2d_parameters_list() raises:
+    """Test Conv2dLayer.parameters() returns weight and bias tensors."""
+    var layer = Conv2dLayer(3, 16, 3, 3)
+
+    var params = layer.parameters()
+
+    # Should return [weight, bias]
+    assert_equal(params.size(), 2)
+
+    # First parameter is weight
+    var weight = params[0]
+    var weight_shape = weight.shape()
+    assert_equal(weight_shape[0], 16)
+    assert_equal(weight_shape[1], 3)
+    assert_equal(weight_shape[2], 3)
+    assert_equal(weight_shape[3], 3)
+
+    # Second parameter is bias
+    var bias = params[1]
+    var bias_shape = bias.shape()
+    assert_equal(bias_shape[0], 16)
+
+
+# ============================================================================
+# Test Main
+# ============================================================================
+
+
+fn main() raises:
+    """Run all Conv2dLayer tests."""
+    print("Running Conv2dLayer initialization tests...")
+    test_conv2d_initialization()
+    test_conv2d_initialization_with_stride_padding()
+    test_conv2d_weight_initialization_scale()
+    test_conv2d_bias_initialized_to_zero()
+
+    print("Running Conv2dLayer forward pass tests...")
+    test_conv2d_forward_output_shape()
+    test_conv2d_forward_with_stride()
+    test_conv2d_forward_no_padding()
+    test_conv2d_forward_batch_independence()
+
+    print("Running Conv2dLayer backward pass tests...")
+    test_conv2d_backward_gradient_shapes()
+
+    print("Running Conv2dLayer parameters tests...")
+    test_conv2d_parameters_list()
+
+    print("\nAll Conv2dLayer tests passed! ✓")


### PR DESCRIPTION
## Summary
Add Conv2dLayer and BatchNorm2dLayer wrapper classes to shared/core/layers/.

## Changes
- **shared/core/layers/conv2d.mojo** (NEW) - Conv2dLayer class
- **shared/core/layers/normalization.mojo** (NEW) - BatchNorm2dLayer class
- **tests/shared/core/layers/test_conv2d_layer.mojo** (NEW) - Test cases
- **shared/core/layers/__init__.mojo** (MODIFIED) - Added exports

Closes #2365

(Replaces closed PR #2382, rebased against main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)