### PR TITLE
feat(coverage): Add prominent warning to mock coverage parser

### DIFF
--- a/docs/adr/ADR-008-coverage-tool-blocker.md
+++ b/docs/adr/ADR-008-coverage-tool-blocker.md
@@ -530,6 +530,35 @@ tooling becomes available.
    - Context, rationale, alternatives, consequences
    - Future implementation plan
 
+### Phase 2: Prominent Runtime Warnings (Issue #2612)
+
+**Status**: Implemented
+
+Added prominent runtime warnings to `parse_coverage_report()` function:
+
+1. **Updated docstring** with WARNING section
+   - Clear "⚠️ WARNING: MOCK IMPLEMENTATION ⚠️" header
+   - Explicit statement: "Does NOT actually parse coverage data!"
+   - References to Issues #2583 and #2612
+   - References to ADR-008
+
+2. **Added runtime warning output**
+   - Prominent warning banner with emoji (⚠️) and visual separators (=)
+   - File existence check output
+   - Clear statement: "returns HARDCODED value, NOT actual coverage"
+   - Mojo limitation explanation
+   - Reference information for ADR-008, #2583, #2612
+   - Arrow (➤) indicating mock value being returned
+
+3. **Created unit tests** (`tests/scripts/test_check_coverage.py`)
+   - Verifies mock value (92.5%) is returned
+   - Verifies warnings are printed for both existing and nonexistent files
+   - Validates warning content (MOCK, WARNING, ADR-008, issue references)
+   - Validates explanation of Mojo limitation
+   - Confirms prominent formatting (emoji, borders, arrows)
+
+See Issue #2612 for implementation details.
+
 ### Phase 2: GitHub Issue Update
 
 **Tasks**:

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -17,11 +17,26 @@ from typing import Optional
 def parse_coverage_report(coverage_file: Path) -> Optional[float]:
     """Parse coverage report and extract total coverage percentage.
 
+    ⚠️  WARNING: MOCK IMPLEMENTATION ⚠️
+
+    This function does NOT actually parse coverage data!
+    It returns a hardcoded 92.5% if the file exists.
+
+    Real implementation blocked by:
+    - Mojo v0.26+ lacks coverage instrumentation
+    - No coverage report format available to parse
+
+    See Issues:
+    - #2583: Coverage implementation tracking
+    - #2612: Prominent warning documentation
+    - ADR-008: Coverage tool blocker decision
+
     Args:
         coverage_file: Path to coverage report file.
 
     Returns:
-        Coverage percentage (0-100) or None if parsing fails.
+        Mock coverage percentage (92.5%) if file exists, None otherwise.
+        Does NOT read actual coverage data from the file.
     """
     # TODO(#2583): BLOCKED - Waiting on Mojo team to release coverage instrumentation
     #
@@ -38,11 +53,31 @@ def parse_coverage_report(coverage_file: Path) -> Optional[float]:
     #
     # BLOCKED BY: Mojo team (external dependency)
     # REFERENCE: Issue #2583, ADR-008
-    print(f"Parsing coverage report: {coverage_file}")
+    print()
+    print("⚠️" + "=" * 68)
+    print("⚠️  WARNING: MOCK COVERAGE PARSER - NOT READING ACTUAL COVERAGE!")
+    print("⚠️" + "=" * 68)
+    print()
+    print(f"   Coverage file: {coverage_file}")
+    print(f"   File exists: {coverage_file.exists()}")
+    print()
+    print("   This function returns a HARDCODED value, NOT actual coverage!")
+    print("   The coverage file is NOT being parsed.")
+    print()
+    print("   REASON: Mojo does not provide coverage instrumentation")
+    print("   - No `mojo test --coverage` command exists")
+    print("   - No coverage report format to parse")
+    print()
+    print("   REFERENCE: ADR-008, Issue #2583, Issue #2612")
+    print()
 
-    # Placeholder - return mock coverage for testing
     if coverage_file.exists():
-        return 92.5  # Mock coverage above threshold
+        print("   ➤ Returning MOCK value: 92.5% (hardcoded)")
+        print()
+        return 92.5  # MOCK: Does NOT parse file content!
+
+    print("   ➤ Coverage file not found - returning None")
+    print()
     return None
 
 

