### PR TITLE
feat(skills): add agent field for execution context

### DIFF
--- a/.claude/skills/SKILL_FORMAT_TEMPLATE.md
+++ b/.claude/skills/SKILL_FORMAT_TEMPLATE.md
@@ -99,6 +99,9 @@ All skills must have:
 - `description`: One sentence with "Use when" trigger
 - `category`: Skill category (github, mojo, documentation, etc.)
 - `mcp_fallback`: MCP server fallback (if applicable)
+- `agent`: (Optional) Specify which agent type should execute this skill. Examples:
+  `mojo-syntax-validator`, `code-review-orchestrator`, `implementation-engineer`.
+  Use this to provide specialized context for skill execution.
 
 ### Section Order
 

--- a/.claude/skills/analyze-simd-usage/SKILL.md
+++ b/.claude/skills/analyze-simd-usage/SKILL.md
@@ -3,6 +3,7 @@ name: analyze-simd-usage
 description: "Analyze SIMD usage opportunities in Mojo code. Use to find performance optimization opportunities."
 category: mojo
 mcp_fallback: none
+agent: performance-review-specialist
 ---
 
 # Analyze SIMD Usage Opportunities

--- a/.claude/skills/check-memory-safety/SKILL.md
+++ b/.claude/skills/check-memory-safety/SKILL.md
@@ -3,6 +3,7 @@ name: check-memory-safety
 description: "Check Mojo code for memory safety issues (ownership violations, use-after-free, etc.). Use to catch memory bugs."
 category: mojo
 mcp_fallback: none
+agent: safety-review-specialist
 ---
 
 # Check Memory Safety

--- a/.claude/skills/create-review-checklist/SKILL.md
+++ b/.claude/skills/create-review-checklist/SKILL.md
@@ -3,6 +3,7 @@ name: create-review-checklist
 description: "Generate review checklists for different change types. Use to customize review focus based on what was changed."
 category: review
 mcp_fallback: none
+agent: code-review-orchestrator
 ---
 
 # Create Review Checklists

--- a/.claude/skills/gh-batch-merge-by-labels/SKILL.md
+++ b/.claude/skills/gh-batch-merge-by-labels/SKILL.md
@@ -2,6 +2,7 @@
 name: gh-batch-merge-by-labels
 description: "Batch merge multiple PRs by label (e.g., all 'ready-to-merge' PRs). Use when you have multiple approved PRs to merge."
 category: github
+agent: pr-cleanup-specialist
 ---
 
 # Batch Merge PRs by Label

--- a/.claude/skills/gh-check-ci-status/SKILL.md
+++ b/.claude/skills/gh-check-ci-status/SKILL.md
@@ -2,6 +2,7 @@
 name: gh-check-ci-status
 description: "Check CI/CD status of a pull request including workflow runs and test results. Use when verifying if PR checks are passing or investigating CI failures."
 category: github
+agent: cicd-orchestrator
 ---
 
 # Check CI Status

--- a/.claude/skills/gh-create-pr-linked/SKILL.md
+++ b/.claude/skills/gh-create-pr-linked/SKILL.md
@@ -2,6 +2,7 @@
 name: gh-create-pr-linked
 description: "Create a pull request properly linked to a GitHub issue using gh pr create --issue. Use when creating a PR that implements or addresses a specific issue."
 category: github
+agent: implementation-engineer
 ---
 
 # Create PR Linked to Issue

--- a/.claude/skills/gh-fix-pr-feedback/SKILL.md
+++ b/.claude/skills/gh-fix-pr-feedback/SKILL.md
@@ -2,6 +2,7 @@
 name: gh-fix-pr-feedback
 description: "Address PR review feedback by making changes and replying to comments. Use when a PR has open review comments needing responses."
 category: github
+agent: implementation-engineer
 ---
 
 # Fix PR Review Feedback

--- a/.claude/skills/gh-get-review-comments/SKILL.md
+++ b/.claude/skills/gh-get-review-comments/SKILL.md
@@ -2,6 +2,7 @@
 name: gh-get-review-comments
 description: "Retrieve all review comments from a pull request using the GitHub API. Use when you need to see what feedback has been provided on a PR."
 category: github
+agent: code-review-orchestrator
 ---
 
 # Get PR Review Comments

--- a/.claude/skills/gh-implement-issue/SKILL.md
+++ b/.claude/skills/gh-implement-issue/SKILL.md
@@ -2,6 +2,7 @@
 name: gh-implement-issue
 description: "End-to-end implementation workflow for a GitHub issue from planning through PR creation. Use when starting work on an issue from scratch."
 category: github
+agent: implementation-specialist
 ---
 
 # Implement GitHub Issue

--- a/.claude/skills/gh-post-issue-update/SKILL.md
+++ b/.claude/skills/gh-post-issue-update/SKILL.md
@@ -2,6 +2,7 @@
 name: gh-post-issue-update
 description: "Post structured updates to GitHub issues. Use to report progress, findings, and implementation notes directly to issues."
 category: github
+agent: documentation-engineer
 ---
 
 # Post Issue Update

