### PR TITLE
feat(ci): integrate justfile commands into CI workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,11 +8,12 @@ on their purpose: testing, validation, security, and performance monitoring.
 The CI/CD strategy uses GitHub Actions with the following principles:
 
 1. **Pixi-based Setup**: All workflows use Pixi for environment management instead of modular/setup-mojo
-2. **Parallel Execution**: Test workflows use matrix strategies for parallelization
-3. **Fail-Fast Control**: Strategic use of `fail-fast: false` allows complete test runs without early stopping
-4. **Artifact Preservation**: Test results and reports are uploaded for 7-30 days for analysis
-5. **PR Comments**: Test summaries automatically comment on PRs for quick feedback
-6. **Scheduled Runs**: Weekly security and benchmark runs ensure ongoing system health
+2. **Justfile Integration**: Workflows use justfile recipes for consistency between local and CI environments
+3. **Parallel Execution**: Test workflows use matrix strategies for parallelization
+4. **Fail-Fast Control**: Strategic use of `fail-fast: false` allows complete test runs without early stopping
+5. **Artifact Preservation**: Test results and reports are uploaded for 7-30 days for analysis
+6. **PR Comments**: Test summaries automatically comment on PRs for quick feedback
+7. **Scheduled Runs**: Weekly security and benchmark runs ensure ongoing system health
 
 ## Workflow Summary
 
@@ -409,6 +410,45 @@ The CI/CD strategy uses GitHub Actions with the following principles:
 ---
 
 ## Common Patterns
+
+### Justfile Integration
+
+All CI workflows use justfile recipes for consistent command execution between local development and CI:
+
+```yaml
+# Install Just in workflow
+- name: Install Just
+  run: |
+    curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+
+# Use justfile recipes
+- name: Build package
+  run: just ci-build
+
+- name: Run test group
+  run: just ci-test-group "tests/shared/core" "test_*.mojo"
+
+- name: Run all tests
+  run: just ci-test-mojo
+```
+
+**Benefits**:
+
+1. **Reproducibility**: Developers can run `just ci-validate` locally to reproduce CI results
+2. **Maintainability**: Complex logic lives in justfile, not scattered across workflow YAML
+3. **Consistency**: Identical flags and commands between local and CI environments
+4. **Documentation**: Justfile is self-documenting with `just --list`
+
+**Available CI Recipes**:
+
+- `just ci-build` - Build shared package with compilation validation
+- `just ci-compile` - Compile package (validation only, no output artifact)
+- `just ci-test-group PATH PATTERN` - Run specific test group
+- `just ci-test-mojo` - Run all Mojo tests
+- `just ci-validate` - Full validation (build + test)
+- `just ci-lint` - Run pre-commit hooks
+
+**See**: `/justfile` for complete implementation and `CLAUDE.md` for developer documentation.
 
 ### Pixi-Based Environment Setup
 

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -45,23 +45,21 @@ jobs:
           restore-keys: |
             pixi-${{ runner.os }}-
 
+      - name: Install Just
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+
       - name: Build Mojo packages
         run: |
           echo "Building Mojo packages..."
 
-          # Check if Mojo source files exist
-          if [ -d "src" ] && [ -n "$(find src -name '*.mojo' -o -name '*.🔥' 2>/dev/null)" ]; then
-            echo "Found Mojo source files. Building..."
-
-            # Compile all Mojo files to check for syntax errors
-            find src -name "*.mojo" -o -name "*.🔥" | while read -r file; do
-              echo "Checking: $file"
-              pixi run mojo build -Werror -I . "$file" -o "/tmp/$(basename "$file" .mojo)" || exit 1
-            done
-
-            echo "✅ All Mojo files compiled successfully"
+          # Check if shared package exists
+          if [ -d "shared" ]; then
+            echo "Building shared package using justfile..."
+            just ci-build
+            echo "✅ Shared package built successfully"
           else
-            echo "⚠️  No Mojo source files found yet"
+            echo "⚠️  No shared package found yet"
             echo "This is expected during initial development."
           fi
 
@@ -71,8 +69,8 @@ jobs:
 
           # Check if smoke tests exist
           if [ -d "tests/smoke" ]; then
-            echo "Running smoke tests..."
-            pixi run mojo test -Werror -I . tests/smoke/ --verbose || true
+            echo "Running smoke tests using justfile..."
+            just ci-test-group "tests/smoke" "test_*.mojo" || true
           else
             echo "⚠️  No smoke tests found yet (tests/smoke/)"
           fi

--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -57,21 +57,24 @@ jobs:
       - name: Check Mojo version
         run: pixi run mojo --version
 
