### PR TITLE
feat(ci): add mypy pre-commit hook for Python type checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,15 @@ repos:
         files: \.py$
         types: [python]
 
+  # Python type checking
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        files: ^scripts/.*\.py$
+        args: [--ignore-missing-imports, --no-strict-optional, --explicit-package-bases, --python-version, "3.10"]
+        additional_dependencies: [types-PyYAML]
+
   # Python formatting and linting
   - repo: local
     hooks:

--- a/scripts/generators/templates.py
+++ b/scripts/generators/templates.py
@@ -63,7 +63,7 @@ def validate_template(template: str, required_vars: list[str]) -> list[str]:
     Returns:
         List of missing variable names (empty if all present)
     """
-    missing = []
+    missing: list[str] = []
     for var in required_vars:
         pattern = r"\{\{\s*" + re.escape(var) + r"\s*\}\}"
         if not re.search(pattern, template):

--- a/scripts/validation.py
+++ b/scripts/validation.py
@@ -88,7 +88,7 @@ def check_required_sections(
     Returns:
         Tuple of (all_found, missing_sections).
     """
-    missing = []
+    missing: list[str] = []
 
     for section in required_sections:
         # Match heading at various levels (##, ###, etc.)


### PR DESCRIPTION
## Summary

- Add mypy hook to `.pre-commit-config.yaml` targeting `scripts/*.py`
- Configure with `--ignore-missing-imports`, `--no-strict-optional`, `--explicit-package-bases`, `--python-version 3.10`
- Add `types-PyYAML` as `additional_dependencies` so mypy's isolated env has YAML stubs
- Fix `missing: list[str] = []` type annotations in `scripts/generators/templates.py` and `scripts/validation.py`
- `mypy` was already present in `pixi.toml` — no changes needed there

## Test plan

- [x] `pixi run mypy scripts/ --ignore-missing-imports --no-strict-optional --explicit-package-bases --python-version 3.10` passes with no errors
- [x] `pixi run pre-commit run mypy --all-files` passes
- [x] `pixi run pre-commit run --all-files` — all hooks pass

Closes #3159

🤖 Generated with [Claude Code](https://claude.com/claude-code)