### PR TITLE
fix(docker): replace cargo install just with pre-built binary, pin Pixi version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get update && apt-get install -y \
     wget \
     uuid \
     sudo \
-    cargo \
     && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub CLI (gh) as root
@@ -35,6 +34,9 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
 # Install Claude Code CLI
 RUN curl -fsSL https://claude.ai/install.sh | bash
 
+# Install just tool (pre-built binary, much faster than cargo install)
+RUN curl -fsSL https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+
 # ---------------------------
 # Stage 1.5: Create dev user
 # ---------------------------
@@ -47,7 +49,7 @@ RUN groupadd -g ${GROUP_ID} ${USER_NAME} && \
 
 # Set environment for dev user
 ENV HOME=/home/${USER_NAME}
-ENV PATH="$HOME/.local/bin:$HOME/.pixi/bin:$PATH:$HOME/.cargo/bin"
+ENV PATH="$HOME/.local/bin:$HOME/.pixi/bin:$PATH"
 
 # ---------------------------
 # Stage 2: Development environment
@@ -75,9 +77,6 @@ COPY --chown=${USER_NAME}:${USER_NAME} . .
 
 # Set Python path
 ENV PYTHONPATH=/workspace:${PYTHONPATH:-}
-
-# Install just tool
-RUN cargo install just --version 1.14.0
 
 # Install project dependencies
 RUN pixi install

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -8,6 +8,7 @@ FROM ubuntu:24.04 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PATH="/root/.pixi/bin:$PATH"
+ENV PIXI_VERSION=0.65.0
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
@@ -19,8 +20,8 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /build
 
-# Install Pixi
-RUN curl -fsSL https://pixi.sh/install.sh | bash
+# Install Pixi (pinned version for reproducible builds)
+RUN curl -fsSL https://pixi.sh/install.sh | PIXI_VERSION=${PIXI_VERSION} bash
 
 # Copy dependency files first (better layer caching)
 COPY pixi.toml pixi.lock ./
@@ -41,6 +42,7 @@ FROM ubuntu:24.04 AS runtime
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PATH="/root/.pixi/bin:$PATH"
 ENV PYTHONPATH=/app
+ENV PIXI_VERSION=0.65.0
 
 # Install minimal runtime dependencies
 RUN apt-get update && apt-get install -y \
@@ -50,8 +52,8 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /app
 
-# Install Pixi
-RUN curl -fsSL https://pixi.sh/install.sh | bash
+# Install Pixi (pinned version for reproducible builds)
+RUN curl -fsSL https://pixi.sh/install.sh | PIXI_VERSION=${PIXI_VERSION} bash
 
 # Copy dependency files
 COPY pixi.toml pixi.lock ./


### PR DESCRIPTION
## Summary

Fixes two Docker build performance issues identified in #3152:

- **Dockerfile**: Remove `cargo` apt dependency and `$HOME/.cargo/bin` from PATH (no longer needed)
- **Dockerfile**: Move `just` installation to base stage as root using the official pre-built binary installer (`just.systems/install.sh`) instead of slow `cargo install just --version 1.14.0` (which compiles from source via Rust)
- **Dockerfile.ci**: Pin `PIXI_VERSION=0.65.0` in both `builder` and `runtime` stages for reproducible builds instead of unpinned curl pipe

## Changes

- `Dockerfile:12-21` — remove `cargo` from apt deps
- `Dockerfile:34-38` — add `just` pre-built binary install in base stage (as root)
- `Dockerfile:49` — remove `$HOME/.cargo/bin` from PATH
- `Dockerfile:78-80` — remove `cargo install just` from development stage
- `Dockerfile.ci:11` — add `PIXI_VERSION=0.65.0` env in builder stage
- `Dockerfile.ci:24` — use `PIXI_VERSION` in pixi install
- `Dockerfile.ci:45` — add `PIXI_VERSION=0.65.0` env in runtime stage
- `Dockerfile.ci:56` — use `PIXI_VERSION` in pixi install

## Test plan

- [x] Pre-commit hooks pass (markdownlint, YAML, trailing whitespace, etc.)
- [x] No duplicate package installs
- [x] `cargo` removed — no Rust compilation required for `just`
- [x] Pixi version pinned for reproducible Docker builds

Closes #3152

🤖 Generated with [Claude Code](https://claude.com/claude-code)