### PR TITLE
[E2.4] Add ReLULayer, DropoutLayer classes

### DIFF
--- a/shared/core/layers/__init__.mojo
+++ b/shared/core/layers/__init__.mojo
@@ -32,5 +32,7 @@ Example:.    from shared.core.layers import Linear, ReLU
 from .linear import Linear
 from .conv2d import Conv2dLayer
 from .batchnorm import BatchNorm2dLayer
+from .relu import ReLULayer
+from .dropout import DropoutLayer
 # from .activation import ReLU, Sigmoid, Tanh
 # from .pooling import MaxPool2D, AvgPool2D

--- a/shared/core/layers/dropout.mojo
+++ b/shared/core/layers/dropout.mojo
@@ -1,0 +1,249 @@
+"""Dropout layer for regularization during training.
+
+This module provides a Dropout layer that randomly zeroes input elements
+during training to prevent overfitting. During inference (training=False),
+dropout is disabled and the input is scaled appropriately.
+
+Key components:
+- DropoutLayer: Dropout regularization layer
+  Implements: y = mask * x / (1 - dropout_rate) during training
+               y = x during inference
+"""
+
+from shared.core.extensor import ExTensor, zeros_like, full
+from random import random_float64
+
+
+struct DropoutLayer(Copyable, Movable):
+    """Dropout layer for regularization.
+
+    Dropout randomly sets input elements to zero during training to prevent
+    co-adaptation and reduce overfitting. The remaining elements are scaled
+    by 1/(1-p) where p is the dropout rate, ensuring expected value is preserved.
+
+    During inference (training=False), the layer is disabled and passes input
+    through unchanged.
+
+    Attributes:
+        dropout_rate: Probability of dropping each element (default: 0.5).
+        training: Whether layer is in training mode (default: False).
+
+    Examples:
+        ```mojo
+        var layer = DropoutLayer(0.5)
+        layer.set_training(True)  # Enable dropout for training
+
+        var input = randn([4, 10], DType.float32)
+        var output = layer.forward(input)
+
+        # Backward pass
+        var grad_output = randn(output.shape(), DType.float32)
+        var grad_input = layer.backward(grad_output, layer.last_mask)
+        ```
+    """
+
+    var dropout_rate: Float32
+    var training: Bool
+    var last_mask: ExTensor  # Store mask for backward pass
+
+    fn __init__(out self, dropout_rate: Float32 = 0.5) raises:
+        """Initialize dropout layer.
+
+        Args:
+            dropout_rate: Probability of dropping each element. Must be in [0, 1).
+                         (default: 0.5)
+
+        Raises:
+            Error if dropout_rate is not in valid range.
+
+        Example:
+            ```mojo
+            var layer = DropoutLayer(0.5)  # 50% dropout
+            var layer2 = DropoutLayer(0.1)  # 10% dropout
+            ```
+        """
+        if dropout_rate < 0.0 or dropout_rate >= 1.0:
+            raise Error(
+                "dropout_rate must be in [0, 1), got: "
+                + String(dropout_rate)
+            )
+
+        self.dropout_rate = dropout_rate
+        self.training = False
+
+        # Initialize with a dummy mask (will be replaced in forward pass)
+        self.last_mask = zeros_like(ExTensor(List[Int](1), DType.float32))
+
+    fn set_training(mut self, training: Bool):
+        """Set training mode.
+
+        Args:
+            training: True to enable dropout during forward pass,
+                     False to disable dropout (inference mode).
+
+        Example:
+            ```mojo
+            var layer = DropoutLayer(0.5)
+            layer.set_training(True)   # Enable dropout for training
+            var output = layer.forward(input)
+            layer.set_training(False)  # Disable for inference
+            var output = layer.forward(input)
+            ```
+        """
+        self.training = training
+
+    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+        """Forward pass: apply dropout during training, pass through during inference.
+
+        During training (training=True):
+        1. Generate random mask where each element is in [0, 1]
+        2. Keep elements where mask > dropout_rate, zero others
+        3. Scale output by 1/(1-dropout_rate) to maintain expected value
+        4. Store mask for backward pass
+
+        During inference (training=False):
+        - Return input unchanged (no dropout applied)
+
+        Args:
+            input: Input tensor of any shape.
+
+        Returns:
+            Output tensor with dropout applied (if training) or unchanged (if inference).
+
+        Raises:
+            Error if tensor operations fail.
+
+        Example:
+            ```mojo
+            var layer = DropoutLayer(0.5)
+            var input = ones([4, 10], DType.float32)
+
+            # During training
+            layer.set_training(True)
+            var output = layer.forward(input)  # ~50% zeros, others scaled by 2.0
+
+            # During inference
+            layer.set_training(False)
+            var output = layer.forward(input)  # Unchanged
+            ```
+        """
+        if not self.training:
+            # During inference, return input unchanged
+            return input
+
+        # Generate random mask: elements > dropout_rate are kept, others dropped
+        var mask = ExTensor(input._shape, DType.float32)
+
+        if input._dtype == DType.float32:
+            for i in range(input._numel):
+                # Generate random value in [0, 1)
+                var rand_val = Float32(random_float64())
+                # Keep element if rand_val > dropout_rate, else drop it
+                mask._data.bitcast[Float32]()[i] = Float32(1.0) if (rand_val > Float32(self.dropout_rate)) else Float32(0.0)
+        elif input._dtype == DType.float64:
+            for i in range(input._numel):
+                var rand_val = random_float64()
+                mask._data.bitcast[Float32]()[i] = Float32(1.0) if (rand_val > Float64(self.dropout_rate)) else Float32(0.0)
+        elif input._dtype == DType.float16:
+            for i in range(input._numel):
+                var rand_val = Float32(random_float64())
+                mask._data.bitcast[Float32]()[i] = Float32(1.0) if (rand_val > Float32(self.dropout_rate)) else Float32(0.0)
+        else:
+            raise Error("dropout: only float16/32/64 dtypes supported")
+
+        # Store mask for backward pass
+        self.last_mask = mask
+
+        # Apply mask and scale: output = mask * input / (1 - dropout_rate)
+        var scale = Float32(1.0) / (Float32(1.0) - self.dropout_rate)
+        var result = ExTensor(input._shape, input._dtype)
+
+        if input._dtype == DType.float32:
+            for i in range(input._numel):
+                var input_val = input._data.bitcast[Float32]()[i]
+                var mask_val = mask._data.bitcast[Float32]()[i]
+                result._data.bitcast[Float32]()[i] = mask_val * input_val * scale
+        elif input._dtype == DType.float64:
+            for i in range(input._numel):
+                var input_val = input._data.bitcast[Float64]()[i]
+                var mask_val = Float64(mask._data.bitcast[Float32]()[i])
+                result._data.bitcast[Float64]()[i] = mask_val * input_val * Float64(scale)
+        elif input._dtype == DType.float16:
+            for i in range(input._numel):
+                var input_val = input._data.bitcast[Float16]()[i]
+                var mask_val = Float16(mask._data.bitcast[Float32]()[i])
+                result._data.bitcast[Float16]()[i] = mask_val * input_val * Float16(scale)
+        else:
+            raise Error("dropout: only float16/32/64 dtypes supported")
+
+        return result
+
+    fn backward(
+        self,
+        grad_output: ExTensor,
+        mask: ExTensor
+    ) raises -> ExTensor:
+        """Backward pass: apply same mask as forward pass.
+
+        During training, propagates gradient through kept elements only,
+        using the same scale factor as forward pass.
+
+        Args:
+            grad_output: Gradient w.r.t. output from upstream.
+            mask: The dropout mask from forward pass (1 for kept, 0 for dropped).
+
+        Returns:
+            Gradient w.r.t. input with dropout mask applied:
+            grad_input = mask * grad_output / (1 - dropout_rate)
+
+        Raises:
+            Error if tensor operations fail.
+
+        Example:
+            ```mojo
+            var layer = DropoutLayer(0.5)
+            layer.set_training(True)
+            var input = ExTensor(...)
+            var output = layer.forward(input)
+            var grad_output = ExTensor(...)
+            var grad_input = layer.backward(grad_output, layer.last_mask)
+            ```
+        """
+        var scale = Float32(1.0) / (Float32(1.0) - self.dropout_rate)
+        var result = ExTensor(grad_output._shape, grad_output._dtype)
+
+        if grad_output._dtype == DType.float32:
+            for i in range(grad_output._numel):
+                var grad_val = grad_output._data.bitcast[Float32]()[i]
+                var mask_val = mask._data.bitcast[Float32]()[i]
+                result._data.bitcast[Float32]()[i] = mask_val * grad_val * scale
+        elif grad_output._dtype == DType.float64:
+            for i in range(grad_output._numel):
+                var grad_val = grad_output._data.bitcast[Float64]()[i]
+                var mask_val = Float64(mask._data.bitcast[Float32]()[i])
+                result._data.bitcast[Float64]()[i] = mask_val * grad_val * Float64(scale)
+        elif grad_output._dtype == DType.float16:
+            for i in range(grad_output._numel):
+                var grad_val = grad_output._data.bitcast[Float16]()[i]
+                var mask_val = Float16(mask._data.bitcast[Float32]()[i])
+                result._data.bitcast[Float16]()[i] = mask_val * grad_val * Float16(scale)
+        else:
+            raise Error("dropout backward: only float16/32/64 dtypes supported")
+
+        return result
+
+    fn parameters(self) raises -> List[ExTensor]:
+        """Get list of trainable parameters.
+
+        Returns:
+            Empty list since Dropout has no learnable parameters.
+
+        Example:
+            ```mojo
+            var layer = DropoutLayer(0.5)
+            var params = layer.parameters()
+            # params is empty
+            ```
+        """
+        var params = List[ExTensor]()
+        return params^

