### PR TITLE
fix(examples): replace += with explicit addition in googlenet training

### DIFF
--- a/examples/googlenet-cifar10/train.mojo
+++ b/examples/googlenet-cifar10/train.mojo
@@ -317,7 +317,7 @@ fn train_epoch(
 
         # Compute loss
         var loss = cross_entropy(logits, batch_labels)
-        total_loss += loss
+        total_loss = total_loss + loss
 
         # Backward pass (see structure above)
         # ... (would be ~2500 lines of gradient computation)


### PR DESCRIPTION
Closes #2869

## Summary
Fixed Float32 in-place addition operator issue in googlenet training by replacing `+=` with explicit addition.

## Problem  
The `__iadd__()` operator is not available for Float32 in Mojo, causing compilation error at line 320.

## Solution
Changed from:
```mojo
total_loss += loss
```

To:
```mojo
total_loss = total_loss + loss
```

## Verification
- [x] Pre-commit hooks passed
- [x] Rebased against origin/main
- [x] Only changed the specific line causing the issue (minimal changes principle)