### PR TITLE
fix(benchmarks): fix Mojo syntax errors in benchmark files

### DIFF
--- a/tests/shared/benchmarks/bench_data_loading.mojo
+++ b/tests/shared/benchmarks/bench_data_loading.mojo
@@ -46,13 +46,14 @@ fn bench_batch_loading_speed() raises -> List[BenchmarkResult]:
     # Benchmark batch creation (simulates data loading)
     # Test different batch sizes
     var batch_sizes: List[Int] = [16, 32, 64, 128]
-    for batch_size in batch_sizes:
+    for idx in range(len(batch_sizes)):
+        var batch_size = batch_sizes[idx]
         var data_shape = List[Int]()
-        data_shape.append(batch_size[])
+        data_shape.append(batch_size)
         data_shape.append(784)  # MNIST-like feature size
 
         var label_shape = List[Int]()
-        label_shape.append(batch_size[])
+        label_shape.append(batch_size)
 
         # Warmup
         for _ in range(10):
@@ -76,7 +77,7 @@ fn bench_batch_loading_speed() raises -> List[BenchmarkResult]:
 
         results.append(
             BenchmarkResult(
-                name="BatchLoad-" + str(batch_size[]) + "-784",
+                name="BatchLoad-" + String(batch_size) + "-784",
                 duration_ms=avg_time_ms,
                 throughput=batches_per_sec,
                 memory_mb=0.0,

--- a/tests/shared/benchmarks/bench_layers.mojo
+++ b/tests/shared/benchmarks/bench_layers.mojo
@@ -69,7 +69,7 @@ fn bench_linear_forward() raises -> List[BenchmarkResult]:
 
     # Calculate metrics
     var total_ns = end_ns - start_ns
-    var avg_time_ns = total_ns // n_iters
+    var avg_time_ns = Int(total_ns) // n_iters
     var avg_time_ms = Float64(avg_time_ns) / 1_000_000.0
 
     # Throughput: samples per second
@@ -129,7 +129,7 @@ fn bench_linear_backward() raises -> BenchmarkResult:
     var end_ns = perf_counter_ns()
 
     var total_ns = end_ns - start_ns
-    var avg_time_ns = total_ns // n_iters
+    var avg_time_ns = Int(total_ns) // n_iters
     var avg_time_ms = Float64(avg_time_ns) / 1_000_000.0
     var samples_per_sec = Float64(batch_size * n_iters) / (
         Float64(total_ns) / 1e9

--- a/tests/shared/benchmarks/bench_optimizers.mojo
+++ b/tests/shared/benchmarks/bench_optimizers.mojo
@@ -47,9 +47,10 @@ fn bench_sgd_update_speed() raises -> List[BenchmarkResult]:
 
     # Test different parameter counts
     var param_counts: List[Int] = [10000, 100000, 1000000]
-    for n_params in param_counts:
+    for idx in range(len(param_counts)):
+        var n_params = param_counts[idx]
         var param_shape = List[Int]()
-        param_shape.append(n_params[])
+        param_shape.append(n_params)
 
         # Create parameters and gradients
         var params = randn(param_shape, DType.float32)
@@ -70,13 +71,13 @@ fn bench_sgd_update_speed() raises -> List[BenchmarkResult]:
 
         var total_ns = end_ns - start_ns
         var avg_time_ms = Float64(total_ns) / Float64(n_iters) / 1_000_000.0
-        var params_per_sec = Float64(n_params[] * n_iters) / (
+        var params_per_sec = Float64(n_params * n_iters) / (
             Float64(total_ns) / 1e9
         )
 
         results.append(
             BenchmarkResult(
-                name="SGD-" + str(n_params[]) + "-params",
+                name="SGD-" + String(n_params) + "-params",
                 duration_ms=avg_time_ms,
                 throughput=params_per_sec,
                 memory_mb=0.0,
@@ -163,9 +164,10 @@ fn bench_adam_update_speed() raises -> List[BenchmarkResult]:
 
     # Test different parameter counts
     var param_counts: List[Int] = [10000, 100000, 1000000]
-    for n_params in param_counts:
+    for idx in range(len(param_counts)):
+        var n_params = param_counts[idx]
         var param_shape = List[Int]()
-        param_shape.append(n_params[])
+        param_shape.append(n_params)
 
         # Create parameters and optimizer states
         var params = randn(param_shape, DType.float32)
@@ -180,25 +182,25 @@ fn bench_adam_update_speed() raises -> List[BenchmarkResult]:
 
         # Warmup (10 iterations)
         for i in range(10):
-            adam_step(params, grads, m, v, lr, beta1, beta2, epsilon, t + i)
+            adam_step(params, grads, m, v, t + i, lr, beta1, beta2, epsilon)
 
         # Benchmark (100 iterations)
         var start_ns = perf_counter_ns()
         for i in range(n_iters):
             adam_step(
-                params, grads, m, v, lr, beta1, beta2, epsilon, t + 10 + i
+                params, grads, m, v, t + 10 + i, lr, beta1, beta2, epsilon
             )
         var end_ns = perf_counter_ns()
 
         var total_ns = end_ns - start_ns
         var avg_time_ms = Float64(total_ns) / Float64(n_iters) / 1_000_000.0
-        var params_per_sec = Float64(n_params[] * n_iters) / (
+        var params_per_sec = Float64(n_params * n_iters) / (
             Float64(total_ns) / 1e9
         )
 
         results.append(
             BenchmarkResult(
-                name="Adam-" + str(n_params[]) + "-params",
+                name="Adam-" + String(n_params) + "-params",
                 duration_ms=avg_time_ms,
                 throughput=params_per_sec,
                 memory_mb=0.0,
@@ -308,11 +310,11 @@ fn bench_optimizer_comparison() raises -> List[BenchmarkResult]:
             grads,
             m,
             v,
+            i + 1,
             Float64(0.001),
             Float64(0.9),
             Float64(0.999),
             Float64(1e-8),
-            i + 1,
         )
     start_ns = perf_counter_ns()
     for i in range(n_iters):
@@ -321,11 +323,11 @@ fn bench_optimizer_comparison() raises -> List[BenchmarkResult]:
             grads,
             m,
             v,
+            i + 11,
             Float64(0.001),
             Float64(0.9),
             Float64(0.999),
             Float64(1e-8),
-            i + 11,
         )
     end_ns = perf_counter_ns()
     total_ns = end_ns - start_ns


### PR DESCRIPTION
## Summary
Fix Mojo syntax errors in benchmark files that were causing CI failures.

## Changes Made
- Use indexed iteration for List (`range(len(list))`) instead of direct iteration which yields non-subscriptable elements
- Replace `str()` with `String()` for proper type conversion (str is not a Mojo builtin)
- Cast `UInt64` to `Int` for floordiv compatibility (`perf_counter_ns()` returns `UInt64`)
- Fix `adam_step` argument order (`t: Int` comes before `learning_rate: Float64`)

## Files Modified
- `tests/shared/benchmarks/bench_data_loading.mojo`
- `tests/shared/benchmarks/bench_layers.mojo`
- `tests/shared/benchmarks/bench_optimizers.mojo`

## Verification
- Benchmark files now compile without syntax errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)