### PR TITLE
fix(hooks): improve path resolution and macOS compatibility

### DIFF
--- a/.claude/hooks/test-safety-hooks.sh
+++ b/.claude/hooks/test-safety-hooks.sh
@@ -12,7 +12,12 @@ NC='\033[0m'
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 export PROJECT_ROOT
 
-HOOK_SCRIPT=".claude/hooks/pre-bash-exec.sh"
+# Check for project-local hook first, then fall back to home directory
+if [[ -f ".claude/hooks/pre-bash-exec.sh" ]]; then
+    HOOK_SCRIPT=".claude/hooks/pre-bash-exec.sh"
+else
+    HOOK_SCRIPT="$HOME/.claude/hooks/pre-bash-exec.sh"
+fi
 
 total_tests=0
 passed_tests=0


### PR DESCRIPTION
@mvillmow thanks so much for pointing me at your hooks for claude guardrails. I made some small changes so it works on OSX in both a project's `.claude/hooks` and global `$home/.claude/hooks`

## Summary

Improves the safety hooks for better path resolution and cross-platform compatibility.

## Changes

- **pre-bash-exec.sh**:
  - Add handling for non-existent parent directories in `resolve_path()` to catch typos
  - Use `[[:space:]]` instead of `\s` for macOS sed compatibility
  - Restructure validation logic to check project root paths first before blocking
  - Properly distinguish between project paths and home directory paths

- **test-safety-hooks.sh**:
  - Add fallback to find hook script in home directory if not found in project

## Test results

```
=== Dangerous ===
Test 1: rm -rf / ✓ BLOCKED
Test 2: rm -rf /  ✓ BLOCKED
Test 3: rm -rf ~/ ✓ BLOCKED
Test 4: rm -rf $HOME ✓ BLOCKED
Test 5: rm .git ✓ BLOCKED
Test 6: rm .git/config ✓ BLOCKED
Test 7: rm /etc/passwd ✓ BLOCKED
Test 8: rm -rf /tmp/something ✓ BLOCKED
Test 9: sudo rm -rf /tmp/file ✓ BLOCKED
Test 10: rm ./logs/test.log ✓ BLOCKED
Test 11: rm logs/test.log ✓ BLOCKED

=== Safe ===
Test 12: rm temp.txt ✓ PASS
Test 13: rm -rf build/ ✓ PASS
Test 14: rm ./tests/README.md ✓ PASS
Test 15: rm tests/README.md ✓ PASS
Test 16: rm file1.txt file2.txt ✓ PASS
Test 17: ls -la ✓ PASS
Test 18: git status ✓ PASS
Test 19: rm -rf ✓ PASS
Test 20: echo yes | rm file.txt ✓ PASS

Passed: 20 / 20
```