### PR TITLE
fix(data): add main function for build validation in random_transform_base

### DIFF
--- a/shared/data/random_transform_base.mojo
+++ b/shared/data/random_transform_base.mojo
@@ -84,3 +84,18 @@ struct RandomTransformBase(Copyable, Movable):
         """
         var rand_val = random_float()
         return rand_val < self.p
+
+
+# ============================================================================
+# Main function for standalone compilation validation
+# ============================================================================
+
+
+fn main():
+    """Main function for build validation.
+
+    This module is a library and should be imported, not run directly.
+    This main() function exists only to satisfy mojo build requirements
+    for compilation validation.
+    """
+    print("random_transform_base.mojo: Library module - import for use")


### PR DESCRIPTION
- Root cause: Library module lacked main() function required by mojo build
- Solution: Added minimal main() for compilation validation
- Patterns used: Main function with library usage documentation
- Build verified: Compiles with zero warnings (exit code 0)

This module is a library and should be imported, not executed directly.
The main() function exists solely to satisfy mojo build requirements
for CI/CD validation pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>