--- a/shared/core/layers/relu.mojo
+++ b/shared/core/layers/relu.mojo
@@ -1,0 +1,121 @@
+"""ReLU (Rectified Linear Unit) activation layer.
+
+This module provides a ReLU layer wrapper that applies the ReLU activation
+function: max(0, x). The layer includes both forward and backward passes
+for use in neural network training.
+
+Key components:
+- ReLULayer: ReLU activation layer
+  Implements: y = max(0, x) forward, ∂L/∂x = grad * (x > 0) backward
+"""
+
+from shared.core.extensor import ExTensor, zeros_like
+from shared.core.activation import relu, relu_backward
+
+
+struct ReLULayer(Copyable, Movable):
+    """ReLU activation layer: y = max(0, x).
+
+    A simple activation layer that applies the Rectified Linear Unit (ReLU)
+    function element-wise. ReLU is the most common activation in deep learning,
+    promoting sparse activation patterns by zeroing negative values.
+
+    Attributes:
+        No learnable parameters.
+
+    Examples:
+        ```mojo
+        var layer = ReLULayer()
+        var input = randn([4, 10], DType.float32)
+        var output = layer.forward(input)
+
+        # Backward pass
+        var grad_output = randn(output.shape(), DType.float32)
+        var grad_input = layer.backward(grad_output, input)
+        ```
+    """
+
+    fn __init__(out self):
+        """Initialize ReLU layer.
+
+        ReLU has no learnable parameters or state.
+
+        Example:
+            ```mojo
+            var layer = ReLULayer()
+            ```
+        """
+        pass
+
+    fn forward(self, input: ExTensor) raises -> ExTensor:
+        """Forward pass: y = max(0, x).
+
+        Applies ReLU activation element-wise to the input tensor.
+
+        Args:
+            input: Input tensor of any shape.
+
+        Returns:
+            Output tensor with ReLU applied, same shape as input.
+
+        Raises:
+            Error if tensor operations fail.
+
+        Example:
+            ```mojo
+            var layer = ReLULayer()
+            var input = ExTensor.from_list([-2, -1, 0, 1, 2], DType.float32)
+            var output = layer.forward(input)  # [0, 0, 0, 1, 2]
+            ```
+        """
+        return relu(input)
+
+    fn backward(
+        self,
+        grad_output: ExTensor,
+        input: ExTensor
+    ) raises -> ExTensor:
+        """Backward pass: compute gradient w.r.t. input.
+
+        Computes the gradient of ReLU with respect to input.
+        Gradient is passed through where input > 0, zeroed elsewhere.
+
+        Args:
+            grad_output: Gradient w.r.t. output from upstream, same shape as input.
+            input: Input tensor from forward pass.
+
+        Returns:
+            Gradient w.r.t. input, same shape as input:
+            - grad_input[i] = grad_output[i] if input[i] > 0
+            - grad_input[i] = 0 if input[i] <= 0
+
+        Raises:
+            Error if tensor operations fail.
+
+        Example:
+            ```mojo
+            var layer = ReLULayer()
+            var input = ExTensor.from_list([-2, -1, 0, 1, 2], DType.float32)
+            var output = layer.forward(input)
+            var grad_output = ExTensor.from_list([0.1, 0.2, 0.3, 0.4, 0.5], DType.float32)
+            var grad_input = layer.backward(grad_output, input)
+            # grad_input = [0, 0, 0, 0.4, 0.5]
+            ```
+        """
+        return relu_backward(grad_output, input)
+
+    fn parameters(self) raises -> List[ExTensor]:
+        """Get list of trainable parameters.
+
+        Returns:
+            Empty list since ReLU has no learnable parameters.
+
+        Example:
+            ```mojo
+            var layer = ReLULayer()
+            var params = layer.parameters()
+            # params is empty
+            ```
+        """
+        var params = List[ExTensor]()
+        return params^

