### PR TITLE
fix(training): update NOTE with Track 4 tracking reference

### DIFF
--- a/shared/training/__init__.mojo
+++ b/shared/training/__init__.mojo
@@ -408,9 +408,10 @@ struct TrainingLoop[
         var total_loss = Float64(0.0)
         var num_batches = Int(0)
 
-        # NOTE: Batch iteration blocked by Track 4 (Python↔Mojo interop).
+        # NOTE(#3092): Batch iteration blocked by Track 4 (Python↔Mojo interop).
         # The data_loader is currently a PythonObject, but step() requires ExTensor.
         # Once Track 4 data loading infrastructure is ready, integrate batching here.
+        # Track resolution via #3076. Implement when Python↔Mojo interop is available.
         _ = data_loader  # Suppress unused variable warning
 
         # Return average loss


### PR DESCRIPTION
## Summary

- Updated NOTE comment in `shared/training/__init__.mojo:411` to reference issue #3092 for traceability
- Added tracking reference via #3076 (Python interop blocker NOTEs)
- No logic changes — comment-only update

## Files Modified

- `shared/training/__init__.mojo` — Updated NOTE at line 411 with issue references

## Test plan

- [ ] No logic changes — only comment update
- [ ] Verified diff touches only the NOTE comment lines

Closes #3092
Part of #3059

🤖 Generated with [Claude Code](https://claude.com/claude-code)