### PR TITLE
fix(scripts): standardize get_repo_root() usage across 5 scripts

### DIFF
--- a/scripts/agents/check_frontmatter.py
+++ b/scripts/agents/check_frontmatter.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from common import get_agents_dir
+from common import get_agents_dir, get_repo_root
 
 from agent_utils import extract_frontmatter_with_lines
 
@@ -192,21 +192,19 @@ Examples:
     )
 
     args = parser.parse_args()
-    # Use get_agents_dir() if no custom path specified
-    if args.agents_dir is None:
-        args.agents_dir = get_agents_dir()
 
-    # Find repository root (directory containing .claude)
-    repo_root = Path.cwd()
-    while repo_root != repo_root.parent:
-        if (repo_root / ".claude").exists():
-            break
-        repo_root = repo_root.parent
-    else:
-        print("Error: Could not find .claude directory in current or parent directories", file=sys.stderr)
+    # Get repository root
+    try:
+        repo_root = get_repo_root()
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
         return 1
 
-    agents_dir = repo_root / args.agents_dir
+    # Determine agents directory
+    if args.agents_dir is None:
+        agents_dir = get_agents_dir()
+    else:
+        agents_dir = repo_root / args.agents_dir
 
     if not agents_dir.exists():
         print(f"Error: Agents directory not found: {agents_dir}", file=sys.stderr)

--- a/scripts/agents/list_agents.py
+++ b/scripts/agents/list_agents.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from common import get_agents_dir
+from common import get_agents_dir, get_repo_root
 
 from agent_utils import AgentInfo, load_all_agents
 
@@ -182,21 +182,19 @@ Examples:
     )
 
     args = parser.parse_args()
-    # Use get_agents_dir() if no custom path specified
-    if args.agents_dir is None:
-        args.agents_dir = get_agents_dir()
 
-    # Find repository root
-    repo_root = Path.cwd()
-    while repo_root != repo_root.parent:
-        if (repo_root / ".claude").exists():
-            break
-        repo_root = repo_root.parent
-    else:
-        print("Error: Could not find .claude directory", file=sys.stderr)
+    # Get repository root
+    try:
+        repo_root = get_repo_root()
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
         return 1
 
-    agents_dir = repo_root / args.agents_dir
+    # Determine agents directory
+    if args.agents_dir is None:
+        agents_dir = get_agents_dir()
+    else:
+        agents_dir = repo_root / args.agents_dir
 
     if not agents_dir.exists():
         print(f"Error: Agents directory not found: {agents_dir}", file=sys.stderr)

--- a/scripts/agents/validate_agents.py
+++ b/scripts/agents/validate_agents.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from typing import Dict, List, Set
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from common import get_agents_dir
+from common import get_agents_dir, get_repo_root
 
 from agent_utils import extract_frontmatter_parsed
 
@@ -369,21 +369,19 @@ Examples:
     )
 
     args = parser.parse_args()
-    # Use get_agents_dir() if no custom path specified
-    if args.agents_dir is None:
-        args.agents_dir = get_agents_dir()
 
-    # Find repository root
-    repo_root = Path.cwd()
-    while repo_root != repo_root.parent:
-        if (repo_root / ".claude").exists():
-            break
-        repo_root = repo_root.parent
-    else:
-        print("Error: Could not find .claude directory", file=sys.stderr)
+    # Get repository root
+    try:
+        repo_root = get_repo_root()
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
         return 1
 
-    agents_dir = repo_root / args.agents_dir
+    # Determine agents directory
+    if args.agents_dir is None:
+        agents_dir = get_agents_dir()
+    else:
+        agents_dir = repo_root / args.agents_dir
 
     if not agents_dir.exists():
         print(f"Error: Agents directory not found: {agents_dir}", file=sys.stderr)

--- a/scripts/fix_invalid_links.py
+++ b/scripts/fix_invalid_links.py
@@ -15,6 +15,8 @@ import sys
 from pathlib import Path
 from typing import Tuple
 
+from common import get_repo_root
+
 
 def fix_system_path_links(content: str) -> Tuple[str, int]:
     """
@@ -87,7 +89,11 @@ def main():
     if dry_run:
         print("DRY RUN MODE - No files will be modified\n")
 
-    repo_root = Path(__file__).parent.parent
+    try:
+        repo_root = get_repo_root()
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
 
     # Find all markdown files
     md_files = list(repo_root.glob("**/*.md"))

--- a/scripts/fix_list_syntax_batch.py
+++ b/scripts/fix_list_syntax_batch.py
@@ -12,6 +12,8 @@ import sys
 from pathlib import Path
 from typing import List, Tuple
 
+from common import get_repo_root
+
 # Phase 2: Test files
 PHASE_2_FILES = [
     "tests/shared/core/test_extensor_operators.mojo",
@@ -124,8 +126,12 @@ def process_phase(phase_name: str, file_list: List[str], repo_root: Path) -> Tup
 
 def main():
     """Main entry point."""
-    # Get repository root (assume script is in scripts/ directory)
-    repo_root = Path(__file__).parent.parent.resolve()
+    # Get repository root
+    try:
+        repo_root = get_repo_root()
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
     print(f"Repository root: {repo_root}")
 
     # Process all phases


### PR DESCRIPTION
## Summary

Migrated 5 scripts to use the centralized `get_repo_root()` function from `scripts/common.py` instead of local implementations that used unreliable patterns.

## Changes Made

| Script | Old Pattern | New Pattern |
|--------|-------------|-------------|
| `scripts/agents/check_frontmatter.py` | `Path.cwd()` loop searching for `.claude` | `get_repo_root()` |
| `scripts/agents/validate_agents.py` | `Path.cwd()` loop searching for `.claude` | `get_repo_root()` |
| `scripts/agents/list_agents.py` | `Path.cwd()` loop searching for `.claude` | `get_repo_root()` |
| `scripts/fix_invalid_links.py` | `Path(__file__).parent.parent` | `get_repo_root()` |
| `scripts/fix_list_syntax_batch.py` | `Path(__file__).parent.parent.resolve()` | `get_repo_root()` |

## Benefits

- **Consistent behavior**: All scripts now use the same reliable method
- **Works from any directory**: Scripts work when run from repo root, subdirectories, or even outside the repo
- **Proper error handling**: RuntimeError with clear message when repo root not found

## Test Plan

- [x] Run `check_frontmatter.py` from repo root
- [x] Run `validate_agents.py` from repo root
- [x] Run `list_agents.py` from repo root  
- [x] Run `fix_invalid_links.py --dry-run` from repo root
- [x] Run `fix_list_syntax_batch.py` from repo root
- [x] Run scripts from subdirectory (`scripts/`, `shared/`)
- [x] Pre-commit hooks pass

Closes #2603

🤖 Generated with [Claude Code](https://claude.com/claude-code)