### PR TITLE
fix(ci): fix link-check and security scanning workflows on main

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -53,6 +53,7 @@ jobs:
             --timeout 15
             --accept "200..=204,503,504"
             --exclude 'file:///'
+            --root-dir .
             '**/*.md'
 
           # Output results to a file

--- a/.github/workflows/security-pr-scan.yml
+++ b/.github/workflows/security-pr-scan.yml
@@ -1,4 +1,4 @@
-name: Security Scanning
+name: Secret Scanning
 
 # Comprehensive security scanning for secrets
 # Target duration: < 5 minutes

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -96,10 +96,9 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Run Semgrep
-        uses: returntocorp/semgrep-action@v1
+        uses: semgrep/semgrep-action@v1
         with:
           config: auto
-          generateSarif: true
 
       - name: Upload SARIF results
         if: always()

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -31,10 +31,3 @@ coderower\.com
 pullchecklist\.com
 geeksforgeeks\.org
 
-# Ignore root-relative links (lychee cannot resolve these without --root-url)
-# These are valid repo-relative paths in CLAUDE.md, docs/adr/, notebooks/README.md
-^/CLAUDE\.md$
-^/\.claude/
-^/agents/
-^/docs/
-^/examples/


### PR DESCRIPTION
## Summary

Fixes three CI configuration bugs causing consistent failures on main:

- **Check Markdown Links**: Added `--root-dir .` to lychee args so root-relative links
  (e.g. `/.claude/shared/pr-workflow.md`) resolve against the checkout directory.
  Removed now-unnecessary root-relative ignore patterns from `.lycheeignore`.
- **Security Scanning (semgrep)**: Replaced deprecated `returntocorp/semgrep-action@v1`
  with `semgrep/semgrep-action@v1` and removed the invalid `generateSarif` input that
  caused the action to fail.
- **Duplicate workflow name**: Renamed `security-pr-scan.yml` from "Security Scanning" to
  "Secret Scanning" to eliminate the confusing duplicate in the Actions UI.

## Files Modified

- `.github/workflows/link-check.yml` — add `--root-dir .` to lychee args
- `.lycheeignore` — remove root-relative ignore patterns (lines 34-40)
- `.github/workflows/security-scan.yml` — fix semgrep action reference and remove invalid input
- `.github/workflows/security-pr-scan.yml` — rename workflow to "Secret Scanning"

## Test Plan

- [ ] Check Markdown Links workflow passes (root-relative links resolve correctly)
- [ ] Security Scanning workflow passes (semgrep runs without invalid input error)
- [ ] Actions UI shows "Security Scanning" and "Secret Scanning" as distinct workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)