### PR TITLE
fix: format test_base_loader.mojo to pass pre-commit CI

### DIFF
--- a/tests/shared/data/loaders/test_base_loader.mojo
+++ b/tests/shared/data/loaders/test_base_loader.mojo
@@ -29,7 +29,7 @@ struct StubDataset:
         return (Float32(index), index)
 
 
-struct StubBatch(Sized, Copyable, Movable):
+struct StubBatch(Copyable, Movable, Sized):
     """Minimal stub batch for testing batch operations."""
 
     var batch_size: Int


### PR DESCRIPTION
## Summary
Fixes recurring pre-commit CI failures on main branch by applying mojo format to test_base_loader.mojo.

## Changes Made
Applied `mojo format` to fix trait declaration ordering on StubBatch struct:
- **Before**: `struct StubBatch(Sized, Copyable, Movable):`
- **After**: `struct StubBatch(Copyable, Movable, Sized):`

## Root Cause
The `mojo format` hook reorders trait declarations alphabetically, but this file had traits in non-alphabetical order, causing the pre-commit check to fail on every commit.

## Verification
- [x] Runs `mojo format` with no changes after this fix
- [x] Pre-commit hooks pass

## Related
Part of comprehensive CI/CD failure fixes on main branch.