### PR TITLE
[Refactor] Standardize TrainingArgs Usage Across Training Scripts

### DIFF
--- a/examples/googlenet-cifar10/train.mojo
+++ b/examples/googlenet-cifar10/train.mojo
@@ -60,28 +60,9 @@ from shared.data import (
     DatasetInfo,
 )
 from shared.data.datasets import load_cifar10_train
+from shared.training.schedulers import step_lr
+from shared.utils.training_args import parse_training_args_with_defaults
 from model import GoogLeNet, InceptionModule
-
-
-fn compute_learning_rate(initial_lr: Float32, epoch: Int) -> Float32:
-    """Compute learning rate with step decay schedule.
-
-    Schedule: Multiply by 0.2 every 60 epochs.
-
-    Args:
-        initial_lr: Initial learning rate
-        epoch: Current epoch number
-
-    Returns:
-        Adjusted learning rate.
-    """
-    var decay_factor = Float32(0.2)
-    var decay_epochs = 60
-    var num_decays = epoch // decay_epochs
-    var lr = initial_lr
-    for i in range(num_decays):
-        lr = lr * decay_factor
-    return lr
 
 
 fn train_epoch(
@@ -398,13 +379,26 @@ fn main() raises:
     print("=" * 60)
     print()
 
-    # Configuration
-    var epochs = 200
-    var batch_size = 128
-    var initial_lr = Float32(0.01)
-    var momentum = Float32(0.9)
-    var data_dir = "datasets/cifar10"
-    var weights_dir = "googlenet_weights"
+    # Parse arguments using standardized TrainingArgs
+    var args = parse_training_args_with_defaults(
+        default_epochs=200,
+        default_batch_size=128,
+        default_lr=0.01,
+        default_momentum=0.9,
+        default_data_dir="datasets/cifar10",
+        default_weights_dir="googlenet_weights",
+        default_lr_decay_epochs=60,
+        default_lr_decay_factor=0.2,
+    )
+
+    var epochs = args.epochs
+    var batch_size = args.batch_size
+    var initial_lr = Float32(args.learning_rate)
+    var momentum = Float32(args.momentum)
+    var data_dir = args.data_dir
+    var weights_dir = args.weights_dir
+    var lr_decay_epochs = args.lr_decay_epochs
+    var lr_decay_factor = Float32(args.lr_decay_factor)
 
     print("Configuration:")
     print("  Epochs: " + String(epochs))
@@ -413,6 +407,8 @@ fn main() raises:
     print("  Momentum: " + String(momentum))
     print("  Data directory: " + String(data_dir))
     print("  Weights directory: " + String(weights_dir))
+    print("  LR Decay Epochs: " + String(lr_decay_epochs))
+    print("  LR Decay Factor: " + String(lr_decay_factor))
     print()
 
     # Load CIFAR-10 dataset
@@ -447,7 +443,14 @@ fn main() raises:
     print()
 
     for epoch in range(epochs):
-        var lr = compute_learning_rate(initial_lr, epoch)
+        var lr = initial_lr
+        if lr_decay_epochs > 0:
+            lr = step_lr(
+                initial_lr,
+                epoch,
+                step_size=lr_decay_epochs,
+                gamma=lr_decay_factor,
+            )
 
         # Train for one epoch
         var train_loss = train_epoch(
@@ -494,9 +497,14 @@ fn main() raises:
     print("Training Summary")
     print("=" * 60)
     print("Total epochs: " + String(epochs))
-    print(
-        "Final learning rate: "
-        + String(compute_learning_rate(initial_lr, epochs - 1))
-    )
+    var final_lr = initial_lr
+    if lr_decay_epochs > 0:
+        final_lr = step_lr(
+            initial_lr,
+            epochs - 1,
+            step_size=lr_decay_epochs,
+            gamma=lr_decay_factor,
+        )
+    print("Final learning rate: " + String(final_lr))
     print("Model saved to: " + String(weights_dir) + "/")
     print("=" * 60)

--- a/examples/resnet18-cifar10/train.mojo
+++ b/examples/resnet18-cifar10/train.mojo
@@ -231,14 +231,25 @@ fn main() raises:
     print("=" * 60)
     print()
 
-    # Configuration (hardcoded for demonstration)
-    var epochs = 200
-    var batch_size = 128
-    var initial_lr = Float32(0.01)
-    var momentum = Float32(0.9)
-    var data_dir = "datasets/cifar10"
-    var lr_decay_epochs = 60  # Decay every 60 epochs
-    var lr_decay_factor = Float32(0.2)  # Multiply by 0.2
+    # Parse arguments using standardized TrainingArgs
+    var args = parse_training_args_with_defaults(
+        default_epochs=200,
+        default_batch_size=128,
+        default_lr=0.01,
+        default_momentum=0.9,
+        default_data_dir="datasets/cifar10",
+        default_weights_dir="resnet18_weights",
+        default_lr_decay_epochs=60,
+        default_lr_decay_factor=0.2,
+    )
+
+    var epochs = args.epochs
+    var batch_size = args.batch_size
+    var initial_lr = Float32(args.learning_rate)
+    var momentum = Float32(args.momentum)
+    var data_dir = args.data_dir
+    var lr_decay_epochs = args.lr_decay_epochs
+    var lr_decay_factor = Float32(args.lr_decay_factor)
 
     print("Configuration:")
     print("  Epochs: " + String(epochs))

--- a/shared/utils/arg_parser.mojo
+++ b/shared/utils/arg_parser.mojo
@@ -331,7 +331,10 @@ fn create_training_parser() raises -> ArgumentParser:
             - weight-decay (float, default 0.0)
             - model-path (string, default "model.weights")
             - data-dir (string, default "datasets")
+            - weights-dir (string, default "weights")
             - seed (int, default 42)
+            - lr-decay-epochs (int, default 0)
+            - lr-decay-factor (float, default 0.1)
             - verbose (flag)
 
     Returns:
@@ -350,7 +353,10 @@ fn create_training_parser() raises -> ArgumentParser:
     parser.add_argument("weight-decay", "float", "0.0")
     parser.add_argument("model-path", "string", "model.weights")
     parser.add_argument("data-dir", "string", "datasets")
+    parser.add_argument("weights-dir", "string", "weights")
     parser.add_argument("seed", "int", "42")
+    parser.add_argument("lr-decay-epochs", "int", "0")
+    parser.add_argument("lr-decay-factor", "float", "0.1")
     parser.add_flag("verbose")
 
     return parser^


### PR DESCRIPTION
## Summary

Standardizes command-line argument handling across all 7 training scripts by leveraging the shared `TrainingArgs` struct. This eliminates ~100 lines of duplicated argument parsing code and provides a consistent CLI interface across all models.

## Changes Made

### Core Infrastructure

- **Extended TrainingArgs**: Added `lr_decay_epochs` and `lr_decay_factor` fields to support learning rate scheduling
- **Updated arg_parser**: Added `--lr-decay-epochs` and `--lr-decay-factor` CLI arguments
- **Enhanced validation**: Added validation for LR decay parameters (lr_decay_epochs >= 0, lr_decay_factor in (0.0, 1.0])

### Training Script Migrations

| Script | Before | After | Lines Removed |
|--------|--------|-------|---------------|
| lenet-emnist | Custom `TrainConfig` struct | `parse_training_args_with_defaults()` | ~45 |
| alexnet-cifar10 | Tuple-based parsing | `parse_training_args_with_defaults()` | ~21 |
| vgg16-cifar10 | Tuple-based parsing | `parse_training_args_with_defaults()` | ~21 |
| resnet18-cifar10 | Hardcoded values | `parse_training_args_with_defaults()` | ~10 |
| mobilenetv1-cifar10 | Hardcoded + custom LR func | `parse_training_args_with_defaults()` + `step_lr()` | ~15 |
| googlenet-cifar10 | Hardcoded + custom LR func | `parse_training_args_with_defaults()` + `step_lr()` | ~15 |

**Total code reduction**: ~100 lines of duplicated argument parsing code removed

### Per-Model Defaults Preserved

Each script uses model-appropriate defaults via `parse_training_args_with_defaults()`:

```mojo
# LeNet-5 (EMNIST)
default_epochs=10, default_batch_size=32, default_lr=0.001

# AlexNet, VGG-16, ResNet-18, MobileNetV1, GoogLeNet (CIFAR-10)
default_epochs=200, default_batch_size=128, default_lr=0.01
default_lr_decay_epochs=30-60, default_lr_decay_factor=0.1-0.2
```

## Benefits

1. **Single Source of Truth**: `TrainingArgs` is now the only struct for training configuration
2. **Consistent CLI**: All scripts support identical CLI arguments (`--epochs`, `--batch-size`, `--lr`, `--momentum`, `--lr-decay-epochs`, `--lr-decay-factor`)
3. **Type Safety**: No more tuple unpacking for arguments
4. **Configurability**: LR scheduling now configurable via CLI for all models
5. **Maintainability**: Changes to argument handling need only be made once

## Testing

- [x] All pre-commit hooks pass (mojo format, linters)
- [x] No breaking changes to CLI interfaces
- [x] Per-model defaults verified to match previous hardcoded values

## Related Issues

Closes #2743

🤖 Generated with [Claude Code](https://claude.com/claude-code)