### PR TITLE
docs(examples): add issue reference for CIFAR-10 loader TODO

### DIFF
--- a/examples/resnet18-cifar10/train.mojo
+++ b/examples/resnet18-cifar10/train.mojo
@@ -39,7 +39,8 @@ from shared.core.normalization import batch_norm2d, batch_norm2d_backward
 from shared.core.arithmetic import add, add_backward
 from shared.data import extract_batch_pair, compute_num_batches, DatasetInfo
 
-# from shared.data.datasets import load_cifar10_train, load_cifar10_test  # TODO: Implement these functions
+# NOTE(#3013): CIFAR-10 dataset loading not yet implemented.
+# from shared.data.datasets import load_cifar10_train, load_cifar10_test
 from shared.training.optimizers import sgd_momentum_update_inplace
 from shared.training.metrics import evaluate_with_predict, top1_accuracy
 from shared.utils.training_args import parse_training_args_with_defaults
@@ -268,7 +269,7 @@ fn main() raises:
     print()
 
     # Load CIFAR-10 dataset
-    # TODO: Implement load_cifar10_train and load_cifar10_test functions
+    # NOTE(#3013): CIFAR-10 loading awaits dataset infrastructure implementation.
     # print("Loading CIFAR-10 dataset...")
     # var train_data = load_cifar10_train("datasets/cifar10")
     # var train_images = train_data[0]


### PR DESCRIPTION
## Summary
Converts TODO comments to NOTE with proper issue reference for CIFAR-10 loader.

## Changes Made
- Changed `# TODO: Implement these functions` to `# NOTE(#3013)`
- Changed `# TODO: Implement load_cifar10_train and load_cifar10_test functions` to NOTE
- Both now reference Issue #3013 (ExTensor Operations)

## Rationale
- CIFAR-10 dataset loading depends on data infrastructure in shared/data/
- Tracked by Issue #3013 which includes dataset operations
- Example code is placeholder until infrastructure is ready

## Files Modified
- `examples/resnet18-cifar10/train.mojo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)