### PR TITLE
fix(scripts): add retry logic and User-Agent headers to dataset downloads

### DIFF
--- a/scripts/download_cifar10.py
+++ b/scripts/download_cifar10.py
@@ -13,21 +13,83 @@ Default output: datasets/cifar10
 
 import sys
 import tarfile
+import time
 from pathlib import Path
-from urllib.request import urlretrieve
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 # CIFAR-10 dataset URL
 CIFAR10_URL = "https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz"
 
+# User-Agent header to avoid bot blocking
+USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
 
-def download_progress(block_num: int, block_size: int, total_size: int):
-    """Display download progress."""
-    downloaded = block_num * block_size
-    percent = min(100, downloaded * 100 / total_size)
-    bar_length = 50
-    filled = int(bar_length * downloaded / total_size)
-    bar = "=" * filled + "-" * (bar_length - filled)
-    print(f"\rDownloading: [{bar}] {percent:.1f}%", end="", flush=True)
+# Retry configuration
+MAX_RETRIES = 3
+RETRY_DELAYS = [1, 2, 4]  # Exponential backoff: 1s, 2s, 4s
+
+
+def download_with_retry(url: str, output_path: Path, max_retries: int = MAX_RETRIES) -> None:
+    """
+    Download file with User-Agent header and retry logic.
+
+    Uses exponential backoff for retries to handle transient failures.
+
+    Args:
+        url: URL to download from
+        output_path: Path to save downloaded file
+        max_retries: Maximum number of retry attempts
+
+    Raises:
+        RuntimeError: If download fails after all retries
+    """
+    last_error = None
+
+    for attempt in range(max_retries):
+        if attempt > 0:
+            delay = RETRY_DELAYS[min(attempt - 1, len(RETRY_DELAYS) - 1)]
+            print(f"  Retry {attempt}/{max_retries - 1} after {delay}s delay...")
+            time.sleep(delay)
+
+        try:
+            request = Request(url, headers={"User-Agent": USER_AGENT})
+            with urlopen(request) as response:
+                total_size = int(response.headers.get("Content-Length", 0))
+                downloaded = 0
+                block_size = 8192
+
+                with open(output_path, "wb") as f:
+                    while True:
+                        block = response.read(block_size)
+                        if not block:
+                            break
+                        f.write(block)
+                        downloaded += len(block)
+
+                        # Progress bar
+                        if total_size > 0:
+                            percent = min(100, downloaded * 100 / total_size)
+                            bar_length = 50
+                            filled = int(bar_length * downloaded / total_size)
+                            bar = "=" * filled + "-" * (bar_length - filled)
+                            print(f"\rDownloading: [{bar}] {percent:.1f}%", end="", flush=True)
+
+                print()  # New line after progress bar
+                return
+
+        except HTTPError as e:
+            last_error = f"HTTP {e.code}: {e.reason}"
+            print(f"\n  Download failed: {last_error}")
+        except URLError as e:
+            last_error = f"URL Error: {e.reason}"
+            print(f"\n  Download failed: {last_error}")
+        except Exception as e:
+            last_error = str(e)
+            print(f"\n  Download failed: {last_error}")
+
+    raise RuntimeError(f"Failed to download {url} after {max_retries} attempts. Last error: {last_error}")
 
 
 def download_cifar10(output_dir: str):
@@ -45,8 +107,8 @@ def download_cifar10(output_dir: str):
     # Download if not exists
     if not tar_path.exists():
         print(f"Downloading CIFAR-10 from {CIFAR10_URL}...")
-        urlretrieve(CIFAR10_URL, tar_path, reporthook=download_progress)
-        print("\nDownload complete!")
+        download_with_retry(CIFAR10_URL, tar_path)
+        print("Download complete!")
     else:
         print(f"CIFAR-10 archive already exists: {tar_path}")
 


### PR DESCRIPTION
## Summary

- Add exponential backoff retry logic (1s, 2s, 4s delays) to both download scripts
- Add User-Agent headers to avoid HTTP 403 bot blocking in GitHub Actions CI
- Add fallback mirror URL for EMNIST dataset (NIST alternate endpoint)

## Changes

### `scripts/download_emnist.py`
- Added `EMNIST_FALLBACK_URLS` with alternate NIST mirror
- Added `USER_AGENT` header constant
- Added `MAX_RETRIES=3` and `RETRY_DELAYS=[1, 2, 4]` configuration
- Created `download_file_with_retry()` function that uses wget/curl with:
  - Exponential backoff between retries
  - User-Agent header to avoid bot blocking
  - Clear error messages for HTTP 403, 404, connection refused
- Updated `main()` to try all URLs in sequence until one succeeds

### `scripts/download_cifar10.py`
- Added `USER_AGENT` header constant
- Added `MAX_RETRIES=3` and `RETRY_DELAYS=[1, 2, 4]` configuration
- Created `download_with_retry()` function replacing `urllib.request.urlretrieve`:
  - Uses `urllib.request.Request` with User-Agent header
  - Exponential backoff between retries
  - Progress bar during download
  - Proper error handling for HTTPError/URLError

## Testing

- Manual verification of download functions
- Pre-commit hooks pass

## Related Issues

Closes #2679

🤖 Generated with [Claude Code](https://claude.com/claude-code)