### PR TITLE
feat(training): export script_runner and dataset_loaders utilities

### DIFF
--- a/shared/training/__init__.mojo
+++ b/shared/training/__init__.mojo
@@ -489,17 +489,16 @@ struct CrossEntropyLoss(Loss, Movable):
 # Public API
 # ============================================================================
 
-# See Issue #3034 for tracking training script utilities export
-# TODO: Export training script utilities when script_runner module is implemented
-# from shared.training.script_runner import (
-#     TrainingCallbacks,
-#     run_epoch_with_batches,
-#     print_training_header,
-#     print_dataset_info,
-# )
-# from shared.training.dataset_loaders import (
-#     DatasetSplit,
-#     load_emnist_dataset,
-#     load_cifar10_dataset,
-#     print_dataset_summary,
-# )
+# Training script utilities (Issue #3034)
+from shared.training.script_runner import (
+    TrainingCallbacks,
+    run_epoch_with_batches,
+    print_training_header,
+    print_dataset_info,
+)
+from shared.training.dataset_loaders import (
+    DatasetSplit,
+    load_emnist_dataset,
+    load_cifar10_dataset,
+    print_dataset_summary,
+)


### PR DESCRIPTION
## Summary

Exports the training script utilities from the newly implemented `script_runner` and `dataset_loaders` modules.

## Exports Added

### From script_runner
- `TrainingCallbacks` - Progress reporting struct
- `run_epoch_with_batches` - Epoch runner
- `print_training_header` - Configuration display
- `print_dataset_info` - Dataset info display

### From dataset_loaders
- `DatasetSplit` - Train/test data container
- `load_emnist_dataset` - EMNIST loader
- `load_cifar10_dataset` - CIFAR-10 loader
- `print_dataset_summary` - Statistics display

## Changes

- Removed TODO comment and uncommented the export statements
- Added reference to Issue #3034 in comment

Closes #3034

🤖 Generated with [Claude Code](https://claude.com/claude-code)