### PR TITLE
fix(testing): apply mojo format to layer_testers.mojo; document ADR-009 findings

### DIFF
--- a/docs/adr/ADR-009-heap-corruption-workaround.md
+++ b/docs/adr/ADR-009-heap-corruption-workaround.md
@@ -32,6 +32,10 @@ rather than a bug in our code.
 3. **Cannot create minimal reproduction** - Tried 17 different isolated test cases
 4. **Requires exact sequence of 15 specific tests** - Any subset <15 works fine
 5. **Heap corruption in Mojo allocator** - Crash in `libKGENCompilerRTShared.so`
+6. **`^` operator in `__moveinit__` is NOT a fix** - Switching `_shape` and `_strides`
+   from `.copy()` to `^` corrupts list element values when the source List has been
+   mutated in-place (e.g. by `slice()`). The `.copy()` workaround in `__moveinit__`
+   is correct and necessary for Mojo 0.26.1.
 
 ### Constraints
 
@@ -184,9 +188,12 @@ bug that occurs after ~15 cumulative tests. See Issue #2942.
 
 ## Revision History
 
-| Version | Date       | Author      | Changes                              |
-| ------- | ---------- | ----------- | ------------------------------------ |
-| 1.0     | 2025-12-30 | Claude Code | Initial ADR documenting workaround   |
+| Version | Date       | Author      | Changes                                                              |
+| ------- | ---------- | ----------- | -------------------------------------------------------------------- |
+| 1.0     | 2025-12-30 | Claude Code | Initial ADR documenting workaround                                   |
+| 1.1     | 2026-03-06 | Claude Code | Investigation: `^` in `__moveinit__` corrupts slice shapes in Mojo  |
+|         |            |             | 0.26.1 — workaround (file splitting + `.copy()`) remains correct.   |
+|         |            |             | Also fixes `mojo format` line-length in `layer_testers.mojo`.       |
 
 ---
 

--- a/shared/testing/layer_testers.mojo
+++ b/shared/testing/layer_testers.mojo
@@ -611,7 +611,10 @@ struct LayerTester:
         # floating-point rounding errors, making gradient checking inherently less precise.
         # CI testing showed 6.89% error on AlexNet Conv1, so 5% tolerance is insufficient.
         # Epsilon selection for float32: see GRADIENT_CHECK_EPSILON_FLOAT32 and issue #2704.
-        var epsilon = GRADIENT_CHECK_EPSILON_FLOAT32 if dtype == DType.float32 else GRADIENT_CHECK_EPSILON_OTHER
+        var epsilon = (
+            GRADIENT_CHECK_EPSILON_FLOAT32 if dtype
+            == DType.float32 else GRADIENT_CHECK_EPSILON_OTHER
+        )
         var tolerance = 1e-1  # 10% tolerance for all dtypes
 
         # Define forward function for gradient checking
@@ -770,7 +773,10 @@ struct LayerTester:
 
         # Epsilon for gradient checking: float32 uses GRADIENT_CHECK_EPSILON_FLOAT32 (3e-4)
         # to avoid precision loss in matmul operations. See issue #2704 for full analysis.
-        var epsilon = GRADIENT_CHECK_EPSILON_FLOAT32 if dtype == DType.float32 else GRADIENT_CHECK_EPSILON_OTHER
+        var epsilon = (
+            GRADIENT_CHECK_EPSILON_FLOAT32 if dtype
+            == DType.float32 else GRADIENT_CHECK_EPSILON_OTHER
+        )
 
         # Define forward function for gradient checking
         fn forward(x: ExTensor) raises escaping -> ExTensor:
@@ -932,7 +938,10 @@ struct LayerTester:
 
         # Epsilon for gradient checking: float32 uses GRADIENT_CHECK_EPSILON_FLOAT32 (3e-4)
         # to prevent precision loss. See issue #2704 for full analysis.
-        var epsilon = GRADIENT_CHECK_EPSILON_FLOAT32 if dtype == DType.float32 else GRADIENT_CHECK_EPSILON_OTHER
+        var epsilon = (
+            GRADIENT_CHECK_EPSILON_FLOAT32 if dtype
+            == DType.float32 else GRADIENT_CHECK_EPSILON_OTHER
+        )
         var tolerance = 1e-2 if dtype == DType.float32 else 1e-1
 
         # Define forward function for gradient checking


### PR DESCRIPTION
## Summary

- Fix `mojo format` failure: wrap 3 long ternary expressions in `shared/testing/layer_testers.mojo` into parenthesized multi-line form
- Update ADR-009 revision history with investigation findings from issue #2942

## Investigation: `^` operator in `ExTensor.__moveinit__`

The original plan hypothesized that replacing `.copy()` with `^` in `ExTensor.__moveinit__` would fix the heap corruption. **This was tested and disproved:**

Using `existing._shape^` instead of `existing._shape.copy()` in `__moveinit__` corrupts List element values when the source List was mutated in-place before the move (as `slice()` does: `result._shape[axis] = end - start`). This broke `test_slicing.mojo` (`Batch shape[2]` assertion) and `test_trait_based_serialization.mojo`.

The `.copy()` workaround in `__moveinit__` is **correct and necessary** for Mojo 0.26.1. The original comment "to avoid potential corruption issues with List's internal buffer" was accurate — the corruption is real, just in a different direction than the plan expected.

## Changes

- `shared/testing/layer_testers.mojo`: mojo format wrap for 3 long ternaries
- `docs/adr/ADR-009-heap-corruption-workaround.md`: revision history + finding #6

## Test plan

- [x] Pre-commit hooks pass locally (mojo format, markdown lint)
- [ ] CI: pre-commit passes (no more long-line failures)
- [ ] CI: Core Tensors passes (test_slicing.mojo not affected)
- [ ] CI: link-check — pre-existing failure on all PRs, not caused by this

Related: #2942

🤖 Generated with [Claude Code](https://claude.com/claude-code)