### PR TITLE
docs(tests): clarify from_array() implementation status

### DIFF
--- a/tests/shared/core/test_creation.mojo
+++ b/tests/shared/core/test_creation.mojo
@@ -308,23 +308,30 @@ fn test_arange_float() raises:
 
 
 fn test_from_array_1d() raises:
-    """Test creating tensor from 1D array."""
-    # TODO: Implement once from_array() is available
-    # Not yet implemented
+    """Test creating tensor from 1D array.
+
+    NOTE(#3013): from_array() is not yet implemented. This test is a
+    placeholder for array-to-tensor conversion. Current workaround
+    is to use arange(), zeros(), or manual element initialization.
+    """
     pass
 
 
 fn test_from_array_2d() raises:
-    """Test creating tensor from 2D nested array."""
-    # TODO: Implement once from_array() is available
-    # Not yet implemented
+    """Test creating tensor from 2D nested array.
+
+    NOTE(#3013): from_array() is not yet implemented. See test_from_array_1d
+    for details.
+    """
     pass
 
 
 fn test_from_array_3d() raises:
-    """Test creating tensor from 3D nested array."""
-    # TODO: Implement once from_array() is available
-    # Not yet implemented
+    """Test creating tensor from 3D nested array.
+
+    NOTE(#3013): from_array() is not yet implemented. See test_from_array_1d
+    for details.
+    """
     pass
 
 


### PR DESCRIPTION
## Summary
Converts TODO comments to NOTE with proper issue reference for from_array() tests.

## Changes Made
- Changed 3 `# TODO: Implement once from_array() is available` comments
- Converted to `NOTE(#3013)` format with explanation
- Added workaround suggestion (arange, zeros, manual initialization)

## Rationale
- `from_array()` is not yet implemented in shared/core/
- Tracked by Issue #3013 (ExTensor Operations)
- These are intentional placeholder tests following TDD principles

## Files Modified
- `tests/shared/core/test_creation.mojo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)