### PR TITLE
feat(agents): add disallowedTools field for tool blocking

### DIFF
--- a/.claude/agents/algorithm-review-specialist.md
+++ b/.claude/agents/algorithm-review-specialist.md
@@ -7,6 +7,7 @@ tools: Read,Grep,Glob
 model: sonnet
 delegates_to: []
 receives_from: [code-review-orchestrator]
+disallowedTools: [Edit, Write, Bash, WebFetch, Task]
 ---
 
 # Algorithm Review Specialist

--- a/.claude/agents/architecture-review-specialist.md
+++ b/.claude/agents/architecture-review-specialist.md
@@ -7,6 +7,7 @@ tools: Read,Grep,Glob
 model: sonnet
 delegates_to: []
 receives_from: [code-review-orchestrator]
+disallowedTools: [Edit, Write, Bash, WebFetch, Task]
 ---
 
 # Architecture Review Specialist

--- a/.claude/agents/data-engineering-review-specialist.md
+++ b/.claude/agents/data-engineering-review-specialist.md
@@ -7,6 +7,7 @@ tools: Read,Grep,Glob
 model: sonnet
 delegates_to: []
 receives_from: [code-review-orchestrator]
+disallowedTools: [Edit, Write, Bash, WebFetch, Task]
 ---
 
 # Data Engineering Review Specialist

--- a/.claude/agents/dependency-review-specialist.md
+++ b/.claude/agents/dependency-review-specialist.md
@@ -7,6 +7,7 @@ tools: Read,Grep,Glob
 model: sonnet
 delegates_to: []
 receives_from: [code-review-orchestrator]
+disallowedTools: [Edit, Write, Bash, WebFetch, Task]
 ---
 
 # Dependency Review Specialist

--- a/.claude/agents/documentation-review-specialist.md
+++ b/.claude/agents/documentation-review-specialist.md
@@ -7,6 +7,7 @@ tools: Read,Grep,Glob
 model: sonnet
 delegates_to: []
 receives_from: [code-review-orchestrator]
+disallowedTools: [Edit, Write, Bash, WebFetch, Task]
 ---
 
 # Documentation Review Specialist

--- a/.claude/agents/implementation-review-specialist.md
+++ b/.claude/agents/implementation-review-specialist.md
@@ -7,6 +7,7 @@ tools: Read,Grep,Glob
 model: sonnet
 delegates_to: []
 receives_from: [code-review-orchestrator]
+disallowedTools: [Edit, Write, Bash, WebFetch, Task]
 ---
 
 # Implementation Review Specialist

--- a/.claude/agents/junior-documentation-engineer.md
+++ b/.claude/agents/junior-documentation-engineer.md
@@ -7,6 +7,7 @@ tools: Read,Write,Edit,Grep,Glob
 model: haiku
 delegates_to: []
 receives_from: [documentation-engineer, documentation-specialist]
+disallowedTools: [Bash, WebFetch, Task]
 ---
 
 # Junior Documentation Engineer

--- a/.claude/agents/junior-implementation-engineer.md
+++ b/.claude/agents/junior-implementation-engineer.md
@@ -7,6 +7,7 @@ tools: Read,Write,Edit,Grep,Glob
 model: haiku
 delegates_to: []
 receives_from: [implementation-engineer, implementation-specialist]
+disallowedTools: [Bash, WebFetch, Task]
 ---
 
 # Junior Implementation Engineer

--- a/.claude/agents/junior-test-engineer.md
+++ b/.claude/agents/junior-test-engineer.md
@@ -7,6 +7,7 @@ tools: Read,Write,Edit,Grep,Glob
 model: haiku
 delegates_to: []
 receives_from: [test-engineer, test-specialist]
+disallowedTools: [Bash, WebFetch, Task]
 ---
 
 # Junior Test Engineer

--- a/.claude/agents/mojo-language-review-specialist.md
+++ b/.claude/agents/mojo-language-review-specialist.md
@@ -7,6 +7,7 @@ tools: Read,Grep,Glob
 model: sonnet
 delegates_to: []
 receives_from: [code-review-orchestrator]
+disallowedTools: [Edit, Write, Bash, WebFetch, Task]
 ---
 
 # Mojo Language Review Specialist

--- a/.claude/agents/paper-review-specialist.md
+++ b/.claude/agents/paper-review-specialist.md
@@ -7,6 +7,7 @@ tools: Read,Grep,Glob
 model: sonnet
 delegates_to: []
 receives_from: [code-review-orchestrator]
+disallowedTools: [Edit, Write, Bash, WebFetch, Task]
 ---
 
 # Paper Review Specialist

--- a/.claude/agents/performance-review-specialist.md
+++ b/.claude/agents/performance-review-specialist.md
@@ -7,6 +7,7 @@ tools: Read,Grep,Glob
 model: sonnet
 delegates_to: []
 receives_from: [code-review-orchestrator]
