### PR TITLE
fix(examples): replace ambiguous NOTE prints with plain status messages

### DIFF
--- a/examples/alexnet-cifar10/train_new.mojo
+++ b/examples/alexnet-cifar10/train_new.mojo
@@ -424,7 +424,7 @@ fn main() raises:
 
     # Simple training loop - process one batch per epoch for demonstration
     print("Starting training...")
-    print("Note: Processing single batch per epoch for demonstration")
+    print("Processing single batch per epoch (demonstration mode)")
     print()
 
     var _ = config.batch_size  # batch_size not used in simplified version
@@ -454,4 +454,4 @@ fn main() raises:
     print()
 
     print("Training complete!")
-    print("\nNote: This is a simplified version for demonstration.")
+    print("\nThis is a simplified demonstration version.")

--- a/examples/lenet-emnist/inference.mojo
+++ b/examples/lenet-emnist/inference.mojo
@@ -263,7 +263,7 @@ fn main() raises:
     print()
 
     print("Inference complete!")
-    print("\nNote: This implementation demonstrates the inference structure.")
+    print("\nThis implementation demonstrates the inference structure.")
     print(
         "Batch processing will be more efficient when tensor slicing is"
         " optimized."

--- a/examples/resnet18-cifar10/inference.mojo
+++ b/examples/resnet18-cifar10/inference.mojo
@@ -305,8 +305,7 @@ fn main() raises:
         print("  python examples/resnet18-cifar10/download_cifar10.py")
         print("  mojo run examples/resnet18-cifar10/train.mojo --epochs 200")
         print()
-        print("Note: Training requires batch_norm2d_backward implementation.")
-        print("See GAP_ANALYSIS.md for details.")
+        print("Training requires batch_norm2d_backward (see GAP_ANALYSIS.md).")
         return
 
     # Run inference


### PR DESCRIPTION
## Summary

- Audited all `examples/*/train.mojo` and `examples/*/infer.mojo` files for runtime `NOTE`/`TODO`/`FIXME` prints per issue #3194
- Removed 4 remaining `Note:` prefixed print statements across 3 files, rewording them as plain factual messages
- Zero `print.*NOTE|TODO|FIXME` matches remain in `examples/`

## Changes Made

| File | Change |
|------|--------|
| `examples/resnet18-cifar10/inference.mojo:308` | Merged two-line "Note:" into one factual statement |
| `examples/lenet-emnist/inference.mojo:266` | Removed `Note:` prefix |
| `examples/alexnet-cifar10/train_new.mojo:427` | Removed `Note:` prefix |
| `examples/alexnet-cifar10/train_new.mojo:457` | Removed `Note:` prefix |

## Verification

- `grep -rn 'print.*NOTE\|print.*TODO\|print.*FIXME' examples/` → **0 matches**
- All pre-commit hooks pass

Closes #3194