### PR TITLE
[D2.1] Update examples/ to use evaluation.mojo

### DIFF
--- a/examples/lenet-emnist/run_infer.mojo
+++ b/examples/lenet-emnist/run_infer.mojo
@@ -15,7 +15,7 @@ Arguments:
 """
 
 from model import LeNet5
-from shared.data import load_idx_labels, load_idx_images, normalize_images
+from shared.data import load_idx_labels, load_idx_images, normalize_images, DatasetInfo
 from shared.core import ExTensor, zeros
 from shared.utils.arg_parser import ArgumentParser
 from shared.training.metrics import top1_accuracy, AccuracyMetric
@@ -273,7 +273,8 @@ fn main() raises:
 
     # Initialize and load model
     print("Loading model from", config.checkpoint_dir, "...")
-    var model = LeNet5(num_classes=47)
+    var dataset_info = DatasetInfo("emnist_balanced")
+    var model = LeNet5(num_classes=dataset_info.num_classes())
     model.load_weights(config.checkpoint_dir)
     print("  Model loaded successfully")
     print()


### PR DESCRIPTION
## Summary
- Update lenet-emnist examples to use `evaluate_model_simple` from `shared.training.evaluation`
- Remove duplicate `evaluate()` function from run_train.mojo (~35 lines)
- Use `DatasetInfo` for num_classes instead of hardcoded values

## Changes
- `examples/lenet-emnist/run_train.mojo`: Import and use shared evaluation module
- `examples/lenet-emnist/train.mojo`: Use DatasetInfo for class counts
- `examples/lenet-emnist/run_infer.mojo`: Minor cleanup

## Test Plan
- [ ] Build examples with `pixi run mojo build`
- [ ] Verify evaluation works with shared module

Closes #2354

🤖 Generated with [Claude Code](https://claude.com/claude-code)