### PR TITLE
fix(examples): resolve import error in trait_example.mojo

### DIFF
--- a/examples/mojo-patterns/trait_example.mojo
+++ b/examples/mojo-patterns/trait_example.mojo
@@ -8,7 +8,100 @@ Usage:
 See documentation: docs/core/mojo-patterns.md
 """
 
-from shared.core.types import Tensor
+from memory import UnsafePointer, alloc
+
+# Note: This is a conceptual example demonstrating trait patterns.
+# It uses a simplified Tensor stub for illustration purposes.
+
+
+struct Tensor(Copyable, ImplicitlyCopyable):
+    """Simplified tensor stub for demonstration purposes.
+
+    Note: This is a minimal stub for demonstrating traits.
+    In real implementations, gradients are managed separately.
+    This stub uses a pointer to break circular reference.
+    """
+
+    var size: Int
+    var _grad_ptr: UnsafePointer[
+        Int, origin=MutAnyOrigin
+    ]  # Points to grad size
+
+    fn __init__(out self, size: Int):
+        """Create tensor with given size."""
+        self.size = size
+        # Allocate space for gradient size
+        self._grad_ptr = alloc[Int](1)
+        self._grad_ptr[] = size
+
+    fn __copyinit__(out self, existing: Self):
+        """Copy constructor."""
+        self.size = existing.size
+        self._grad_ptr = alloc[Int](1)
+        self._grad_ptr[] = existing._grad_ptr[]
+
+    fn __del__(deinit self):
+        """Destructor to free gradient pointer."""
+        if self._grad_ptr:
+            self._grad_ptr.free()
+
+    fn get_grad(self) -> Tensor:
+        """Get gradient as a Tensor (stub - returns zero tensor of same size).
+        """
+        return Tensor(self._grad_ptr[])
+
+    fn set_grad(mut self, value: Tensor):
+        """Set gradient (stub - just updates size)."""
+        self._grad_ptr[] = value.size
+
+    fn __mul__(self, scalar: Float64) -> Tensor:
+        """Multiply tensor by scalar (stub)."""
+        return Tensor(self.size)
+
+    fn __rmul__(self, scalar: Float64) -> Tensor:
+        """Right multiply: scalar * tensor (stub)."""
+        return Tensor(self.size)
+
+    @staticmethod
+    fn randn(rows: Int, cols: Int) -> Tensor:
+        """Create tensor with random values (stub)."""
+        return Tensor(rows * cols)
+
+    @staticmethod
+    fn zeros(size: Int, dtype: DType) -> Tensor:
+        """Create tensor filled with zeros (stub)."""
+        return Tensor(size)
+
+    @staticmethod
+    fn zeros_like(other: Tensor) -> Tensor:
+        """Create tensor of zeros with same shape (stub)."""
+        return Tensor(other.size)
+
+    fn __matmul__(self, other: Tensor) -> Tensor:
+        """Matrix multiplication stub."""
+        return Tensor(self.size)
+
+    fn __add__(self, other: Tensor) -> Tensor:
+        """Addition stub."""
+        return Tensor(self.size)
+
+    fn __sub__(self, other: Float64) -> Tensor:
+        """Subtraction stub."""
+        return Tensor(self.size)
+
+    fn __isub__(mut self, other: Tensor):
+        """In-place subtraction stub."""
+        pass
+
+    fn transpose(self) -> Tensor:
+        """Transpose stub (accessed as .T property in example)."""
+        return Tensor(self.size)
+
+    fn shape(self) -> List[Int]:
+        """Return shape stub."""
+        var result = List[Int]()
+        result.append(self.size)
+        return result^
 
 
 trait Module:
@@ -33,7 +126,7 @@ trait Optimizer:
     fn zero_grad(self, mut parameters: List[Tensor]):
         """Zero gradients."""
         for i in range(len(parameters)):
-            parameters[i].grad = Tensor.zeros_like(parameters[i])
+            parameters[i].set_grad(Tensor.zeros_like(parameters[i]))
 
 
 struct Linear(Module):
@@ -47,7 +140,7 @@ struct Linear(Module):
         self.bias = Tensor.zeros(output_size, DType.float32)
 
     fn forward(mut self, input: Tensor) -> Tensor:
-        return input @ self.weight.T + self.bias
+        return input @ self.weight.transpose() + self.bias
 
     fn parameters(mut self) -> List[Tensor]:
         return [self.weight, self.bias]
@@ -74,7 +167,8 @@ struct Adam(Optimizer):
         # Adam update logic
         for i in range(len(parameters)):
             # Update with momentum and adaptive learning rate
-            parameters[i] -= self.lr * parameters[i].grad
+            var grad = parameters[i].get_grad()
+            parameters[i] -= self.lr * grad
 
 
 fn main() raises:
@@ -86,4 +180,10 @@ fn main() raises:
     var output = layer.forward(input)
 
     print("Layer output shape:", output.shape())
+
+    # Demonstrate optimizer trait methods
+    var params = layer.parameters()
+    optimizer.zero_grad(params)
+    optimizer.step(params)
+
     print("Trait-based design example complete!")


### PR DESCRIPTION
- Root cause: File imported from non-existent shared.core.types module
- Solution: Created local Tensor stub struct to demonstrate trait patterns
- Patterns used:
  * UnsafePointer with MutAnyOrigin for grad storage (breaks circular ref)
  * Copyable + ImplicitlyCopyable traits for list literal support
  * alloc/free for manual memory management
  * get_grad/set_grad methods instead of direct field access
  * __matmul__, __add__, __sub__, __isub__, __rmul__ operators
  * transpose() method instead of .T property (Mojo doesn't have @property)
  * deinit instead of deprecated owned keyword

The stub allows the example to compile while demonstrating trait-based
design patterns without requiring the full ExTensor API.