### PR TITLE
feat(training): add val_accuracy tracking to ValidationLoop.run()

### DIFF
--- a/shared/training/loops/validation_loop.mojo
+++ b/shared/training/loops/validation_loop.mojo
@@ -211,8 +211,19 @@ struct ValidationLoop:
             self.num_classes,
         )
 
-        # Update metrics
-        metrics.update_val_metrics(val_loss, 0.0)  # Accuracy placeholder.
+        # Compute accuracy over the full validation set if enabled
+        var val_accuracy = Float64(0.0)
+        if self.compute_accuracy:
+            var accuracy_metric = AccuracyMetric()
+            val_loader.reset()
+            while val_loader.has_next():
+                var batch = val_loader.next()
+                var predictions = model_forward(batch.data)
+                accuracy_metric.update(predictions, batch.labels)
+            val_accuracy = accuracy_metric.compute()
+
+        # Update metrics with computed accuracy
+        metrics.update_val_metrics(val_loss, val_accuracy)
 
         return val_loss
 

--- a/tests/training/test_training_infrastructure.mojo
+++ b/tests/training/test_training_infrastructure.mojo
@@ -274,6 +274,45 @@ fn test_validation_loop_initialization() raises:
     print("  ✓ ValidationLoop initialization correct")
 
 
+fn test_validation_loop_run_updates_val_accuracy() raises:
+    """Test that ValidationLoop.run() updates metrics.val_accuracy when compute_accuracy=True.
+
+    Uses deterministic data where all labels are class 0 and the mock model
+    returns input unchanged (zeros → argmax selects class 0), so accuracy = 1.0.
+    """
+    print("Testing ValidationLoop.run() updates val_accuracy...")
+
+    # Create data: 4 samples, 3 features (2D so argmax selects predicted class)
+    var data_shape = List[Int]()
+    data_shape.append(4)
+    data_shape.append(3)
+    var data = ExTensor(data_shape, DType.float32)
+
+    # Labels: shape [4], dtype int32, all zeros (class 0)
+    var labels_shape = List[Int]()
+    labels_shape.append(4)
+    var labels = ExTensor(labels_shape, DType.int32)
+
+    var val_loader = DataLoader(data, labels, batch_size=4)
+    var validation_loop = ValidationLoop(compute_accuracy=True)
+    var metrics = TrainingMetrics()
+
+    assert_equal(metrics.val_accuracy, 0.0, "val_accuracy starts at 0.0")
+
+    _ = validation_loop.run(
+        mock_model_forward, mock_compute_loss, val_loader, metrics
+    )
+
+    # mock_model_forward returns input (zeros, shape [4,3]) → argmax gives class 0
+    # labels are all 0 → accuracy = 1.0
+    assert_true(
+        metrics.val_accuracy > 0.0,
+        "val_accuracy updated to non-zero after run()",
+    )
+
+    print("  ✓ ValidationLoop.run() updates val_accuracy correctly")
+
+
 # ==================================================================
 # BaseTrainer Tests
 # ==================================================================
@@ -466,6 +505,7 @@ fn main() raises:
     print("\nValidationLoop Tests (#314)")
     print("-" * 70)
     test_validation_loop_initialization()
+    test_validation_loop_run_updates_val_accuracy()
 
     print("\nBaseTrainer Tests (#319)")
     print("-" * 70)
@@ -490,7 +530,7 @@ fn main() raises:
     print("  ✓ TrainingMetrics: Initialization, updates, reset, best tracking")
     print("  ✓ DataLoader: Batch iteration, reset, size calculation")
     print("  ✓ TrainingLoop: Initialization and configuration")
-    print("  ✓ ValidationLoop: Initialization and configuration")
+    print("  ✓ ValidationLoop: Initialization, configuration, and accuracy tracking")
     print("  ✓ BaseTrainer: Full lifecycle (init, metrics, checkpoints, reset)")
     print("  ✓ Factory functions: create_trainer, create_default_trainer")
     print("  ✓ Integration: Config→Trainer, Metrics flow")


### PR DESCRIPTION
## Summary

- Fix `ValidationLoop.run()` to compute and store real accuracy in `TrainingMetrics.val_accuracy` instead of the hardcoded `0.0` placeholder
- Add `test_validation_loop_run_updates_val_accuracy()` to verify `metrics.val_accuracy > 0.0` after `run()` with `compute_accuracy=True`

## Changes Made

### `shared/training/loops/validation_loop.mojo`

- In `run()`: after calling `validate()`, compute accuracy via a second pass using `AccuracyMetric` when `self.compute_accuracy=True`
- Pass the computed `val_accuracy` to `metrics.update_val_metrics()` instead of `0.0`

### `tests/training/test_training_infrastructure.mojo`

- Add `test_validation_loop_run_updates_val_accuracy()`: creates a `DataLoader` with deterministic data (4 samples, 3 features, all-zero values), instantiates `ValidationLoop(compute_accuracy=True)`, calls `run()`, and asserts `metrics.val_accuracy > 0.0`
- The test is deterministic: zero input → `argmax` selects class 0 → all-zero int32 labels match → accuracy = 1.0

## Verification

- All pre-commit hooks passed (mojo format, syntax validation, test coverage check)
- Mojo runtime unavailable locally due to GLIBC version mismatch; CI validates

Closes #3183