+      - name: Install Just
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+
       - name: Compile shared package
         run: |
           echo "=================================================="
           echo "Compiling shared package..."
           echo "=================================================="
 
-          REPO_ROOT="$(pwd)"
           mkdir -p compilation-results
 
           # Count total files for reporting
           total_files=$(find shared -name "*.mojo" -type f | wc -l)
           echo "Total .mojo files in shared/: $total_files"
 
-          # Build the shared package (compiles all modules properly with relative imports)
-          if pixi run mojo package -I "$REPO_ROOT" shared -o /tmp/shared.mojopkg 2>&1; then
+          # Build the shared package using justfile
+          if just ci-compile 2>&1; then
             echo "✅ PASSED: shared package compiled successfully"
             echo "compilation_status=success" >> $GITHUB_ENV
           else
@@ -184,6 +187,10 @@ jobs:
           restore-keys: |
             pixi-${{ runner.os }}-
 
+      - name: Install Just
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+
       - name: Run test group
         # Integration tests may have segfaults on CI runners due to memory constraints
         # Allow them to fail without blocking the workflow (tracked in issue)
@@ -196,108 +203,38 @@ jobs:
           echo ""
 
           mkdir -p test-results
-
-          test_count=0
-          passed_count=0
-          failed_count=0
-          failed_tests=""
           start_time=$(date +%s)
 
-          # Save repository root for imports
-          REPO_ROOT="$(pwd)"
-          TEST_PATH="${{ matrix.test-group.path }}"
-
-          # Expand pattern into actual files (from repo root)
-          test_files=""
-          for pattern in ${{ matrix.test-group.pattern }}; do
-            # Check if pattern contains wildcards or is a direct path
-            if [[ "$pattern" == *"*"* ]]; then
-              # Glob pattern - expand it with TEST_PATH prefix
-              for file in $TEST_PATH/$pattern; do
-                if [ -f "$file" ]; then
-                  test_files="$test_files $file"
-                fi
-              done
-            else
-              # Direct file or subdirectory pattern
-              if [ -f "$TEST_PATH/$pattern" ]; then
-                test_files="$test_files $TEST_PATH/$pattern"
-              elif [[ "$pattern" == *"/"* ]]; then
-                # Subdirectory pattern like "datasets/test_*.mojo"
-                for file in $TEST_PATH/$pattern; do
-                  if [ -f "$file" ]; then
-                    test_files="$test_files $file"
-                  fi
-                done
-              fi
-            fi
-          done
-
-          if [ -z "$test_files" ]; then
-            echo "⚠️  No test files found for this group"
-            echo "This may be expected if tests haven't been created yet."
-            echo '{"group": "${{ matrix.test-group.name }}", "tests": 0, "passed": 0, "failed": 0, "duration": 0}' > "test-results/${{ matrix.test-group.name }}.json"
-            exit 0
+          # Use justfile to run test group
+          # The justfile handles all the complexity of test discovery and execution
+          if just ci-test-group "${{ matrix.test-group.path }}" "${{ matrix.test-group.pattern }}"; then
+            test_result="passed"
+            exit_code=0
+          else
+            test_result="failed"
+            exit_code=1
           fi
-
-          # Run each test file
-          for test_file in $test_files; do
-            if [ -f "$test_file" ]; then
-              echo ""
-              echo "=================================================="
-              echo "Running: $test_file"
-              echo "=================================================="
-              test_count=$((test_count + 1))
-
-              if pixi run mojo -I "$REPO_ROOT" -I . "$test_file"; then
-                echo "✅ PASSED: $test_file"
-                passed_count=$((passed_count + 1))
-              else
-                echo "❌ FAILED: $test_file"
-                failed_count=$((failed_count + 1))
-                failed_tests="$failed_tests\\n  - $test_file"
-              fi
-            fi
-          done
 
           end_time=$(date +%s)
           duration=$((end_time - start_time))
 
-          echo ""
-          echo "=================================================="
-          echo "Test Group Summary: ${{ matrix.test-group.name }}"
-          echo "=================================================="
-          echo "Total: $test_count tests"
-          echo "Passed: $passed_count tests"
-          echo "Failed: $failed_count tests"
-          echo "Duration: ${duration}s"
-          echo ""
-
-          # Save results as JSON for aggregation
+          # Create simplified result files
+          # Note: Detailed metrics are in justfile output, these are for aggregation
           cat > "test-results/${{ matrix.test-group.name }}.json" << EOF
           {
             "group": "${{ matrix.test-group.name }}",
-            "tests": $test_count,
-            "passed": $passed_count,
-            "failed": $failed_count,
+            "tests": 1,
+            "passed": $([ "$test_result" = "passed" ] && echo 1 || echo 0),
+            "failed": $([ "$test_result" = "failed" ] && echo 1 || echo 0),
             "duration": $duration
           }
           EOF
 
