### PR TITLE
[Cleanup] Update stale FIXME/TODO issue references

### DIFF
--- a/shared/__init__.mojo
+++ b/shared/__init__.mojo
@@ -38,20 +38,9 @@ Example:
         print("Epoch", epoch, "Loss:", loss)
     ```
 
-FIXME(#3010): Placeholder tests in tests/shared/integration/test_packaging.mojo require:
-- test_subpackage_accessibility (line 28)
-- test_root_level_imports (line 49)
-- test_module_level_imports (line 65)
-- test_nested_imports (line 74)
-- test_core_training_integration (line 88)
-- test_core_data_integration (line 108)
-- test_training_data_integration (line 124)
-- test_complete_training_workflow (line 145)
-- test_paper_implementation_pattern (line 181)
-- test_public_api_exports (line 218)
-- test_no_private_exports (line 237)
-- test_deprecated_imports (line 254)
-See Issue #49 for details
+Placeholder tests in tests/shared/integration/test_packaging.mojo require implementation.
+See Issue #3033 for tracking: 12 placeholder tests for packaging integration.
+Tests require corresponding modules to be implemented first.
 """
 
 # Package version

--- a/shared/core/__init__.mojo
+++ b/shared/core/__init__.mojo
@@ -52,13 +52,9 @@ Example:
     var a1 = relu(h1)
     ```
 
-FIXME(#3010): Placeholder import tests in tests/shared/test_imports.mojo require:
-- test_core_imports (line 17)
-- test_core_layers_imports (line 31)
-- test_core_activations_imports (line 46)
-- test_core_types_imports (line 60)
-All tests marked as "(placeholder - awaiting implementation)" and require module
-imports to be uncommented as Issue #49 progresses. See Issue #49 for details
+Placeholder import tests in tests/shared/test_imports.mojo require implementation.
+See Issue #3033 for tracking: 4 tests for core module imports.
+Tests require corresponding modules to be implemented first.
 """
 
 # Package version

--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -20,12 +20,12 @@ Array API Categories:
 - Arithmetic: add, subtract, multiply, divide, floor_divide, modulo, power ✓
 - Comparison: equal, not_equal, less, less_equal, greater, greater_equal ✓
 - Reduction: sum, mean, max, min (all-elements only) ✓
-- Matrix: matmul, transpose, dot, outer (TODO(#3013))
-- Shape manipulation: reshape, squeeze, unsqueeze, concatenate (TODO(#3013))
-- Broadcasting: Full support for different-shape operations (TODO(#3013))
-- Element-wise math: exp, log, sqrt, sin, cos, tanh (TODO(#3013))
-- Statistical: var, std, median, percentile (TODO(#3013))
-- Indexing: slicing, advanced indexing (TODO(#3013))
+- Matrix: matmul, transpose, dot, outer (See Issue #3032)
+- Shape manipulation: reshape, squeeze, unsqueeze, concatenate (See Issue #3032)
+- Broadcasting: Full support for different-shape operations (See Issue #3032)
+- Element-wise math: exp, log, sqrt, sin, cos, tanh (See Issue #3032)
+- Statistical: var, std, median, percentile (See Issue #3032)
+- Indexing: slicing, advanced indexing (See Issue #3032)
 
 Reference: https://data-apis.org/array-api/latest/API_specification/index.html
 """

--- a/shared/core/types/mxfp4.mojo
+++ b/shared/core/types/mxfp4.mojo
@@ -713,16 +713,10 @@ struct MXFP4Block(Copyable, Movable, Representable, Stringable):
                 max_abs = abs_val
 
         # Compute scale (avoid division by zero)
-        # **FIXME (#3008 - TEST-002 - P0 CRITICAL)**: Scale = 0 edge case untested
+        # P0 CRITICAL: See Issue #3031 for zero-block edge case testing
         # When all values in block are zero or near-zero (< 1e-10), we fallback to scale=1.0
-        # This behavior is COMPLETELY UNTESTED. Missing test cases:
-        #   1. Block with all zeros (should encode as scale=1.0, all E2M1 values = 0)
-        #   2. Block with values < 1e-10 (should trigger fallback)
-        #   3. _e8m0_from_float32(0.0) direct behavior
-        #   4. Round-trip conversion: zeros -> MXFP4 -> zeros (verify lossless)
+        # Missing test coverage for zero blocks, near-zero values, and round-trip conversion
         # Impact: Zero blocks are common in ML (dead neurons, zero gradients)
-        # Severity: BLOCKING - edge case must be tested before production use
-        # See: COMPREHENSIVE_REVIEW_FINDINGS.md (TEST-002)
         var scale_val = max_abs / 6.0
         if scale_val < 1e-10:
             scale_val = 1.0

--- a/shared/testing/layer_testers.mojo
+++ b/shared/testing/layer_testers.mojo
@@ -1124,12 +1124,9 @@ struct LayerTester:
         )
         assert_dtype(input, dtype, "BatchNorm backward: input dtype mismatch")
 
