### PR TITLE
docs(training): remove stale NOTE and update TrainingLoop trait bounds

### DIFF
--- a/tests/shared/training/test_training_loop.mojo
+++ b/tests/shared/training/test_training_loop.mojo
@@ -36,14 +36,16 @@ from shared.core.extensor import ExTensor
 from shared.core import ones, zeros, randn
 from shared.testing import SimpleMLP
 
-# NOTE: TrainingLoop is now generic with trait bounds (Issue #34 Track 2)
-# Generic instantiation pattern:
+# TrainingLoop is generic with trait bounds for compile-time type safety.
+#
+# Instantiation pattern:
 #   var training_loop = TrainingLoop[SimpleMLP, MSELoss, SGD](model, optimizer, loss_fn)
 #
 # Type parameters:
-#   [M: Model, L: Loss, O: Optimizer]
+#   [M: Model & Movable, L: Loss & Movable, O: Optimizer & Movable]
 #
-# This provides compile-time type safety - wrong types are rejected at compile time.
+# Wrong types are rejected at compile time. See shared/training/__init__.mojo for
+# full implementation and trait definitions.
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Remove stale `NOTE:` marker referencing resolved Issue #34 Track 2
- Update type parameter signature to match actual implementation (`& Movable` bounds)
- Add cross-reference to `shared/training/__init__.mojo` implementation
- Retain API orientation content useful for test readers

## Changes

`tests/shared/training/test_training_loop.mojo:39-46` — converted ad-hoc `NOTE:` comment into clean structured comment block.

## Test plan

- [ ] Documentation-only change, no functional code modified
- [ ] Comment accurately reflects actual `TrainingLoop` struct signature in `shared/training/__init__.mojo`

Closes #3094

🤖 Generated with [Claude Code](https://claude.com/claude-code)