### PR TITLE
cleanup(linear): remove deprecated LinearBackwardResult type aliases

### DIFF
--- a/shared/core/__init__.mojo
+++ b/shared/core/__init__.mojo
@@ -314,8 +314,6 @@ from shared.core.linear import (
     linear_no_bias,
     linear_backward,
     linear_no_bias_backward,
-    LinearBackwardResult,
-    LinearNoBiasBackwardResult,
 )
 
 from shared.core.conv import (

--- a/shared/core/linear.mojo
+++ b/shared/core/linear.mojo
@@ -11,17 +11,6 @@ from shared.core.reduction import sum
 from shared.core.gradient_types import GradientPair, GradientTriple
 
 
-# Backward compatibility aliases using generic gradient containers
-# DEPRECATED: Use GradientTriple directly instead of LinearBackwardResult
-# These aliases are maintained for backward compatibility during type consolidation.
-# See ADR-002 for the gradient struct return types design decision.
-comptime LinearBackwardResult = GradientTriple
-
-# DEPRECATED: Use GradientPair directly instead of LinearNoBiasBackwardResult
-# These aliases are maintained for backward compatibility during type consolidation.
-comptime LinearNoBiasBackwardResult = GradientPair
-
-
 fn linear(x: ExTensor, weights: ExTensor, bias: ExTensor) raises -> ExTensor:
     """Functional linear transformation: y = xW^T + b.
 
@@ -77,7 +66,7 @@ fn linear_no_bias(x: ExTensor, weights: ExTensor) raises -> ExTensor:
 
 fn linear_backward(
     grad_output: ExTensor, x: ExTensor, weights: ExTensor
-) raises -> LinearBackwardResult:
+) raises -> GradientTriple:
     """Backward pass for linear transformation.
 
         Computes gradients with respect to input, weights, and bias.
@@ -94,7 +83,7 @@ fn linear_backward(
             weights: Weight matrix from forward pass, shape (out_features, in_features).
 
     Returns:
-            LinearBackwardResult containing:
+            GradientTriple containing:
                 - grad_input: Gradient w.r.t. input, shape (batch_size, in_features).
                 - grad_kernel: Gradient w.r.t. weights, shape (out_features, in_features).
                 - grad_bias: Gradient w.r.t. bias, shape (out_features,).
@@ -131,12 +120,12 @@ fn linear_backward(
     # Sum over batch dimension to get (out_features,)
     var grad_bias = sum(grad_output, axis=0)
 
-    return LinearBackwardResult(grad_input^, grad_kernel^, grad_bias^)
+    return GradientTriple(grad_input^, grad_kernel^, grad_bias^)
 
 
 fn linear_no_bias_backward(
     grad_output: ExTensor, x: ExTensor, weights: ExTensor
-) raises -> LinearNoBiasBackwardResult:
+) raises -> GradientPair:
     """Backward pass for linear transformation without bias.
 
         Computes gradients with respect to input and weights only.
@@ -147,7 +136,7 @@ fn linear_no_bias_backward(
             weights: Weight matrix from forward pass, shape (out_features, in_features).
 
     Returns:
-            LinearNoBiasBackwardResult containing:
+            GradientPair containing:
                 - grad_input: Gradient w.r.t. input, shape (batch_size, in_features).
                 - grad_kernel: Gradient w.r.t. weights, shape (out_features, in_features).
 
@@ -160,4 +149,4 @@ fn linear_no_bias_backward(
     # grad_kernel = grad_output^T @ x
     var grad_kernel = matmul(transpose(grad_output), x)
 
-    return LinearNoBiasBackwardResult(grad_input^, grad_kernel^)
+    return GradientPair(grad_input^, grad_kernel^)

--- a/tests/shared/core/test_backward_compat_aliases.mojo
+++ b/tests/shared/core/test_backward_compat_aliases.mojo
@@ -1,10 +1,9 @@
 """Tests for backward compatibility type aliases.
 
 Tests that consolidated type aliases work correctly and maintain backward compatibility
-for code using the old names (LinearBackwardResult, Conv2dBackwardResult, etc).
+for code using the old names (Conv2dBackwardResult, etc).
 
 These aliases map the old type names to the new generic gradient container types:
-- LinearBackwardResult -> GradientTriple
 - Conv2dBackwardResult -> GradientTriple
 - BenchmarkStatistics -> BenchmarkResult
 
@@ -21,8 +20,6 @@ from shared.core import (
     GradientPair,
     GradientTriple,
     GradientQuad,
-    LinearBackwardResult,
-    LinearNoBiasBackwardResult,
     Conv2dBackwardResult,
     Conv2dNoBiasBackwardResult,
     DepthwiseConv2dBackwardResult,
@@ -36,36 +33,6 @@ from tests.shared.conftest import BenchmarkStatistics, BenchmarkResult
 # ============================================================================
 # Gradient Triple Alias Tests
 # ============================================================================
-
-
-fn test_linear_backward_result_alias() raises:
-    """Test LinearBackwardResult is an comptime for GradientTriple."""
-    print("Testing LinearBackwardResult alias...")
-
-    # Create test tensors
-    var shape = List[Int]()
-    shape.append(2)
-    shape.append(3)
-
-    var grad_input = zeros(shape, DType.float32)
-    var grad_weights = zeros(shape, DType.float32)
-    var grad_bias = zeros(shape, DType.float32)
-
-    # Create using comptime name
-    var result: LinearBackwardResult = LinearBackwardResult(
-        grad_input^, grad_weights^, grad_bias^
-    )
-
-    # Verify it's the same as GradientTriple
-    assert_shape(
-        result.grad_input, shape, "grad_input should have correct shape"
-    )
-    assert_shape(
-        result.grad_weights, shape, "grad_weights should have correct shape"
-    )
-    assert_shape(result.grad_bias, shape, "grad_bias should have correct shape")
-
-    print("  ✓ LinearBackwardResult comptime works correctly")
 
 
 fn test_conv2d_backward_result_alias() raises:
@@ -183,34 +150,6 @@ fn test_depthwise_separable_conv2d_backward_result_alias() raises:
 
 
 # ============================================================================
-# Linear No Bias Tests
-# ============================================================================
-
-
-fn test_linear_no_bias_backward_result_alias() raises:
-    """Test LinearNoBiasBackwardResult is an comptime for GradientPair."""
-    print("Testing LinearNoBiasBackwardResult alias...")
-
-    var shape = List[Int]()
-    shape.append(2)
-    shape.append(3)
-
-    var grad_input = zeros(shape, DType.float32)
-    var grad_weights = zeros(shape, DType.float32)
-
-    # Create using comptime name
-    var result: LinearNoBiasBackwardResult = LinearNoBiasBackwardResult(
-        grad_input^, grad_weights^
-    )
-
-    # Verify it's a GradientPair (two fields)
-    assert_shape(result.grad_a, shape, "grad_a should have correct shape")
-    assert_shape(result.grad_b, shape, "grad_b should have correct shape")
-
-    print("  ✓ LinearNoBiasBackwardResult comptime works correctly")
-
-
-# ============================================================================
 # Benchmark Statistics Alias Tests
 # ============================================================================
 
@@ -253,14 +192,12 @@ fn test_alias_interoperability() raises:
     var grad_weights = zeros(shape, DType.float32)
     var grad_bias = zeros(shape, DType.float32)
 
-    # Create using generic GradientTriple (which IS LinearBackwardResult via alias)
+    # Create using GradientTriple directly
     var triple: GradientTriple = GradientTriple(
         grad_input^, grad_weights^, grad_bias^
     )
 
-    # Since LinearBackwardResult is an comptime for GradientTriple, the type IS the same
-    # No assignment needed - just verify the triple works
-    # Access fields through GradientTriple (same as LinearBackwardResult)
+    # Verify the triple fields are accessible
     assert_shape(triple.grad_input, shape, "grad_input should be accessible")
     assert_shape(
         triple.grad_weights, shape, "grad_weights should be accessible"
@@ -279,13 +216,11 @@ fn main() raises:
     """Run all backward compatibility comptime tests."""
     print("\n=== Backward Compatibility Alias Tests ===\n")
 
-    test_linear_backward_result_alias()
     test_conv2d_backward_result_alias()
     test_conv2d_no_bias_backward_result_alias()
     test_depthwise_conv2d_backward_result_alias()
     test_depthwise_separable_conv2d_backward_result_alias()
-    test_linear_no_bias_backward_result_alias()
     test_benchmark_statistics_alias()
     test_alias_interoperability()
 
-    print("\n✓ All 8 backward compatibility comptime tests passed\n")
+    print("\n✓ All 6 backward compatibility comptime tests passed\n")


### PR DESCRIPTION
## Summary

- Remove `LinearBackwardResult` and `LinearNoBiasBackwardResult` deprecated type aliases from `shared/core/linear.mojo`
- Replace all usages with canonical types `GradientTriple` and `GradientPair` directly
- Remove alias exports from `shared/core/__init__.mojo`
- Remove linear alias tests from `tests/shared/core/test_backward_compat_aliases.mojo`

## Files Changed

- `shared/core/linear.mojo` - removed alias definitions (lines 14-22), updated return types and docstrings
- `shared/core/__init__.mojo` - removed `LinearBackwardResult` and `LinearNoBiasBackwardResult` from exports
- `tests/shared/core/test_backward_compat_aliases.mojo` - removed `test_linear_backward_result_alias()` and `test_linear_no_bias_backward_result_alias()` tests

## Verification

- [x] All occurrences of `LinearBackwardResult` and `LinearNoBiasBackwardResult` removed from codebase
- [x] Canonical types `GradientTriple` and `GradientPair` used directly
- [x] Pre-commit hooks will run in CI

Closes #3065
Part of #3059

🤖 Generated with [Claude Code](https://claude.com/claude-code)