### PR TITLE
test(core): add error handling validation tests

### DIFF
--- a/shared/core/__init__.mojo
+++ b/shared/core/__init__.mojo
@@ -190,6 +190,7 @@ from shared.core.shape import (
     transposed_conv2d_output_shape,
     global_avgpool_output_shape,
     linear_output_shape,
+    broadcast_to,
 )
 
 # ============================================================================

--- a/tests/shared/core/test_arithmetic.mojo
+++ b/tests/shared/core/test_arithmetic.mojo
@@ -960,15 +960,26 @@ fn test_add_mismatched_shapes_raises_error() raises:
     var a = ones(shape_a, DType.float32)
     var b = ones(shape_b, DType.float32)
 
-    # This should raise an error
-    # For now, we expect it to return zeros or error
-    # TODO(#2732): Verify proper error handling once implemented
-    # try:
-    #     var c = add(a, b)
-    #     raise Error("Should have raised error for mismatched shapes")
-    # except:
-    #     pass  # Expected
-    pass  # Placeholder until error handling is implemented
+    var error_raised = False
+    try:
+        var c = add(a, b)
+        _ = c  # Suppress unused warning
+    except e:
+        error_raised = True
+        var error_msg = String(e)
+        # Verify error message mentions shape/broadcast incompatibility
+        if (
+            "broadcast" not in error_msg.lower()
+            and "shape" not in error_msg.lower()
+        ):
+            raise Error(
+                "Error message should mention shape or broadcast compatibility"
+            )
+
+    if not error_raised:
+        raise Error(
+            "add with mismatched non-broadcastable shapes should raise error"
+        )
 
 
 fn test_multiply_mismatched_shapes_raises_error() raises:
@@ -983,9 +994,27 @@ fn test_multiply_mismatched_shapes_raises_error() raises:
     var a = ones(shape_a, DType.float32)
     var b = ones(shape_b, DType.float32)
 
-    # This should raise an error
-    # TODO(#2732): Verify proper error handling once implemented
-    pass  # Placeholder until error handling is implemented
+    var error_raised = False
+    try:
+        var c = multiply(a, b)
+        _ = c  # Suppress unused warning
+    except e:
+        error_raised = True
+        var error_msg = String(e)
+        # Verify error message mentions shape/broadcast incompatibility
+        if (
+            "broadcast" not in error_msg.lower()
+            and "shape" not in error_msg.lower()
+        ):
+            raise Error(
+                "Error message should mention shape or broadcast compatibility"
+            )
+
+    if not error_raised:
+        raise Error(
+            "multiply with mismatched non-broadcastable shapes should raise"
+            " error"
+        )
 
 
 fn test_add_mismatched_dtypes_raises_error() raises:
@@ -996,9 +1025,19 @@ fn test_add_mismatched_dtypes_raises_error() raises:
     var a = ones(shape, DType.float32)
     var b = ones(shape, DType.float64)
 
-    # This should raise an error
-    # TODO(#2732): Verify proper error handling once implemented
-    pass  # Placeholder until error handling is implemented
+    var error_raised = False
+    try:
+        var c = add(a, b)
+        _ = c  # Suppress unused warning
+    except e:
+        error_raised = True
+        var error_msg = String(e)
+        # Verify error message mentions dtype mismatch
+        if "dtype" not in error_msg.lower():
+            raise Error("Error message should mention dtype mismatch")
+
+    if not error_raised:
+        raise Error("add with mismatched dtypes should raise error")
 
 
 # ============================================================================

--- a/tests/shared/core/test_shape.mojo
+++ b/tests/shared/core/test_shape.mojo
@@ -20,6 +20,7 @@ from shared.core import (
     concatenate,
     stack,
     flatten_to_2d,
+    broadcast_to,
 )
 
 # Import test helpers
@@ -53,16 +54,29 @@ fn test_reshape_valid() raises:
 
 fn test_reshape_invalid_size() raises:
     """Test that reshape with incompatible size raises error."""
-    var shape = List[Int]()
-    shape.append(12)
-    var a = arange(0.0, 12.0, 1.0, DType.float32)
-    # var new_shape = List[Int]()
-    # new_shape[0] = 3
-    # new_shape[1] = 5  # 15 elements, incompatible with 12
-    # varb = reshape(a, new_shape)  # Should raise error
+    var a = arange(0.0, 12.0, 1.0, DType.float32)  # 12 elements
+    var new_shape = List[Int]()
+    new_shape.append(3)
+    new_shape.append(5)  # 15 elements, incompatible with 12
 
