### PR TITLE
docs(claude-md): document matmul() as canonical call syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -864,6 +864,7 @@ Skills with `mcp_fallback` in YAML frontmatter will be updated to use direct CLI
 - **Mutating methods**: Use `mut self`
 - **Ownership transfer**: Use `^` operator for List/Dict/String
 - **List initialization**: Use literals `[1, 2, 3]` not `List[Int](1, 2, 3)`
+- **Matrix multiply**: Use `matmul(A, B)` — never call `A.__matmul__(B)` directly at call sites
 
 **Common Mistakes**: See [mojo-anti-patterns.md](/.claude/shared/mojo-anti-patterns.md) for 64+ failure patterns
 


### PR DESCRIPTION
Closes #3216