### PR TITLE
fix(ci): add security-events permission for Trivy SARIF upload

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,7 @@ env:
 permissions:
   contents: read
   packages: write
+  security-events: write  # For Trivy SARIF uploads
 
 jobs:
   # ============================================================================


### PR DESCRIPTION
## Summary
- Added `security-events: write` permission to docker.yml workflow

## Problem
The `security-scan` job in the docker.yml workflow was failing with:
```
##[error]Resource not accessible by integration
```

The `github/codeql-action/upload-sarif@v4` action requires the `security-events: write` permission to upload SARIF results to GitHub's code scanning API.

## Fix
Added the missing permission to the workflow's permissions block.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, the security-scan job on main should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)