### PR TITLE
cleanup(generators): mark template placeholders with TEMPLATE: prefix

### DIFF
--- a/scripts/generators/generate_dataset.py
+++ b/scripts/generators/generate_dataset.py
@@ -13,6 +13,12 @@ Usage:
         --format "text,label" \\
         --source csv \\
         --output datasets/text_dataset.mojo
+
+Template Placeholders:
+    The generated Mojo dataset files contain TEMPLATE: markers indicating
+    sections that must be implemented for the specific data source and format.
+    These are intentional scaffolding in the generated output, not
+    implementation gaps in this script.
 """
 
 import argparse
@@ -63,7 +69,7 @@ struct {{name}}(Dataset):
         Args:
             split: Data split to load ("train" or "test")
         \"\"\"
-        # TODO: Implement loading logic
+        # TEMPLATE: Implement loading logic
         # Example structure:
         # data_dir/
         #   train/
@@ -118,7 +124,7 @@ struct {{name}}(Dataset):
             batch_labels.append(sample[1])
 
         # Stack into batch tensors
-        # TODO: Implement proper stacking
+        # TEMPLATE: Implement proper stacking
         return (batch_images[0], ExTensor.from_list(batch_labels))
 """,
     "text": """
@@ -166,13 +172,13 @@ struct {{name}}(Dataset):
         Args:
             data_path: Path to data file
         \"\"\"
-        # TODO: Implement loading logic
+        # TEMPLATE: Implement loading logic
         # Supports: CSV, JSON, plain text
         raise Error("Not implemented: _load_data")
 
     fn _build_vocab(mut self):
         \"\"\"Build vocabulary from loaded texts.\"\"\"
-        # TODO: Implement vocabulary building
+        # TEMPLATE: Implement vocabulary building
         # Add special tokens: <PAD>, <UNK>, <BOS>, <EOS>
         self.vocab["<PAD>"] = 0
         self.vocab["<UNK>"] = 1
@@ -187,7 +193,7 @@ struct {{name}}(Dataset):
         Returns:
             List of token indices
         \"\"\"
-        # TODO: Implement tokenization
+        # TEMPLATE: Implement tokenization
         raise Error("Not implemented: _tokenize")
 
     fn __len__(self) -> Int:
@@ -243,7 +249,7 @@ struct {{name}}(Dataset):
             data_path: Path to CSV file
             target_column: Name of target column
         \"\"\"
-        # TODO: Implement CSV loading
+        # TEMPLATE: Implement CSV loading
         # 1. Read header for feature names
         # 2. Parse numeric values
         # 3. Separate features and labels
@@ -271,7 +277,7 @@ struct {{name}}(Dataset):
             mean: Optional precomputed mean
             std: Optional precomputed std
         \"\"\"
-        # TODO: Implement normalization
+        # TEMPLATE: Implement normalization
         raise Error("Not implemented: normalize")
 """,
     "custom": """
@@ -300,7 +306,7 @@ struct {{name}}(Dataset):
         Args:
             data_path: Path to data
         \"\"\"
-        # TODO: Implement custom loading logic
+        # TEMPLATE: Implement custom loading logic
         raise Error("Not implemented: _load_data")
 
     fn __len__(self) -> Int:

--- a/scripts/generators/generate_layer.py
+++ b/scripts/generators/generate_layer.py
@@ -13,6 +13,11 @@ Usage:
         --inputs "x:ExTensor" \\
         --params "reduction:Int=16" \\
         --output shared/nn/se_block.mojo
+
+Template Placeholders:
+    The generated Mojo layer files contain TEMPLATE: markers indicating sections
+    that must be implemented for the specific layer. These are intentional
+    scaffolding in the generated output, not implementation gaps in this script.
 """
 
 import argparse
