### PR TITLE
[Refactor] Extract normalize_ops.mojo from normalization.mojo

### DIFF
--- a/shared/core/__init__.mojo
+++ b/shared/core/__init__.mojo
@@ -233,6 +233,14 @@ from .normalization import (
     instance_norm_backward,
 )
 
+from .normalize_ops import (
+    normalize_rgb,
+    sqrt_scalar_f32,
+    sqrt_scalar_f64,
+    pow_scalar_f32,
+    pow_scalar_f64,
+)
+
 # ============================================================================
 # Attention Mechanisms
 # ============================================================================

--- a/shared/core/normalization.mojo
+++ b/shared/core/normalization.mojo
@@ -8,6 +8,13 @@ from .extensor import ExTensor, zeros, zeros_like, ones_like, full_like
 from .arithmetic import subtract, add, multiply, divide, power
 from .elementwise import sqrt
 from .reduction import mean as reduce_mean, sum as reduce_sum
+from .normalize_ops import (
+    normalize_rgb,
+    sqrt_scalar_f32,
+    sqrt_scalar_f64,
+    pow_scalar_f32,
+    pow_scalar_f64,
+)
 
 
 fn batch_norm2d(
@@ -261,96 +268,6 @@ fn batch_norm2d(
         # Running stats unchanged in inference mode
         return (output, running_mean, running_var)
 
-
-# Helper functions for scalar sqrt
-fn sqrt_scalar_f32(x: Float32) -> Float32:
-    """Compute sqrt of a scalar float32."""
-    return x ** 0.5
-
-
-fn sqrt_scalar_f64(x: Float64) -> Float64:
-    """Compute sqrt of a scalar float64."""
-    return x ** 0.5
-
-
-fn normalize_rgb(
-    images: ExTensor,
-    mean: Tuple[Float32, Float32, Float32],
-    std: Tuple[Float32, Float32, Float32]
-) raises -> ExTensor:
-    """Normalize RGB images with per-channel mean and standard deviation.
-
-    Applies normalization to RGB images using the formula:
-        normalized = (pixel / 255.0 - mean) / std
-
-    This is commonly used with ImageNet statistics for transfer learning.
-
-    Args:.        `images`: Input uint8 tensor of shape (N, 3, H, W)
-        `mean`: Mean values for R, G, B channels (e.g., (0.485, 0.456, 0.406))
-        `std`: Std deviation values for R, G, B channels (e.g., (0.229, 0.224, 0.225))
-
-    Returns:.        Normalized float32 tensor of shape (N, 3, H, W)
-
-    Example:.        ```mojo.
-        from shared.core import normalize_rgb
-
-        # ImageNet normalization
-        var mean = (Float32(0.485), Float32(0.456), Float32(0.406))
-        var std = (Float32(0.229), Float32(0.224), Float32(0.225))
-        var normalized = normalize_rgb(images, mean, std)
-        ```
-
-    Note:
-        - Input must be uint8 [0, 255]
-        - Output is float32 with normalized values
-        - Common for CIFAR-10, ImageNet, and other RGB datasets
-    """
-    var shape = images.shape()
-    if len(shape) != 4:
-        raise Error("normalize_rgb requires 4D input (N, 3, H, W)")
-
-    var num_images = shape[0]
-    var num_channels = shape[1]
-    var num_rows = shape[2]
-    var num_cols = shape[3]
-
-    if num_channels != 3:
-        raise Error("normalize_rgb requires 3 RGB channels, got: " + String(num_channels))
-
-    # Create output tensor (float32)
-    var normalized = zeros(shape, DType.float32)
-
-    var src_data = images._data
-    var dst_data = normalized._data.bitcast[Float32]()
-
-    # Extract mean and std values
-    var mean_r = mean[0]
-    var mean_g = mean[1]
-    var mean_b = mean[2]
-    var std_r = std[0]
-    var std_g = std[1]
-    var std_b = std[2]
-
-    # Normalize each image
-    for n in range(num_images):
-        for h in range(num_rows):
-            for w in range(num_cols):
-                # R channel (c=0)
-                var idx_r = n * (num_channels * num_rows * num_cols) + 0 * (num_rows * num_cols) + h * num_cols + w
-                var pixel_r = Float32(src_data[idx_r]) / 255.0
-                dst_data[idx_r] = (pixel_r - mean_r) / std_r
-
-                # G channel (c=1)
-                var idx_g = n * (num_channels * num_rows * num_cols) + 1 * (num_rows * num_cols) + h * num_cols + w
-                var pixel_g = Float32(src_data[idx_g]) / 255.0
-                dst_data[idx_g] = (pixel_g - mean_g) / std_g
-
-                # B channel (c=2)
-                var idx_b = n * (num_channels * num_rows * num_cols) + 2 * (num_rows * num_cols) + h * num_cols + w
-                var pixel_b = Float32(src_data[idx_b]) / 255.0
-                dst_data[idx_b] = (pixel_b - mean_b) / std_b
-
-    return normalized
 
 
 fn batch_norm2d_backward(
@@ -759,17 +676,6 @@ fn batch_norm2d_backward(
             raise Error("batch_norm2d_backward: only float32/64 dtypes supported")
 
     return (grad_input, grad_gamma, grad_beta)
-
-
-# Helper function for scalar power
-fn pow_scalar_f32(x: Float32, y: Float32) -> Float32:
-    """Compute x^y for scalar float32."""
-    return x ** y
-
-
-fn pow_scalar_f64(x: Float64, y: Float64) -> Float64:
-    """Compute x^y for scalar float64."""
-    return x ** y
 
 
 fn layer_norm(

--- a/shared/core/normalize_ops.mojo
+++ b/shared/core/normalize_ops.mojo
@@ -1,0 +1,170 @@
+"""Normalization operations for data preprocessing.
+
+This module provides pure functional operations for normalizing input data.
+Unlike normalization.mojo which contains statistical normalization layers
+(batch norm, layer norm, etc.), this module contains utility functions for
+preprocessing and data transformations.
+
+Functions:
+    `normalize_rgb`: Normalize RGB images with per-channel mean and std deviation.
+    `sqrt_scalar_f32`: Compute square root of a float32 scalar.
+    `sqrt_scalar_f64`: Compute square root of a float64 scalar.
+    `pow_scalar_f32`: Compute power (x^y) for float32 scalars.
+    `pow_scalar_f64`: Compute power (x^y) for float64 scalars.
+
+Example:
+    from shared.core.normalize_ops import normalize_rgb
+
+    # Normalize RGB images with ImageNet statistics
+    var mean = (Float32(0.485), Float32(0.456), Float32(0.406))
+    var std = (Float32(0.229), Float32(0.224), Float32(0.225))
+    var normalized = normalize_rgb(images, mean, std)
+"""
+
+from .extensor import ExTensor, zeros
+
+
+# ============================================================================
+# Scalar Helper Functions
+# ============================================================================
+
+
+fn sqrt_scalar_f32(x: Float32) -> Float32:
+    """Compute square root of a scalar float32.
+
+    Args:
+        x: Input float32 value.
+
+    Returns:
+        Square root of x.
+    """
+    return x ** 0.5
+
+
+fn sqrt_scalar_f64(x: Float64) -> Float64:
+    """Compute square root of a scalar float64.
+
+    Args:
+        x: Input float64 value.
+
+    Returns:
+        Square root of x.
+    """
+    return x ** 0.5
+
+
+fn pow_scalar_f32(x: Float32, y: Float32) -> Float32:
+    """Compute x^y for scalar float32 values.
+
+    Args:
+        x: Base value (float32).
+        y: Exponent value (float32).
+
+    Returns:
+        Result of x^y.
+    """
+    return x ** y
+
+
+fn pow_scalar_f64(x: Float64, y: Float64) -> Float64:
+    """Compute x^y for scalar float64 values.
+
+    Args:
+        x: Base value (float64).
+        y: Exponent value (float64).
+
+    Returns:
+        Result of x^y.
+    """
+    return x ** y
+
+
+# ============================================================================
+# RGB Image Normalization
+# ============================================================================
+
+
+fn normalize_rgb(
+    images: ExTensor,
+    mean: Tuple[Float32, Float32, Float32],
+    std: Tuple[Float32, Float32, Float32]
+) raises -> ExTensor:
+    """Normalize RGB images with per-channel mean and standard deviation.
+
+    Applies normalization to RGB images using the formula:
+        normalized = (pixel / 255.0 - mean) / std
+
+    This is commonly used with ImageNet statistics for transfer learning.
+
+    Args:
+        images: Input uint8 tensor of shape (N, 3, H, W).
+        mean: Mean values for R, G, B channels (e.g., (0.485, 0.456, 0.406)).
+        std: Std deviation values for R, G, B channels (e.g., (0.229, 0.224, 0.225)).
+
+    Returns:
+        Normalized float32 tensor of shape (N, 3, H, W).
+
+    Raises:
+        Error: If input is not 4D or doesn't have 3 channels.
+
+    Example:
+        ```mojo
+        from shared.core.normalize_ops import normalize_rgb
+
+        # ImageNet normalization
+        var mean = (Float32(0.485), Float32(0.456), Float32(0.406))
+        var std = (Float32(0.229), Float32(0.224), Float32(0.225))
+        var normalized = normalize_rgb(images, mean, std)
+        ```
+
+    Note:
+        - Input must be uint8 [0, 255]
+        - Output is float32 with normalized values
+        - Common for CIFAR-10, ImageNet, and other RGB datasets
+    """
+    var shape = images.shape()
+    if len(shape) != 4:
+        raise Error("normalize_rgb requires 4D input (N, 3, H, W)")
+
+    var num_images = shape[0]
+    var num_channels = shape[1]
+    var num_rows = shape[2]
+    var num_cols = shape[3]
+
+    if num_channels != 3:
+        raise Error("normalize_rgb requires 3 RGB channels, got: " + String(num_channels))
+
+    # Create output tensor (float32)
+    var normalized = zeros(shape, DType.float32)
+
+    var src_data = images._data
+    var dst_data = normalized._data.bitcast[Float32]()
+
+    # Extract mean and std values
+    var mean_r = mean[0]
+    var mean_g = mean[1]
+    var mean_b = mean[2]
+    var std_r = std[0]
+    var std_g = std[1]
+    var std_b = std[2]
+
+    # Normalize each image
+    for n in range(num_images):
+        for h in range(num_rows):
+            for w in range(num_cols):
+                # R channel (c=0)
+                var idx_r = n * (num_channels * num_rows * num_cols) + 0 * (num_rows * num_cols) + h * num_cols + w
+                var pixel_r = Float32(src_data[idx_r]) / 255.0
+                dst_data[idx_r] = (pixel_r - mean_r) / std_r
+
+                # G channel (c=1)
+                var idx_g = n * (num_channels * num_rows * num_cols) + 1 * (num_rows * num_cols) + h * num_cols + w
+                var pixel_g = Float32(src_data[idx_g]) / 255.0
+                dst_data[idx_g] = (pixel_g - mean_g) / std_g
+
+                # B channel (c=2)
+                var idx_b = n * (num_channels * num_rows * num_cols) + 2 * (num_rows * num_cols) + h * num_cols + w
+                var pixel_b = Float32(src_data[idx_b]) / 255.0
+                dst_data[idx_b] = (pixel_b - mean_b) / std_b
+
+    return normalized


### PR DESCRIPTION
## Summary
- Create new `normalize_ops.mojo` module for data preprocessing utilities
- Extract `normalize_rgb()` for RGB image normalization with ImageNet stats
- Extract scalar helper functions (`sqrt_scalar_f32/f64`, `pow_scalar_f32/f64`)
- Update `normalization.mojo` to import from new module
- Export new functions from `__init__.mojo`

## Benefits
- **Separation of concerns**: Data preprocessing vs statistical normalization
- **Modularity**: `normalize_ops` can be imported independently
- **Maintainability**: Helper functions in dedicated module

## Changes
- `shared/core/normalize_ops.mojo` - New module (171 lines)
- `shared/core/normalization.mojo` - Now imports from normalize_ops
- `shared/core/__init__.mojo` - Added normalize_ops exports

## Test plan
- [x] All existing normalization tests should pass
- [x] normalize_rgb and scalar helpers work through imports

Closes #2465

🤖 Generated with [Claude Code](https://claude.com/claude-code)