### PR TITLE
docs(analysis-prompt): add output destination note

### DIFF
--- a/docs/ANALYSIS_PROMPT.md
+++ b/docs/ANALYSIS_PROMPT.md
@@ -3,6 +3,9 @@
 Use this prompt to perform a comprehensive per-component quality analysis of this repository.
 Paste it into a new Claude Code session at the root of ProjectOdyssey.
 
+**Output**: Present the analysis as conversation text only. Do not create files or commit
+the analysis to the repository.
+
 ---
 
 You are a senior software architect performing a comprehensive code and project quality review


### PR DESCRIPTION
## Summary

- Added a note to `docs/ANALYSIS_PROMPT.md` after line 4 clarifying that analysis output should be presented as conversation text only, not committed to the repository

## Changes

- `docs/ANALYSIS_PROMPT.md`: Added **Output** note after "Paste it into a new Claude Code session..." line

## Verification

- [x] `just pre-commit-all` passes (markdownlint and all other hooks pass)

Closes #3160