@@ -132,7 +137,7 @@ def generate_layer_code(
             List of parameter tensors
         """
         var params = List[ExTensor]()
-        # TODO: Collect trainable parameters
+        # TEMPLATE: Collect trainable parameters
         # params.append(self.weight)
         # params.append(self.bias)
         return params'''
@@ -164,7 +169,7 @@ struct {name}(Module):
     """
 
 {member_vars_str}
-    # TODO: Add trainable parameters as needed
+    # TEMPLATE: Add trainable parameters as needed
     # var weight: ExTensor
     # var bias: ExTensor
 
@@ -174,7 +179,7 @@ struct {name}(Module):
         Args:{init_docs_str}
         """
 {member_inits_str}
-        # TODO: Initialize trainable parameters
+        # TEMPLATE: Initialize trainable parameters
         # self.weight = ExTensor.randn([out_features, in_features])
         # self.bias = ExTensor.zeros([out_features])
 
@@ -187,7 +192,7 @@ struct {name}(Module):
         Returns:
             Output tensor
         """
-        # TODO: Implement forward computation
+        # TEMPLATE: Implement forward computation
         {"var x = " + inputs[0][0] if inputs else "var x = input"}
 
         # Example computation:

--- a/scripts/generators/generate_model.py
+++ b/scripts/generators/generate_model.py
@@ -13,6 +13,13 @@ Usage:
         --type generative \\
         --layers "encoder:Conv2d,decoder:ConvTranspose2d" \\
         --output models/vae.mojo
+
+Template Placeholders:
+    The generated Mojo model files contain TEMPLATE: markers indicating sections
+    that must be implemented for the specific model architecture. These are
+    intentional scaffolding in the generated output, not implementation gaps
+    in this script. The Python fallback code (used when no layers are provided)
+    also emits TEMPLATE: markers to signal that layers must be added.
 """
 
 import argparse
@@ -97,7 +104,7 @@ struct {{name}}(Module):
             Latent representation
         \"\"\"
         var x = input
-        # TODO: Implement encoder
+        # TEMPLATE: Implement encoder
         return x
 
     fn decode(self, z: ExTensor) -> ExTensor:
@@ -110,7 +117,7 @@ struct {{name}}(Module):
             Reconstructed output
         \"\"\"
         var x = z
-        # TODO: Implement decoder
+        # TEMPLATE: Implement decoder
         return x
 
     fn forward(self, input: ExTensor) -> ExTensor:
@@ -166,7 +173,7 @@ struct {{name}}(Module):
 
 {{forward_pass}}
 
-        # TODO: Return class scores and bbox predictions
+        # TEMPLATE: Return class scores and bbox predictions
         return (x, x)
 
     fn parameters(self) -> List[ExTensor]:
@@ -263,7 +270,7 @@ def parse_layers(layers_str: str) -> list[tuple[str, str, dict]]:
 def generate_layer_declarations(layers: list[tuple[str, str, dict]]) -> str:
     """Generate layer variable declarations."""
     if not layers:
-        return "    # TODO: Add layer declarations\n    var placeholder: Linear"
+        return "    # TEMPLATE: Add layer declarations\n    var placeholder: Linear"
 
     lines = []
     for name, layer_type, _ in layers:
@@ -290,7 +297,7 @@ def generate_layer_initializations(layers: list[tuple[str, str, dict]], indent: 
 def generate_forward_pass(layers: list[tuple[str, str, dict]], indent: int = 8) -> str:
     """Generate forward pass code."""
     if not layers:
-        return " " * indent + "# TODO: Implement forward pass\n" + " " * indent + "x = self.placeholder(x)"
+        return " " * indent + "# TEMPLATE: Implement forward pass\n" + " " * indent + "x = self.placeholder(x)"
 
     lines = []
     prefix = " " * indent

--- a/scripts/generators/generate_tests.py
+++ b/scripts/generators/generate_tests.py
@@ -11,6 +11,12 @@ Usage:
         --module shared.nn.linear \\
         --test-type layer \\
         --output tests/shared/nn/test_linear.mojo
+
+Template Placeholders:
+    The generated Mojo test files contain TEMPLATE: markers indicating sections
+    that must be customized for the specific module under test. These are not
+    implementation gaps in this script — they are intentional scaffolding for
+    developers to fill in after code generation.
 """
 
 import argparse
@@ -45,13 +51,13 @@ fn create_test_data() -> ExTensor:
 # =============================================================================
 fn test_initialization():
     """Test basic initialization."""
-    # TODO: Test object creation
+    # TEMPLATE: Test object creation
     pass
 
 
 fn test_basic_operation():
     """Test basic operations."""
-    # TODO: Test core functionality
+    # TEMPLATE: Test core functionality
     pass
 
 
@@ -60,19 +66,19 @@ fn test_basic_operation():
 # =============================================================================
 fn test_empty_input():
     """Test behavior with empty inputs."""
-    # TODO: Test empty case handling
+    # TEMPLATE: Test empty case handling
     pass
 
 
 fn test_single_element():
     """Test behavior with single element."""
-    # TODO: Test single element case
+    # TEMPLATE: Test single element case
     pass
 
 
 fn test_large_input():
     """Test behavior with large inputs."""
-    # TODO: Test scalability
+    # TEMPLATE: Test scalability
     pass
 
 
@@ -81,7 +87,7 @@ fn test_large_input():
 # =============================================================================
 fn test_invalid_input():
     """Test error handling for invalid inputs."""
-    # TODO: Test error cases
+    # TEMPLATE: Test error cases
     pass
 
 
@@ -90,7 +96,7 @@ fn test_invalid_input():
 # =============================================================================
 fn test_integration():
     """Test integration with other components."""
-    # TODO: Test component interactions
+    # TEMPLATE: Test component interactions
     pass
 
 
@@ -147,7 +153,7 @@ from shared.testing import gradient_check, LayerTester
 # =============================================================================
 fn create_layer() -> {layer_type}:
     """Create layer instance for testing."""
-    # TODO: Configure layer parameters
+    # TEMPLATE: Configure layer parameters
     return {layer_type}()
 
 
@@ -167,7 +173,7 @@ fn test_forward_shape():
 
     var output = layer.forward(input)
 
-    # TODO: Verify expected output shape
+    # TEMPLATE: Verify expected output shape
     # assert_equal(output.shape()[0], expected_batch)
     # assert_equal(output.shape()[1], expected_features)
 
@@ -179,7 +185,7 @@ fn test_forward_values():
 
     var output = layer.forward(input)
 
-    # TODO: Verify expected output values
+    # TEMPLATE: Verify expected output values
     # With known inputs and weights, verify outputs
     pass
 
@@ -241,7 +247,7 @@ fn test_parameters():
     var layer = create_layer()
     var params = layer.parameters()
 
-    # TODO: Verify parameter count and shapes
+    # TEMPLATE: Verify parameter count and shapes
     # assert_true(len(params) > 0, "Layer should have parameters")
     pass
 
@@ -295,7 +301,7 @@ fn test_dtypes():
     var output_f32 = layer_f32.forward(input_f32)
     assert_equal(output_f32.dtype(), DType.float32)
 
-    # TODO: Test with other dtypes as supported
+    # TEMPLATE: Test with other dtypes as supported
     # var layer_f16 = create_layer()
     # var input_f16 = input_f32.to(DType.float16)
     # var output_f16 = layer_f16.forward(input_f16)
@@ -372,7 +378,7 @@ fn create_model() -> {model_type}:
 
 fn create_input() -> ExTensor:
     """Create test input tensor."""
-    # TODO: Adjust shape for model input requirements
+    # TEMPLATE: Adjust shape for model input requirements
     return ExTensor.randn([BATCH_SIZE, 3, 32, 32], seed=42)
 
 
@@ -533,7 +539,7 @@ fn test_parameter_count():
     for p in params:
         total_params += p[].numel()
 
-    # TODO: Update with expected parameter count
+    # TEMPLATE: Update with expected parameter count
     assert_true(total_params > 0, "Model should have parameters")
     print("  Total parameters:", total_params)
 


### PR DESCRIPTION
## Summary

- Reviewed all TODO comments across 4 generator scripts (31 total)
- Classified all TODOs as intentional template placeholders (none required separate issues or removal)
- Replaced `# TODO:` with `# TEMPLATE:` prefix in all generated Mojo output sections
- Added `Template Placeholders` documentation to each script's module docstring

## Files Changed

- `scripts/generators/generate_tests.py` - 14 TODOs → TEMPLATE:, added docstring section
- `scripts/generators/generate_model.py` - 5 TODOs → TEMPLATE:, added docstring section
- `scripts/generators/generate_layer.py` - 4 TODOs → TEMPLATE:, added docstring section
- `scripts/generators/generate_dataset.py` - 8 TODOs → TEMPLATE:, added docstring section

## Classification Results

All 31 TODOs were intentional template placeholders in the generated Mojo code scaffolding. No actual implementation gaps in the Python scripts were found, and no separate issues need to be created.

## Test plan

- [x] All pre-commit hooks pass (ruff format, ruff check, markdownlint, trailing whitespace, yaml)
- [x] No remaining `# TODO:` comments in the 4 generator scripts
- [x] Generated output now uses `# TEMPLATE:` to clearly signal developer action points

Closes #3080