### PR TITLE
fix(examples): fix docstring validation in benchmark_model_inference

### DIFF
--- a/examples/performance/benchmark_model_inference.mojo
+++ b/examples/performance/benchmark_model_inference.mojo
@@ -53,8 +53,8 @@ fn simple_forward(
     """Perform a simple forward pass.
 
     Args:
-        network: Neural network struct
-        input_data: Input tensor
+        network: Neural network struct.
+        input_data: Input tensor.
 
     Returns:
         Output tensor from forward pass.


### PR DESCRIPTION
- Root cause: Parameter descriptions in simple_forward() docstring did not end with periods
- Solution: Added periods to 'network' and 'input_data' parameter descriptions
- Pattern: All docstring parameter descriptions must end with period or backtick per --validate-doc-strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>