### PR TITLE
docs(adr): update ADR-003 status to Accepted (Deferred)

### DIFF
--- a/docs/adr/ADR-003-memory-pool-architecture.md
+++ b/docs/adr/ADR-003-memory-pool-architecture.md
@@ -1,6 +1,6 @@
 # ADR-003: Memory Pool Architecture for Small Tensor Allocations
 
-**Status**: Accepted
+**Status**: Accepted (Deferred)
 
 **Date**: 2025-12-28
 
@@ -298,7 +298,7 @@ struct PoolConfig:
 ## Document Metadata
 
 - **Location**: `/docs/adr/ADR-003-memory-pool-architecture.md`
-- **Status**: Accepted
+- **Status**: Accepted (Deferred)
 - **Review Frequency**: As-needed
 - **Next Review**: When Mojo v0.26+ releases
 - **Supersedes**: None


### PR DESCRIPTION
## Summary

- Update `docs/adr/ADR-003-memory-pool-architecture.md` status from `Accepted` to `Accepted (Deferred)` in both the header and Document Metadata section
- The ADR already had a "Current Limitation" section documenting that `pooled_alloc()`/`pooled_free()` bypass the pool via direct malloc pending Mojo global variable support — the status label now matches this reality

## Test plan

- [x] `markdownlint-cli2` passes on modified file
- [x] No functional code changes — documentation only

Closes #3151

🤖 Generated with [Claude Code](https://claude.com/claude-code)