### PR TITLE
[Cleanup] Convert float16 FIXMEs to documented NOTEs in AlexNet tests

### DIFF
--- a/tests/models/test_alexnet_layers.mojo
+++ b/tests/models/test_alexnet_layers.mojo
@@ -1098,10 +1098,9 @@ fn main() raises:
     test_conv1_forward_float32()
     print(" OK")
 
-    # FIXME(#3009): test_conv1_forward_float16 disabled - float16 precision insufficient
-    # for 11x11 kernel accumulation (363 multiplications per output element).
-    # See: https://github.com/mvillmow/ProjectOdyssey/issues/2701
-    print("  test_conv1_forward_float16... FIXME(#3009)")
+    # NOTE: Float16 precision insufficient for 11x11 kernel accumulation
+    # (363 multiplications per output element). Known limitation - see #3009.
+    print("  test_conv1_forward_float16... SKIPPED (float16 precision)")
 
     print("  test_conv1_backward_float32...", end="")
     test_conv1_backward_float32()
@@ -1112,10 +1111,9 @@ fn main() raises:
     test_conv2_forward_float32()
     print(" OK")
 
-    # FIXME(#3009): test_conv2_forward_float16 disabled - float16 precision insufficient
-    # for 5x5 kernel with 64 input channels (1600 multiplications per output element).
-    # See: https://github.com/mvillmow/ProjectOdyssey/issues/2701
-    print("  test_conv2_forward_float16... FIXME(#3009)")
+    # NOTE: Float16 precision insufficient for 5x5 kernel with 64 input channels
+    # (1600 multiplications per output element). Known limitation - see #3009.
+    print("  test_conv2_forward_float16... SKIPPED (float16 precision)")
 
     # Conv2 backward - uses sampled gradient checking (200 samples)
     print("  test_conv2_backward_float32...", end="")
@@ -1127,10 +1125,9 @@ fn main() raises:
     test_conv3_forward_float32()
     print(" OK")
 
-    # FIXME(#3009): test_conv3_forward_float16 disabled - float16 precision insufficient
-    # for 3x3 kernel with 192 input channels (1728 multiplications per output element).
-    # See: https://github.com/mvillmow/ProjectOdyssey/issues/2701
-    print("  test_conv3_forward_float16... FIXME(#3009)")
+    # NOTE: Float16 precision insufficient for 3x3 kernel with 192 input channels
+    # (1728 multiplications per output element). Known limitation - see #3009.
+    print("  test_conv3_forward_float16... SKIPPED (float16 precision)")
 
     # Conv3 backward - uses sampled gradient checking (100 samples)
     print("  test_conv3_backward_float32...", end="")


### PR DESCRIPTION
## Summary

Convert `FIXME(#3009)` references to `NOTE:` comments documenting known float16 precision limitations.

## Context

Issue #3009 was closed with the resolution "document as known limitation". These tests cannot pass due to fundamental float16 precision constraints in large convolution accumulations.

## Changes

| Test | Kernel | Accumulations | Status |
|------|--------|---------------|--------|
| test_conv1_forward_float16 | 11x11 | 363 | SKIPPED |
| test_conv2_forward_float16 | 5x5 × 64ch | 1,600 | SKIPPED |
| test_conv3_forward_float16 | 3x3 × 192ch | 1,728 | SKIPPED |

## Verification

- [x] Pre-commit hooks pass
- [x] Tests still skip gracefully with clear messaging

Resolves stale FIXME referencing closed #3009

🤖 Generated with [Claude Code](https://claude.com/claude-code)