### PR TITLE
perf(elementwise): eliminate Float64 conversions in forward passes

### DIFF
--- a/shared/core/elementwise.mojo
+++ b/shared/core/elementwise.mojo
@@ -391,7 +391,9 @@ fn _log2_forward_impl[
         out_ptr[i] = math_log(val) / ln2
 
 
-fn _dispatch_log2_forward(result: ExTensor, tensor: ExTensor, numel: Int) raises:
+fn _dispatch_log2_forward(
+    result: ExTensor, tensor: ExTensor, numel: Int
+) raises:
     """Runtime dispatch for log2 forward pass."""
     var dtype = tensor.dtype()
     if dtype == DType.float16:
@@ -559,7 +561,9 @@ fn _dispatch_logical_or(
         raise Error("logical_or: unsupported dtype")
 
 
-fn _logical_not_impl[dtype: DType](result: ExTensor, tensor: ExTensor, numel: Int):
+fn _logical_not_impl[
+    dtype: DType
+](result: ExTensor, tensor: ExTensor, numel: Int):
     """Dtype-specialized logical NOT."""
     alias zero = Scalar[dtype](0)
     alias one = Scalar[dtype](1)
@@ -570,9 +574,7 @@ fn _logical_not_impl[dtype: DType](result: ExTensor, tensor: ExTensor, numel: In
         out_ptr[i] = one if bool_result else zero
 
 
-fn _dispatch_logical_not(
-    result: ExTensor, tensor: ExTensor, numel: Int
-) raises:
+fn _dispatch_logical_not(result: ExTensor, tensor: ExTensor, numel: Int) raises:
     """Runtime dispatch for logical NOT."""
     var dtype = tensor.dtype()
     if dtype == DType.float16:


### PR DESCRIPTION
## Summary

Add dtype-specialized helper functions and dispatchers for forward pass operations to eliminate per-element Float64 conversions.

## Changes Made

- `clip`: Use `_dispatch_clip_forward` for clamping values
- `trunc`: Use existing `dispatch_float_unary` with `_trunc_op`
- `logical_and/or/xor`: Use `_dispatch_logical_*` for broadcasting ops
- `logical_not`: Use `_dispatch_logical_not` for unary NOT
- `log10`: Use `_dispatch_log10_forward` for base-10 log
- `log2`: Use `_dispatch_log2_forward` for base-2 log

Each helper uses typed pointer access (`bitcast[Scalar[dtype]]()`) instead of `_get_float64`/`_set_float64` conversions.

## Test Plan

- [x] All 26 elementwise tests pass

Part of comprehensive #2590 Float64 elimination effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)