### PR TITLE
docs(adr): add ADR-009 to README index

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,6 +24,7 @@ An Architecture Decision Record captures a single architecture decision, includi
 | [ADR-006](ADR-006-benchmarking-infrastructure.md) | Benchmarking Infrastructure | Accepted | 2025-12-28 |
 | [ADR-007](ADR-007-training-infrastructure.md) | Training Infrastructure | Accepted | 2025-12-28 |
 | [ADR-008](ADR-008-coverage-tool-blocker.md) | Defer Code Coverage Until Mojo Tooling Available | Accepted | 2025-12-10 |
+| [ADR-009](ADR-009-heap-corruption-workaround.md) | Heap Corruption Workaround for Mojo Runtime Bug | Accepted | 2025-12-30 |
 
 ## ADR Status Lifecycle
 


### PR DESCRIPTION
## Summary

- ADR-009-heap-corruption-workaround.md existed but was not listed in the ADR index table in `docs/adr/README.md`
- Added the missing row with title, status (Accepted), and date (2025-12-30) sourced from the ADR file itself

## Test plan

- [x] `pixi run pre-commit run --all-files` passes (Markdown Lint, all other hooks)

Closes #3150

🤖 Generated with [Claude Code](https://claude.com/claude-code)