### PR TITLE
fix(tests): remove unused out_shape variable

### DIFF
--- a/tests/shared/core/test_backward.mojo
+++ b/tests/shared/core/test_backward.mojo
@@ -258,7 +258,6 @@ fn test_conv2d_backward_shapes() raises:
 
     # Forward pass to get output shape
     var output = conv2d(x, kernel, bias, stride=1, padding=0)
-    # FIXME(unusued) var out_shape = output.shape()
 
     # Create grad_output with same shape as output
     var grad_output = ones_like(output)


### PR DESCRIPTION
## Summary
Removes commented FIXME line for unused variable `out_shape` in test_backward.mojo.

## Changes Made
- Removed: `# FIXME(unusued) var out_shape = output.shape()`
- The variable was declared but never used

## Files Modified
- `tests/shared/core/test_backward.mojo`

## Verification
- [x] Trivial change - CI will validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)