-        # Test gradient checking with appropriate epsilon and tolerance for dtype
-        # FIXME(#3011, unused) var epsilon = 1e-5 if dtype == DType.float32 else 1e-4
-        # FIXME(#3011, unused) var tolerance = 1e-2 if dtype == DType.float32 else 1e-1
-
         # Note: Actual BatchNorm backward gradient checking would be implemented
         # when BatchNorm forward pass is available
+        # Epsilon and tolerance values will be dtype-specific when gradient checking is added
         # For now, we validate that we can compute numerical gradients on the input
 
         # Verify no NaN/Inf in input

--- a/shared/training/__init__.mojo
+++ b/shared/training/__init__.mojo
@@ -6,15 +6,9 @@ schedulers, metrics, callbacks, and training loops for ML Odyssey paper implemen
 
 All components are implemented in Mojo for maximum performance.
 
-FIXME(#3010): Placeholder import tests in tests/shared/test_imports.mojo require:
-- test_training_imports (line 80+)
-- test_training_optimizers_imports (line 95+)
-- test_training_schedulers_imports (line 110+)
-- test_training_metrics_imports (line 125+)
-- test_training_callbacks_imports (line 140+)
-- test_training_loops_imports (line 155+)
-All tests marked as "(placeholder)" and require uncommented imports as Issue #49 progresses.
-See Issue #49 for details.
+Placeholder import tests in tests/shared/test_imports.mojo require implementation.
+See Issue #3033 for tracking: 6 tests for training module imports.
+Tests require corresponding modules to be implemented first.
 """
 
 from python import PythonObject
@@ -414,10 +408,10 @@ struct TrainingLoop[
         var total_loss = Float64(0.0)
         var num_batches = Int(0)
 
-        # TODO(#3013): Iterate through batches when Python integration is complete
+        # Blocked: Track 4 (Python↔Mojo interop)
+        # TODO: Iterate through batches when Python data loader integration is complete
         # The data_loader is currently a PythonObject, but step() requires ExTensor.
-        # Real blocker: Python↔Mojo interop for data loading (Track 4 initiative)
-        # Once data loading infrastructure is ready, integrate batching here.
+        # Once Track 4 data loading infrastructure is ready, integrate batching here.
         _ = data_loader  # Suppress unused variable warning
 
         # Return average loss
@@ -495,7 +489,8 @@ struct CrossEntropyLoss(Loss, Movable):
 # Public API
 # ============================================================================
 
-# TODO(#2597): Export training script utilities when implemented
+# See Issue #3034 for tracking training script utilities export
+# TODO: Export training script utilities when script_runner module is implemented
 # from shared.training.script_runner import (
 #     TrainingCallbacks,
 #     run_epoch_with_batches,

--- a/shared/training/mixed_precision.mojo
+++ b/shared/training/mixed_precision.mojo
@@ -280,7 +280,8 @@ fn convert_to_fp32_master(params: ExTensor) raises -> ExTensor:
 
     # If FP16, use SIMD-optimized conversion when available
     if params.dtype() == DType.float16:
-        # TODO(#3015): Implement SIMD FP16→FP32 vectorization
+        # Blocked: Mojo FP16 SIMD not supported
+        # TODO: Implement SIMD FP16→FP32 vectorization when compiler adds support
         #
         # Current Limitation: Mojo v0.26.1+ does not support SIMD vectorization for
         # FP16 load operations. This prevents efficient bulk conversion from FP16 to FP32.
@@ -363,7 +364,8 @@ fn update_model_from_master(
         return
 
     # If FP16, use optimized conversion (scalar until Mojo supports FP16 SIMD)
-    # TODO(#3015): Implement SIMD FP32→FP16 vectorization when compiler support available
+    # Blocked: Mojo FP16 SIMD not supported
+    # TODO: Implement SIMD FP32→FP16 vectorization when compiler adds support
     # See convert_to_fp32_master() for detailed notes on FP16 SIMD limitations
     if model_params.dtype() == DType.float16:
         _convert_fp32_to_fp16_simd(master_params, model_params)

--- a/shared/training/trainer_interface.mojo
+++ b/shared/training/trainer_interface.mojo
@@ -388,9 +388,9 @@ struct DataLoader(Copyable, Movable):
         var batch_labels = ExTensor(batch_labels_shape, self.labels.dtype())
 
         # Tensor slicing is implemented in ExTensor.slice() and __getitem__()
-        # The real blocker is integrating with Python data loaders (Track 4)
-        # For now, we'll just create placeholders
-        # TODO(#3013): Implement proper tensor slicing in ExTensor
+        # Blocked: Track 4 (Python↔Mojo interop)
+        # TODO: Integrate with Python data loaders when Track 4 infrastructure is ready
+        # For now, we just create placeholder tensors
 
         self.current_batch += 1
 

--- a/shared/utils/__init__.mojo
+++ b/shared/utils/__init__.mojo
@@ -23,13 +23,9 @@ Example:
     config = load_config("experiment.yaml")
     ```
 
-FIXME(#3010): Placeholder import tests in tests/shared/test_imports.mojo require:
-- test_utils_imports (line 210+)
-- test_utils_logging_imports (line 220+)
-- test_utils_visualization_imports (line 230+)
-- test_utils_config_imports (line 240+)
-All tests marked as "(placeholder)" and require uncommented imports as Issue #49 progresses.
-See Issue #49 for details
+Placeholder import tests in tests/shared/test_imports.mojo require implementation.
+See Issue #3033 for tracking: 4 tests for utils module imports.
+Tests require corresponding modules to be implemented first.
 """
 
 # Package version

--- a/shared/utils/logging.mojo
+++ b/shared/utils/logging.mojo
@@ -438,7 +438,8 @@ fn get_log_level_from_env() -> Int:
     # Try to get environment variable
     # Note: Mojo doesn't have os.getenv, so we use print + stderr approach
     # For now, return default INFO level
-    # TODO: Implement env var reading when Mojo has stdlib support
+    # Blocked: Mojo stdlib limitation - no os.getenv equivalent
+    # TODO: Implement env var reading when Mojo adds stdlib support
     return LogLevel.INFO
 
 

--- a/shared/utils/profiling.mojo
+++ b/shared/utils/profiling.mojo
@@ -646,7 +646,8 @@ fn export_profiling_report(
         # Default to text format for unknown formats
         _content = report.to_string()
 
-    # TODO(#2714): Enable actual file writing when Mojo FileIO is stable
+    # Blocked: Mojo FileIO unstable
+    # TODO: Enable actual file writing when Mojo FileIO is stable
     # Once available, write _content to filepath using Mojo's file APIs
     # Similar to: File(filepath, "w").write(_content)
 


### PR DESCRIPTION
## Summary

Updates all stale FIXME/TODO comments in the shared/ directory to reference new tracking issues and add proper context for blocked items.

## Changes Made

### New Issue References
- Replaced closed issue #3008 → New issue #3031 (MXFP4 zero-block tests)
- Replaced closed issue #3013 → New issue #3032 (Array API Standard)
- Replaced closed issue #3010, #49 → New issue #3033 (Placeholder import tests)
- Replaced closed issue #2597 → New issue #3034 (Training script utilities)

### Blocked Annotations Added
- `Blocked: Mojo stdlib limitation` - logging.mojo (env vars)
- `Blocked: Mojo FileIO unstable` - profiling.mojo (file writing)
- `Blocked: Mojo FP16 SIMD not supported` - mixed_precision.mojo (vectorization)
- `Blocked: Track 4 (Python↔Mojo interop)` - trainer_interface.mojo, __init__.mojo (data loaders)

### Code Cleanup
- Removed unused epsilon/tolerance variables from layer_testers.mojo

## Files Modified
- `shared/__init__.mojo`
- `shared/core/__init__.mojo`
- `shared/utils/__init__.mojo`
- `shared/training/__init__.mojo`
- `shared/core/extensor.mojo`
- `shared/core/types/mxfp4.mojo`
- `shared/training/mixed_precision.mojo`
- `shared/training/trainer_interface.mojo`
- `shared/utils/logging.mojo`
- `shared/utils/profiling.mojo`
- `shared/testing/layer_testers.mojo`

## Related Issues
- #3031 - [P0] Add MXFP4 Zero-Block Edge Case Tests
- #3032 - [Feature] Complete Array API Standard Implementation in ExTensor
- #3033 - [Testing] Implement Placeholder Import Tests (26 tests)
- #3034 - [Feature] Export Training Script Utilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)