### PR TITLE
docs(lenet-emnist): document image loading limitation and Python interop workaround

### DIFF
--- a/examples/lenet-emnist/README.md
+++ b/examples/lenet-emnist/README.md
@@ -250,6 +250,32 @@ This example follows **Keep It Simple, Stupid** principles:
 - **Original MNIST**: <http://yann.lecun.com/exdb/mnist/>
 - **LeNet-5 Architecture**: <http://yann.lecun.com/exdb/lenet/>
 
+## Image Loading Limitations
+
+PNG/JPEG image loading is not natively supported in Mojo v0.26.1 (no stdlib image IO).
+
+The inference pipeline currently supports **IDX format only** (the same binary format used by MNIST/EMNIST).
+
+### Workaround: Python Interop
+
+Use Python PIL to preprocess images before inference:
+
+```python
+from PIL import Image
+import numpy as np
+
+img = Image.open("input.png").convert("L").resize((28, 28))
+raw = np.array(img, dtype=np.float32) / 255.0
+raw.tofile("input.raw")
+```
+
+Then pass `input.raw` as the input to `run_infer.mojo`.
+
+### Future Support
+
+Tracked in [#3087](https://github.com/homericintelligence/projectodyssey/issues/3087) (part of #3059).
+Will be resolved when Mojo stdlib adds image IO or a Python interop wrapper is added.
+
 ## Contributing
 
 This example is part of ML Odyssey. Contributions welcome!

--- a/examples/lenet-emnist/run_infer.mojo
+++ b/examples/lenet-emnist/run_infer.mojo
@@ -338,8 +338,12 @@ fn main() raises:
 
         # Load image (currently supports IDX format only)
         # NOTE: PNG/JPEG image loading requires external image processing libraries.
-        # Mojo does not yet have native image decoding support in its stdlib.
-        # For now, convert images to IDX format using Python preprocessing scripts.
+        # Status: Deferred (not implemented in Mojo)
+        # Why deferred: Mojo lacks native PNG/JPEG decoding; no stdlib image IO as of v0.26.1
+        # Workaround: Use Python interop (PIL/OpenCV) to load and convert images to raw tensors
+        #   before passing to this inference pipeline. See examples/lenet-emnist/README.md.
+        # Acceptance criteria: When Mojo stdlib ships image IO, or a Python interop wrapper is added
+        # Tracked in: GitHub issue #3087 (part of #3059)
         var image = load_image(config.image_path)
 
         if image.shape()[0] == 0:


### PR DESCRIPTION
## Summary

- Expands the bare `NOTE` comment in `run_infer.mojo:340` with structured deferred-item format (Status / Why Deferred / Workaround / Acceptance Criteria / Tracking)
- Adds an **Image Loading Limitations** section to `examples/lenet-emnist/README.md` with a Python PIL workaround snippet for users who need to load PNG/JPEG images

## Changes

- `examples/lenet-emnist/run_infer.mojo` — structured NOTE comment at line ~340
- `examples/lenet-emnist/README.md` — new "Image Loading Limitations" section before "Contributing"

## Verification

- [x] `markdownlint` passes
- [x] All other pre-commit hooks pass
- [x] Documentation-only change — no Mojo tests required

Closes #3087
Part of #3059