### PR TITLE
[Feat] Export math_constants and numerical_constants from shared.core

### DIFF
--- a/shared/core/__init__.mojo
+++ b/shared/core/__init__.mojo
@@ -80,6 +80,32 @@ from .defaults import (
 )
 
 # ============================================================================
+# Mathematical Constants
+# ============================================================================
+
+from .math_constants import (
+    PI,
+    SQRT_2,
+    SQRT_2_OVER_PI,
+    INV_SQRT_2PI,
+    GELU_COEFF,
+    LN2,
+    LN10,
+)
+
+# ============================================================================
+# Numerical Stability Constants
+# ============================================================================
+
+from .numerical_constants import (
+    EPSILON_DIV,
+    EPSILON_LOSS,
+    EPSILON_NORM,
+    GRADIENT_MAX_NORM,
+    GRADIENT_MIN_NORM,
+)
+
+# ============================================================================
 # Core Tensor Type and Creation Functions
 # ============================================================================
 


### PR DESCRIPTION
## Summary

- Add exports for mathematical constants (PI, SQRT_2, LN2, etc.) from `math_constants.mojo`
- Add exports for numerical stability constants (EPSILON_DIV, EPSILON_NORM, etc.) from `numerical_constants.mojo`

These modules were created earlier but not exported from `shared/core/__init__.mojo`, making them harder to discover and use.

## Test plan

- [x] Verify file compiles
- [ ] CI passes all tests

Closes #2481

🤖 Generated with [Claude Code](https://claude.com/claude-code)