### PR TITLE
fix(justfile): add -it flags to shell recipe for interactive TTY

### DIFF
--- a/justfile
+++ b/justfile
@@ -278,7 +278,7 @@ list-models:
 
 # Open development shell
 shell:
-    @docker compose exec -e USER_ID={{USER_ID}} -e GROUP_ID={{GROUP_ID}} {{docker_service}} bash
+    @docker compose exec -it -e USER_ID={{USER_ID}} -e GROUP_ID={{GROUP_ID}} {{docker_service}} bash
 
 # Serve documentation
 docs-serve:


### PR DESCRIPTION
## Summary
- Fixed `just shell` command failing to start an interactive shell
- Added `-it` flags to `docker compose exec` for proper TTY allocation

## Problem
The shell recipe was using `docker compose exec` without TTY allocation flags, causing interactive shell sessions to fail or behave incorrectly.

## Solution
Added `-it` flags to enable interactive mode (`-i`) and pseudo-TTY allocation (`-t`).

## Test plan
- [x] Run `just shell` to verify interactive shell works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)