### PR TITLE
fix(core): Mark reshape/slice results as views to prevent double-free

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -505,6 +505,7 @@ struct ExTensor(Copyable, Movable, ImplicitlyCopyable):
 
         # Create view by explicitly copying (increments refcount via __copyinit__)
         var result = self.copy()
+        result._is_view = True  # Mark as view since it shares data with original
 
         # Update shape
         result._shape = List[Int]()
@@ -587,6 +588,7 @@ struct ExTensor(Copyable, Movable, ImplicitlyCopyable):
 
         # Create view by explicitly copying (increments refcount via __copyinit__)
         var result = self.copy()
+        result._is_view = True  # Mark as view since it shares data with original
 
         # Update shape with sliced dimension
         result._shape = List[Int]()


### PR DESCRIPTION
## Summary

- Fix memory corruption bug in `ExTensor.slice()` and `ExTensor.reshape()` methods
- Both methods create views that share data with the original tensor but failed to mark them as views

## Problem

The `slice()` and `reshape()` methods were creating views (sharing data with original tensor) but not setting `_is_view = True`. This caused:

1. `__copyinit__` to incorrectly increment refcount for views
2. `__del__` to incorrectly decrement refcount and free shared memory
3. Double-free when multiple views went out of scope

Error seen in CI:
```
CHECK in ReportCorruptedFree: Attempted to free corrupted pointer
```

## Fix

Added `result._is_view = True` after `var result = self.copy()` in both methods.

## Test plan

- [x] `test_tensor_dataset.mojo` passes (was failing with memory corruption)
- [x] `test_base_dataset.mojo` passes
- [x] `test_cifar10.mojo` passes
- [x] `test_extensor_new_methods.mojo` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)