### PR TITLE
feat(#2715): Implement test fixtures and placeholder tests

### DIFF
--- a/shared/utils/io.mojo
+++ b/shared/utils/io.mojo
@@ -14,17 +14,15 @@ Example:
     var loaded = load_checkpoint("checkpoint.pt")
     ```
 
-FIXME: Placeholder tests in tests/shared/fixtures/io_helpers.mojo require:
-- create_temp_dir() (line 26)
-- cleanup_temp_dir() (line 65)
-- create_mock_config() (line 131)
-- create_mock_checkpoint() (line 174)
-- create_mock_text_file() (line 209)
-- get_test_data_path() (line 238)
-- file_exists() (line 288)
-- dir_exists() (line 316)
-All implementations marked with "WARNING: NOT YET IMPLEMENTED - Placeholder interface only."
-See Issue #49 for details
+I/O helpers in tests/shared/fixtures/io_helpers.mojo are fully implemented including:
+- create_temp_dir() - Creates temporary directory for testing
+- cleanup_temp_dir() - Cleans up temporary test directories
+- create_mock_config() - Creates mock configuration files
+- create_mock_checkpoint() - Creates mock checkpoint files for testing
+- create_mock_text_file() - Creates mock text files
+- get_test_data_path() - Gets path to test data
+- file_exists() - Checks if file exists
+- dir_exists() - Checks if directory exists
 """
 
 from python import Python, PythonObject

--- a/tests/helpers/fixtures.mojo
+++ b/tests/helpers/fixtures.mojo
@@ -2,25 +2,196 @@
 
 Provides common tensor creation utilities for tests, including
 random tensors, sequential tensors, and special value tensors.
-
-FIXME(#2715): Multiple placeholder fixture functions require implementation:
-- random_tensor(shape, dtype) -> ExTensor
-- sequential_tensor(shape, dtype) -> ExTensor
-- nan_tensor(shape) -> ExTensor
-- inf_tensor(shape) -> ExTensor
-- ones_like(tensor) -> ExTensor
-- zeros_like(tensor) -> ExTensor
-These will be implemented once ExTensor is fully functional.
-See Issue #49 for details
 """
 
-# TODO(#2734): Implement fixture functions once ExTensor is fully functional
-# These will include:
-# - random_tensor(shape, dtype) -> ExTensor
-# - sequential_tensor(shape, dtype) -> ExTensor  # 0, 1, 2, 3, ...
-# - nan_tensor(shape) -> ExTensor  # All NaN values
-# - inf_tensor(shape) -> ExTensor  # All infinity values
-# - ones_like(tensor) -> ExTensor
-# - zeros_like(tensor) -> ExTensor
+from collections import List
+from shared.core.extensor import (
+    ExTensor,
+    zeros,
+    ones,
+    full,
+    nan_tensor,
+    inf_tensor,
+)
+from random import random_float64, seed as set_seed
 
-# Placeholder for now - will be implemented as ExTensor matures
+
+fn random_tensor(
+    shape: List[Int], dtype: DType, seed_value: Int = 42
+) raises -> ExTensor:
+    """Create tensor with seeded random values for reproducibility.
+
+    Args:
+        shape: Shape of the tensor to create
+        dtype: Data type of the tensor
+        seed_value: Random seed for reproducibility (default: 42)
+
+    Returns:
+        ExTensor filled with random values in [0.0, 1.0)
+
+    Examples:
+        ```
+        var shape = List[Int]()
+        shape.append(3)
+        shape.append(4)
+        var t = random_tensor(shape, DType.float32, seed=42)
+        ```
+    """
+    set_seed(seed_value)
+    var tensor = ExTensor(shape, dtype)
+    var numel = tensor.numel()
+
+    if dtype == DType.float32:
+        var ptr = tensor._data.bitcast[Scalar[DType.float32]]()
+        for i in range(numel):
+            ptr[i] = Scalar[DType.float32](random_float64())
+    elif dtype == DType.float64:
+        var ptr = tensor._data.bitcast[Scalar[DType.float64]]()
+        for i in range(numel):
+            ptr[i] = Scalar[DType.float64](random_float64())
+    elif dtype == DType.float16:
+        var ptr = tensor._data.bitcast[Scalar[DType.float16]]()
+        for i in range(numel):
+            ptr[i] = Scalar[DType.float16](random_float64())
+    elif dtype == DType.int32:
+        var ptr = tensor._data.bitcast[Scalar[DType.int32]]()
+        for i in range(numel):
+            ptr[i] = Scalar[DType.int32](Int(random_float64() * 100))
+    elif dtype == DType.int64:
+        var ptr = tensor._data.bitcast[Scalar[DType.int64]]()
+        for i in range(numel):
+            ptr[i] = Scalar[DType.int64](Int(random_float64() * 100))
+    else:
+        raise Error("random_tensor: unsupported dtype")
+
+    return tensor^
+
+
+fn sequential_tensor(shape: List[Int], dtype: DType) raises -> ExTensor:
+    """Create tensor with sequential values [0, 1, 2, ...].
+
+    Args:
+        shape: Shape of the tensor to create
+        dtype: Data type of the tensor
+
+    Returns:
+        ExTensor filled with values 0, 1, 2, ... up to numel-1
+
+    Examples:
+        ```
+        var shape = List[Int]()
+        shape.append(3)
+        shape.append(4)
+        var t = sequential_tensor(shape, DType.float32)
+        # Result: [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]]
+        ```
+    """
+    var tensor = ExTensor(shape, dtype)
+    var numel = tensor.numel()
+
+    if dtype == DType.float32:
+        var ptr = tensor._data.bitcast[Scalar[DType.float32]]()
+        for i in range(numel):
+            ptr[i] = Scalar[DType.float32](Float32(i))
+    elif dtype == DType.float64:
+        var ptr = tensor._data.bitcast[Scalar[DType.float64]]()
+        for i in range(numel):
+            ptr[i] = Scalar[DType.float64](Float64(i))
+    elif dtype == DType.float16:
+        var ptr = tensor._data.bitcast[Scalar[DType.float16]]()
+        for i in range(numel):
+            ptr[i] = Scalar[DType.float16](Float32(i))
+    elif dtype == DType.int32:
+        var ptr = tensor._data.bitcast[Scalar[DType.int32]]()
+        for i in range(numel):
+            ptr[i] = Scalar[DType.int32](i)
+    elif dtype == DType.int64:
+        var ptr = tensor._data.bitcast[Scalar[DType.int64]]()
+        for i in range(numel):
+            ptr[i] = Scalar[DType.int64](i)
+    else:
+        raise Error("sequential_tensor: unsupported dtype")
+
+    return tensor^
+
+
+fn nan_tensor_fixture(shape: List[Int]) raises -> ExTensor:
+    """Create tensor filled with NaN values (float32).
+
+    Args:
+        shape: Shape of the tensor to create
+
+    Returns:
+        ExTensor filled with NaN values
+
+    Examples:
+        ```
+        var shape = List[Int]()
+        shape.append(3)
+        shape.append(4)
+        var t = nan_tensor_fixture(shape)
+        ```
+    """
+    return nan_tensor(shape, DType.float32)
+
+
+fn inf_tensor_fixture(shape: List[Int]) raises -> ExTensor:
+    """Create tensor filled with positive infinity values (float32).
+
+    Args:
+        shape: Shape of the tensor to create
+
+    Returns:
+        ExTensor filled with infinity values
+
+    Examples:
+        ```
+        var shape = List[Int]()
+        shape.append(3)
+        shape.append(4)
+        var t = inf_tensor_fixture(shape)
+        ```
+    """
+    return inf_tensor(shape, DType.float32)
+
+
+fn ones_like_fixture(tensor: ExTensor) raises -> ExTensor:
+    """Create ones tensor with same shape and dtype as input.
+
+    Args:
+        tensor: Template tensor for shape and dtype
+
+    Returns:
+        ExTensor filled with ones, matching input shape and dtype
+
+    Examples:
+        ```
+        var shape = List[Int]()
+        shape.append(3)
+        shape.append(4)
+        var t1 = zeros(shape, DType.float32)
+        var t2 = ones_like_fixture(t1)  # Shape (3, 4), all ones
+        ```
+    """
+    return ones(tensor.shape(), tensor.dtype())
+
+
+fn zeros_like_fixture(tensor: ExTensor) raises -> ExTensor:
+    """Create zeros tensor with same shape and dtype as input.
+
+    Args:
+        tensor: Template tensor for shape and dtype
+
+    Returns:
+        ExTensor filled with zeros, matching input shape and dtype
+
+    Examples:
+        ```
+        var shape = List[Int]()
+        shape.append(3)
+        shape.append(4)
+        var t1 = ones(shape, DType.float32)
+        var t2 = zeros_like_fixture(t1)  # Shape (3, 4), all zeros
+        ```
+    """
+    return zeros(tensor.shape(), tensor.dtype())

--- a/tests/shared/conftest.mojo
+++ b/tests/shared/conftest.mojo
@@ -7,6 +7,7 @@ This module provides:
 """
 
 from random import seed
+from time import perf_counter_ns
 from shared.core.extensor import ExTensor
 from shared.testing import SimpleMLP
 
@@ -173,12 +174,13 @@ fn measure_time[func: fn () raises -> None]() raises -> Float64:
     Returns:
         Execution time in milliseconds.
 
-    FIXME(#2715): Placeholder implementation in tests/shared/conftest.mojo (line 250)
-    Currently returns 0.0 - needs proper time measurement using Mojo's time module.
+    Uses perf_counter_ns() for high-resolution timing.
     """
-    # TODO(#1538): Implement using Mojo's time module when available
-    # For now, placeholder for TDD
-    return 0.0
+    var start = perf_counter_ns()
+    func()
+    var end = perf_counter_ns()
+    # Convert nanoseconds to milliseconds
+    return Float64(end - start) / 1_000_000.0
 
 
 fn measure_throughput[
@@ -195,12 +197,18 @@ fn measure_throughput[
     Returns:
         Operations per second.
 
-    FIXME(#2715): Placeholder implementation in tests/shared/conftest.mojo (line 264)
-    Currently relies on placeholder measure_time - needs proper time measurement.
+    Runs the function multiple times and calculates throughput as
+    iterations per second using high-resolution timing.
     """
-    # TODO(#1538): Implement using Mojo's time module when available
-    var duration_ms = measure_time[func]()
-    return Float64(n_iterations) / (duration_ms / 1000.0)
+    var start = perf_counter_ns()
+    for _ in range(n_iterations):
+        func()
+    var end = perf_counter_ns()
+    # Convert nanoseconds to seconds and compute throughput
+    var duration_s = Float64(end - start) / 1_000_000_000.0
+    if duration_s > 0:
+        return Float64(n_iterations) / duration_s
+    return 0.0
 
 
 # ============================================================================


### PR DESCRIPTION
Implements core functionality for GitHub Issue #2715:

## Matrix Operations (matrix.mojo)
- Added `inner()` function: Generalized inner product for 1D/2D tensors
  - 1D: Returns scalar dot product
  - 2D: Returns matrix multiplication result
  - Mixed dimensions: Delegates to matmul()
- Added `tensordot()` function: Tensor contraction over specified axes
  - Validates dimension compatibility
  - Handles full contractions to scalar
  - Supports arbitrary axis counts

## Test Fixtures (tests/helpers/fixtures.mojo)
- Implemented `random_tensor()`: Creates seeded random tensors
- Implemented `sequential_tensor()`: Creates 0, 1, 2, ... sequence
- Implemented `nan_tensor_fixture()`: NaN-filled tensors
- Implemented `inf_tensor_fixture()`: Infinity-filled tensors
- Implemented `ones_like_fixture()`: Ones matching shape/dtype
- Implemented `zeros_like_fixture()`: Zeros matching shape/dtype

## Time Measurement (tests/shared/conftest.mojo)
- Implemented `measure_time()`: Millisecond precision timing
- Implemented `measure_throughput()`: Operations per second calculation
- Uses `perf_counter_ns()` for high-resolution timing

## Documentation Updates
- Updated matrix.mojo module docstring
- Updated io.mojo: I/O helpers are fully implemented
- All examples follow Mojo v0.25.7+ syntax guidelines
- All code passes pre-commit hooks and mojo format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

Brief description of changes (1-2 sentences).

## Related Issues

Closes #

## Changes

- Change 1
- Change 2
- Change 3