+disallowedTools: [Edit, Write, Bash, WebFetch, Task]
 ---
 
 # Performance Review Specialist

--- a/.claude/agents/research-review-specialist.md
+++ b/.claude/agents/research-review-specialist.md
@@ -7,6 +7,7 @@ tools: Read,Grep,Glob
 model: sonnet
 delegates_to: []
 receives_from: [code-review-orchestrator]
+disallowedTools: [Edit, Write, Bash, WebFetch, Task]
 ---
 
 # Research Review Specialist

--- a/.claude/agents/safety-review-specialist.md
+++ b/.claude/agents/safety-review-specialist.md
@@ -7,6 +7,7 @@ tools: Read,Grep,Glob
 model: sonnet
 delegates_to: []
 receives_from: [code-review-orchestrator]
+disallowedTools: [Edit, Write, Bash, WebFetch, Task]
 ---
 
 # Safety Review Specialist

--- a/.claude/agents/security-review-specialist.md
+++ b/.claude/agents/security-review-specialist.md
@@ -7,6 +7,7 @@ tools: Read,Grep,Glob
 model: sonnet
 delegates_to: []
 receives_from: [code-review-orchestrator]
+disallowedTools: [Edit, Write, Bash, WebFetch, Task]
 ---
 
 # Security Review Specialist

--- a/.claude/agents/templates/review-specialist-template.md
+++ b/.claude/agents/templates/review-specialist-template.md
@@ -2,6 +2,24 @@
 
 This template provides common sections for all review specialists to eliminate duplication.
 
+## Agent Frontmatter - disallowedTools Field (New Feature)
+
+The `disallowedTools` field blocks specific tools for safety. All review specialists have:
+
+```yaml
+disallowedTools: [Edit, Write, Bash, WebFetch, Task]
+```
+
+This enforces read-only mode - review specialists cannot modify files, run commands, or delegate tasks.
+
+Junior engineers have:
+
+```yaml
+disallowedTools: [Bash, WebFetch, Task]
+```
+
+This blocks command execution and web fetching for safety.
+
 ## Output Location (Include Verbatim in All Specialists)
 
 **CRITICAL**: All review feedback MUST be posted directly to the GitHub pull request using

--- a/.claude/agents/test-review-specialist.md
+++ b/.claude/agents/test-review-specialist.md
@@ -7,6 +7,7 @@ tools: Read,Grep,Glob
 model: sonnet
 delegates_to: []
 receives_from: [code-review-orchestrator]
+disallowedTools: [Edit, Write, Bash, WebFetch, Task]
 ---
 
 # Test Review Specialist


### PR DESCRIPTION
## Summary

Add `disallowedTools` field to agent frontmatter for simpler tool blocking. This provides an alternative to hooks with cleaner syntax for blocking specific tools.

## Changes Made

### Junior Engineers (3 agents)
- **Block**: Bash, WebFetch, Task
- Prevents command execution, web fetching, and task delegation
- Enforces safer operations for junior developers
- Files: junior-implementation-engineer.md, junior-test-engineer.md, junior-documentation-engineer.md

### Review Specialists (13 agents)
- **Block**: Edit, Write, Bash, WebFetch, Task
- Enforces read-only mode completely
- Prevents file modifications, command execution, and task delegation
- Ensures review specialists can only read and analyze code
- Files: All *-review-specialist.md files (algorithm, architecture, data-engineering, dependency, documentation, implementation, mojo-language, paper, performance, research, safety, security, test)

### Template Updated
- Updated review-specialist-template.md with disallowedTools field documentation

## Example Configuration

Junior engineer:
\`\`\`yaml
disallowedTools: [Bash, WebFetch, Task]
\`\`\`

Review specialist:
\`\`\`yaml
disallowedTools: [Edit, Write, Bash, WebFetch, Task]
\`\`\`

## Comparison with Hooks (PR 2)

**Hooks** (PR 2): More flexible, supports patterns and custom reasons
\`\`\`yaml
hooks:
  PreToolUse:
    - matcher: "Bash"
      action: "block"
      reason: "Custom message here"
\`\`\`

**disallowedTools** (PR 3): Simpler syntax for straightforward blocking
\`\`\`yaml
disallowedTools: [Bash, WebFetch, Task]
\`\`\`

Both approaches work together - use hooks for complex cases, disallowedTools for simple blocking.

## Impact

**Before**: Agents had full tool access  
**After**: Junior engineers and review specialists have restricted tool access

## Testing

- [x] Verified YAML frontmatter syntax is correct
- [x] Checked all 16 agent files updated correctly
- [x] Updated template documentation

## Related Work

This is PR 3 of 5 for implementing Claude Code latest features:
- PR 1: Skills `user-invocable` field ✓
- PR 2: Agent-scoped hooks ✓
- **PR 3** (this): Agent `disallowedTools` field ✓
- PR 4: Skills `agent` field
- PR 5: Hooks `once` field

Based on Claude Code changelog: https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)