--- a/tests/scripts/test_check_coverage.py
+++ b/tests/scripts/test_check_coverage.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Tests for check_coverage.py mock warning functionality.
+
+Tests verify that parse_coverage_report() properly displays warnings
+when it returns mock coverage data.
+"""
+
+import sys
+import tempfile
+from io import StringIO
+from pathlib import Path
+from unittest import TestCase, main
+
+# Add scripts directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+from check_coverage import parse_coverage_report
+
+
+class TestParseCoverageReport(TestCase):
+    """Test cases for parse_coverage_report function."""
+
+    def test_existing_file_returns_mock_value(self):
+        """Verify function returns 92.5 for existing files."""
+        with tempfile.NamedTemporaryFile(suffix=".xml") as f:
+            result = parse_coverage_report(Path(f.name))
+            self.assertEqual(result, 92.5)
+
+    def test_nonexistent_file_returns_none(self):
+        """Verify function returns None for nonexistent files."""
+        result = parse_coverage_report(Path("/nonexistent/coverage.xml"))
+        self.assertIsNone(result)
+
+    def test_warning_printed_for_existing_file(self):
+        """Verify warning is printed when file exists."""
+        with tempfile.NamedTemporaryFile(suffix=".xml") as f:
+            captured = StringIO()
+            sys.stdout = captured
+            try:
+                parse_coverage_report(Path(f.name))
+            finally:
+                sys.stdout = sys.__stdout__
+
+            output = captured.getvalue()
+            self.assertIn("WARNING", output)
+            self.assertIn("MOCK", output)
+            self.assertIn("92.5", output)
+
+    def test_warning_printed_for_nonexistent_file(self):
+        """Verify warning is printed when file doesn't exist."""
+        captured = StringIO()
+        sys.stdout = captured
+        try:
+            parse_coverage_report(Path("/nonexistent/coverage.xml"))
+        finally:
+            sys.stdout = sys.__stdout__
+
+        output = captured.getvalue()
+        self.assertIn("WARNING", output)
+        self.assertIn("MOCK", output)
+
+    def test_warning_contains_reference_to_adrs_and_issues(self):
+        """Verify warning references ADR-008 and related issues."""
+        with tempfile.NamedTemporaryFile(suffix=".xml") as f:
+            captured = StringIO()
+            sys.stdout = captured
+            try:
+                parse_coverage_report(Path(f.name))
+            finally:
+                sys.stdout = sys.__stdout__
+
+            output = captured.getvalue()
+            self.assertIn("ADR-008", output)
+            self.assertIn("#2583", output)
+            self.assertIn("#2612", output)
+
+    def test_warning_explains_mojo_limitation(self):
+        """Verify warning explains Mojo lacks coverage instrumentation."""
+        with tempfile.NamedTemporaryFile(suffix=".xml") as f:
+            captured = StringIO()
+            sys.stdout = captured
+            try:
+                parse_coverage_report(Path(f.name))
+            finally:
+                sys.stdout = sys.__stdout__
+
+            output = captured.getvalue()
+            self.assertIn("Mojo does not provide coverage instrumentation", output)
+            self.assertIn("mojo test --coverage", output)
+
+    def test_warning_is_prominent(self):
+        """Verify warning uses prominent formatting (emoji and borders)."""
+        with tempfile.NamedTemporaryFile(suffix=".xml") as f:
+            captured = StringIO()
+            sys.stdout = captured
+            try:
+                parse_coverage_report(Path(f.name))
+            finally:
+                sys.stdout = sys.__stdout__
+
+            output = captured.getvalue()
+            self.assertIn("⚠️", output)
+            self.assertIn("=", output)
+            self.assertIn("➤", output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements Issue #2612: Add prominent runtime warnings to parse_coverage_report() function to clearly indicate it returns a hardcoded mock value and does not actually parse coverage data.

## Changes Made

1. **Updated parse_coverage_report() docstring**
   - Added "⚠️ WARNING: MOCK IMPLEMENTATION ⚠️" header
   - Explicit statement: "Does NOT actually parse coverage data!"
   - References to Issues #2583 and #2612
   - References to ADR-008 architectural decision
   - Updated Returns section documenting mock behavior

2. **Added runtime warning output**
   - Prominent warning banner with emoji (⚠️) and visual separators
   - File existence check
   - Clear statement: "returns HARDCODED value, NOT actual coverage"
   - Explanation of Mojo limitation (no coverage instrumentation)
   - Reference to ADR-008, Issue #2583, and Issue #2612
   - Arrow (➤) indicating which mock value is being returned

3. **Created comprehensive unit tests** (tests/scripts/test_check_coverage.py)
   - Verify mock value (92.5%) is returned for existing files
   - Verify None is returned for nonexistent files
   - Validate warning output content
   - Confirm references to ADR-008 and issue numbers
   - Verify prominent formatting (emoji, borders, arrows)

4. **Updated ADR-008**
   - Added Phase 2 section documenting Issue #2612 implementation
   - References to prominent warning implementation details
   - Link to test coverage improvements

## Files Modified

- scripts/check_coverage.py
  - Updated docstring (lines 18-40)
  - Added runtime warnings (lines 56-81)
  - No functional changes to return values

- tests/scripts/test_check_coverage.py (new)
  - 7 comprehensive test cases
  - All tests passing

- docs/adr/ADR-008-coverage-tool-blocker.md
  - Added Phase 2 implementation section

## Testing

✅ All 7 unit tests pass
✅ Markdown linting passes
✅ Python formatting and ruff checks pass
✅ Warning output is clear and prominent
✅ No functional changes to mock behavior

## Verification

When parse_coverage_report() is called, developers now see:

⚠️==================================================================== ⚠️  WARNING: MOCK COVERAGE PARSER - NOT READING ACTUAL COVERAGE! ⚠️====================================================================

   Coverage file: [path]
   File exists: [true/false]

   This function returns a HARDCODED value, NOT actual coverage!
   The coverage file is NOT being parsed.

   REASON: Mojo does not provide coverage instrumentation
   - No `mojo test --coverage` command exists
   - No coverage report format to parse

   REFERENCE: ADR-008, Issue #2583, Issue #2612

   ➤ Returning MOCK value: 92.5% (hardcoded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

Brief description of changes (1-2 sentences).

## Related Issues

Closes #

## Changes

- Change 1
- Change 2
- Change 3
