### PR TITLE
fix(ci): use lowercase image name for Docker SBOM generation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  # Docker image names must be lowercase - github.repository preserves case
+  IMAGE_NAME: mvillmow/projectodyssey
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Fixes failing Docker Build and Publish workflow by using lowercase image name.

## Problem
The SBOM generation step was failing with:
```
could not parse reference: ghcr.io/mvillmow/ProjectOdyssey:main
```

Docker image names must be lowercase, but `github.repository` preserves the original case (`mvillmow/ProjectOdyssey`).

## Solution
Hardcode the lowercase image name (`mvillmow/projectodyssey`) instead of using `github.repository`.

## Verification
- [ ] Docker Build and Publish workflow passes
- [ ] SBOM is generated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)