### PR TITLE
Replace MIT license with BSD license

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Description here.
 
 [![Mojo](https://img.shields.io/badge/Mojo-0.26+-orange.svg)](https://www.modular.com/mojo)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](LICENSE)
 [![Tests](https://img.shields.io/badge/tests-122%2B-brightgreen.svg)](tests/)
 [![Coverage](https://img.shields.io/badge/coverage-pending-lightgrey.svg)](#coverage-status)
 

--- a/shared/__init__.mojo
+++ b/shared/__init__.mojo
@@ -47,7 +47,7 @@ Tests require corresponding modules to be implemented first.
 from shared.version import VERSION
 
 comptime AUTHOR = "ML Odyssey Team"
-comptime LICENSE = "MIT"
+comptime LICENSE = "BSD"
 
 # ============================================================================
 # Core Exports - Most commonly used components

--- a/tests/shared/integration/test_packaging.mojo
+++ b/tests/shared/integration/test_packaging.mojo
@@ -20,7 +20,7 @@ fn test_package_version() raises:
 
     assert_equal(VERSION, "0.1.0")
     assert_equal(AUTHOR, "ML Odyssey Team")
-    assert_equal(LICENSE, "MIT")
+    assert_equal(LICENSE, "BSD")
 
     print("✓ Package version test passed")
 

--- a/tests/shared/test_imports.mojo
+++ b/tests/shared/test_imports.mojo
@@ -260,7 +260,7 @@ fn test_version_info() raises:
     # Verify types are correct
     assert_true(VERSION == "0.1.0", "Version should be 0.1.0")
     assert_true(AUTHOR == "ML Odyssey Team", "Author should be ML Odyssey Team")
-    assert_true(LICENSE == "MIT", "License should be MIT")
+    assert_true(LICENSE == "BSD", "License should be BSD")
 
     print("✓ Version info test passed")
 


### PR DESCRIPTION
## Summary

This PR replaces all MIT license references with BSD 3-Clause license references throughout the codebase.

## Changes Made

1. **README.md**: Updated license badge from MIT to BSD 3-Clause
2. **shared/__init__.mojo**: Changed LICENSE constant from "MIT" to "BSD"
3. **tests/shared/integration/test_packaging.mojo**: Updated assertion to expect "BSD" license
4. **tests/shared/test_imports.mojo**: Updated assertion to expect "BSD" license
5. **Documentation files**: Updated example license references in worktrees and build directories

## Files Changed

-  - License badge update
-  - License constant update
-  - Test assertion update
-  - Test assertion update
- Documentation files in worktrees and build directories

## Testing

Pre-commit checks have been run and passed. The changes are minimal and focused on updating license references only.

## License File

The main LICENSE file at the repository root already contains the BSD 3-Clause license, so no changes were needed there.

## Review Checklist

- [x] All MIT license references have been updated to BSD
- [x] Test files updated to reflect new license
- [x] Documentation updated consistently
- [x] No functional code changes
- [x] Pre-commit checks pass