### PR TITLE
[Refactor] Unify extract_frontmatter() Variants into Shared Utility

### DIFF
--- a/scripts/agents/agent_utils.py
+++ b/scripts/agents/agent_utils.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Shared utilities for agent configuration scripts.
+
+This module provides common functions for working with agent markdown files
+that contain YAML frontmatter.
+"""
+
+import re
+from typing import Dict, Optional, Tuple
+
+import yaml
+
+# Regex pattern for YAML frontmatter (shared across all variants)
+FRONTMATTER_PATTERN = re.compile(r"^---\s*\n(.*?\n)---\s*\n", re.DOTALL)
+
+
+def extract_frontmatter_raw(content: str) -> Optional[str]:
+    """Extract frontmatter text only.
+
+    Args:
+        content: Markdown file content.
+
+    Returns:
+        The raw YAML frontmatter string, or None if not found.
+    """
+    match = FRONTMATTER_PATTERN.match(content)
+    if match:
+        return match.group(1)
+    return None
+
+
+def extract_frontmatter_with_lines(content: str) -> Optional[Tuple[str, int, int]]:
+    """Extract frontmatter with line number tracking.
+
+    Args:
+        content: Markdown file content.
+
+    Returns:
+        Tuple of (frontmatter_text, start_line, end_line), or None if not found.
+        Lines are 1-indexed, counting from the beginning of the file.
+    """
+    match = FRONTMATTER_PATTERN.match(content)
+    if match:
+        frontmatter = match.group(1)
+        # start_line is line 1 (the --- marker), end_line is where the closing --- is
+        start_line = 1
+        end_line = content[: match.end()].count("\n")
+        return (frontmatter, start_line, end_line)
+    return None
+
+
+def extract_frontmatter_parsed(content: str) -> Optional[Tuple[str, Dict]]:
+    """Extract and parse frontmatter to Dict.
+
+    Args:
+        content: Markdown file content.
+
+    Returns:
+        Tuple of (frontmatter_text, parsed_dict), or None if not found or invalid.
+    """
+    match = FRONTMATTER_PATTERN.match(content)
+    if match:
+        frontmatter = match.group(1)
+        try:
+            parsed = yaml.safe_load(frontmatter)
+            if isinstance(parsed, dict):
+                return (frontmatter, parsed)
+        except yaml.YAMLError:
+            pass
+    return None

--- a/scripts/agents/check_frontmatter.py
+++ b/scripts/agents/check_frontmatter.py
@@ -15,13 +15,14 @@ Exit Codes:
 """
 
 import argparse
-import re
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from common import get_agents_dir
+
+from agent_utils import extract_frontmatter_with_lines
 
 try:
     import yaml
