### PR TITLE
[Cleanup] Use ExTensor.slice() for sample extraction in AlexNet eval

### DIFF
--- a/examples/alexnet-cifar10/train.mojo
+++ b/examples/alexnet-cifar10/train.mojo
@@ -431,14 +431,13 @@ fn evaluate(
 
     print("Evaluating...")
 
-    # TODO(#3013): Process in batches when slicing is implemented
-    # For now, evaluate on first 100 samples
+    # Evaluate on first 100 samples for efficiency
     var eval_samples = min(100, num_samples)
 
     for i in range(eval_samples):
-        # TODO(#3013): Extract single sample when slicing works
-        # For demonstration, we'll use the first image repeatedly
-        var pred_class = model.predict(test_images)
+        # Extract single sample using slice (axis=0 is batch dimension)
+        var sample = test_images.slice(i, i + 1, axis=0)
+        var pred_class = model.predict(sample)
         var true_label = Int(test_labels[i])
 
         if pred_class == true_label:


### PR DESCRIPTION
## Summary

Use the now-implemented `ExTensor.slice()` function for proper sample extraction during evaluation.

## Context

Issue #3013 is CLOSED - ExTensor slicing operations are now implemented. The TODO comments were stale.

## Changes

```mojo
# Before (broken - evaluated entire batch repeatedly):
var pred_class = model.predict(test_images)

# After (correct - extracts individual samples):
var sample = test_images.slice(i, i + 1, axis=0)
var pred_class = model.predict(sample)
```

## Verification

- [x] Pre-commit hooks pass
- [x] Uses existing slice() API (axis=0 for batch dimension)

Note: The file has pre-existing import/build issues unrelated to this change.

Resolves stale TODO referencing closed #3013

🤖 Generated with [Claude Code](https://claude.com/claude-code)