### PR TITLE
fix(examples): resolve import error in linear_regression.mojo

### DIFF
--- a/examples/autograd/linear_regression.mojo
+++ b/examples/autograd/linear_regression.mojo
@@ -11,8 +11,7 @@ Training: Learn w and b to fit the data y = 2x + 1
 """
 
 from shared.autograd import mse_loss_and_grad, apply_gradient, multiply_scalar
-from shared.core.extensor import ExTensor
-from shared.core.creation import zeros
+from shared.core.extensor import ExTensor, zeros
 from shared.core.arithmetic import add, multiply
 from shared.core.reduction import sum as tensor_sum
 


### PR DESCRIPTION
- Root cause: Imported zeros from non-existent shared.core.creation module
- Solution: Import zeros directly from shared.core.extensor where it's defined
- Pattern: zeros is a creation function exported from extensor module (also re-exported from shared.core.__init__)

The file attempted to import from shared.core.creation which does not exist.
The zeros() function is defined in shared.core.extensor and can be imported
from there directly. This is the correct import pattern for tensor creation
functions in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>