-    # TODO(#2732): Verify error handling
-    pass  # Placeholder
+    var error_raised = False
+    try:
+        var b = reshape(a, new_shape)
+        _ = b  # Suppress unused warning
+    except e:
+        error_raised = True
+        var error_msg = String(e)
+        # Verify error message mentions element count mismatch
+        if (
+            "element count mismatch" not in error_msg
+            and "reshape" not in error_msg.lower()
+        ):
+            raise Error(
+                "Error message should mention reshape or element count mismatch"
+            )
+
+    if not error_raised:
+        raise Error("reshape with incompatible size should raise error")
 
 
 fn test_reshape_infer_dimension() raises:
@@ -379,13 +393,26 @@ fn test_broadcast_to_incompatible() raises:
     """Test that broadcasting to incompatible shape raises error."""
     var shape_orig = List[Int]()
     shape_orig.append(3)
-    var a = arange(0.0, 3.0, 1.0, DType.float32)
-    # var target_shape = List[Int]()
-    # target_shape[0] = 5  # Incompatible: 3 != 5
-    # varb = broadcast_to(a, target_shape)  # Should raise error
+    var a = arange(0.0, 3.0, 1.0, DType.float32)  # Shape (3,)
+    var target_shape = List[Int]()
+    target_shape.append(5)  # Incompatible: 3 != 5 and neither is 1
 
-    # TODO(#2732): Verify error handling
-    pass  # Placeholder
+    var error_raised = False
+    try:
+        var b = broadcast_to(a, target_shape)
+        _ = b  # Suppress unused warning
+    except e:
+        error_raised = True
+        var error_msg = String(e)
+        # Verify error message mentions broadcast compatibility
+        if (
+            "broadcast" not in error_msg.lower()
+            and "compatible" not in error_msg.lower()
+        ):
+            raise Error("Error message should mention broadcast compatibility")
+
+    if not error_raised:
+        raise Error("broadcast_to with incompatible shape should raise error")
 
 
 # ============================================================================

--- a/tests/shared/core/test_utility.mojo
+++ b/tests/shared/core/test_utility.mojo
@@ -288,16 +288,33 @@ fn test_bool_single_element() raises:
 
 
 fn test_bool_requires_single_element() raises:
-    """Test that __bool__ requires single-element tensor."""
+    """Test that item() requires single-element tensor.
+
+    Note: Since __bool__ is not yet implemented, we test item() which
+    has the same single-element requirement and is used for scalar extraction.
+    """
     var shape = List[Int]()
     shape.append(5)
     var t = ones(shape, DType.float32)
 
-    # if t:  # Should raise error for multi-element tensor
-    #     pass
+    var error_raised = False
+    try:
+        var val = item(t)  # Should raise error for multi-element tensor
+        _ = val  # Suppress unused warning
+    except e:
+        error_raised = True
+        var error_msg = String(e)
+        # Verify error message mentions single-element requirement
+        if (
+            "single" not in error_msg.lower()
+            and "element" not in error_msg.lower()
+        ):
+            raise Error(
+                "Error message should mention single-element requirement"
+            )
 
-    # TODO(#2732): Verify error handling
-    pass  # Placeholder
+    if not error_raised:
+        raise Error("item() on multi-element tensor should raise error")
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Implements #2732 - Error Handling Validation Tests.

Adds comprehensive error handling validation tests for core operations:

### Tests Added

| Test | File | Description |
|------|------|-------------|
| `test_reshape_invalid_size` | test_shape.mojo | Verifies reshape with incompatible element count raises error |
| `test_broadcast_to_incompatible` | test_shape.mojo | Verifies broadcast_to with incompatible shape raises error |
| `test_add_mismatched_shapes_raises_error` | test_arithmetic.mojo | Verifies add with non-broadcastable shapes raises error |
| `test_multiply_mismatched_shapes_raises_error` | test_arithmetic.mojo | Verifies multiply with non-broadcastable shapes raises error |
| `test_add_mismatched_dtypes_raises_error` | test_arithmetic.mojo | Verifies add with different dtypes raises error |
| `test_bool_requires_single_element` | test_utility.mojo | Verifies item() on multi-element tensor raises error |

### Changes

- Implemented 6 error handling tests replacing TODO(#2732) placeholders
- Exported `broadcast_to` from `shared.core` for use in tests
- All tests follow the standard pattern with `error_raised` flag

Closes #2732

🤖 Generated with [Claude Code](https://claude.com/claude-code)