### PR TITLE
fix(benchmarks): fix Python interop makedirs() call

### DIFF
--- a/benchmarks/scripts/run_benchmarks.mojo
+++ b/benchmarks/scripts/run_benchmarks.mojo
@@ -377,7 +377,7 @@ fn write_results_file(results: String, filepath: String) raises:
 
         # Create directory if it doesn't exist
         if directory and not os_path.exists(directory):
-            os_module.makedirs(directory, exist_ok=True)
+            os_module.makedirs(directory, 0o777, True)
 
         # Write file using Python
         var file = builtins.open(filepath, "w")


### PR DESCRIPTION
Closes #2868

## Summary
Fixed Python interop error in  at line 380 by converting keyword argument syntax to positional arguments.

## Problem
The  call used keyword argument syntax () which is not supported in Mojo's Python interop, causing compilation error: "invalid call to '__call__()'"

## Solution
Changed from:
```mojo
os_module.makedirs(directory, exist_ok=True)
```

To:
```mojo
os_module.makedirs(directory, 0o777, True)
```

The three positional arguments are:
1. `directory` - path to create
2. `0o777` - mode (default value)
3. `True` - exist_ok parameter

## Verification
- [x] Compilation no longer shows "invalid call to '__call__()'" error at line 380
- [x] Pre-commit hooks passed
- [x] Rebased against origin/main