--- a/.claude/skills/gh-read-issue-context/SKILL.md
+++ b/.claude/skills/gh-read-issue-context/SKILL.md
@@ -2,6 +2,7 @@
 name: gh-read-issue-context
 description: "Read context from GitHub issue including body and comments. Use before starting implementation work or when prior context is needed."
 category: github
+agent: implementation-specialist
 ---
 
 # Read Issue Context

--- a/.claude/skills/gh-reply-review-comment/SKILL.md
+++ b/.claude/skills/gh-reply-review-comment/SKILL.md
@@ -2,6 +2,7 @@
 name: gh-reply-review-comment
 description: "Reply to PR review comments using the correct GitHub API endpoint. Use when responding to inline code review feedback (not gh pr comment)."
 category: github
+agent: implementation-engineer
 ---
 
 # Reply to Review Comments

--- a/.claude/skills/gh-review-pr/SKILL.md
+++ b/.claude/skills/gh-review-pr/SKILL.md
@@ -2,6 +2,7 @@
 name: gh-review-pr
 description: "Comprehensively review a pull request including code changes, CI status, and adherence to project standards. Use when asked to review a PR."
 category: github
+agent: code-review-orchestrator
 ---
 
 # Review Pull Request

--- a/.claude/skills/mojo-build-package/SKILL.md
+++ b/.claude/skills/mojo-build-package/SKILL.md
@@ -3,6 +3,7 @@ name: mojo-build-package
 description: "Build Mojo packages (.mojopkg files) for distribution. Use when creating distributable libraries or during packaging phase."
 mcp_fallback: none
 category: mojo
+agent: senior-implementation-engineer
 ---
 
 # Mojo Build Package Skill

--- a/.claude/skills/mojo-format/SKILL.md
+++ b/.claude/skills/mojo-format/SKILL.md
@@ -3,6 +3,7 @@ name: mojo-format
 description: "Format Mojo code using mojo format command. Use when preparing code for commit or when formatting checks fail."
 mcp_fallback: none
 category: mojo
+agent: mojo-syntax-validator
 ---
 
 # Mojo Format Skill

--- a/.claude/skills/mojo-lint-syntax/SKILL.md
+++ b/.claude/skills/mojo-lint-syntax/SKILL.md
@@ -3,6 +3,7 @@ name: mojo-lint-syntax
 description: "Validate Mojo syntax against current v0.26.1+ standards. Use to catch syntax errors before compilation."
 category: mojo
 mcp_fallback: none
+agent: mojo-syntax-validator
 ---
 
 # Lint Mojo Syntax

--- a/.claude/skills/mojo-memory-check/SKILL.md
+++ b/.claude/skills/mojo-memory-check/SKILL.md
@@ -3,6 +3,7 @@ name: mojo-memory-check
 description: "Verify memory safety in Mojo code including ownership, borrowing, and lifetime management. Use when reviewing code or debugging memory issues."
 mcp_fallback: none
 category: mojo
+agent: safety-review-specialist
 ---
 
 # Memory Safety Check Skill

--- a/.claude/skills/mojo-simd-optimize/SKILL.md
+++ b/.claude/skills/mojo-simd-optimize/SKILL.md
@@ -3,6 +3,7 @@ name: mojo-simd-optimize
 description: "Apply SIMD optimizations to Mojo code for parallel computation. Use when optimizing performance-critical tensor and array operations."
 mcp_fallback: none
 category: mojo
+agent: performance-engineer
 ---
 
 # SIMD Optimization Skill

--- a/.claude/skills/mojo-test-runner/SKILL.md
+++ b/.claude/skills/mojo-test-runner/SKILL.md
@@ -3,6 +3,7 @@ name: mojo-test-runner
 description: "Run Mojo tests using mojo test command. Use when executing tests or verifying test coverage."
 mcp_fallback: none
 category: mojo
+agent: test-engineer
 ---
 
 # Mojo Test Runner Skill

--- a/.claude/skills/mojo-type-safety/SKILL.md
+++ b/.claude/skills/mojo-type-safety/SKILL.md
@@ -3,6 +3,7 @@ name: mojo-type-safety
 description: "Validate type safety in Mojo code including parametric types and trait constraints. Use during code review or when type errors occur."
 mcp_fallback: none
 category: mojo
+agent: mojo-language-review-specialist
 ---
 
 # Type Safety Validation Skill

--- a/.claude/skills/quality-complexity-check/SKILL.md
+++ b/.claude/skills/quality-complexity-check/SKILL.md
@@ -3,6 +3,7 @@ name: quality-complexity-check
 description: Analyze code complexity metrics including cyclomatic complexity and nesting depth. Use to identify code that needs refactoring.
 mcp_fallback: none
 category: quality
+agent: implementation-review-specialist
 ---
 
 # Complexity Check Skill

--- a/.claude/skills/quality-coverage-report/SKILL.md
+++ b/.claude/skills/quality-coverage-report/SKILL.md
@@ -3,6 +3,7 @@ name: quality-coverage-report
 description: Generate test coverage reports showing which code paths are tested. Use to identify untested code and improve test coverage.
 mcp_fallback: none
 category: quality
