### PR TITLE
feat(precision): add Apple Silicon runtime guard to PrecisionConfig.bf16()

### DIFF
--- a/shared/training/precision_config.mojo
+++ b/shared/training/precision_config.mojo
@@ -21,6 +21,8 @@ Usage:
 See examples/mixed_precision_training.mojo for complete usage
 """
 
+from sys.info import is_apple_silicon
+
 from shared.core.extensor import ExTensor, full, zeros
 from shared.core.dtype_cast import cast_tensor
 from shared.core.numerical_safety import has_nan, has_inf
@@ -39,6 +41,22 @@ from shared.training.dtype_utils import (
     is_reduced_precision,
     dtype_to_string,
 )
+
+
+fn _check_bf16_platform_support(is_apple: Bool) raises:
+    """Raise an error if the platform does not support BF16.
+
+    Args:
+        is_apple: True if running on Apple Silicon hardware.
+
+    Raises:
+        Error: If is_apple is True, since bfloat16 is unsupported on Apple Silicon.
+    """
+    if is_apple:
+        raise Error(
+            "BF16 (bfloat16) is not supported on Apple Silicon."
+            " Use PrecisionConfig.fp16() instead."
+        )
 
 
 @fieldwise_init
@@ -197,7 +215,7 @@ struct PrecisionConfig(Copyable, Movable):
         )
 
     @staticmethod
-    fn bf16(initial_scale: Float32 = 65536.0) -> PrecisionConfig:
+    fn bf16(initial_scale: Float32 = 65536.0) raises -> PrecisionConfig:
         """Create BF16 (brain float) configuration.
 
         BF16 has wider exponent range than FP16, reducing overflow risk.
@@ -211,18 +229,18 @@ struct PrecisionConfig(Copyable, Movable):
         Returns:
             PrecisionConfig with BF16 settings.
 
-        Note:
-            Currently uses FP16 as BF16 is not natively supported in Mojo v0.26.1.
-            When Mojo adds native BF16 support, this will automatically use it
-            via the bfloat16_dtype comptime in dtype_utils.mojo.
+        Raises:
+            Error: If called on Apple Silicon where bfloat16 is unsupported.
+                   Use PrecisionConfig.fp16() instead on Apple Silicon.
 
-        BF16 Characteristics (when natively supported):
+        BF16 Characteristics:
             - 1 sign + 8 exponent + 7 mantissa = 16 bits.
             - Range: ~1e-38 to 3.4e38 (same as FP32).
             - Precision: ~2 decimal digits (less than FP16).
             - Better for large models due to wider exponent range.
