### PR TITLE
chore: clean up repository artifacts and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ site/
 # Mojo build artifacts
 *.o
 *.a
+*.mojopkg
 train
 examples/*/train
 examples/*/inference


### PR DESCRIPTION
## Summary

This PR cleans up the repository by:
1. Adding `*.mojopkg` to `.gitignore` to prevent build artifacts from polluting the root directory
2. Removing temporary analysis files and compiled binaries that were accidentally left in the repository

## Changes Made

### `.gitignore` Updates
- Added `*.mojopkg` to Mojo build artifacts section
- Ensures package files go to `build/<mode>/` directories as configured in justfile

### Files Removed (via manual deletion)
**Temporary documentation/analysis files:**
- `API_MISMATCH_ISSUES_SUMMARY.md` - Analysis notes (belongs in GitHub issue comments)
- `IMPLEMENTATION-SUMMARY-2652.md` - Implementation notes (belongs in PR/issue comments)
- `create_api_mismatch_issues.py` - Temporary script
- `create_gh_issues.py` - Temporary script
- `create_issues.sh` - Temporary shell script

**Compiled binaries (should be in build/ directory):**
- `basic_usage` (ELF executable)
- `fp8_example` (ELF executable)
- `integer_example` (ELF executable)
- `trait_based_layer` (ELF executable)
- `compare_results` (ELF executable)
- `shared.mojopkg` (package file)

## Verification

- ✅ Pre-commit hooks pass
- ✅ Only `.gitignore` modified in this PR
- ✅ Build artifacts now properly ignored

## Related Issues

Addresses user feedback about polluting temporary files in the source tree. Part of ongoing work on issue #2784.

## Note

The lenet-emnist `grad_kernel` → `grad_weights` API fix was already merged to main in commit 30fb949d, so no code changes were needed for that issue.