### PR TITLE
feat(training): export CSVMetricsLogger from metrics package

### DIFF
--- a/shared/training/metrics/__init__.mojo
+++ b/shared/training/metrics/__init__.mojo
@@ -7,6 +7,7 @@ Includes:
 - Accuracy (Classification accuracy - top-1, top-k, per-class)
 - LossTracker (Loss tracking and averaging)
 - ConfusionMatrix (Confusion matrix for classification)
+- CSVMetricsLogger (CSV-based training metrics logging)
 - Precision (Precision metric)
 - Recall (Recall metric)
 
@@ -51,6 +52,9 @@ from shared.training.metrics.results_printer import (
     print_training_progress,
     print_training_summary,
 )
+
+# CSV-based training metrics logging
+from shared.training.metrics.csv_metrics_logger import CSVMetricsLogger
 
 # Future exports (to be implemented):
 # from .precision import Precision


### PR DESCRIPTION
## Summary

Completes #2663 - Training Logger feature (TensorBoard-Style Training Visualization).

The implementation already existed but `CSVMetricsLogger` was not exported from the metrics package, making it inaccessible via the standard import path.

### What Exists

| Component | Location | Status |
|-----------|----------|--------|
| `CSVMetricsLogger` struct | `shared/training/metrics/csv_metrics_logger.mojo` | ✅ Exists |
| `plot_training.py` script | `scripts/plot_training.py` | ✅ Exists |
| Package export | `shared/training/metrics/__init__.mojo` | ✅ **Added** |

### Changes

- Export `CSVMetricsLogger` from `shared/training/metrics/__init__.mojo`
- Update module docstring to list `CSVMetricsLogger`

### Usage

```mojo
from shared.training.metrics import CSVMetricsLogger

var logger = CSVMetricsLogger("logs/lenet5_run1")
logger.log_scalar("train_loss", 0.5)
logger.step()
_ = logger.save()
```

```bash
# Plot training curves
python scripts/plot_training.py logs/lenet5_run1
```

Closes #2663

🤖 Generated with [Claude Code](https://claude.com/claude-code)