### PR TITLE
fix(extensor): fix reverse slicing with negative step in __getitem__(Slice)

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -830,11 +830,19 @@ struct ExTensor(
         if len(self._shape) != 1:
             raise Error("Single slice only supported for 1D tensors")
 
-        # Handle slice parameters
+        # Handle slice parameters — extract step first so defaults depend on sign
         var size = self._shape[0]
-        var start = slice.start.or_else(0)
-        var end = slice.end.or_else(size)
         var step = slice.step.or_else(1)
+
+        var start: Int
+        var end: Int
+        if step < 0:
+            # Negative step: default start=last element, default end=before index 0
+            start = slice.start.or_else(size - 1)
+            end = slice.end.or_else(-size - 1)
+        else:
+            start = slice.start.or_else(0)
+            end = slice.end.or_else(size)
 
         # Normalize negative indices
         if start < 0:
@@ -842,22 +850,15 @@ struct ExTensor(
         if end < 0:
             end = size + end
 
-        # Clamp to valid range
-        start = max(0, min(start, size))
-        end = max(0, min(end, size))
-
         # Handle negative step (reverse)
         var result_size: Int
         if step < 0:
-            # For reverse slicing
             var neg_step = -step
-            # Swap start and end, adjust for reverse indexing
-            var temp = start
-            start = end if end < size - 1 else size - 1
-            end = temp
-
-            # Calculate size
-            result_size = max(0, ceildiv(start - end + 1, neg_step))
+            # Clamp start to [0, size-1], end to [-1, size-1]
+            start = max(0, min(start, size - 1))
+            end = max(-1, min(end, size - 1))
+            # No swap: iterate src_idx = start - i * neg_step while src_idx > end
+            result_size = max(0, ceildiv(start - end, neg_step))
 
             # Create result tensor with shape
             var shape = List[Int]()
@@ -872,14 +873,16 @@ struct ExTensor(
 
             for i in range(result_size):
                 var src_idx = start - i * neg_step
-                if src_idx >= 0 and src_idx < size:
-                    var src_offset = src_idx * dtype_size
-                    var dst_offset = i * dtype_size
-                    for b in range(dtype_size):
-                        dst_ptr[dst_offset + b] = src_ptr[src_offset + b]
+                var src_offset = src_idx * dtype_size
+                var dst_offset = i * dtype_size
+                for b in range(dtype_size):
+                    dst_ptr[dst_offset + b] = src_ptr[src_offset + b]
 
             return result^
         else:
+            # Clamp forward slice to [0, size]
+            start = max(0, min(start, size))
+            end = max(0, min(end, size))
             # Normal forward slice
             result_size = max(0, ceildiv(end - start, step))
 

--- a/tests/shared/core/test_extensor_slicing.mojo
+++ b/tests/shared/core/test_extensor_slicing.mojo
@@ -329,8 +329,7 @@ fn main() raises:
     print("Testing strided slicing...")
     test_slice_1d_strided()
     test_slice_1d_strided_step3()
-    # Skip reverse for now - needs debugging
-    # test_slice_1d_reverse()
+    test_slice_1d_reverse()
     print("Strided slicing: PASSED")
 
     # Multi-dimensional slicing - skip for now


### PR DESCRIPTION
## Summary

- Fix wrong default sentinels for `start`/`end` when step is negative
- Fix broken swap/adjust logic that produced empty results for e.g. `t[3:1:-1]`
- Re-enable `test_slice_1d_reverse` which was skipped pending this fix

## Root Cause

The old code applied `or_else(0)` / `or_else(size)` as defaults before checking step sign, then swapped start/end with incorrect logic. For `t[3:1:-1]` this produced `result_size=0` instead of 2.

## Fix

Extract `step` first, then use sign-correct defaults (`size-1` / sentinel `-size-1` for negative step). Compute `result_size = ceildiv(start - end, neg_step)` with `end` clamped to `[-1, size-1]` — no swap needed.

## Verification

Traced through key cases:
- `t[::-1]` on size=5 → start=4, end=-1, size=5, indices [4,3,2,1,0] ✓
- `t[3:1:-1]` → start=3, end=1, size=2, indices [3,2] ✓
- `t[::-2]` on size=5 → start=4, end=-1, size=3, indices [4,2,0] ✓

Pre-commit hooks: all passed.

Closes #3191