### PR TITLE
docs(ci): improve documentation for emergency CI fixes

### DIFF
--- a/justfile
+++ b/justfile
@@ -364,14 +364,25 @@ ci-test-group path pattern:
     fi
 
 # CI: Build shared package with -Werror enforcement
-# TEMPORARY: Disabled docstring warnings while fixing 2,997 warnings across 109 files
-# See GitHub issue for tracking docstring cleanup progress
+#
+# TEMPORARY WORKAROUND (Issue #2688):
+# Docstring warnings are temporarily disabled via --disable-warnings flag.
+# This allows CI to pass while we systematically fix 2,997 docstring warnings
+# across 109 files in the shared/ module.
+#
+# Why this is temporary:
+# - Mojo 0.26.1 introduced stricter docstring validation
+# - Missing periods, unknown arguments, and formatting issues block builds
+# - Comprehensive fixes are tracked in issue #2688 and will be done via PRs
+#
+# TODO: Remove --disable-warnings once all docstring fixes are merged
+# Related: https://github.com/mvillmow/ml-odyssey/issues/2688
 ci-build:
     #!/usr/bin/env bash
     set -e
     REPO_ROOT="$(pwd)"
     mkdir -p build
-    echo "Building shared package (docstring warnings temporarily disabled)..."
+    echo "Building shared package (docstring warnings temporarily disabled - see issue #2688)..."
     pixi run mojo package --disable-warnings -I "$REPO_ROOT" shared -o build/ml-odyssey-shared.mojopkg
 
 # CI: Compile shared package (validation only, no output)

--- a/shared/utils/arg_parser.mojo
+++ b/shared/utils/arg_parser.mojo
@@ -252,8 +252,11 @@ struct ArgumentParser(Copyable, Movable):
         # Initialize with defaults (using ref for non-copyable dict entries)
         for ref item in self.arguments.items():
             var name = item.key
+            # Use ref binding instead of var to avoid implicit copy
+            # ArgumentSpec is not ImplicitlyCopyable, so `var spec = item.value`
+            # would trigger a compile error. `ref spec` creates a reference alias.
             ref spec = item.value
-            # Access value fields directly to avoid implicit copy
+            # Access value fields directly via reference
             if not spec.is_flag and len(spec.default_value) > 0:
                 result.set(name, spec.default_value)
 


### PR DESCRIPTION
## Summary

This cleanup PR adds comprehensive documentation to explain the emergency fixes made in commit 4446eba2, which resolved two critical CI failures that were blocking main.

## Context

Commit 4446eba2 was pushed directly to main (without a PR) to immediately unblock CI. While this fixed the urgent issues, it lacked proper documentation explaining:
- Why the changes were made
- What the temporary workaround does
- How to properly resolve it long-term

This PR adds that missing documentation.

## Changes Made

### 1. Enhanced `justfile` Documentation (lines 366-379)

**Before**:
```bash
# TEMPORARY: Disabled docstring warnings while fixing 2,997 warnings across 109 files
# See GitHub issue for tracking docstring cleanup progress
```

**After**:
```bash
# TEMPORARY WORKAROUND (Issue #2688):
# Docstring warnings are temporarily disabled via --disable-warnings flag.
# This allows CI to pass while we systematically fix 2,997 docstring warnings
# across 109 files in the shared/ module.
#
# Why this is temporary:
# - Mojo 0.26.1 introduced stricter docstring validation
# - Missing periods, unknown arguments, and formatting issues block builds
# - Comprehensive fixes are tracked in issue #2688 and will be done via PRs
#
# TODO: Remove --disable-warnings once all docstring fixes are merged
# Related: https://github.com/mvillmow/ml-odyssey/issues/2688
```

### 2. Enhanced `arg_parser.mojo` Comments (lines 255-259)

**Before**:
```mojo
ref spec = item.value
# Access value fields directly to avoid implicit copy
```

**After**:
```mojo
# Use ref binding instead of var to avoid implicit copy
# ArgumentSpec is not ImplicitlyCopyable, so `var spec = item.value`
# would trigger a compile error. `ref spec` creates a reference alias.
ref spec = item.value
# Access value fields directly via reference
```

## Why This PR Matters

Future developers will now understand:
- ✅ **Why the workaround exists** - Mojo 0.26.1 stricter validation
- ✅ **What needs to be done** - Fix 2,997 docstrings (tracked in #2688)
- ✅ **The technical reasoning** - ArgumentSpec is not ImplicitlyCopyable
- ✅ **How to remove it** - Re-enable warnings after docstring fixes merge

## Related Issues

- Emergency fixes: Commit 4446eba2
- Docstring cleanup tracking: #2688
- Original CI failures: Build Validation, Comprehensive Tests

## Verification

- [x] Pre-commit hooks pass
- [x] Documentation is clear and comprehensive
- [x] Links to issue #2688 are included
- [x] TODO added for future cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)