### PR TITLE
feat(tooling): Add 8 custom slash commands for common workflows

### DIFF
--- a/.claude/commands/feedback.md
+++ b/.claude/commands/feedback.md
@@ -1,0 +1,25 @@
+Address review feedback on PR #$ARGUMENTS.
+
+1. Get review comments:
+
+   ```bash
+   gh api repos/mvillmow/ml-odyssey/pulls/$ARGUMENTS/comments
+   ```
+
+2. For each unaddressed comment:
+   - Read the feedback and understand what's requested
+   - Navigate to the file and line mentioned
+   - Make the requested change
+   - Reply to the comment:
+
+     ```bash
+     gh api repos/mvillmow/ml-odyssey/pulls/$ARGUMENTS/comments/<id>/replies \
+       --method POST -f body="Fixed - <brief description>"
+     ```
+
+3. After all changes:
+   - Commit with message: "fix(review): Address PR feedback"
+   - Push changes
+   - Wait for CI and verify it passes
+
+4. Report summary of changes made.

--- a/.claude/commands/fix-ci.md
+++ b/.claude/commands/fix-ci.md
@@ -1,0 +1,12 @@
+Fix CI failures for PR $ARGUMENTS.
+
+1. Get the PR number (use $ARGUMENTS or detect from current branch if empty)
+2. Check CI status: `gh pr checks <pr>`
+3. If failing, get failed run logs: `gh run view <run-id> --log-failed`
+4. Identify the failing test/build step
+5. Read the relevant source files
+6. Fix the issue
+7. Commit and push the fix
+8. Wait for CI and verify it passes
+
+If multiple PRs provided, fix each one sequentially.

--- a/.claude/commands/impl.md
+++ b/.claude/commands/impl.md
@@ -1,0 +1,11 @@
+Implement GitHub issue #$ARGUMENTS.
+
+1. Read issue context: `gh issue view $ARGUMENTS --comments`
+2. Understand requirements and acceptance criteria
+3. Check if a worktree exists for this issue, create if needed:
+   - `git worktree add worktree/$ARGUMENTS-<desc> -b $ARGUMENTS-<desc>`
+4. Implement the changes following project standards from CLAUDE.md
+5. Run tests to verify: `mojo test -I . tests/`
+6. Commit with conventional commit format
+7. Create PR linked to issue: `gh pr create --body "Closes #$ARGUMENTS"`
+8. Enable auto-merge: `gh pr merge --auto --rebase`

--- a/.claude/commands/merge-ready.md
+++ b/.claude/commands/merge-ready.md
@@ -1,0 +1,14 @@
+Check if PRs are ready to merge: $ARGUMENTS
+
+For each PR number (or all open PRs if none specified):
+
+1. Check CI status: `gh pr checks <pr>`
+2. Check for merge conflicts: `gh pr view <pr> --json mergeable`
+3. Check approval status: `gh pr view <pr> --json reviews`
+
+Output a summary table:
+
+| PR | Title | CI | Conflicts | Approvals | Ready? |
+
+For PRs that are ready, suggest: `gh pr merge <pr> --rebase`
+For PRs that are blocked, explain what's missing.

--- a/.claude/commands/pr-status.md
+++ b/.claude/commands/pr-status.md
@@ -1,0 +1,11 @@
+Check CI status for PRs: $ARGUMENTS
+
+For each PR number provided (or all open PRs if none specified):
+
+1. Run `gh pr checks <pr>` to get current status
+2. Summarize: PR number, title, status (pass/fail/pending)
+3. If any failing, show which check failed
+
+Output as a concise table:
+
+| PR | Title | Status | Failed Check |

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,13 @@
+Review PR #$ARGUMENTS comprehensively.
+
+1. Get PR details: `gh pr view $ARGUMENTS`
+2. Get the diff: `gh pr diff $ARGUMENTS`
+3. Check CI status: `gh pr checks $ARGUMENTS`
+4. Review the changes for:
+   - Code correctness and logic
+   - Mojo syntax standards (out self in __init__, mut for mutating, List not DynamicVector)
+   - Test coverage for new functionality
+   - Documentation updates if needed
+   - Memory safety (ownership, transfer operators)
+5. Provide structured feedback with specific file:line references
+6. Summarize: approve, request changes, or comment

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,15 @@
+Run tests: $ARGUMENTS
+
+If no arguments provided:
+
+- Detect changed files from `git status` and `git diff --name-only`
+- Identify which test files correspond to changed modules
+- Run tests for those modules
+
+If path provided:
+
+- If it's a directory: `mojo test -I . $ARGUMENTS`
+- If it's a file: `mojo test -I . $ARGUMENTS`
+
+Show test results summary with pass/fail counts.
+After tests complete, report any failures with file:line references.

--- a/.claude/commands/wt.md
+++ b/.claude/commands/wt.md
@@ -1,0 +1,33 @@
+Worktree management command: $ARGUMENTS
+
+Supported subcommands:
+
+**list** - Show all worktrees
+
+```bash
+git worktree list
+```
+
+**create issue-number** - Create worktree for a GitHub issue
+
+```bash
+# Get issue title for branch name
+gh issue view <issue> --json title
+git worktree add worktree/<issue>-<desc> -b <issue>-<desc>
+```
+
+**cleanup** - Remove merged worktrees and prune stale references
+
+```bash
+# For each worktree, check if branch is merged to main
+git worktree remove <path>
+git worktree prune
+```
+
+**switch issue-number** - Change to the worktree directory
+
+```bash
+cd worktree/<issue>-*
+```
+
+Execute the requested operation based on the first word of $ARGUMENTS.


### PR DESCRIPTION
## Summary

Add 8 custom slash commands in `.claude/commands/` to reduce typing for common workflows:

| Command | Description |
|---------|-------------|
| `/fix-ci` | Fix CI failures for PRs |
| `/pr-status` | Quick PR status check |
| `/impl` | Implement a GitHub issue end-to-end |
| `/wt` | Worktree management (list, create, cleanup, switch) |
| `/test` | Run tests with smart selection |
| `/review` | Comprehensively review a PR |
| `/merge-ready` | Check if PRs are ready to merge |
| `/feedback` | Address PR review feedback |

## Usage Examples

```bash
/fix-ci 2498        # Fix CI for PR 2498
/pr-status          # Check all open PRs
/impl 2456          # Implement issue #2456
/wt list            # List all worktrees
/test shared/core   # Run core tests
/review 2498        # Review PR #2498
/merge-ready        # Check all open PRs
/feedback 2498      # Address review feedback
```

## Test plan

- [x] All markdown files pass linting
- [ ] Commands work when invoked via `/command-name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)