### PR TITLE
refactor(metrics): remove unused batch_size initialization

### DIFF
--- a/shared/training/metrics/evaluate.mojo
+++ b/shared/training/metrics/evaluate.mojo
@@ -151,9 +151,9 @@ fn compute_accuracy_on_batch(
         ```
     """
     var pred_shape = predictions.shape()
-    # FIXME(#2712, unused) var batch_size = 0
 
     # Determine if predictions are logits (2D) or class indices (1D)
+    var batch_size: Int
     if len(pred_shape) == 2:
         batch_size = pred_shape[0]
     elif len(pred_shape) == 1:


### PR DESCRIPTION
Closes #2712

## Summary
Removed unused initialization of batch_size variable

## Changes Made
- Removed dead code: `var batch_size = 0`
- Changed to declaration: `var batch_size: Int`
- Variable is assigned in all code paths before use

## Files Modified
- `shared/training/metrics/evaluate.mojo`

## Verification
- [x] All code paths assign batch_size before use
- [x] No functional changes
- [x] Pre-commit hooks pass