### PR TITLE
docs: Fix broken Modular documentation links

### DIFF
--- a/docs/advanced/performance.md
+++ b/docs/advanced/performance.md
@@ -354,9 +354,8 @@ fn main() raises:
 
 ## References
 
-- [Mojo Manual: SIMD](https://docs.modular.com/mojo/manual/intrinsics/simd/)
-- [Mojo Manual: Vectorization](https://docs.modular.com/mojo/manual/algorithm/vectorize/)
-- [Intel Intrinsics Guide](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html)
+- [Mojo SIMD Module](https://docs.modular.com/mojo/stdlib/builtin/simd/)
+- [Mojo Vectorize Function](https://docs.modular.com/mojo/stdlib/algorithm/functional/vectorize/)
 - [Performance Optimization Guide](../core/mojo-patterns.md)
 
 See Also:

--- a/docs/core/mojo-patterns.md
+++ b/docs/core/mojo-patterns.md
@@ -333,6 +333,6 @@ See the following files for complete working examples:
 
 ## References
 
-- [Mojo Manual: SIMD](https://docs.modular.com/mojo/manual/intrinsics/simd/)
-- [Mojo Manual: Vectorization](https://docs.modular.com/mojo/manual/algorithm/vectorize/)
+- [Mojo SIMD Module](https://docs.modular.com/mojo/stdlib/builtin/simd/)
+- [Mojo Vectorize Function](https://docs.modular.com/mojo/stdlib/algorithm/functional/vectorize/)
 - [sys.info: simd_width_of](https://docs.modular.com/mojo/stdlib/sys/info/)


### PR DESCRIPTION
## Summary

- Update SIMD module link to correct path (`/mojo/stdlib/builtin/simd/`)
- Update vectorize function link to correct path (`/mojo/stdlib/algorithm/functional/vectorize/`)
- Remove Intel Intrinsics Guide link that was returning 403

These broken links were causing the `link-check` CI job to fail.

## Files Changed

- `docs/advanced/performance.md`
- `docs/core/mojo-patterns.md`

## Test Plan

- [x] CI link-check should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)