### PR TITLE
docs: document centralized utilities in common.py

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -3,6 +3,17 @@
 Shared utilities and constants for ML Odyssey scripts
 
 This module provides common functionality used across multiple scripts to avoid duplication.
+
+Centralized Utilities:
+- LABEL_COLORS: GitHub label colors for 5-phase workflow
+- get_repo_root(): Repository root finder (used by 20+ scripts)
+- get_agents_dir(): .claude/agents path helper
+- Colors: ANSI terminal colors with disable() method
+
+Related Issues:
+- #2601: Colors class centralization
+- #2603: get_repo_root() audit
+- #2634: Script utilities consolidation
 """
 
 from pathlib import Path


### PR DESCRIPTION
## Summary

Documents the successful consolidation of shared script utilities in `scripts/common.py`.

## Background

This PR closes #2634, which tracked consolidation of shared utilities. The actual implementation was completed through previous PRs:
- #2601: Moved Colors class to common.py
- #2603: Audited and verified get_repo_root() usage

## Changes Made

Added comprehensive module docstring to `scripts/common.py` documenting:
- All 4 centralized utilities
- Usage statistics (20+ scripts using)
- References to related issues

## Verification

✅ **All utilities already implemented**:
- `LABEL_COLORS`: GitHub label colors
- `get_repo_root()`: Used by 20+ scripts, no duplicates
- `get_agents_dir()`: Agent directory helper
- `Colors`: ANSI colors with disable() method

✅ **No code changes needed** - all consolidation already complete

✅ **Pre-commit hooks pass**

## Related Issues

Closes #2634
Related to #2601, #2603