### PR TITLE
feat(core): implement __str__ and __repr__ on ExTensor

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -43,7 +43,9 @@ comptime MAX_TENSOR_BYTES: Int = 2_000_000_000  # 2 GB max per tensor
 comptime WARN_TENSOR_BYTES: Int = 500_000_000  # 500 MB warning threshold
 
 
-struct ExTensor(Copyable, ImplicitlyCopyable, Movable, Sized, Stringable, Representable):
+struct ExTensor(
+    Copyable, ImplicitlyCopyable, Movable, Representable, Sized, Stringable
+):
     """Dynamic tensor with runtime-determined shape and data type.
 
         ExTensor provides a flexible tensor implementation for machine learning workloads,

--- a/tests/shared/core/test_utility.mojo
+++ b/tests/shared/core/test_utility.mojo
@@ -352,7 +352,9 @@ fn test_str_readable() raises:
     """Test __str__ produces readable output."""
     var t = arange(0.0, 3.0, 1.0, DType.float32)
     var s = String(t)
-    assert_equal(s, "ExTensor([0.0, 1.0, 2.0], dtype=float32)", "__str__ format")
+    assert_equal(
+        s, "ExTensor([0.0, 1.0, 2.0], dtype=float32)", "__str__ format"
+    )
 
 
 fn test_repr_complete() raises:
@@ -364,7 +366,10 @@ fn test_repr_complete() raises:
     var r = repr(t)
     assert_equal(
         r,
-        "ExTensor(shape=[2, 2], dtype=float32, numel=4, data=[1.0, 1.0, 1.0, 1.0])",
+        (
+            "ExTensor(shape=[2, 2], dtype=float32, numel=4, data=[1.0, 1.0,"
+            " 1.0, 1.0])"
+        ),
         "__repr__ format",
     )
 


### PR DESCRIPTION
## Summary

- Add `Stringable` and `Representable` traits to `ExTensor` struct
- Implement `__str__` producing `ExTensor([v0, v1, ...], dtype=<dtype>)`
- Implement `__repr__` producing `ExTensor(shape=[...], dtype=<dtype>, numel=N, data=[...])`
- Activate `test_str_readable` and `test_repr_complete` in `test_utility.mojo`
- Add `assert_equal` to imports in `test_utility.mojo`

## Files Changed

- `shared/core/extensor.mojo` — added traits + `__str__`/`__repr__` methods after `__len__`
- `tests/shared/core/test_utility.mojo` — uncommented tests with concrete assertions

## Test plan

- [ ] `test_str_readable` passes: `String(t)` for `arange(0,3,1,float32)` == `"ExTensor([0.0, 1.0, 2.0], dtype=float32)"`
- [ ] `test_repr_complete` passes: `repr(t)` for `ones([2,2],float32)` == `"ExTensor(shape=[2, 2], dtype=float32, numel=4, data=[1.0, 1.0, 1.0, 1.0])"`
- [ ] All existing `test_utility.mojo` tests still pass
- [ ] Pre-commit hooks pass

Closes #3162

🤖 Generated with [Claude Code](https://claude.com/claude-code)