### PR TITLE
fix(mojo): fix syntax errors and warnings for Mojo v0.26.1+

### DIFF
--- a/shared/core/conv.mojo
+++ b/shared/core/conv.mojo
@@ -287,7 +287,7 @@ fn conv2d(
         raise Error("Kernel in_channels must match input in_channels")
 
     # Compute output dimensions using shape computation helper
-    var out_h, var out_w = conv2d_output_shape(
+    var (out_h, out_w) = conv2d_output_shape(
         in_height, in_width, kH, kW, stride, padding
     )
     var out_height = out_h
@@ -808,7 +808,7 @@ fn depthwise_conv2d(
         )
 
     # Compute output dimensions
-    var out_h, var out_w = conv2d_output_shape(
+    var (out_h, out_w) = conv2d_output_shape(
         in_height, in_width, kH, kW, stride, padding
     )
     var out_height = out_h

--- a/shared/core/pooling.mojo
+++ b/shared/core/pooling.mojo
@@ -71,7 +71,7 @@ fn maxpool2d(
     var actual_stride = stride if stride > 0 else kernel_size
 
     # Compute output dimensions using shape computation helper
-    var out_h, var out_w = pool_output_shape(
+    var (out_h, out_w) = pool_output_shape(
         in_height, in_width, kernel_size, actual_stride, padding
     )
     var out_height = out_h
@@ -330,7 +330,7 @@ fn avgpool2d(
     var actual_stride = stride if stride > 0 else kernel_size
 
     # Compute output dimensions using shape computation helper
-    var out_h, var out_w = pool_output_shape(
+    var (out_h, out_w) = pool_output_shape(
         in_height, in_width, kernel_size, actual_stride, padding
     )
     var out_height = out_h


### PR DESCRIPTION
## Summary
Fix Mojo syntax errors and compiler warnings found during local build testing.

## Changes Made

### 1. Tuple Unpacking Syntax (conv.mojo, pooling.mojo)
Changed redundant nested `var` patterns in tuple unpacking:
```mojo
# Before (warning: nested 'var' or 'ref' patterns are redundant)
var out_h, var out_w = conv2d_output_shape(...)

# After (correct syntax)
var (out_h, out_w) = conv2d_output_shape(...)
```

### 2. AlexNet Training Loop (train.mojo)
Fixed closure capturing non-copyable struct error:
```
error: cannot synthesize fieldwise init because field 'field0' has non-copyable and non-movable type 'AlexNet'
```

Root cause: The `compute_batch_loss` closure captured the `AlexNet` model, but `AlexNet` contains non-copyable `ExTensor` fields.

Solution: Replaced closure-based `TrainingLoop.run_epoch_manual()` with manual batch iteration to avoid closure capture entirely.

## Files Modified
- `shared/core/conv.mojo` - Fixed 2 tuple unpacking patterns
- `shared/core/pooling.mojo` - Fixed 2 tuple unpacking patterns  
- `examples/alexnet-cifar10/train.mojo` - Replaced closure with manual iteration

## References
- Mojo Manual: https://docs.modular.com/mojo/manual/
- Mojo v0.26.1+ syntax requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)