### PR TITLE
refactor(activation): merge identical float16/float32 tanh branches

### DIFF
--- a/shared/core/activation.mojo
+++ b/shared/core/activation.mojo
@@ -273,9 +273,7 @@ fn _tanh_op[T: DType](x: Scalar[T]) -> Scalar[T]:
     """Tanh operation for float dtypes."""
 
     @parameter
-    if T == DType.float16:
-        return Scalar[T](math_tanh(Float32(x)))
-    elif T == DType.float32:
+    if T == DType.float16 or T == DType.float32:
         return Scalar[T](math_tanh(Float32(x)))
     else:  # float64
         return Scalar[T](math_tanh(Float64(x)))


### PR DESCRIPTION
## Summary
Merges identical tanh implementations for float16 and float32 into single condition.

## Changes
- Consolidate duplicate float16 and float32 branches in `_tanh_op`
- Single condition: `T == DType.float16 or T == DType.float32`

## Files Modified
- `shared/core/activation.mojo`

Closes #2618

🤖 Generated with [Claude Code](https://claude.com/claude-code)