### PR TITLE
[Refactor] Standardize Config structs with Copyable, Movable traits

### DIFF
--- a/shared/training/mixed_precision.mojo
+++ b/shared/training/mixed_precision.mojo
@@ -28,7 +28,7 @@ from ..core.numerical_safety import has_nan, has_inf
 from math import log2
 
 
-struct GradientScaler:
+struct GradientScaler(Copyable, Movable):
     """Manages gradient scaling for mixed precision training.
 
     Prevents gradient underflow in FP16 by scaling loss and gradients.

--- a/shared/training/precision_config.mojo
+++ b/shared/training/precision_config.mojo
@@ -77,7 +77,7 @@ struct PrecisionMode(Copyable, Movable, Stringable, ImplicitlyCopyable):
             return "unknown"
 
 
-struct PrecisionConfig:
+struct PrecisionConfig(Copyable, Movable):
     """Central configuration for multi-precision training.
 
     Manages precision settings including:


### PR DESCRIPTION
## Summary

- Adds `(Copyable, Movable)` traits to `PrecisionConfig` and `GradientScaler`
- Ensures consistency with other Config structs (`BenchmarkConfig`, `InferenceConfig`, `TrainerConfig`)

## Analysis

Reviewed all Config structs in the codebase:
- **BenchmarkConfig** - Already has `@fieldwise_init` + `(Copyable, Movable)` ✓
- **InferenceConfig** - Already has `@fieldwise_init` + `(Copyable, Movable)` ✓
- **TrainerConfig** - Has `(Copyable, Movable)` with manual `__init__` for defaults ✓
- **PrecisionConfig** - Was missing traits (fixed)
- **GradientScaler** - Was missing traits (fixed, required for PrecisionConfig)

Note: Structs with complex initialization (defaults, validation, factory methods) correctly keep manual `__init__` instead of `@fieldwise_init`.

Closes #2460

🤖 Generated with [Claude Code](https://claude.com/claude-code)