--- a/tests/shared/core/layers/test_dropout.mojo
+++ b/tests/shared/core/layers/test_dropout.mojo
@@ -1,0 +1,359 @@
+"""Unit tests for DropoutLayer.
+
+Tests cover:
+- Initialization with various dropout rates
+- Training vs inference modes
+- Forward pass dropout application and scaling
+- Backward pass gradient propagation
+- Shape preservation across forward/backward passes
+"""
+
+from testing import assert_true, assert_false
+from shared.core.layers import DropoutLayer
+from shared.core.extensor import ExTensor, zeros, ones, full
+
+
+fn test_dropout_init_valid() raises:
+    """Test dropout layer initialization with valid dropout rates."""
+    # Valid dropout rates: 0.0 to 0.99
+    var layer1 = DropoutLayer(0.0)
+    assert_true(layer1.dropout_rate == 0.0, "Should initialize with dropout_rate=0.0")
+
+    var layer2 = DropoutLayer(0.5)
+    assert_true(layer2.dropout_rate == 0.5, "Should initialize with dropout_rate=0.5")
+
+    var layer3 = DropoutLayer(0.99)
+    assert_true(layer3.dropout_rate == 0.99, "Should initialize with dropout_rate=0.99")
+
+    print("✓ test_dropout_init_valid passed")
+
+
+fn test_dropout_init_invalid() raises:
+    """Test dropout layer initialization with invalid dropout rates."""
+    # Test invalid rates
+    var error_caught = False
+    try:
+        var layer = DropoutLayer(-0.1)
+    except e:
+        error_caught = True
+        assert_true("dropout_rate" in String(e), "Error should mention dropout_rate")
+
+    assert_true(error_caught, "Should raise error for negative dropout_rate")
+
+    error_caught = False
+    try:
+        var layer = DropoutLayer(1.0)
+    except e:
+        error_caught = True
+        assert_true("dropout_rate" in String(e), "Error should mention dropout_rate")
+
+    assert_true(error_caught, "Should raise error for dropout_rate=1.0")
+
+    error_caught = False
+    try:
+        var layer = DropoutLayer(1.5)
+    except e:
+        error_caught = True
+        assert_true("dropout_rate" in String(e), "Error should mention dropout_rate")
+
+    assert_true(error_caught, "Should raise error for dropout_rate>1.0")
+
+    print("✓ test_dropout_init_invalid passed")
+
+
+fn test_dropout_training_mode() raises:
+    """Test setting training mode."""
+    var layer = DropoutLayer(0.5)
+
+    # Default should be False (inference mode)
+    assert_true(layer.training == False, "Default should be inference mode")
+
+    # Enable training
+    layer.set_training(True)
+    assert_true(layer.training == True, "Should enable training mode")
+
+    # Disable training
+    layer.set_training(False)
+    assert_true(layer.training == False, "Should disable training mode")
+
+    print("✓ test_dropout_training_mode passed")
+
+
+fn test_dropout_forward_inference_mode() raises:
+    """Test dropout forward pass in inference mode (training=False)."""
+    var layer = DropoutLayer(0.5)
+    layer.set_training(False)
+
+    # Create input
+    var input = ExTensor(List[Int](4), DType.float32)
+    var input_values = List[Float32](1.0, 2.0, 3.0, 4.0)
+    for i in range(4):
+        input._data.bitcast[Float32]()[i] = input_values[i]
+
+    var output = layer.forward(input)
+
+    # In inference mode, output should be identical to input
+    for i in range(4):
+        var out_val = output._data.bitcast[Float32]()[i]
+        assert_true(
+            out_val == input_values[i],
+            "Inference mode should pass input unchanged"
+        )
+
+    print("✓ test_dropout_forward_inference_mode passed")
+
+
+fn test_dropout_forward_training_mode_shape() raises:
+    """Test dropout forward pass preserves shape during training."""
+    var layer = DropoutLayer(0.5)
+    layer.set_training(True)
+
+    # Create input with various shapes
+    var input_1d = ExTensor(List[Int](10), DType.float32)
+    for i in range(10):
+        input_1d._data.bitcast[Float32]()[i] = Float32(i)
+
+    var output_1d = layer.forward(input_1d)
+    assert_true(
+        len(output_1d._shape) == 1 and output_1d._shape[0] == 10,
+        "1D output shape should be preserved"
+    )
+
+    var input_2d = ExTensor(List[Int](4, 5), DType.float32)
+    for i in range(20):
+        input_2d._data.bitcast[Float32]()[i] = Float32(i)
+
+    var output_2d = layer.forward(input_2d)
+    assert_true(
+        len(output_2d._shape) == 2 and output_2d._shape[0] == 4 and output_2d._shape[1] == 5,
+        "2D output shape should be preserved"
+    )
+
+    print("✓ test_dropout_forward_training_mode_shape passed")
+
+
+fn test_dropout_forward_training_mode_zeros() raises:
+    """Test dropout forward pass zeros some elements during training."""
+    var layer = DropoutLayer(0.5)
+    layer.set_training(True)
+
+    # Create input with all ones
+    var input = ExTensor(List[Int](100), DType.float32)
+    for i in range(100):
+        input._data.bitcast[Float32]()[i] = 1.0
+
+    var output = layer.forward(input)
+
+    # Count non-zero elements (should be roughly 50%)
+    var non_zero_count = 0
+    for i in range(100):
+        var val = output._data.bitcast[Float32]()[i]
+        if val != 0.0:
+            non_zero_count += 1
+
+    # With dropout=0.5, expect roughly 50% to be non-zero
+    # Allow some variance: 30-70% non-zero
+    assert_true(
+        non_zero_count > 30 and non_zero_count < 70,
+        "Dropout should zero approximately 50% of elements"
+    )
+
+    print("✓ test_dropout_forward_training_mode_zeros passed")
+
+
+fn test_dropout_forward_training_mode_scale() raises:
+    """Test dropout forward pass scales kept elements."""
+    var layer = DropoutLayer(0.5)
+    layer.set_training(True)
+
+    # Create input with all ones
+    var input = ExTensor(List[Int](100), DType.float32)
+    for i in range(100):
+        input._data.bitcast[Float32]()[i] = 1.0
+
+    var output = layer.forward(input)
+
+    # Non-zero elements should be scaled by 2.0 (1/(1-0.5) = 2)
+    for i in range(100):
+        var val = output._data.bitcast[Float32]()[i]
+        if val != 0.0:
+            assert_true(
+                val == 2.0,
+                "Non-zero elements should be scaled by 2.0 for dropout=0.5"
+            )
+
+    print("✓ test_dropout_forward_training_mode_scale passed")
+
+
+fn test_dropout_backward_shape() raises:
+    """Test dropout backward pass preserves shape."""
+    var layer = DropoutLayer(0.5)
+    layer.set_training(True)
+
+    # Create input and forward pass to get mask
+    var input = ExTensor(List[Int](4, 5), DType.float32)
+    for i in range(20):
+        input._data.bitcast[Float32]()[i] = 1.0
+
+    var output = layer.forward(input)
+
+    # Create gradient
+    var grad_output = ExTensor(List[Int](4, 5), DType.float32)
+    for i in range(20):
+        grad_output._data.bitcast[Float32]()[i] = 0.1
+
+    var grad_input = layer.backward(grad_output, layer.last_mask)
+
+    assert_true(
+        len(grad_input._shape) == 2 and grad_input._shape[0] == 4 and grad_input._shape[1] == 5,
+        "Backward pass should preserve shape"
+    )
+
+    print("✓ test_dropout_backward_shape passed")
+
+
+fn test_dropout_backward_scaling() raises:
+    """Test dropout backward pass applies mask and scaling."""
+    var layer = DropoutLayer(0.5)
+    layer.set_training(True)
+
+    # Create input and forward pass
+    var input = ExTensor(List[Int](4), DType.float32)
+    for i in range(4):
+        input._data.bitcast[Float32]()[i] = 1.0
+
+    var output = layer.forward(input)
+    var mask = layer.last_mask
+
+    // Create gradient with all ones
+    var grad_output = ExTensor(List[Int](4), DType.float32)
+    for i in range(4):
+        grad_output._data.bitcast[Float32]()[i] = 1.0
+
+    var grad_input = layer.backward(grad_output, mask)
+
+    // Backward should apply same mask and scale
+    // For elements where mask=1: grad = 1.0 * 2.0 = 2.0
+    // For elements where mask=0: grad = 0.0 * 2.0 = 0.0
+    for i in range(4):
+        var grad_val = grad_input._data.bitcast[Float32]()[i]
+        var mask_val = mask._data.bitcast[Float32]()[i]
+
+        if mask_val == 1.0:
+            assert_true(grad_val == 2.0, "Unmasked gradient should be scaled by 2.0")
+        else:
+            assert_true(grad_val == 0.0, "Masked gradient should be 0.0")
+
+    print("✓ test_dropout_backward_scaling passed")
+
+
+fn test_dropout_parameters() raises:
+    """Test that dropout has no learnable parameters."""
+    var layer = DropoutLayer(0.5)
+    var params = layer.parameters()
+    assert_true(len(params) == 0, "Dropout should have no parameters")
+
+    print("✓ test_dropout_parameters passed")
+
+
+fn test_dropout_forward_float64() raises:
+    """Test dropout forward pass with float64 dtype."""
+    var layer = DropoutLayer(0.5)
+    layer.set_training(True)
+
+    var input = ExTensor(List[Int](50), DType.float64)
+    for i in range(50):
+        input._data.bitcast[Float64]()[i] = 1.0
+
+    var output = layer.forward(input)
+
+    // Count non-zero elements
+    var non_zero_count = 0
+    for i in range(50):
+        var val = output._data.bitcast[Float64]()[i]
+        if val != 0.0:
+            non_zero_count += 1
+
+    // Expect roughly 50% non-zero
+    assert_true(
+        non_zero_count > 15 and non_zero_count < 35,
+        "Dropout should zero approximately 50% for float64"
+    )
+
+    print("✓ test_dropout_forward_float64 passed")
+
+
+fn test_dropout_zero_dropout_rate() raises:
+    """Test dropout with dropout_rate=0 (no dropout)."""
+    var layer = DropoutLayer(0.0)
+    layer.set_training(True)
+
+    var input = ExTensor(List[Int](10), DType.float32)
+    for i in range(10):
+        input._data.bitcast[Float32]()[i] = 1.0
+
+    var output = layer.forward(input)
+
+    // With dropout_rate=0, nothing should be dropped
+    // Scale factor = 1/(1-0) = 1
+    for i in range(10):
+        var val = output._data.bitcast[Float32]()[i]
+        assert_true(val == 1.0, "With dropout_rate=0, output should be unchanged")
+
+    print("✓ test_dropout_zero_dropout_rate passed")
+
+
+fn test_dropout_high_dropout_rate() raises:
+    """Test dropout with high dropout_rate."""
+    var layer = DropoutLayer(0.9)
+    layer.set_training(True)
+
+    var input = ExTensor(List[Int](100), DType.float32)
+    for i in range(100):
+        input._data.bitcast[Float32]()[i] = 1.0
+
+    var output = layer.forward(input)
+
+    // Count non-zero elements (should be roughly 10%)
+    var non_zero_count = 0
+    for i in range(100):
+        var val = output._data.bitcast[Float32]()[i]
+        if val != 0.0:
+            non_zero_count += 1
+
+    // With dropout_rate=0.9, expect roughly 10% to remain
+    // Allow variance: 0-30% non-zero
+    assert_true(
+        non_zero_count >= 0 and non_zero_count <= 30,
+        "Dropout with rate=0.9 should keep roughly 10% of elements"
+    )
+
+    // Check scaling: kept elements should be scaled by 1/(1-0.9) = 10
+    for i in range(100):
+        var val = output._data.bitcast[Float32]()[i]
+        if val != 0.0:
+            assert_true(val == 10.0, "Scale factor for dropout=0.9 should be 10.0")
+
+    print("✓ test_dropout_high_dropout_rate passed")
+
+
+fn main():
+    """Run all Dropout tests."""
+    print("Running DropoutLayer tests...")
+    try:
+        test_dropout_init_valid()
+        test_dropout_init_invalid()
+        test_dropout_training_mode()
+        test_dropout_forward_inference_mode()
+        test_dropout_forward_training_mode_shape()
+        test_dropout_forward_training_mode_zeros()
+        test_dropout_forward_training_mode_scale()
+        test_dropout_backward_shape()
+        test_dropout_backward_scaling()
+        test_dropout_parameters()
+        test_dropout_forward_float64()
+        test_dropout_zero_dropout_rate()
+        test_dropout_high_dropout_rate()
+        print("\nAll DropoutLayer tests passed!")
+    except e:
+        print("Test failed:", e)

