### PR TITLE
docs: Add auto-merge requirement for all PRs

### DIFF
--- a/.claude/shared/pr-workflow.md
+++ b/.claude/shared/pr-workflow.md
@@ -9,6 +9,7 @@ git checkout -b {issue-number}-{description}
 # Make changes, commit
 git push -u origin {branch-name}
 gh pr create --title "[Type] Description" --body "Closes #{issue}"
+gh pr merge --auto --rebase  # Always enable auto-merge
 ```
 
 ## Verification
@@ -24,6 +25,7 @@ After creating PR:
 - PR must be linked to GitHub issue
 - PR title should be clear and descriptive
 - PR description should summarize changes
+- **Always enable auto-merge** (`gh pr merge --auto --rebase`)
 - Do NOT create PR without linking to issue
 
 ## Responding to Review Comments

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1282,6 +1282,14 @@ See `.claude/shared/github-issue-workflow.md` for complete workflow patterns.
      --label "appropriate-label"
    ```
 
+1. **Enable auto-merge:**
+
+   ```bash
+   gh pr merge --auto --rebase
+   ```
+
+   **Always enable auto-merge** so PRs merge automatically once CI passes.
+
 ### Never Push Directly to Main
 
 ❌ **NEVER DO THIS:**
@@ -1299,6 +1307,7 @@ git checkout -b <issue-number>-description
 git commit -m "changes"
 git push -u origin <issue-number>-description
 gh pr create --title "..." --body "Closes #<issue>" --label "..."
+gh pr merge --auto --rebase  # Enable auto-merge
 ```
 
 ### Commit Message Format


### PR DESCRIPTION
## Summary

Add requirement that all pull requests should enable auto-merge so they merge automatically once CI passes.

## Changes

### CLAUDE.md

- Added step 5 "Enable auto-merge" to PR creation workflow
- Added `gh pr merge --auto --squash` to the "ALWAYS DO THIS" example

### .claude/shared/pr-workflow.md

- Added auto-merge command to PR creation example
- Added "Always enable auto-merge" to PR Requirements

## Why

- Reduces manual intervention
- PRs merge automatically when CI passes
- Speeds up development workflow

## Test plan

- [x] Markdown lint passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)