+            - NOT supported on Apple Silicon hardware.
         """
-        # NOTE (Mojo v0.26.1): bfloat16_dtype aliases to float16_dtype until Mojo adds native BF16 support
+        _check_bf16_platform_support(is_apple_silicon())
         return PrecisionConfig(
             mode=PrecisionMode.BF16,
             compute_dtype=bfloat16_dtype,

--- a/tests/shared/training/test_bf16_apple_silicon_guard.mojo
+++ b/tests/shared/training/test_bf16_apple_silicon_guard.mojo
@@ -1,0 +1,111 @@
+"""Tests for the Apple Silicon guard in PrecisionConfig.bf16().
+
+These tests verify that:
+- The guard helper raises an error when Apple Silicon is simulated.
+- The guard helper does not raise on non-Apple Silicon (e.g., Linux CI).
+- PrecisionConfig.bf16() succeeds on non-Apple Silicon.
+- The error message matches the expected string.
+"""
+
+from shared.training.precision_config import PrecisionConfig, _check_bf16_platform_support
+
+
+fn test_check_bf16_platform_support_raises_on_apple() raises:
+    """Test that _check_bf16_platform_support raises when is_apple=True."""
+    print("Testing _check_bf16_platform_support raises on Apple Silicon...")
+
+    var caught = False
+    try:
+        _check_bf16_platform_support(True)
+    except e:
+        caught = True
+        var msg = String(e)
+        if "Apple Silicon" not in msg:
+            raise Error(
+                "Error message should mention 'Apple Silicon', got: " + msg
+            )
+        if "fp16" not in msg:
+            raise Error(
+                "Error message should suggest fp16 alternative, got: " + msg
+            )
+
+    if not caught:
+        raise Error(
+            "_check_bf16_platform_support(True) should raise an error"
+        )
+
+    print("✓ _check_bf16_platform_support raises on simulated Apple Silicon")
+
+
+fn test_check_bf16_platform_support_no_raise_on_non_apple() raises:
+    """Test that _check_bf16_platform_support does not raise when is_apple=False."""
+    print("Testing _check_bf16_platform_support passes on non-Apple Silicon...")
+
+    _check_bf16_platform_support(False)
+
+    print("✓ _check_bf16_platform_support does not raise on non-Apple Silicon")
+
+
+fn test_bf16_succeeds_on_non_apple_silicon() raises:
+    """Test that PrecisionConfig.bf16() succeeds on Linux CI (non-Apple Silicon)."""
+    print("Testing PrecisionConfig.bf16() succeeds on non-Apple Silicon...")
+
+    # On Linux CI, is_apple_silicon() returns False, so bf16() should not raise.
+    var config = PrecisionConfig.bf16()
+
+    if config.compute_dtype != DType.bfloat16:
+        raise Error("BF16 config should use bfloat16 compute dtype")
+    if config.storage_dtype != DType.bfloat16:
+        raise Error("BF16 config should use bfloat16 storage dtype")
+
+    print("✓ PrecisionConfig.bf16() succeeds on non-Apple Silicon")
+
+
+fn test_bf16_error_message_content() raises:
+    """Test the exact content of the Apple Silicon error message."""
+    print("Testing Apple Silicon error message content...")
+
+    var caught = False
+    var error_msg = String("")
+    try:
+        _check_bf16_platform_support(True)
+    except e:
+        caught = True
+        error_msg = String(e)
+
+    if not caught:
+        raise Error("Expected error was not raised")
+
+    if "BF16" not in error_msg and "bfloat16" not in error_msg:
+        raise Error(
+            "Error message should mention BF16/bfloat16, got: " + error_msg
+        )
+    if "Apple Silicon" not in error_msg:
+        raise Error(
+            "Error message should mention Apple Silicon, got: " + error_msg
+        )
+    if "PrecisionConfig.fp16()" not in error_msg:
+        raise Error(
+            "Error message should suggest PrecisionConfig.fp16(), got: "
+            + error_msg
+        )
+
+    print("✓ Error message has correct content")
+
+
+fn main() raises:
+    """Run all Apple Silicon guard tests."""
+    print("=" * 60)
+    print("BF16 APPLE SILICON GUARD TESTS")
+    print("=" * 60)
+    print()
+
+    test_check_bf16_platform_support_raises_on_apple()
+    test_check_bf16_platform_support_no_raise_on_non_apple()
+    test_bf16_succeeds_on_non_apple_silicon()
+    test_bf16_error_message_content()
+
+    print()
+    print("=" * 60)
+    print("ALL BF16 APPLE SILICON GUARD TESTS PASSED! ✓")
+    print("=" * 60)


### PR DESCRIPTION
## Summary

- Add a runtime guard in `PrecisionConfig.bf16()` that raises a descriptive `Error` when called on Apple Silicon hardware, where `DType.bfloat16` is unsupported
- Extract the guard logic into a testable helper `_check_bf16_platform_support(is_apple: Bool)` so CI (Linux) can exercise the error path without Apple Silicon hardware
- Add new test file with 4 tests covering the guard behavior

## Changes Made

### `shared/training/precision_config.mojo`

- Added `from sys.info import is_apple_silicon` import
- Added `_check_bf16_platform_support(is_apple: Bool) raises` module-level helper
- Updated `bf16()` signature from `-> PrecisionConfig` to `raises -> PrecisionConfig`
- `bf16()` now calls `_check_bf16_platform_support(is_apple_silicon())` before constructing the config

### `tests/shared/training/test_bf16_apple_silicon_guard.mojo` (new)

- `test_check_bf16_platform_support_raises_on_apple`: Verifies guard raises with `is_apple=True`
- `test_check_bf16_platform_support_no_raise_on_non_apple`: Verifies guard passes with `is_apple=False`
- `test_bf16_succeeds_on_non_apple_silicon`: Verifies `PrecisionConfig.bf16()` succeeds on Linux CI
- `test_bf16_error_message_content`: Verifies error message mentions BF16, Apple Silicon, and `fp16()` alternative

## Design Decisions

- **Fail loudly**: Raises `Error` rather than silently falling back to FP16. Silent fallback would change semantics without warning and cause correctness bugs. Users who want FP16 should call `PrecisionConfig.fp16()` explicitly.
- **Testable helper**: The `_check_bf16_platform_support` helper accepts an `is_apple: Bool` argument so tests can exercise the error path on Linux CI without requiring Apple Silicon hardware.
- All existing callers of `bf16()` already have `raises` in their function signatures, so no other files needed updating.

## Verification

- All pre-commit hooks pass (mojo format, trailing whitespace, etc.)
- Existing tests are unaffected (all callers already propagate `raises`)
- Mojo tests must run in CI (Docker) due to GLIBC version incompatibility on local machine

Closes #3203