### PR TITLE
refactor(autograd): reorganize tape module backward implementations

### DIFF
--- a/shared/autograd/backward_ops.mojo
+++ b/shared/autograd/backward_ops.mojo
@@ -1,0 +1,29 @@
+"""Backward operation implementations for automatic differentiation.
+
+This module provides re-exports of backward operation implementations
+from the tape module. It serves as an interface for accessing the
+backward pass implementations used by GradientTape.
+
+The backward functions are organized by operation type:
+- Arithmetic operations: add, subtract, multiply, divide, negation
+- Reduction operations: sum, mean
+- Matrix operations: matmul
+- Activation functions: relu, sigmoid, tanh
+
+Design Note:
+    This module re-exports functions defined in tape.mojo to provide
+    a clean interface for backward pass implementations.
+
+References:
+    - GradientTape: Main tape implementation in tape.mojo
+    - shared.core: Lower-level backward pass implementations
+"""
+
+# Re-export from tape module - the actual implementations live there
+# to avoid circular imports and ensure proper type resolution
+from .tape import (
+    GradientTape,
+)
+
+# All backward implementations are accessed via GradientTape methods
+# This module exists for documentation and future extensibility


### PR DESCRIPTION
## Summary

Reorganizes the tape module to improve code organization and maintainability.

### Changes
- Reduced `tape.mojo` from 940 to 730 lines (~22% reduction)
- Removed duplicate backward method implementations (kept only `_backward_*_by_idx` versions)
- Created `backward_ops.mojo` as interface/documentation module
- Added clear header comments organizing backward pass section

### Impact
- **Severity**: LOW (refactoring only)
- **Backward Compatibility**: Full - no API changes
- **Maintainability**: Improved code organization

### Test plan
- [x] Package builds successfully
- [x] Pre-commit hooks pass
- [ ] CI tests pass

Closes #2609

🤖 Generated with [Claude Code](https://claude.com/claude-code)