### PR TITLE
cleanup(logging): remove unimplemented RotatingFileHandler placeholder

### DIFF
--- a/tests/shared/utils/test_logging.mojo
+++ b/tests/shared/utils/test_logging.mojo
@@ -203,17 +203,6 @@ fn test_file_handler() raises:
     # Clean up would happen after test (in real test framework)
 
 
-fn test_rotating_file_handler():
-    """Test rotating handler creates new file when size limit reached."""
-    # NOTE: RotatingFileHandler not yet implemented
-    # Placeholder for future implementation
-    # Would need to:
-    # - Create handler with 1KB max size
-    # - Write 2KB of log messages
-    # - Verify multiple log files created
-    pass
-
-
 fn test_multiple_handlers() raises:
     """Test logger can have multiple handlers (console + file)."""
     var logger = Logger("multi_handler_test", LogLevel.INFO)
@@ -431,7 +420,6 @@ fn main() raises:
     test_colored_output()
     test_console_handler()
     test_file_handler()
-    test_rotating_file_handler()
     test_multiple_handlers()
     test_log_training_start()
     test_log_epoch_metrics()


### PR DESCRIPTION
## Summary

- Removed `test_rotating_file_handler()` function from `tests/shared/utils/test_logging.mojo`
- Removed its call from `main()`

`RotatingFileHandler` requires file-size introspection and file renaming/rotation not available in Mojo v0.26.1's stdlib. The test body was already a no-op (`pass` with no assertions), so removing it eliminates dead code without losing test coverage.

## Test plan

- [x] No `RotatingFileHandler` references remain in the test file
- [x] Pre-commit hooks pass (all checks: Passed)
- [x] Part of cleanup tracked by #3059

Closes #3083

🤖 Generated with [Claude Code](https://claude.com/claude-code)