### PR TITLE
fix(ci): enforce security scanning on PRs and fix scan gaps

### DIFF
--- a/.github/workflows/security-pr-scan.yml
+++ b/.github/workflows/security-pr-scan.yml
@@ -41,12 +41,13 @@ jobs:
           chmod +x gitleaks
 
           # Run gitleaks detect with .gitleaks.toml config if it exists
+          # Use git log mode (default) to scan full git history, not just working directory
           if [ -f .gitleaks.toml ]; then
             echo "Using .gitleaks.toml configuration"
-            ./gitleaks detect --source=. --config=.gitleaks.toml --verbose --no-git --exit-code=1
+            ./gitleaks detect --source=. --config=.gitleaks.toml --verbose --exit-code=1
           else
             echo "No .gitleaks.toml found, using default configuration"
-            ./gitleaks detect --source=. --verbose --no-git --exit-code=1
+            ./gitleaks detect --source=. --verbose --exit-code=1
           fi
 
       - name: Display scan summary

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -4,6 +4,9 @@ name: Security Scanning
 # Target duration: < 5 minutes
 
 on:
+  # Run on all pull requests
+  pull_request:
+
   # Run on pushes to main
   push:
     branches:
@@ -97,7 +100,6 @@ jobs:
         with:
           config: auto
           generateSarif: true
-        continue-on-error: true
 
       - name: Upload SARIF results
         if: always()


### PR DESCRIPTION
## Summary

- Add `pull_request` trigger to `security-scan.yml` so SAST/dependency scanning runs on all PRs (not just push to main)
- Remove `continue-on-error: true` from the Semgrep step so scan failures block PR merge
- Remove `--no-git` from Gitleaks in `security-pr-scan.yml` to scan full git history instead of working directory only

## Changes

- `.github/workflows/security-scan.yml`: Added `pull_request:` trigger; removed `continue-on-error` from Semgrep step
- `.github/workflows/security-pr-scan.yml`: Removed `--no-git` flag from both Gitleaks invocations

## Test plan

- [x] YAML syntax validated for both modified files
- [x] `pull_request` trigger present in `security-scan.yml`
- [x] Semgrep step has no `continue-on-error`
- [x] Gitleaks uses git-aware mode (no `--no-git`)
- [x] `dependency-audit.yml` unchanged (no duplication issues)

Closes #3143

🤖 Generated with [Claude Code](https://claude.com/claude-code)