### PR TITLE
[Cleanup] Clarify image loading limitation in LeNet inference

### DIFF
--- a/examples/lenet-emnist/run_infer.mojo
+++ b/examples/lenet-emnist/run_infer.mojo
@@ -336,8 +336,10 @@ fn main() raises:
         # Single image inference
         print("Loading image from", config.image_path, "...")
 
-        # Load image (currently supports IDX format)
-        # TODO(#2394): Add PNG image loading when external image libraries become available
+        # Load image (currently supports IDX format only)
+        # NOTE: PNG/JPEG image loading requires external image processing libraries.
+        # Mojo does not yet have native image decoding support in its stdlib.
+        # For now, convert images to IDX format using Python preprocessing scripts.
         var image = load_image(config.image_path)
 
         if image.shape()[0] == 0:


### PR DESCRIPTION
## Summary

Update TODO referencing closed issue #2394 to a NOTE explaining the actual limitation: Mojo lacks native image decoding support in its stdlib.

## Changes

- Convert `TODO(#2394)` to `NOTE` explaining the limitation
- Document that IDX format is currently the only supported format
- Explain that PNG/JPEG requires external image processing libraries
- Suggest workaround: use Python preprocessing to convert to IDX

## Test Plan

- [x] Pre-commit hooks pass
- [ ] CI/CD pipeline validates

Resolves stale reference to closed #2394

🤖 Generated with [Claude Code](https://claude.com/claude-code)