### PR TITLE
docs(training): add issue refs to Track 4 Python interop NOTEs

### DIFF
--- a/shared/training/__init__.mojo
+++ b/shared/training/__init__.mojo
@@ -402,12 +402,12 @@ struct TrainingLoop[
 
         Note:
             data_loader remains PythonObject until Track 4 implements
-            Mojo data loading infrastructure.
+            Mojo data loading infrastructure. Tracked in #3076 (parent: #3059).
         """
         var total_loss = Float64(0.0)
         var num_batches = Int(0)
 
-        # NOTE(#3092): Batch iteration blocked by Track 4 (Python↔Mojo interop).
+        # NOTE: Batch iteration blocked by Track 4 (Python↔Mojo interop) - see #3076 (parent: #3059).
         # The data_loader is currently a PythonObject, but step() requires ExTensor.
         # Once Track 4 data loading infrastructure is ready, integrate batching here.
         # Track resolution via #3076. Implement when Python↔Mojo interop is available.

--- a/shared/training/script_runner.mojo
+++ b/shared/training/script_runner.mojo
@@ -94,9 +94,9 @@ fn run_epoch_with_batches(
 
     Note:
         Currently returns 0.0 as placeholder until Python/Mojo
-        data loader integration is complete (Track 4 initiative).
+        data loader integration is complete (Track 4 initiative). Tracked in #3076 (parent: #3059).
     """
-    # Blocked: Track 4 (Python↔Mojo interop)
+    # Blocked: Track 4 (Python↔Mojo interop) - see #3076 (parent: #3059)
     # Full implementation requires Python data loader integration
     _ = py_loader
     _ = callbacks

--- a/shared/training/trainer_interface.mojo
+++ b/shared/training/trainer_interface.mojo
@@ -389,7 +389,7 @@ struct DataLoader(Copyable, Movable):
 
         # Tensor slicing is implemented in ExTensor.slice() and __getitem__()
         # NOTE: Python data loader integration blocked by Track 4 (Python↔Mojo interop).
-        # For now, we create placeholder tensors until Track 4 infrastructure is ready.
+        # Tracked in #3076 (parent: #3059). Placeholder tensors used until Track 4 is ready.
 
         self.current_batch += 1
 


### PR DESCRIPTION
## Summary

Updates 3 NOTE comments in `shared/training/` that document Python↔Mojo data loader
integration blocked by Track 4. Adds issue references (#3076 / #3059) so the blockers
are properly tracked and discoverable. No functional code changes.

## Files Modified

- `shared/training/trainer_interface.mojo:391-392` — add `#3076`/`#3059` reference
- `shared/training/__init__.mojo:404-413` — add references in docstring Note and inline comment
- `shared/training/script_runner.mojo:95-100` — add references in docstring and inline comment

## Verification

- All pre-commit hooks pass (mojo-format skipped: pre-existing GLIBC incompatibility in this
  environment, not related to comment-only changes)
- No compilation impact: comment-only changes cannot break Mojo builds

Closes #3076