### PR TITLE
[Cleanup] Convert float16 FIXME to NOTE in LeNet-5 FC layers test

### DIFF
--- a/tests/models/test_lenet5_fc_layers.mojo
+++ b/tests/models/test_lenet5_fc_layers.mojo
@@ -183,11 +183,10 @@ fn test_fc3_forward_float32() raises:
 fn test_fc3_forward_float16() raises:
     """Test FC3 (84→10) forward pass with float16.
 
-    FIXME(#3009): This test may fail due to float16 precision limitations.
+    NOTE: This test may be sensitive to float16 precision limitations.
     FC3 performs 84 multiplications per output, which can cause accumulation
     errors in float16 (limited to ~3.3 decimal digits precision).
-
-    If this test fails, we need to implement float32 accumulation in linear().
+    Known limitation - see issue #3009 for discussion.
     """
     var dtype = DType.float16
     var _result = create_fc3_parameters(dtype)


### PR DESCRIPTION
## Summary

Convert `FIXME(#3009)` in `test_fc3_forward_float16` docstring to a `NOTE:` documenting potential float16 precision sensitivity.

## Context

Issue #3009 was closed with the resolution "document as known limitation".

## Difference from AlexNet

Unlike the AlexNet tests (which are fully skipped), this LeNet-5 FC layer test:
- Still executes (84 multiplications is borderline for float16)
- Documents that it may be sensitive to precision issues

## Verification

- [x] Pre-commit hooks pass

Resolves stale FIXME referencing closed #3009

🤖 Generated with [Claude Code](https://claude.com/claude-code)