### PR TITLE
fix(justfile): add -it flags to shell recipe for interactive TTY

### DIFF
--- a/justfile
+++ b/justfile
@@ -278,7 +278,7 @@ list-models:
 
 # Open development shell
 shell:
-    @docker compose exec -e USER_ID={{USER_ID}} -e GROUP_ID={{GROUP_ID}} {{docker_service}} bash
+    @docker compose exec -it -e USER_ID={{USER_ID}} -e GROUP_ID={{GROUP_ID}} {{docker_service}} bash
 
 # Serve documentation
 docs-serve:


### PR DESCRIPTION
The shell recipe was missing TTY allocation flags, causing interactive shell sessions to fail. Added -it flags to enable proper interactive terminal support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

