### PR TITLE
fix(docker): install gh and claude CLI as root to avoid sudo issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,25 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     ca-certificates \
     vim \
+    wget \
     uuid \
     sudo \
     cargo \
     && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI (gh) as root
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+    && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    && cat $out | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && mkdir -p -m 755 /etc/apt/sources.list.d \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Claude Code CLI
+RUN curl -fsSL https://claude.ai/install.sh | bash
 
 # ---------------------------
 # Stage 1.5: Create dev user
@@ -32,7 +47,7 @@ RUN groupadd -g ${GROUP_ID} ${USER_NAME} && \
 
 # Set environment for dev user
 ENV HOME=/home/${USER_NAME}
-ENV PATH="$HOME/.pixi/bin:$PATH:$HOME/.cargo/bin"
+ENV PATH="$HOME/.local/bin:$HOME/.pixi/bin:$PATH:$HOME/.cargo/bin"
 
 # ---------------------------
 # Stage 2: Development environment


### PR DESCRIPTION
## Summary
- Move GitHub CLI installation to base stage (runs as root) to fix sudo password prompt failure
- Add Claude Code CLI installation
- Add `$HOME/.local/bin` to PATH for Claude CLI access

## Problem
Docker build was failing with:
```
sudo: a terminal is required to read the password
```

The `gh` CLI was being installed in the development stage after switching to the `dev` user, which required sudo but had no password configured.

## Solution
Install both `gh` and `claude` CLIs in the base stage as root, eliminating the need for sudo entirely.

## Test plan
- [ ] `just docker-build` completes successfully
- [ ] `gh --version` works in container
- [ ] `claude --version` works in container

🤖 Generated with [Claude Code](https://claude.com/claude-code)