### PR TITLE
fix(blog): correct Python file count to exclude hidden directories

### DIFF
--- a/notes/blog/12-31-2025.md
+++ b/notes/blog/12-31-2025.md
@@ -299,7 +299,7 @@ Level 5: Junior Engineers (Boilerplate)
 | Language | Files | Purpose |
 |----------|-------|---------|
 | Mojo | 496 | Core ML framework, models, tests |
-| Python | 10,032 | Automation, scripts, tooling |
+| Python | 162 | Automation, scripts, tooling |
 | Markdown | 200+ | Documentation, blogs, ADRs |
 | YAML | 50+ | CI/CD, configs, agent specs |
 
@@ -338,7 +338,7 @@ Level 5: Junior Engineers (Boilerplate)
 - **Skills:** 82+ automation capabilities
 - **Models:** 6 classic architectures implemented
 - **Mojo files:** 496
-- **Python scripts:** 10,032
+- **Python scripts:** 162
 
 ### Testing
 


### PR DESCRIPTION
## Summary

Corrects the Python file count in the year-end blog from 10,032 to 162.

## Issue

The original count included files from hidden directories (`.pixi`, `.git`, etc.) which inflated the number significantly.

## Fix

Used `find -not -path '*/\.*'` to exclude hidden directories:
- Before: 10,032 (included .pixi virtualenv)
- After: 162 (actual project Python files)

## Test plan

- [x] Verified count with `find . -name "*.py" -type f -not -path '*/\.*' | wc -l`

🤖 Generated with [Claude Code](https://claude.com/claude-code)