+agent: test-review-specialist
 ---
 
 # Test Coverage Report Skill

--- a/.claude/skills/quality-fix-formatting/SKILL.md
+++ b/.claude/skills/quality-fix-formatting/SKILL.md
@@ -3,6 +3,7 @@ name: quality-fix-formatting
 description: Automatically fix code formatting issues using mojo format, markdownlint, and pre-commit hooks. Use when formatting checks fail or before committing code.
 mcp_fallback: none
 category: quality
+agent: implementation-engineer
 ---
 
 # Fix Formatting Skill

--- a/.claude/skills/quality-run-linters/SKILL.md
+++ b/.claude/skills/quality-run-linters/SKILL.md
@@ -3,6 +3,7 @@ name: quality-run-linters
 description: Run all configured linters including mojo format, markdownlint, and pre-commit hooks. Use before committing code to ensure quality standards are met.
 mcp_fallback: none
 category: quality
+agent: implementation-engineer
 ---
 
 # Run Linters Skill

--- a/.claude/skills/quality-security-scan/SKILL.md
+++ b/.claude/skills/quality-security-scan/SKILL.md
@@ -3,6 +3,7 @@ name: quality-security-scan
 description: Scan code for security vulnerabilities and unsafe patterns. Use before committing sensitive code or in security reviews.
 mcp_fallback: none
 category: quality
+agent: security-review-specialist
 ---
 
 # Security Scan Skill

--- a/.claude/skills/review-pr-changes/SKILL.md
+++ b/.claude/skills/review-pr-changes/SKILL.md
@@ -2,6 +2,7 @@
 name: review-pr-changes
 description: "Review PR changes with structured checklist for quality and standards compliance. Use for comprehensive PR code review."
 category: review
+agent: code-review-orchestrator
 ---
 
 # Review PR Changes with Checklist

--- a/.claude/skills/validate-mojo-patterns/SKILL.md
+++ b/.claude/skills/validate-mojo-patterns/SKILL.md
@@ -3,6 +3,7 @@ name: validate-mojo-patterns
 description: "Validate Mojo code patterns (out self, mut, List, etc.) against best practices. Use to ensure code follows project standards."
 category: mojo
 mcp_fallback: none
+agent: mojo-language-review-specialist
 ---
 
 # Validate Mojo Patterns


### PR DESCRIPTION
## Summary

Add `agent` field to 27 skills to specify which agent type should execute them. This provides specialized execution context and ensures skills run with the appropriate agent's knowledge and capabilities.

## Changes Made

### Mojo Skills (10 skills)
- **mojo-format, mojo-lint-syntax** → `mojo-syntax-validator`
- **mojo-test-runner** → `test-engineer`
- **mojo-build-package** → `senior-implementation-engineer`
- **validate-mojo-patterns, mojo-type-safety** → `mojo-language-review-specialist`
- **mojo-memory-check, check-memory-safety** → `safety-review-specialist`
- **mojo-simd-optimize** → `performance-engineer`
- **analyze-simd-usage** → `performance-review-specialist`

### GitHub Skills (10 skills)
- **gh-check-ci-status** → `cicd-orchestrator`
- **gh-create-pr-linked, gh-fix-pr-feedback, gh-reply-review-comment** → `implementation-engineer`
- **gh-get-review-comments, gh-review-pr** → `code-review-orchestrator`
- **gh-post-issue-update** → `documentation-engineer`
- **gh-read-issue-context, gh-implement-issue** → `implementation-specialist`
- **gh-batch-merge-by-labels** → `pr-cleanup-specialist`

### Quality Skills (5 skills)
- **quality-complexity-check** → `implementation-review-specialist`
- **quality-coverage-report** → `test-review-specialist`
- **quality-fix-formatting, quality-run-linters** → `implementation-engineer`
- **quality-security-scan** → `security-review-specialist`

### Review Skills (2 skills)
- **review-pr-changes, create-review-checklist** → `code-review-orchestrator`

### Template Updated
- Updated SKILL_FORMAT_TEMPLATE.md to document the agent field

## Example Configuration

\`\`\`yaml
---
name: mojo-format
description: "Format Mojo code using mojo format command."
category: mojo
agent: mojo-syntax-validator
---
\`\`\`

## Impact

**Before**: Skills execute in generic context  
**After**: Skills execute with specialized agent context tailored to their domain

## Benefits

1. **Better Context**: Skills run with agent-specific knowledge
2. **Type Safety**: Mojo skills run with Mojo-aware agents
3. **Domain Expertise**: Security skills run with security specialists
4. **Clear Ownership**: Each skill has a designated agent type

## Testing

- [x] Verified YAML frontmatter syntax is correct
- [x] Checked all 27 skill files updated correctly
- [x] Updated template documentation

## Related Work

This is PR 4 of 5 for implementing Claude Code latest features:
- PR 1: Skills `user-invocable` field ✓
- PR 2: Agent-scoped hooks ✓
- PR 3: Agent `disallowedTools` field ✓
- **PR 4** (this): Skills `agent` field ✓
- PR 5: Hooks `once` field

Based on Claude Code changelog: https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)