### PR TITLE
[Docs] Convert Track 4 TODOs to NOTEs in training modules

### DIFF
--- a/shared/training/__init__.mojo
+++ b/shared/training/__init__.mojo
@@ -408,8 +408,7 @@ struct TrainingLoop[
         var total_loss = Float64(0.0)
         var num_batches = Int(0)
 
-        # Blocked: Track 4 (Python↔Mojo interop)
-        # TODO: Iterate through batches when Python data loader integration is complete
+        # NOTE: Batch iteration blocked by Track 4 (Python↔Mojo interop).
         # The data_loader is currently a PythonObject, but step() requires ExTensor.
         # Once Track 4 data loading infrastructure is ready, integrate batching here.
         _ = data_loader  # Suppress unused variable warning

--- a/shared/training/trainer_interface.mojo
+++ b/shared/training/trainer_interface.mojo
@@ -388,9 +388,8 @@ struct DataLoader(Copyable, Movable):
         var batch_labels = ExTensor(batch_labels_shape, self.labels.dtype())
 
         # Tensor slicing is implemented in ExTensor.slice() and __getitem__()
-        # Blocked: Track 4 (Python↔Mojo interop)
-        # TODO: Integrate with Python data loaders when Track 4 infrastructure is ready
-        # For now, we just create placeholder tensors
+        # NOTE: Python data loader integration blocked by Track 4 (Python↔Mojo interop).
+        # For now, we create placeholder tensors until Track 4 infrastructure is ready.
 
         self.current_batch += 1
 


### PR DESCRIPTION
## Summary

Convert TODO comments to NOTE comments to clarify these are blocked by Track 4 (Python↔Mojo interop) infrastructure, not actionable items.

## Files Updated

- `shared/training/__init__.mojo`: Batch iteration NOTE
- `shared/training/trainer_interface.mojo`: Python data loader NOTE

## Details

These items require Track 4 infrastructure which provides Python↔Mojo data loading interoperability. The placeholder implementations work for current use cases.

## Test Plan

- [x] Pre-commit hooks pass
- [ ] CI/CD validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)