### PR TITLE
fix(ci): remove ARM64 Docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -83,7 +83,7 @@ jobs:
           context: .
           file: ./Dockerfile.ci
           target: ${{ matrix.target }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: ${{ (github.event_name != 'pull_request' || github.event.inputs.push == 'true') && matrix.target != 'ci' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -451,7 +451,7 @@ jobs:
           context: .
           file: ./Dockerfile.ci
           target: production
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:${{ needs.validate-version.outputs.version }}


### PR DESCRIPTION
## Summary

Remove ARM64 (`linux/arm64`) platform from Docker build workflows since `pixi.toml` only supports `linux-64` (x86_64).

## Problem

Docker builds were failing on every PR with:
```
× The workspace does not support 'linux-aarch64'.
│ Add it with 'pixi workspace platform add linux-aarch64'.
help: supported platforms are linux-64
```

## Solution

Changed `platforms: linux/amd64,linux/arm64` to `platforms: linux/amd64` in:
- `.github/workflows/docker.yml` (PR and push builds)
- `.github/workflows/release.yml` (release builds)

## Related

- Related to #995 (Add support for ARM64 Docker builds)
- This is a temporary fix until ARM64 support is properly added to pixi.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)