### PR TITLE
fix(tests): resolve test_serialization.mojo API signature mismatches

### DIFF
--- a/tests/shared/test_serialization.mojo
+++ b/tests/shared/test_serialization.mojo
@@ -75,13 +75,13 @@ fn test_hex_encoding() raises:
 
     # Create new tensor and decode hex
     var tensor2 = zeros(shape, DType.float32)
-    hex_to_bytes(hex_str, tensor2._data)
+    hex_to_bytes(hex_str, tensor2)
 
     # Verify data matches
     for i in range(tensor.numel()):
         var v1 = tensor._get_float64(i)
         var v2 = tensor2._get_float64(i)
-        assert_almost_equal(v1, v2, 1e-6, "Hex decode mismatch")
+        assert_almost_equal(v1, v2, tolerance=1e-6, message="Hex decode mismatch")
 
 
 fn test_single_tensor_serialization() raises:
@@ -113,7 +113,9 @@ fn test_single_tensor_serialization() raises:
         assert_equal(loaded.numel(), 6, "Wrong number of elements")
         for i in range(loaded.numel()):
             var v = loaded._get_float64(i)
-            assert_almost_equal(v, 3.14, 1e-6, "Value mismatch after load")
+            assert_almost_equal(
+                v, 3.14, tolerance=1e-6, message="Value mismatch after load"
+            )
 
     finally:
         # Clean up


### PR DESCRIPTION
## Summary
Fixes 3 API signature compilation errors in tests/shared/test_serialization.mojo that prevent the test file from compiling with Mojo v0.25.7+.

## Changes Made
1. **Line 78**: `hex_to_bytes()` API change
   - Old: `hex_to_bytes(hex_str, tensor2._data)` (passing raw pointer)
   - New: `hex_to_bytes(hex_str, tensor2)` (passing ExTensor)

2. **Line 84**: `assert_almost_equal()` parameter names
   - Old: `assert_almost_equal(v1, v2, 1e-6, "Hex decode mismatch")` (4 positional args)
   - New: `assert_almost_equal(v1, v2, tolerance=1e-6, message="Hex decode mismatch")` (named params)

3. **Lines 116-118**: Same `assert_almost_equal()` fix
   - Old: `assert_almost_equal(v, 3.14, 1e-6, "Value mismatch after load")`
   - New: `assert_almost_equal(v, 3.14, tolerance=1e-6, message="Value mismatch after load")`

## Verification
- [x] Compiles successfully with `just ci-compile`
- [x] Fixes align with Mojo v0.25.7+ API changes

## Notes
- Part of Phase 1 of the comprehensive CI/CD failure fixes
- Model file compilation fixes were already addressed in commit e03fcdaa
- This PR focuses solely on test_serialization.mojo API signature fixes