### PR TITLE
fix(testing): wrap long epsilon lines for mojo format compliance

### DIFF
--- a/shared/testing/layer_testers.mojo
+++ b/shared/testing/layer_testers.mojo
@@ -611,7 +611,10 @@ struct LayerTester:
         # floating-point rounding errors, making gradient checking inherently less precise.
         # CI testing showed 6.89% error on AlexNet Conv1, so 5% tolerance is insufficient.
         # Epsilon selection for float32: see GRADIENT_CHECK_EPSILON_FLOAT32 and issue #2704.
-        var epsilon = GRADIENT_CHECK_EPSILON_FLOAT32 if dtype == DType.float32 else GRADIENT_CHECK_EPSILON_OTHER
+        var epsilon = (
+            GRADIENT_CHECK_EPSILON_FLOAT32 if dtype
+            == DType.float32 else GRADIENT_CHECK_EPSILON_OTHER
+        )
         var tolerance = 1e-1  # 10% tolerance for all dtypes
 
         # Define forward function for gradient checking
@@ -770,7 +773,10 @@ struct LayerTester:
 
         # Epsilon for gradient checking: float32 uses GRADIENT_CHECK_EPSILON_FLOAT32 (3e-4)
         # to avoid precision loss in matmul operations. See issue #2704 for full analysis.
-        var epsilon = GRADIENT_CHECK_EPSILON_FLOAT32 if dtype == DType.float32 else GRADIENT_CHECK_EPSILON_OTHER
+        var epsilon = (
+            GRADIENT_CHECK_EPSILON_FLOAT32 if dtype
+            == DType.float32 else GRADIENT_CHECK_EPSILON_OTHER
+        )
 
         # Define forward function for gradient checking
         fn forward(x: ExTensor) raises escaping -> ExTensor:
@@ -932,7 +938,10 @@ struct LayerTester:
 
         # Epsilon for gradient checking: float32 uses GRADIENT_CHECK_EPSILON_FLOAT32 (3e-4)
         # to prevent precision loss. See issue #2704 for full analysis.
-        var epsilon = GRADIENT_CHECK_EPSILON_FLOAT32 if dtype == DType.float32 else GRADIENT_CHECK_EPSILON_OTHER
+        var epsilon = (
+            GRADIENT_CHECK_EPSILON_FLOAT32 if dtype
+            == DType.float32 else GRADIENT_CHECK_EPSILON_OTHER
+        )
         var tolerance = 1e-2 if dtype == DType.float32 else 1e-1
 
         # Define forward function for gradient checking


### PR DESCRIPTION
## Summary

Fixes the root blocker for CI on all 40 open PRs.

Three `var epsilon = ...` ternary expressions in `shared/testing/layer_testers.mojo`
(lines 614, 773, 935) exceeded mojo format's line length limit. This caused `mojo format`
to reformat the file on every CI run, making the required `pre-commit` check fail on
every PR branched from main.

## Changes

- `shared/testing/layer_testers.mojo`: Wrap 3 long ternary lines into the
  parenthesized multi-line form that `mojo format` produces

## Impact

Once this merges to main, rebasing all 40 open PRs onto the new main will fix
the `pre-commit` CI failure that is currently blocking auto-merge on all of them.

## Verification

- Exact format matches what `mojo format` produces (verified from CI diff in run 22772182873)
- No other changes to logic or behavior