### PR TITLE
fix(training): update FP16 SIMD blocker NOTEs with current status

### DIFF
--- a/shared/training/mixed_precision.mojo
+++ b/shared/training/mixed_precision.mojo
@@ -280,28 +280,14 @@ fn convert_to_fp32_master(params: ExTensor) raises -> ExTensor:
 
     # If FP16, use SIMD-optimized conversion when available
     if params.dtype() == DType.float16:
-        # NOTE: FP16 SIMD vectorization is blocked by Mojo compiler limitation.
-        # Mojo does not support SIMD load/store operations for FP16 types.
-        #
-        # Current Limitation: Mojo v0.26.1+ does not support SIMD vectorization for
-        # FP16 load operations. This prevents efficient bulk conversion from FP16 to FP32.
-        #
-        # Compiler Limitation Details:
-        # - DTypePointer.load[width=N]() doesn't support FP16 types
-        # - FP16 SIMD types exist but load/store operations are unimplemented
-        # - No way to vectorize bulk FP16→FP32 conversions in current compiler
+        # NOTE: FP16 SIMD vectorization is blocked by a Mojo compiler limitation
+        # (FP16 not supported as a SIMD element type as of Mojo v0.26.1).
+        # Tracked in project issue #3015; no upstream Mojo issue filed yet.
+        # Re-evaluate when Mojo adds FP16 SIMD load/store support.
         #
         # Workaround: Scalar loop conversion (one element at a time)
         # Performance Impact: ~10-15x slower than FP32→FP32 SIMD path
         # Expected Speedup When Fixed: ~4x (matching FP32→FP32 performance)
-        #
-        # Implementation Plan:
-        # When Mojo adds FP16 SIMD load support:
-        # 1. Load FP16 vectors with DTypePointer[Float16].load[width]()
-        # 2. Convert to FP32 with explicit cast or builtin function
-        # 3. Store with DTypePointer[Float32].store[width]()
-        #
-        # Reference: Track Mojo compiler releases for FP16 SIMD support
         var src_ptr = params._data.bitcast[Float16]()
         var dst_ptr = result._data.bitcast[Float32]()
         for i in range(size):
@@ -364,7 +350,10 @@ fn update_model_from_master(
         return
 
     # If FP16, use optimized conversion (scalar until Mojo supports FP16 SIMD)
-    # NOTE: FP16 SIMD vectorization is blocked by Mojo compiler limitation.
+    # NOTE: FP16 SIMD vectorization is blocked by a Mojo compiler limitation
+    # (FP16 not supported as a SIMD element type as of Mojo v0.26.1).
+    # Tracked in project issue #3015; no upstream Mojo issue filed yet.
+    # Re-evaluate when Mojo adds FP16 SIMD load/store support.
     # See convert_to_fp32_master() for detailed notes on FP16 SIMD limitations.
     if model_params.dtype() == DType.float16:
         _convert_fp32_to_fp16_simd(master_params, model_params)


### PR DESCRIPTION
## Summary

Updates the two FP16 SIMD blocker NOTEs in `shared/training/mixed_precision.mojo` with current tracking status.

## Changes

- Updated NOTE at line ~283 (`convert_to_fp32_master`): adds Mojo v0.26.1 version confirmation, project issue #3015 reference, and re-evaluation trigger; removes verbose implementation plan that duplicated info in helper function docs
- Updated NOTE at line ~367 (`update_model_from_master`): same version/tracking info added alongside existing cross-reference to detailed notes

## Verification

- FP16 SIMD limitation confirmed present in Mojo v0.26.1 (pixi.toml pins `>=0.26.1.0,<0.27`)
- All non-Mojo pre-commit hooks pass (mojo-format skipped due to GLIBC incompatibility in local env; CI Docker handles this)
- No functional code changes — comment-only update

Closes #3075