### PR TITLE
fix(benchmarks): update TestConfig constructor to use out self parameter

### DIFF
--- a/benchmarks/simple_test.mojo
+++ b/benchmarks/simple_test.mojo
@@ -2,7 +2,7 @@ struct TestConfig:
     var value: Int
 
     fn __init__(
-        mut self,
+        out self,
         val: Int = 10,
     ):
         self.value = val


### PR DESCRIPTION
- Root cause: Constructor used deprecated mut self convention
- Solution: Changed to out self per Mojo v0.26.1+ guidelines
- Pattern: All __init__ methods must use out self for proper initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>