### PR TITLE
perf(arithmetic): use tensor ops for subtract_backward

### DIFF
--- a/shared/core/arithmetic.mojo
+++ b/shared/core/arithmetic.mojo
@@ -554,11 +554,9 @@ fn subtract_backward(
     # Gradient for A passes through unchanged (but reduced for broadcasting)
     var grad_a = _reduce_broadcast_dims(grad_output, a.shape())
 
-    # Gradient for B is negated
-    # Create a tensor of -1s with same shape as grad_output
-    var neg_grad = ExTensor(grad_output.shape(), grad_output.dtype())
-    for i in range(grad_output.numel()):
-        neg_grad._set_float64(i, -grad_output._get_float64(i))
+    # Gradient for B is negated using tensor operations (multiply by -1.0)
+    var neg_one = full(grad_output.shape(), -1.0, grad_output.dtype())
+    var neg_grad = multiply(grad_output, neg_one)
 
     # Reduce for broadcasting
     var grad_b = _reduce_broadcast_dims(neg_grad, b.shape())


### PR DESCRIPTION
## Summary

Replace element-wise Float64 conversions with tensor operations in `subtract_backward()` for improved performance and cleaner code.

## Changes

- **Before**: Manual loop with `_get_float64()`/`_set_float64()` per element (2 conversions per element)
- **After**: `multiply(grad_output, full(-1.0))` (zero conversions)

This follows the same pattern used in `divide_backward()` (commit 03e225fd).

## Files Changed

- `shared/core/arithmetic.mojo` (lines 557-559)

## Test Plan

- [x] `test_subtract_backward_gradient` passes
- [x] `test_subtract_backward_b_gradient` passes
- [x] All backward pass tests pass
- [x] Pre-commit hooks pass

Closes #2590

🤖 Generated with [Claude Code](https://claude.com/claude-code)