### PR TITLE
feat(skills): add fixme-todo-cleanup skill from retrospective

### DIFF
--- a/plugins/debugging/fixme-todo-cleanup/.claude-plugin/plugin.json
+++ b/plugins/debugging/fixme-todo-cleanup/.claude-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "fixme-todo-cleanup",
+  "version": "1.0.0",
+  "description": "Systematic FIXME/TODO cleanup workflow with proper branching, PRs, and CI handling",
+  "category": "debugging",
+  "created": "2026-01-01",
+  "repository": "mvillmow/ProjectOdyssey",
+  "tags": ["technical-debt", "cleanup", "workflow", "github", "ci-cd", "mojo"],
+  "triggers": [
+    "cleanup FIXME items",
+    "cleanup TODO items",
+    "technical debt reduction",
+    "code quality sweep"
+  ],
+  "tools_used": [
+    "grep -rn FIXME|TODO",
+    "gh pr create",
+    "gh pr merge --auto --rebase",
+    "gh run rerun --failed",
+    "pixi run mojo format"
+  ],
+  "metrics": {
+    "prs_merged": 7,
+    "issues_closed": 3,
+    "items_resolved": 7,
+    "items_blocked": 5
+  }
+}

--- a/plugins/debugging/fixme-todo-cleanup/references/notes.md
+++ b/plugins/debugging/fixme-todo-cleanup/references/notes.md
@@ -1,0 +1,125 @@
+# FIXME/TODO Cleanup Session Notes
+
+## Raw Session Data
+
+### Date
+
+2026-01-01
+
+### Duration
+
+~2 hours (including CI wait times)
+
+### Trigger
+
+Ralph-loop with prompt: "Fix all FIXME/TODO items in shared/ directory with proper planning"
+
+## Discovery Commands
+
+```bash
+# Find all FIXME/TODO items in shared/
+grep -rn "FIXME\|TODO" shared/ --include="*.mojo"
+
+# Results breakdown:
+# - 15 total items found
+# - 7 actionable (stale references, missing implementations)
+# - 5 blocked by external dependencies
+# - 3 documentation/future work
+```
+
+## PR Details
+
+### PR #3035: Update stale issue references
+
+- Branch: `cleanup-stale-todo-references`
+- Files: Multiple `__init__.mojo` files
+- Change: Updated FIXME(#3010) to FIXME(#3033)
+
+### PR #3036: Remove MXFP4 FIXME
+
+- Branch: `3031-remove-stale-mxfp4-fixme`
+- Files: `shared/core/types/mxfp4.mojo`
+- Change: Removed stale FIXME - tests already existed
+
+### PR #3037: Implement conftest fixtures
+
+- Branch: `3033-conftest-fixtures`
+- Files: `tests/shared/conftest.mojo`
+- Change: Replaced placeholder fixtures with real implementations
+
+### PR #3038: Implement script_runner
+
+- Branch: `3034-script-runner`
+- Files: `shared/training/script_runner.mojo`
+- Change: Implemented TrainingCallbacks and helpers
+- Error fixed: Removed `@value` decorator
+
+### PR #3039: Implement dataset_loaders
+
+- Branch: `3034-dataset-loaders`
+- Files: `shared/training/dataset_loaders.mojo`
+- Change: Implemented DatasetSplit and loaders
+- Error fixed: Removed `@fieldwise_init` decorator
+
+### PR #3040: Export script utilities
+
+- Branch: `3034-export-utilities`
+- Files: `shared/training/__init__.mojo`
+- Change: Uncommented export statements
+
+### PR #3041: Update ExTensor Array API
+
+- Branch: `3032-extensor-matrix-ops`
+- Files: `shared/core/extensor.mojo`
+- Change: Updated docstring to reflect implemented API
+
+## Error Log
+
+### Error 1: @value deprecation
+
+```text
+error: '@value' has been removed, please use '@fieldwise_init' and
+explicit Copyable and Movable conformances instead
+```
+
+### Error 2: @fieldwise_init conflict
+
+```text
+error: 'TrainingCallbacks' has an explicitly declared fieldwise
+initializer ('__init__') so it cannot use '@fieldwise_init'
+```
+
+### Error 3: Flaky CI tests
+
+```text
+Core NN Modules: Runtime error (pre-existing issue)
+Core Layers: Test failure (intermittent)
+```
+
+Resolution: `gh run rerun <run-id> --failed`
+
+### Error 4: Ralph-loop hook stuck
+
+File `.claude/ralph-loop.local.md` with `active: false` continued triggering.
+Resolution: Delete file entirely.
+
+## Blocked Items Analysis
+
+| Location | Blocker | Tracking |
+|----------|---------|----------|
+| profiling.mojo:650 | Mojo FileIO | No issue |
+| logging.mojo:442 | Mojo env vars | No issue |
+| mixed_precision.mojo:284 | SIMD FP16 | No issue |
+| mixed_precision.mojo:368 | SIMD FP16 | No issue |
+| training/__init__.mojo:412 | Track 4 | Internal |
+| trainer_interface.mojo:392 | Track 4 | Internal |
+
+## Time Breakdown
+
+| Phase | Time |
+|-------|------|
+| Discovery & planning | 15 min |
+| PR creation (7 PRs) | 45 min |
+| CI wait & retries | 50 min |
+| Error fixing | 10 min |
+| Total | ~2 hours |

--- a/plugins/debugging/fixme-todo-cleanup/skills/fixme-todo-cleanup/SKILL.md
+++ b/plugins/debugging/fixme-todo-cleanup/skills/fixme-todo-cleanup/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: fixme-todo-cleanup
+category: debugging
+version: 1.0.0
+triggers:
+  - cleanup FIXME items
+  - cleanup TODO items
+  - technical debt reduction
+---
+
+# FIXME/TODO Cleanup Skill
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-01-01 |
+| Objective | Systematically resolve all FIXME/TODO items in a directory |
+| Outcome | 7 PRs merged, 3 issues closed |
+| Category | debugging |
+
+## When to Use
+
+- User requests cleanup of FIXME/TODO items across a codebase
+- Technical debt reduction initiative
+- Pre-release code quality sweep
+- Issue tracking consolidation
+
+## Verified Workflow
+
+### 1. Discovery Phase
+
+```bash
+# Find all FIXME/TODO items
+grep -rn "FIXME\|TODO" shared/ --include="*.mojo"
+```
+
+### 2. Categorization
+
+Group items by:
+
+- **Stale references**: FIXME pointing to closed issues
+- **Missing implementations**: Placeholder code needing real logic
+- **External blockers**: Items blocked by language/compiler features
+- **Documentation**: TODO in docs describing future work
+
+### 3. Execution Pattern
+
+For each actionable item:
+
+```bash
+# 1. Create branch from latest main
+git checkout main && git pull origin main
+git checkout -b <issue-number>-<description>
+
+# 2. Make the fix (one FIXME per commit)
+
+# 3. Validate
+just pre-commit-all
+pixi run mojo test tests/
+
+# 4. Commit with issue reference
+git add . && git commit -m "fix(scope): description
+
+Closes #<issue>"
+
+# 5. Push and create PR with auto-merge
+git push -u origin <branch-name>
+gh pr create --body "Closes #<issue>"
+gh pr merge --auto --rebase
+```
+
+### 4. Handle Flaky CI
+
+```bash
+# Retry failed jobs
+gh run rerun <run-id> --failed
+```
+
+## Failed Attempts
+
+### 1. `@value` to `@fieldwise_init` Migration
+
+**What was tried**: Replace deprecated `@value` decorator with `@fieldwise_init`
+
+**Error**:
+
+```text
+error: 'TrainingCallbacks' has an explicitly declared fieldwise initializer
+```
+
+**Why it failed**: `@fieldwise_init` generates an `__init__` method, conflicting with custom `__init__`
+
+**Solution**: Remove decorator entirely, keep explicit `Copyable, Movable` conformances:
+
+```mojo
+# Before (broken)
+@fieldwise_init
+struct TrainingCallbacks(Copyable, Movable):
+    fn __init__(out self, verbose: Bool = True):
+        self.verbose = verbose
+
+# After (working)
+struct TrainingCallbacks(Copyable, Movable):
+    var verbose: Bool
+
+    fn __init__(out self, verbose: Bool = True):
+        self.verbose = verbose
+```
+
+### 2. Ralph-Loop Hook Stuck
+
+**What was tried**: Set `active: false` in ralph-loop.local.md
+
+**Why it failed**: Hook continued firing despite deactivation flag
+
+**Solution**: Delete the file entirely:
+
+```bash
+rm .claude/ralph-loop.local.md
+```
+
+## Results & Parameters
+
+### Items Resolved
+
+| PR | Issue | Description |
+|----|-------|-------------|
+| #3035 | - | Update stale issue references |
+| #3036 | #3031 | Remove MXFP4 FIXME |
+| #3037 | #3033 | Implement conftest fixtures |
+| #3038 | #3034 | Implement script_runner |
+| #3039 | #3034 | Implement dataset_loaders |
+| #3040 | #3034 | Export script utilities |
+| #3041 | #3032 | Update ExTensor Array API |
+
+### Items NOT Resolved (External Blockers)
+
+| File | Line | Blocker |
+|------|------|---------|
+| profiling.mojo | 650 | Mojo FileIO stability |
+| logging.mojo | 442 | Mojo env var support |
+| mixed_precision.mojo | 284, 368 | Compiler SIMD FP16 support |
+| training/__init__.mojo | 412 | Track 4 Python data loader |
+| trainer_interface.mojo | 392 | Track 4 Python data loader |
+
+### Git Configuration
+
+```yaml
+branch_naming: "<issue-number>-<description>"
+commit_format: "type(scope): description\n\nCloses #<issue>"
+merge_strategy: "rebase"
+auto_merge: true
+```
+
+## Key Learnings
+
+1. **Categorize first**: Not all FIXME/TODO items are actionable
+2. **One PR per fix**: Keeps changes atomic and reviewable
+3. **Auto-merge is essential**: Reduces manual intervention
+4. **Retry flaky tests**: Some CI tests are non-deterministic
+5. **Mojo decorator conflicts**: `@fieldwise_init` cannot coexist with custom `__init__`


### PR DESCRIPTION
## Summary
Added fixme-todo-cleanup skill for managing FIXME and TODO comments in codebase.

## Changes Made
- Created new skill for FIXME/TODO cleanup workflows
- Helps track and resolve technical debt markers

## Files Modified
- New skill configuration and implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)