### PR TITLE
test(unsigned): add narrowing conversion tests (UInt64 -> UInt8 truncation)

### DIFF
--- a/tests/shared/core/test_unsigned.mojo
+++ b/tests/shared/core/test_unsigned.mojo
@@ -306,6 +306,43 @@ fn test_uint_type_min_max_operations() raises:
         raise Error("UInt32 max - 1 failed")
 
 
+fn test_uint_narrowing_conversion() raises:
+    """Test narrowing conversions that truncate via modulo 2^N semantics.
+
+    When casting a UInt64 value > 255 to UInt8, the result is the low 8 bits
+    of the original value, equivalent to value % 256.
+    """
+    # 256 % 256 = 0
+    var v256: UInt64 = 256
+    if v256.cast[DType.uint8]() != 0:
+        raise Error("UInt64(256).cast[DType.uint8]() should be 0")
+
+    # 257 % 256 = 1
+    var v257: UInt64 = 257
+    if v257.cast[DType.uint8]() != 1:
+        raise Error("UInt64(257).cast[DType.uint8]() should be 1")
+
+    # 511 % 256 = 255
+    var v511: UInt64 = 511
+    if v511.cast[DType.uint8]() != 255:
+        raise Error("UInt64(511).cast[DType.uint8]() should be 255")
+
+    # 512 % 256 = 0
+    var v512: UInt64 = 512
+    if v512.cast[DType.uint8]() != 0:
+        raise Error("UInt64(512).cast[DType.uint8]() should be 0")
+
+    # 255 fits exactly — no truncation
+    var v255: UInt64 = 255
+    if v255.cast[DType.uint8]() != 255:
+        raise Error("UInt64(255).cast[DType.uint8]() should be 255")
+
+    # 0 is a no-op
+    var v0: UInt64 = 0
+    if v0.cast[DType.uint8]() != 0:
+        raise Error("UInt64(0).cast[DType.uint8]() should be 0")
+
+
 fn main():
     """Main test runner for unsigned integer type tests."""
     try:
@@ -385,6 +422,12 @@ fn main():
         print("OK test_uint_widening_conversion")
     except e:
         print("FAIL test_uint_widening_conversion:", e)
+
+    try:
+        test_uint_narrowing_conversion()
+        print("OK test_uint_narrowing_conversion")
+    except e:
+        print("FAIL test_uint_narrowing_conversion:", e)
 
     try:
         test_uint_to_int_conversion()


### PR DESCRIPTION
## Summary

- Add `test_uint_narrowing_conversion()` to document truncation semantics of `.cast[DType.uint8]()` on `UInt64` values > 255
- Tests 6 boundary values: 256→0, 257→1, 511→255, 512→0, 255→255, 0→0
- Wire new test into `main()` alongside existing widening conversion test

## Test plan

- [x] All 6 narrowing boundary assertions added
- [x] Follows same pattern as existing `test_uint_widening_conversion()`
- [x] Pre-commit hooks pass (mojo format, trailing whitespace, etc.)
- [x] Total assertion count stays well within safe limits

Closes #3179

🤖 Generated with [Claude Code](https://claude.com/claude-code)