### PR TITLE
feat(hooks): add SessionEnd hook for retrospective prompts

### DIFF
--- a/.claude/hooks/retrospective-trigger.py
+++ b/.claude/hooks/retrospective-trigger.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+Hook script triggered on SessionEnd to prompt for retrospective.
+
+Receives JSON input with:
+- session_id: Session identifier
+- transcript_path: Path to session transcript (.jsonl)
+- reason: "exit" | "clear" | "logout" | "prompt_input_exit" | "other"
+- cwd: Current working directory
+
+Outputs JSON to stdout for Claude to process.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def main():
+    """Main entry point for the hook."""
+    try:
+        # Read hook input from stdin
+        input_data = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        # Invalid input, exit silently
+        sys.exit(0)
+
+    reason = input_data.get("reason", "other")
+    transcript_path = input_data.get("transcript_path", "")
+
+    # Only trigger on explicit session end (not other reasons)
+    if reason not in ("exit", "clear"):
+        sys.exit(0)
+
+    # Check if transcript has meaningful content (> 10 messages)
+    try:
+        transcript = Path(transcript_path)
+        if transcript.exists():
+            line_count = sum(1 for _ in transcript.open())
+            if line_count < 10:
+                # Session too short for retrospective
+                sys.exit(0)
+        else:
+            # No transcript file
+            sys.exit(0)
+    except Exception:
+        # Error reading transcript, exit silently
+        sys.exit(0)
+
+    # Output message prompting retrospective
+    output = {
+        "systemMessage": (
+            "Session ending. Consider running /retrospective to capture learnings "
+            "from this session. Would you like to save your learnings to the "
+            "skills marketplace before ending?"
+        )
+    }
+
+    print(json.dumps(output))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,17 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/retrospective-trigger.py\"",
+            "timeout": 120
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

- Add `retrospective-trigger.py` hook that prompts users to run `/retrospective` on session exit or clear
- Update `.claude/settings.json` with SessionEnd hook configuration
- Integrates with ProjectMnemosyne skills marketplace for team knowledge capture

## Changes

- `.claude/hooks/retrospective-trigger.py` - New hook script
- `.claude/settings.json` - Added SessionEnd hook configuration

## Test Plan

- [ ] Start Claude Code session in ProjectOdyssey
- [ ] Run `/exit` or `/clear` after 10+ messages
- [ ] Verify retrospective prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)