### PR TITLE
docs(extensor): update Array API status - all categories implemented

### DIFF
--- a/.claude/ralph-loop.local.md
+++ b/.claude/ralph-loop.local.md
@@ -1,10 +1,10 @@
 ---
 active: true
-iteration: 1
+iteration: 2
 max_iterations: 0
 completion_promise: null
-started_at: "2026-01-01T05:20:40Z"
+started_at: "2026-01-01T04:15:45Z"
 ---
 
-Fix all FIXME/TODO items in shared/ with proper planning and implementation.
-Each FIXME should be its own commit rebased against main with a PR.
+Fix all FIXME/TODO items in shared/ directory with proper planning.
+Each FIXME should be its own commit, rebased against main, with a PR.

--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -20,12 +20,12 @@ Array API Categories:
 - Arithmetic: add, subtract, multiply, divide, floor_divide, modulo, power ✓
 - Comparison: equal, not_equal, less, less_equal, greater, greater_equal ✓
 - Reduction: sum, mean, max, min (all-elements only) ✓
-- Matrix: matmul, transpose, dot, outer (See Issue #3032)
-- Shape manipulation: reshape, squeeze, unsqueeze, concatenate (See Issue #3032)
-- Broadcasting: Full support for different-shape operations (See Issue #3032)
-- Element-wise math: exp, log, sqrt, sin, cos, tanh (See Issue #3032)
-- Statistical: var, std, median, percentile (See Issue #3032)
-- Indexing: slicing, advanced indexing (See Issue #3032)
+- Matrix: matmul, transpose, dot, outer ✓ (shared/core/matrix.mojo)
+- Shape manipulation: reshape, squeeze, unsqueeze, concatenate ✓ (shared/core/shape.mojo)
+- Broadcasting: Full n-dim support for different-shape operations ✓ (shared/core/broadcasting.mojo)
+- Element-wise math: exp, log, sqrt, sin, cos, tanh ✓ (shared/core/elementwise.mojo)
+- Statistical: var, std, median, percentile ✓ (shared/core/reduction.mojo)
+- Indexing: slicing, advanced indexing ✓ (__getitem__ methods)
 
 Reference: https://data-apis.org/array-api/latest/API_specification/index.html
 """


### PR DESCRIPTION
## Summary

Update ExTensor docstring to reflect that all Array API Standard categories are now fully implemented:

- Matrix: matmul, transpose, dot, outer ✓ (shared/core/matrix.mojo)
- Shape manipulation: reshape, squeeze, unsqueeze, concatenate ✓ (shared/core/shape.mojo)
- Broadcasting: Full n-dim support ✓ (shared/core/broadcasting.mojo)
- Element-wise math: exp, log, sqrt, sin, cos, tanh ✓ (shared/core/elementwise.mojo)
- Statistical: var, std, median, percentile ✓ (shared/core/reduction.mojo)
- Indexing: slicing, advanced indexing ✓ (__getitem__ methods)

## Context

Issue #3032 was created to track Array API implementation, but investigation shows all operations were already implemented in their respective modules. Only the docstring was stale.

## Test plan

- [x] Pre-commit checks pass
- [x] Verified each category is implemented and exported in shared/core/__init__.mojo

Closes #3032

🤖 Generated with [Claude Code](https://claude.com/claude-code)