--- a/tests/shared/core/layers/test_relu.mojo
+++ b/tests/shared/core/layers/test_relu.mojo
@@ -1,0 +1,254 @@
+"""Unit tests for ReLULayer.
+
+Tests cover:
+- Forward pass: verifies max(0, x) behavior
+- Backward pass: verifies gradient computation
+- Various input shapes and dtypes
+"""
+
+from testing import assert_true, assert_false
+from shared.core.layers import ReLULayer
+from shared.core.extensor import ExTensor, zeros, ones, full
+
+
+fn test_relu_forward_basic() raises:
+    """Test ReLU forward pass with basic inputs."""
+    var layer = ReLULayer()
+
+    # Create input with mixed positive and negative values
+    var input = ExTensor(List[Int](5), DType.float32)
+    var input_values = List[Float32](-2.0, -1.0, 0.0, 1.0, 2.0)
+    for i in range(5):
+        input._data.bitcast[Float32]()[i] = input_values[i]
+
+    var output = layer.forward(input)
+
+    # Expected: [0, 0, 0, 1, 2]
+    var expected = List[Float32](0.0, 0.0, 0.0, 1.0, 2.0)
+    for i in range(5):
+        var out_val = output._data.bitcast[Float32]()[i]
+        assert_true(
+            out_val == expected[i],
+            "ReLU output mismatch at index " + String(i)
+        )
+
+    print("✓ test_relu_forward_basic passed")
+
+
+fn test_relu_forward_all_negative() raises:
+    """Test ReLU forward pass with all negative inputs."""
+    var layer = ReLULayer()
+
+    var input = ExTensor(List[Int](4), DType.float32)
+    var input_values = List[Float32](-5.0, -2.0, -0.1, -10.0)
+    for i in range(4):
+        input._data.bitcast[Float32]()[i] = input_values[i]
+
+    var output = layer.forward(input)
+
+    # Expected: [0, 0, 0, 0]
+    for i in range(4):
+        var out_val = output._data.bitcast[Float32]()[i]
+        assert_true(out_val == 0.0, "ReLU should zero negative values")
+
+    print("✓ test_relu_forward_all_negative passed")
+
+
+fn test_relu_forward_all_positive() raises:
+    """Test ReLU forward pass with all positive inputs."""
+    var layer = ReLULayer()
+
+    var input = ExTensor(List[Int](4), DType.float32)
+    var input_values = List[Float32](0.5, 1.0, 5.0, 10.0)
+    for i in range(4):
+        input._data.bitcast[Float32]()[i] = input_values[i]
+
+    var output = layer.forward(input)
+
+    # Expected: [0.5, 1.0, 5.0, 10.0]
+    for i in range(4):
+        var out_val = output._data.bitcast[Float32]()[i]
+        assert_true(
+            out_val == input_values[i],
+            "ReLU should preserve positive values"
+        )
+
+    print("✓ test_relu_forward_all_positive passed")
+
+
+fn test_relu_forward_batch() raises:
+    """Test ReLU forward pass with 2D batch input."""
+    var layer = ReLULayer()
+
+    # Create 2x3 batch
+    var input = ExTensor(List[Int](2, 3), DType.float32)
+    var input_values = List[Float32](-1.0, 0.5, -0.5, 2.0, -2.0, 1.5)
+    for i in range(6):
+        input._data.bitcast[Float32]()[i] = input_values[i]
+
+    var output = layer.forward(input)
+
+    var expected = List[Float32](0.0, 0.5, 0.0, 2.0, 0.0, 1.5)
+    for i in range(6):
+        var out_val = output._data.bitcast[Float32]()[i]
+        assert_true(out_val == expected[i], "Batch ReLU mismatch")
+
+    print("✓ test_relu_forward_batch passed")
+
+
+fn test_relu_backward_basic() raises:
+    """Test ReLU backward pass with basic inputs."""
+    var layer = ReLULayer()
+
+    # Input: [-2, -1, 0, 1, 2]
+    var input = ExTensor(List[Int](5), DType.float32)
+    var input_values = List[Float32](-2.0, -1.0, 0.0, 1.0, 2.0)
+    for i in range(5):
+        input._data.bitcast[Float32]()[i] = input_values[i]
+
+    # Gradient from upstream: [0.1, 0.2, 0.3, 0.4, 0.5]
+    var grad_output = ExTensor(List[Int](5), DType.float32)
+    var grad_values = List[Float32](0.1, 0.2, 0.3, 0.4, 0.5)
+    for i in range(5):
+        grad_output._data.bitcast[Float32]()[i] = grad_values[i]
+
+    var grad_input = layer.backward(grad_output, input)
+
+    # Expected: [0, 0, 0, 0.4, 0.5] (pass through only where input > 0)
+    var expected = List[Float32](0.0, 0.0, 0.0, 0.4, 0.5)
+    for i in range(5):
+        var grad_val = grad_input._data.bitcast[Float32]()[i]
+        assert_true(
+            grad_val == expected[i],
+            "ReLU backward mismatch at index " + String(i)
+        )
+
+    print("✓ test_relu_backward_basic passed")
+
+
+fn test_relu_backward_all_positive() raises:
+    """Test ReLU backward pass with all positive inputs."""
+    var layer = ReLULayer()
+
+    var input = ExTensor(List[Int](4), DType.float32)
+    var input_values = List[Float32](1.0, 2.0, 3.0, 4.0)
+    for i in range(4):
+        input._data.bitcast[Float32]()[i] = input_values[i]
+
+    var grad_output = ExTensor(List[Int](4), DType.float32)
+    var grad_values = List[Float32](0.1, 0.2, 0.3, 0.4)
+    for i in range(4):
+        grad_output._data.bitcast[Float32]()[i] = grad_values[i]
+
+    var grad_input = layer.backward(grad_output, input)
+
+    # Expected: [0.1, 0.2, 0.3, 0.4] (all pass through)
+    for i in range(4):
+        var grad_val = grad_input._data.bitcast[Float32]()[i]
+        assert_true(
+            grad_val == grad_values[i],
+            "ReLU backward should pass through all positive"
+        )
+
+    print("✓ test_relu_backward_all_positive passed")
+
+
+fn test_relu_backward_all_negative() raises:
+    """Test ReLU backward pass with all negative inputs."""
+    var layer = ReLULayer()
+
+    var input = ExTensor(List[Int](4), DType.float32)
+    var input_values = List[Float32](-1.0, -2.0, -3.0, -4.0)
+    for i in range(4):
+        input._data.bitcast[Float32]()[i] = input_values[i]
+
+    var grad_output = ExTensor(List[Int](4), DType.float32)
+    var grad_values = List[Float32](0.1, 0.2, 0.3, 0.4)
+    for i in range(4):
+        grad_output._data.bitcast[Float32]()[i] = grad_values[i]
+
+    var grad_input = layer.backward(grad_output, input)
+
+    # Expected: [0, 0, 0, 0] (all blocked)
+    for i in range(4):
+        var grad_val = grad_input._data.bitcast[Float32]()[i]
+        assert_true(grad_val == 0.0, "ReLU backward should block all negative")
+
+    print("✓ test_relu_backward_all_negative passed")
+
+
+fn test_relu_parameters() raises:
+    """Test that ReLU has no learnable parameters."""
+    var layer = ReLULayer()
+    var params = layer.parameters()
+    assert_true(len(params) == 0, "ReLU should have no parameters")
+
+    print("✓ test_relu_parameters passed")
+
+
+fn test_relu_forward_float64() raises:
+    """Test ReLU forward pass with float64 dtype."""
+    var layer = ReLULayer()
+
+    var input = ExTensor(List[Int](4), DType.float64)
+    var input_values = List[Float64](-1.5, 0.5, -2.5, 3.5)
+    for i in range(4):
+        input._data.bitcast[Float64]()[i] = input_values[i]
+
+    var output = layer.forward(input)
+
+    var expected = List[Float64](0.0, 0.5, 0.0, 3.5)
+    for i in range(4):
+        var out_val = output._data.bitcast[Float64]()[i]
+        assert_true(
+            out_val == expected[i],
+            "ReLU float64 mismatch at index " + String(i)
+        )
+
+    print("✓ test_relu_forward_float64 passed")
+
+
+fn test_relu_backward_float64() raises:
+    """Test ReLU backward pass with float64 dtype."""
+    var layer = ReLULayer()
+
+    var input = ExTensor(List[Int](4), DType.float64)
+    var input_values = List[Float64](-1.0, 0.0, 1.0, 2.0)
+    for i in range(4):
+        input._data.bitcast[Float64]()[i] = input_values[i]
+
+    var grad_output = ExTensor(List[Int](4), DType.float64)
+    var grad_values = List[Float64](0.1, 0.2, 0.3, 0.4)
+    for i in range(4):
+        grad_output._data.bitcast[Float64]()[i] = grad_values[i]
+
+    var grad_input = layer.backward(grad_output, input)
+
+    var expected = List[Float64](0.0, 0.0, 0.3, 0.4)
+    for i in range(4):
+        var grad_val = grad_input._data.bitcast[Float64]()[i]
+        assert_true(
+            grad_val == expected[i],
+            "ReLU float64 backward mismatch at index " + String(i)
+        )
+
+    print("✓ test_relu_backward_float64 passed")
+
+
+fn main():
+    """Run all ReLU tests."""
+    print("Running ReLULayer tests...")
+    try:
+        test_relu_forward_basic()
+        test_relu_forward_all_negative()
+        test_relu_forward_all_positive()
+        test_relu_forward_batch()
+        test_relu_backward_basic()
+        test_relu_backward_all_positive()
+        test_relu_backward_all_negative()
+        test_relu_parameters()
+        test_relu_forward_float64()
+        test_relu_backward_float64()
+        print("\nAll ReLULayer tests passed!")
+    except e:
+        print("Test failed:", e)


### PR DESCRIPTION
## Summary
- ReLULayer: Forward/backward for max(0, x) activation
- DropoutLayer: Training/inference mode with proper scaling
  - Configurable dropout rate
  - Mask storage for backward pass
- Both layers implement Copyable, Movable traits
- Comprehensive tests for both layers

Closes #2369

🤖 Generated with [Claude Code](https://claude.com/claude-code)