@@ -47,30 +48,6 @@ OPTIONAL_FIELDS = {
 
 # Valid model names
 VALID_MODELS = {"sonnet", "opus", "haiku", "claude-3-5-sonnet", "claude-3-opus", "claude-3-haiku"}
-
-
-def extract_frontmatter(content: str) -> Optional[Tuple[str, int, int]]:
-    """
-    Extract YAML frontmatter from markdown content.
-
-    Args:
-        content: The markdown file content
-
-    Returns:
-        Tuple of (frontmatter_text, start_line, end_line) or None if no frontmatter found
-    """
-    # Match YAML frontmatter between --- delimiters
-    pattern = r"^---\s*\n(.*?\n)---\s*\n"
-    match = re.match(pattern, content, re.DOTALL)
-
-    if not match:
-        return None
-
-    frontmatter_text = match.group(1)
-    start_line = 1
-    end_line = content[: match.end()].count("\n")
-
-    return frontmatter_text, start_line, end_line
 
 
 def validate_field_type(field_name: str, value: Any, expected_type: type) -> Optional[str]:
@@ -167,7 +144,7 @@ def check_file(file_path: Path, verbose: bool = False) -> Tuple[bool, List[str]]
         return False, [f"Failed to read file: {e}"]
 
     # Extract frontmatter
-    result = extract_frontmatter(content)
+    result = extract_frontmatter_with_lines(content)
     if result is None:
         return False, ["No YAML frontmatter found (should start with --- and end with ---)"]
 

--- a/scripts/agents/list_agents.py
+++ b/scripts/agents/list_agents.py
@@ -15,13 +15,14 @@ Exit Codes:
 """
 
 import argparse
-import re
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from common import get_agents_dir
+
+from agent_utils import extract_frontmatter_raw
 
 try:
     import yaml
@@ -89,21 +90,6 @@ class AgentInfo:
         return f"AgentInfo(level={self.level}, name={self.name})"
 
 
-def extract_frontmatter(content: str) -> Optional[str]:
-    """
-    Extract YAML frontmatter from markdown content.
-
-    Args:
-        content: The markdown file content
-
-    Returns:
-        Frontmatter text or None if not found
-    """
-    pattern = r"^---\s*\n(.*?\n)---\s*\n"
-    match = re.match(pattern, content, re.DOTALL)
-    return match.group(1) if match else None
-
-
 def load_agent(file_path: Path) -> Optional[AgentInfo]:
     """
     Load agent configuration from a markdown file.
@@ -120,7 +106,7 @@ def load_agent(file_path: Path) -> Optional[AgentInfo]:
         print(f"Warning: Failed to read {file_path.name}: {e}", file=sys.stderr)
         return None
 
-    frontmatter_text = extract_frontmatter(content)
+    frontmatter_text = extract_frontmatter_raw(content)
     if frontmatter_text is None:
         print(f"Warning: No frontmatter in {file_path.name}", file=sys.stderr)
         return None

--- a/scripts/agents/test_agent_loading.py
+++ b/scripts/agents/test_agent_loading.py
@@ -15,13 +15,14 @@ Exit Codes:
 """
 
 import argparse
-import re
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from common import get_agents_dir
+
+from agent_utils import extract_frontmatter_raw
 
 try:
     import yaml
@@ -44,19 +45,6 @@ class AgentInfo:
         return f"AgentInfo(name={self.name}, file={self.file_path.name})"
 
 
-def extract_frontmatter(content: str) -> Optional[str]:
-    """
-    Extract YAML frontmatter from markdown content.
-
-    Args:
-        content: The markdown file content
-
-    Returns:
-        Frontmatter text or None if not found
-    """
-    pattern = r'^---\s*\n(.*?\n)---\s*\n'
-    match = re.match(pattern, content, re.DOTALL)
-    return match.group(1) if match else None
 
 
 def load_agent(file_path: Path, verbose: bool = False) -> Optional[AgentInfo]:
@@ -77,7 +65,7 @@ def load_agent(file_path: Path, verbose: bool = False) -> Optional[AgentInfo]:
         return None
 
     # Extract frontmatter
-    frontmatter_text = extract_frontmatter(content)
+    frontmatter_text = extract_frontmatter_raw(content)
     if frontmatter_text is None:
         print(f"✗ {file_path.name}: No YAML frontmatter found", file=sys.stderr)
         return None

--- a/scripts/agents/validate_agents.py
+++ b/scripts/agents/validate_agents.py
@@ -20,13 +20,14 @@ Exit Codes:
 """
 
 import argparse
-import re
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from common import get_agents_dir
+
+from agent_utils import extract_frontmatter_parsed
 
 try:
     import yaml
@@ -123,35 +124,6 @@ class ValidationResult:
     def has_issues(self) -> bool:
         """Check if there are any errors or warnings."""
         return len(self.errors) > 0 or len(self.warnings) > 0
-
-
-def extract_frontmatter(content: str) -> Optional[Tuple[str, Dict]]:
-    """
-    Extract and parse YAML frontmatter from markdown content.
-
-    Args:
-        content: The markdown file content
-
-    Returns:
-        Tuple of (frontmatter_text, parsed_dict) or None if extraction fails
-    """
-    pattern = r"^---\s*\n(.*?\n)---\s*\n"
-    match = re.match(pattern, content, re.DOTALL)
-
-    if not match:
-        return None
-
-    frontmatter_text = match.group(1)
-
-    try:
-        frontmatter = yaml.safe_load(frontmatter_text)
-    except yaml.YAMLError:
-        return None
-
-    if not isinstance(frontmatter, dict):
-        return None
-
-    return frontmatter_text, frontmatter
 
 
 def validate_frontmatter(frontmatter: Dict, result: ValidationResult):
@@ -330,7 +302,7 @@ def validate_file(file_path: Path, verbose: bool = False) -> ValidationResult:
         return result
 
     # Extract and validate frontmatter
-    fm_result = extract_frontmatter(content)
+    fm_result = extract_frontmatter_parsed(content)
     if fm_result is None:
         result.add_error("No valid YAML frontmatter found")
         return result


### PR DESCRIPTION
## Summary
Create `scripts/agents/agent_utils.py` with three frontmatter extraction variants and update all 4 files to use the shared utilities.

## Changes
### New file: scripts/agents/agent_utils.py
- `extract_frontmatter_raw()` - returns text only
- `extract_frontmatter_with_lines()` - returns text + line numbers
- `extract_frontmatter_parsed()` - returns text + parsed YAML dict

### Updated files
- `validate_agents.py`: uses `extract_frontmatter_parsed`
- `list_agents.py`: uses `extract_frontmatter_raw`
- `check_frontmatter.py`: uses `extract_frontmatter_with_lines`
- `test_agent_loading.py`: uses `extract_frontmatter_raw`

## Testing
All 4 scripts work correctly with the shared utilities.

Closes #2581