### PR TITLE
fix(transforms): remove unused variable in RandomErasing

### DIFF
--- a/shared/data/transforms.mojo
+++ b/shared/data/transforms.mojo
@@ -924,9 +924,8 @@ struct RandomErasing(Copyable, Movable, Transform):
 
         for i in range(total_elements):
             # Check if this element is in the erased rectangle
-            # Calculate (row, col, c) from flat index
+            # Calculate (row, col) from flat index
             var pixel_idx = i // channels
-            # FIXME(#2707, unused) var c = i % channels
             var col = pixel_idx % width
             var row = pixel_idx // width
 


### PR DESCRIPTION
Closes #2707

## Summary
Removed unused variable `c` in RandomErasing transform that was computed but never used.

## Changes Made
- Removed line 929: `var c = i % channels` (flagged as unused)
- Updated comment to reflect that only (row, col) are calculated

## Files Modified
- `shared/data/transforms.mojo` (line 929 removed, line 927 comment updated)

## Verification
- [x] Pre-commit hooks pass
- [x] No compilation errors
- [x] No test failures related to this change