### PR TITLE
feat(training): enable BF16 in recommend_precision_dtype for large models

### DIFF
--- a/shared/training/dtype_utils.mojo
+++ b/shared/training/dtype_utils.mojo
@@ -235,7 +235,9 @@ fn dtype_to_string(dtype: DType) -> String:
 
 
 fn recommend_precision_dtype(
-    model_size_mb: Float64, hardware_has_fp16: Bool = True
+    model_size_mb: Float64,
+    hardware_has_fp16: Bool = True,
+    hardware_has_bf16: Bool = True,
 ) -> DType:
     """Recommend optimal precision dtype based on model size and hardware.
 
@@ -245,6 +247,9 @@ fn recommend_precision_dtype(
     Args:
             model_size_mb: Model size in megabytes.
             hardware_has_fp16: Whether hardware supports FP16 acceleration.
+            hardware_has_bf16: Whether hardware supports BF16 acceleration.
+                NOT supported on Apple Silicon — pass hardware_has_bf16=False
+                on Apple hardware.
 
     Returns:
             Recommended DType (float16, bfloat16, or float32).
@@ -252,7 +257,7 @@ fn recommend_precision_dtype(
         Recommendations:
             - Small models (<100MB): FP32 (speed gain minimal).
             - Medium models (100MB-1GB): FP16 if hardware supports it.
-            - Large models (>1GB): FP16/BF16 strongly recommended.
+            - Large models (>1GB): BF16 strongly recommended (FP16 if no BF16 hardware).
             - No FP16 hardware: FP32 (reduced precision not worth it).
 
         Example:
@@ -272,8 +277,11 @@ fn recommend_precision_dtype(
         # Medium model - FP16 recommended
         return DType.float16
     else:
-        # Large model - FP16 strongly recommended
-        return DType.float16
+        # Large model - BF16 strongly recommended for wider exponent range
+        if hardware_has_bf16:
+            return DType.bfloat16
+        else:
+            return DType.float16
 
 
 fn print_dtype_info(dtype: DType):

--- a/tests/shared/training/test_dtype_utils.mojo
+++ b/tests/shared/training/test_dtype_utils.mojo
@@ -176,12 +176,24 @@ fn test_recommend_precision_dtype() raises:
     var medium_dtype = recommend_precision_dtype(500.0, hardware_has_fp16=True)
     assert_equal(medium_dtype, DType.float16, "Medium models should use FP16")
 
-    # Large model with FP16 hardware - should recommend FP16
+    # Large model with BF16 hardware - should recommend BF16
     var large_dtype = recommend_precision_dtype(2000.0, hardware_has_fp16=True)
-    assert_equal(large_dtype, DType.float16, "Large models should use FP16")
+    assert_equal(large_dtype, DType.bfloat16, "Large models should use BF16")
 
-    # Large model without FP16 hardware - should recommend FP32
-    var no_hw_dtype = recommend_precision_dtype(2000.0, hardware_has_fp16=False)
+    # Large model without BF16 hardware (e.g. Apple Silicon) - should fall back to FP16
+    var large_no_bf16_dtype = recommend_precision_dtype(
+        2000.0, hardware_has_fp16=True, hardware_has_bf16=False
+    )
+    assert_equal(
+        large_no_bf16_dtype,
+        DType.float16,
+        "Large models without BF16 hardware should use FP16",
+    )
+
+    # Large model without FP16 or BF16 hardware - should recommend FP32
+    var no_hw_dtype = recommend_precision_dtype(
+        2000.0, hardware_has_fp16=False, hardware_has_bf16=False
+    )
     assert_equal(
         no_hw_dtype, DType.float32, "Without FP16 hardware should use FP32"
     )


### PR DESCRIPTION
## Summary

- Add `hardware_has_bf16: Bool = True` parameter to `recommend_precision_dtype()`
- For large models (>= 1000 MB), return `DType.bfloat16` when BF16 hardware is available
- Fall back to `DType.float16` when `hardware_has_bf16=False` (e.g. Apple Silicon)
- Update docstring to document the new parameter and corrected recommendation table

## Test plan

- Updated existing large-model assertion: `DType.float16` → `DType.bfloat16`
- Added test: large model with `hardware_has_bf16=False` → `DType.float16` (Apple Silicon guard)
- Added test: large model with `hardware_has_fp16=False, hardware_has_bf16=False` → `DType.float32`
- All pre-commit hooks pass (mojo format, trailing whitespace, end-of-file)

Closes #3202

🤖 Generated with [Claude Code](https://claude.com/claude-code)