### PR TITLE
fix(data): resolve build errors in shared/data/formats/__init__.mojo

### DIFF
--- a/shared/data/formats/__init__.mojo
+++ b/shared/data/formats/__init__.mojo
@@ -7,8 +7,17 @@ Modules:
     cifar_loader: CIFAR-10 and CIFAR-100 binary format loader
 """
 
+
+fn main():
+    """No-op main function to satisfy mojo build requirements.
+
+    This __init__.mojo file is meant to be imported as a package, not executed.
+    """
+    pass
+
+
 # IDX Format Loaders
-from .idx_loader import (
+from shared.data.formats.idx_loader import (
     read_uint32_be,
     load_idx_labels,
     load_idx_images,
@@ -20,8 +29,8 @@ from .idx_loader import (
 )
 
 # CIFAR Binary Format Loaders
-from .cifar_loader import CIFARLoader
-from ..constants import (
+from shared.data.formats.cifar_loader import CIFARLoader
+from shared.data.constants import (
     CIFAR10_IMAGE_SIZE,
     CIFAR10_CHANNELS,
     CIFAR10_BYTES_PER_IMAGE,


### PR DESCRIPTION
- Root cause: Relative imports cannot be used when building __init__.mojo as standalone module
- Additional issue: mojo build requires a main() function for executable creation
- Solution 1: Changed relative imports to absolute imports (. -> shared.data.formats, .. -> shared.data)
- Solution 2: Added no-op main() function to satisfy mojo build requirements
- Pattern: __init__.mojo files meant for import still need main() when built standalone
- Result: File now compiles successfully with zero warnings (exit code 0)