### PR TITLE
refactor: move Colors class to common utilities

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -65,5 +65,36 @@ def get_agents_dir() -> Path:
     return agents_dir
 
 
+class Colors:
+    """ANSI color codes for terminal output."""
+
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+
+    @staticmethod
+    def disable() -> None:
+        """Disable colors for non-terminal output.
+
+        Sets all color codes to empty strings, useful for piping
+        output to files or non-TTY streams.
+        """
+        Colors.HEADER = ""
+        Colors.OKBLUE = ""
+        Colors.OKCYAN = ""
+        Colors.OKGREEN = ""
+        Colors.WARNING = ""
+        Colors.FAIL = ""
+        Colors.ENDC = ""
+        Colors.BOLD = ""
+        Colors.UNDERLINE = ""
+
+
 # NOTE: get_plan_dir() removed - planning now done through GitHub issues
 # See .claude/shared/github-issue-workflow.md for the new workflow

--- a/scripts/migrate_notes_to_github.py
+++ b/scripts/migrate_notes_to_github.py
@@ -40,27 +40,7 @@ try:
 except ImportError:
     HAS_TQDM = False
 
-from common import get_repo_root
-
-
-class Colors:
-    """ANSI color codes for terminal output"""
-
-    HEADER = "\033[95m"
-    OKBLUE = "\033[94m"
-    OKCYAN = "\033[96m"
-    OKGREEN = "\033[92m"
-    WARNING = "\033[93m"
-    FAIL = "\033[91m"
-    ENDC = "\033[0m"
-    BOLD = "\033[1m"
-
-    @staticmethod
-    def disable():
-        """Disable colors for non-terminal output"""
-        Colors.HEADER = Colors.OKBLUE = Colors.OKCYAN = ""
-        Colors.OKGREEN = Colors.WARNING = Colors.FAIL = ""
-        Colors.ENDC = Colors.BOLD = ""
+from common import Colors, get_repo_root
 
 
 def check_github_rate_limit() -> Tuple[int, float]:


### PR DESCRIPTION
## Summary

Move Colors class from migrate_notes_to_github.py to scripts/common.py for reusability.

## Changes

- Add Colors class to scripts/common.py with improved docstrings
- Add `disable()` method for non-TTY output
- Update import in migrate_notes_to_github.py
- Remove duplicate Colors class definition

## Files Modified

- `scripts/common.py` - Added Colors class (+31 lines)
- `scripts/migrate_notes_to_github.py` - Updated import, removed local class (-21 lines)

Closes #2601

🤖 Generated with [Claude Code](https://claude.com/claude-code)