### PR TITLE
feat(training): implement dataset_loaders module

### DIFF
--- a/shared/training/dataset_loaders.mojo
+++ b/shared/training/dataset_loaders.mojo
@@ -1,0 +1,205 @@
+"""Dataset loading utilities.
+
+Provides utilities for loading standard ML datasets like EMNIST and CIFAR-10.
+
+Example:
+    ```mojo
+    from shared.training.dataset_loaders import (
+        DatasetSplit,
+        load_emnist_dataset,
+        print_dataset_summary,
+    )
+
+    # Load dataset
+    var split = load_emnist_dataset("./data/emnist")
+    print_dataset_summary(split, "EMNIST")
+    ```
+
+Note:
+    Currently provides placeholder implementations. Full loading requires
+    file I/O which is limited in the current Mojo version.
+"""
+
+from shared.core.extensor import ExTensor
+from shared.core import zeros
+
+
+struct DatasetSplit(Copyable, Movable):
+    """Represents train/test split of a dataset.
+
+    Holds training and test data tensors along with metadata.
+
+    Attributes:
+        train_images: Training image data tensor.
+        train_labels: Training labels tensor.
+        test_images: Test image data tensor.
+        test_labels: Test labels tensor.
+        num_classes: Number of output classes.
+    """
+
+    var train_images: ExTensor
+    var train_labels: ExTensor
+    var test_images: ExTensor
+    var test_labels: ExTensor
+    var num_classes: Int
+
+    fn __init__(
+        out self,
+        owned train_images: ExTensor,
+        owned train_labels: ExTensor,
+        owned test_images: ExTensor,
+        owned test_labels: ExTensor,
+        num_classes: Int,
+    ):
+        """Initialize dataset split.
+
+        Args:
+            train_images: Training image data.
+            train_labels: Training labels.
+            test_images: Test image data.
+            test_labels: Test labels.
+            num_classes: Number of output classes.
+        """
+        self.train_images = train_images^
+        self.train_labels = train_labels^
+        self.test_images = test_images^
+        self.test_labels = test_labels^
+        self.num_classes = num_classes
+
+    fn train_size(self) -> Int:
+        """Get number of training samples.
+
+        Returns:
+            Number of samples in training set.
+        """
+        return self.train_images.shape()[0]
+
+    fn test_size(self) -> Int:
+        """Get number of test samples.
+
+        Returns:
+            Number of samples in test set.
+        """
+        return self.test_images.shape()[0]
+
+
+fn load_emnist_dataset(path: String) raises -> DatasetSplit:
+    """Load EMNIST dataset from path.
+
+    Creates a DatasetSplit with EMNIST dimensions:
+    - Training: 60,000 samples of 28x28 grayscale images
+    - Test: 10,000 samples
+    - Classes: 62 (digits 0-9, uppercase A-Z, lowercase a-z)
+
+    Args:
+        path: Path to EMNIST data directory.
+
+    Returns:
+        DatasetSplit containing train/test data.
+
+    Note:
+        Currently returns placeholder tensors. Full implementation
+        requires file I/O which is limited in current Mojo version.
+    """
+    _ = path  # Suppress unused parameter warning
+
+    # Placeholder shapes matching EMNIST
+    var train_shape = List[Int]()
+    train_shape.append(60000)
+    train_shape.append(1)
+    train_shape.append(28)
+    train_shape.append(28)
+
+    var train_label_shape = List[Int]()
+    train_label_shape.append(60000)
+
+    var test_shape = List[Int]()
+    test_shape.append(10000)
+    test_shape.append(1)
+    test_shape.append(28)
+    test_shape.append(28)
+
+    var test_label_shape = List[Int]()
+    test_label_shape.append(10000)
+
+    return DatasetSplit(
+        train_images=zeros(train_shape, DType.float32),
+        train_labels=zeros(train_label_shape, DType.int64),
+        test_images=zeros(test_shape, DType.float32),
+        test_labels=zeros(test_label_shape, DType.int64),
+        num_classes=62,
+    )
+
+
+fn load_cifar10_dataset(path: String) raises -> DatasetSplit:
+    """Load CIFAR-10 dataset from path.
+
+    Creates a DatasetSplit with CIFAR-10 dimensions:
+    - Training: 50,000 samples of 32x32 RGB images
+    - Test: 10,000 samples
+    - Classes: 10 (airplane, automobile, bird, cat, deer,
+                   dog, frog, horse, ship, truck)
+
+    Args:
+        path: Path to CIFAR-10 data directory.
+
+    Returns:
+        DatasetSplit containing train/test data.
+
+    Note:
+        Currently returns placeholder tensors. Full implementation
+        requires file I/O which is limited in current Mojo version.
+    """
+    _ = path  # Suppress unused parameter warning
+
+    # Placeholder shapes matching CIFAR-10
+    var train_shape = List[Int]()
+    train_shape.append(50000)
+    train_shape.append(3)
+    train_shape.append(32)
+    train_shape.append(32)
+
+    var train_label_shape = List[Int]()
+    train_label_shape.append(50000)
+
+    var test_shape = List[Int]()
+    test_shape.append(10000)
+    test_shape.append(3)
+    test_shape.append(32)
+    test_shape.append(32)
+
+    var test_label_shape = List[Int]()
+    test_label_shape.append(10000)
+
+    return DatasetSplit(
+        train_images=zeros(train_shape, DType.float32),
+        train_labels=zeros(train_label_shape, DType.int64),
+        test_images=zeros(test_shape, DType.float32),
+        test_labels=zeros(test_label_shape, DType.int64),
+        num_classes=10,
+    )
+
+
+fn print_dataset_summary(split: DatasetSplit, name: String):
+    """Print dataset summary statistics.
+
+    Displays formatted information about the dataset split.
+
+    Args:
+        split: Dataset split to summarize.
+        name: Name to display for the dataset.
+    """
+    print("Dataset:", name)
+    print("  Train size: ", split.train_size())
+    print("  Test size:  ", split.test_size())
+    print("  Num classes:", split.num_classes)
+    var train_shape = split.train_images.shape()
+    if len(train_shape) >= 4:
+        print(
+            "  Image shape:",
+            train_shape[1],
+            "x",
+            train_shape[2],
+            "x",
+            train_shape[3],
+        )


### PR DESCRIPTION
## Summary

Implements the `dataset_loaders` module with dataset loading utilities referenced in Issue #3034.

## New Components

### DatasetSplit Struct
Holds train/test data with metadata:
- `train_images`, `train_labels` - Training data tensors
- `test_images`, `test_labels` - Test data tensors
- `train_size()`, `test_size()` - Sample count accessors
- `num_classes` - Number of output classes

### Dataset Loaders
- `load_emnist_dataset(path)` - Load EMNIST (62 classes, 28x28)
- `load_cifar10_dataset(path)` - Load CIFAR-10 (10 classes, 32x32)

### Utilities
- `print_dataset_summary(split, name)` - Display dataset statistics

## Note

Loader functions return placeholder tensors with correct shapes until Mojo file I/O becomes stable.

Part of #3034

🤖 Generated with [Claude Code](https://claude.com/claude-code)