### PR TITLE
refactor(testing): move GRADIENT_CHECK_EPSILON constants to gradient_checker.mojo

### DIFF
--- a/shared/testing/gradient_checker.mojo
+++ b/shared/testing/gradient_checker.mojo
@@ -40,6 +40,20 @@ References:
 from shared.core import ExTensor, zeros_like
 
 
+# ============================================================================
+# Gradient Checking Constants
+# ============================================================================
+
+# Epsilon for float32 gradient checking in matmul-heavy layers (conv2d, linear).
+# Using 1e-5 causes ~56% precision loss; 1e-4 gives 3.3% error (above tolerance).
+# 3e-4 gives 1.2% error, within the 1.5% tolerance threshold.
+# See issue #2704 (Floating-point precision loss in matmul) for full analysis.
+alias GRADIENT_CHECK_EPSILON_FLOAT32: Float64 = 3e-4
+
+# Epsilon for non-float32 dtypes (BF16, FP16) in gradient checking.
+alias GRADIENT_CHECK_EPSILON_OTHER: Float64 = 1e-3
+
+
 @fieldwise_init
 struct IndexGradientPair(Copyable, Movable):
     """Simple wrapper for (index, gradient) pair returned by sampled gradient checking.

--- a/shared/testing/layer_testers.mojo
+++ b/shared/testing/layer_testers.mojo
@@ -82,21 +82,9 @@ from shared.testing.gradient_checker import (
     compute_sampled_numerical_gradient,
     assert_gradients_close,
     assert_sampled_gradients_close,
+    GRADIENT_CHECK_EPSILON_FLOAT32,
+    GRADIENT_CHECK_EPSILON_OTHER,
 )
-
-
-# ============================================================================
-# Gradient Checking Constants
-# ============================================================================
-
-# Epsilon for float32 gradient checking in matmul-heavy layers (conv2d, linear).
-# Using 1e-5 causes ~56% precision loss; 1e-4 gives 3.3% error (above tolerance).
-# 3e-4 gives 1.2% error, within the 1.5% tolerance threshold.
-# See issue #2704 (Floating-point precision loss in matmul) for full analysis.
-alias GRADIENT_CHECK_EPSILON_FLOAT32: Float64 = 3e-4
-
-# Epsilon for non-float32 dtypes (BF16, FP16) in gradient checking.
-alias GRADIENT_CHECK_EPSILON_OTHER: Float64 = 1e-3
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Moves `GRADIENT_CHECK_EPSILON_FLOAT32` and `GRADIENT_CHECK_EPSILON_OTHER` constants from `layer_testers.mojo` to `gradient_checker.mojo` — the canonical source for gradient checking utilities
- Updates `layer_testers.mojo` to import the constants from `gradient_checker.mojo` instead of defining them locally
- No functional change; constants retain the same values (`3e-4` and `1e-3` respectively)

## Test plan

- [x] Pre-commit hooks pass (mojo format, trailing whitespace, etc.)
- [x] No logic changes — only constant relocation and import update
- [x] CI will validate compilation in Docker environment

Closes #3207

🤖 Generated with [Claude Code](https://claude.com/claude-code)