-          # Also save human-readable format
-          result_file="$REPO_ROOT/test-results/${{ matrix.test-group.name }}.txt"
-          echo "Test Group: ${{ matrix.test-group.name }}" > "$result_file"
-          echo "Total: $test_count tests run, $passed_count passed, $failed_count failed" >> "$result_file"
-          echo "Duration: ${duration}s" >> "$result_file"
-          if [ $failed_count -gt 0 ]; then
-            echo "" >> "$result_file"
-            echo "Failed tests:" >> "$result_file"
-            echo -e "$failed_tests" >> "$result_file"
-          fi
+          echo "Test Group: ${{ matrix.test-group.name }}" > "test-results/${{ matrix.test-group.name }}.txt"
+          echo "Result: $test_result" >> "test-results/${{ matrix.test-group.name }}.txt"
+          echo "Duration: ${duration}s" >> "test-results/${{ matrix.test-group.name }}.txt"
 
-          if [ $failed_count -gt 0 ]; then
-            exit 1
-          fi
+          exit $exit_code
 
       - name: Upload test results
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -876,6 +876,70 @@ This project uses Pixi for environment management:
 
 ## Common Commands
 
+### Justfile Build System
+
+The project uses [Just](https://just.systems/) as a unified command runner for local development and CI/CD consistency.
+
+#### Quick Reference
+
+```bash
+# Show all available recipes
+just --list
+
+# Get help
+just help
+
+# Development commands
+just build                  # Build project in debug mode
+just test                   # Run all tests
+just test-mojo             # Run only Mojo tests
+just lint                  # Run all linters
+just format                # Format all files
+
+# CI-specific commands (match GitHub Actions)
+just ci-validate           # Full CI validation (build + test)
+just ci-build              # Build shared package
+just ci-compile            # Compile package (validation only)
+just ci-test-mojo          # Run all Mojo tests
+just ci-test-group PATH PATTERN  # Run specific test group
+just ci-lint               # Run pre-commit hooks
+
+# Training and inference
+just train                 # Train LeNet-5 with defaults
+just train lenet5 fp16 20  # Train with FP16, 20 epochs
+just infer lenet5 ./weights  # Run inference
+
+# Docker management
+just docker-up             # Start development environment
+just docker-down           # Stop environment
+just docker-shell          # Open shell in container
+```
+
+### Why Use Justfile?
+
+1. **Consistency**: Same commands work locally and in CI
+2. **Simplicity**: Easy-to-read recipes vs complex bash scripts
+3. **Documentation**: Self-documenting with `just --list`
+4. **Reliability**: Ensures identical flags between local dev and CI
+
+### CI Integration
+
+GitHub Actions workflows use justfile recipes to ensure consistency:
+
+```yaml
+# Example from comprehensive-tests.yml
+- name: Run test group
+  run: just ci-test-group "tests/shared/core" "test_*.mojo"
+
+# Example from build-validation.yml
+- name: Build package
+  run: just ci-build
+```
+
+This ensures developers can run `just ci-validate` locally to reproduce CI results exactly.
+
+**See**: `justfile` for complete recipe list and implementation details.
+
 ### GitHub CLI
 
 ```bash


### PR DESCRIPTION
Adds justfile recipes for CI operations and updates workflows to use them for consistent command execution.

## Changes

- Added 8 CI recipes to justfile:
  - `ci-test-file` - Run individual test file
  - `ci-test-group` - Run test group with pattern
  - `ci-build` - Build Mojo code
  - `ci-compile` - Compile-only check
  - `ci-test-mojo` - Run all Mojo tests
  - `ci-validate` - Validate test coverage
  - `ci-lint` - Run all linters
  - `ci-precommit` - Run pre-commit hooks
- Updated `build-validation.yml` to use justfile commands
- Updated `comprehensive-tests.yml` to use justfile commands
- Updated `.github/workflows/README.md` with justfile usage
- Updated `CLAUDE.md` with Justfile Build System section

## Benefits

1. **Consistency**: Same commands work locally and in CI
2. **Simplicity**: Easy-to-read recipes vs complex bash scripts
3. **Documentation**: Self-documenting with `just --list`
4. **Reliability**: Ensures identical flags between local dev and CI

## Example Usage

```bash
# Local development
just ci-test-file tests/shared/core/test_activation.mojo
just ci-test-group tests/shared/core "test_*.mojo"

# CI workflows now use same commands
- run: just ci-test-file ${{ matrix.test }}
```

Closes #2546