### PR TITLE
fix(data): add main function for build validation in generic_transforms

### DIFF
--- a/shared/data/generic_transforms.mojo
+++ b/shared/data/generic_transforms.mojo
@@ -785,3 +785,18 @@ fn compose_transforms(
         ```
     """
     return SequentialTransform(transforms^)
+
+
+# ============================================================================
+# Main function for standalone compilation validation
+# ============================================================================
+
+
+fn main():
+    """Main function for build validation.
+
+    This module is a library and should be imported, not run directly.
+    This main() function exists only to satisfy mojo build requirements
+    for compilation validation.
+    """
+    print("generic_transforms.mojo: Library module - import for use")


### PR DESCRIPTION
- Root cause: Library module lacked main() function required by mojo build
- Solution: Added minimal main() for compilation validation
- Patterns used: Main function with library usage documentation
- Build verified: Compiles with zero warnings (exit code 0)

This module is a library and should be imported, not executed directly.
The main() function exists solely to satisfy mojo build requirements
for CI/CD validation pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>