### PR TITLE
[Feature] Implement environment variable reading for log level

### DIFF
--- a/shared/utils/logging.mojo
+++ b/shared/utils/logging.mojo
@@ -17,6 +17,8 @@ Example:
     ```
 """
 
+from os.env import getenv
+
 
 # ============================================================================
 # Log Level Enumeration
@@ -434,13 +436,34 @@ fn get_log_level_from_env() -> Int:
 
     Returns:
         Log level integer (default: INFO if not set).
+
+    Note:
+        Only works on macOS and Linux. Returns INFO on other platforms.
     """
-    # Try to get environment variable
-    # Note: Mojo doesn't have os.getenv, so we use print + stderr approach
-    # For now, return default INFO level
-    # Blocked: Mojo stdlib limitation - no os.getenv equivalent
-    # TODO: Implement env var reading when Mojo adds stdlib support
-    return LogLevel.INFO
+    # Get environment variable value (empty string if not set)
+    var log_level_str = getenv("ML_ODYSSEY_LOG_LEVEL", "")
+
+    # Handle empty/unset case
+    if len(log_level_str) == 0:
+        return LogLevel.INFO
+
+    # Convert to uppercase for case-insensitive matching
+    var upper_str = log_level_str.upper()
+
+    # Parse log level string
+    if upper_str == "DEBUG":
+        return LogLevel.DEBUG
+    elif upper_str == "INFO":
+        return LogLevel.INFO
+    elif upper_str == "WARNING" or upper_str == "WARN":
+        return LogLevel.WARNING
+    elif upper_str == "ERROR":
+        return LogLevel.ERROR
+    elif upper_str == "CRITICAL":
+        return LogLevel.CRITICAL
+    else:
+        # Invalid value, default to INFO
+        return LogLevel.INFO
 
 
 fn get_logger(name: String, level: Int = LogLevel.INFO) -> Logger:


### PR DESCRIPTION
## Summary

Implement actual environment variable reading in `get_log_level_from_env()` now that Mojo has `getenv` in its stdlib.

## Changes

- Add import for `os.env.getenv`
- Implement env var parsing for `ML_ODYSSEY_LOG_LEVEL`
- Support case-insensitive log level names (DEBUG, INFO, WARNING, ERROR, CRITICAL)
- Also accept "WARN" as alias for WARNING
- Return INFO as default for unset/invalid values

## Usage

```bash
export ML_ODYSSEY_LOG_LEVEL=DEBUG
# Now logs will show debug-level messages
```

## Technical Details

- Uses Mojo's `getenv(name, default)` function from `os.env` module
- Empty default allows detection of unset variables
- String `.upper()` method for case-insensitive matching
- Platform note: Only works on macOS and Linux per Mojo stdlib docs

## Test Plan

- [x] Pre-commit hooks pass
- [ ] CI/CD pipeline validates

## References

- [Mojo getenv Documentation](https://docs.modular.com/mojo/std/os/env/getenv)

🤖 Generated with [Claude Code](https://claude.com/claude-code)