### PR TITLE
docs(layer_testers): document planned epsilon/tolerance for BatchNorm backward (#3208)

### DIFF
--- a/shared/testing/layer_testers.mojo
+++ b/shared/testing/layer_testers.mojo
@@ -1147,10 +1147,14 @@ struct LayerTester:
         )
         assert_dtype(input, dtype, "BatchNorm backward: input dtype mismatch")
 
-        # Note: Actual BatchNorm backward gradient checking would be implemented
-        # when BatchNorm forward pass is available
-        # Epsilon and tolerance values will be dtype-specific when gradient checking is added
-        # For now, we validate that we can compute numerical gradients on the input
+        # Note: Actual BatchNorm backward gradient checking will be implemented
+        # when BatchNorm forward pass is available.
+        # NOTE: When adding gradient checking, use epsilon=3e-4 for float32 to avoid
+        # precision loss in normalization ops (consistent with conv2d/linear, see #2704).
+        # BatchNorm accumulates division errors across N*H*W elements, so use
+        # tolerance=1e-1 (10%) for all dtypes — same as conv2d backward (see #3090).
+        # NOTE: For other dtypes use epsilon=1e-3, tolerance=1e-1 (same pattern as #3090).
+        # For now, we validate that we can compute numerical gradients on the input.
 
         # Verify no NaN/Inf in input
         for i in range(input.numel()):


### PR DESCRIPTION
## Summary

- Upgrades vague comment in `test_batchnorm_layer_backward` to structured `NOTE` comments documenting planned epsilon/tolerance values for when gradient checking is eventually added (consistent with the #3090 pattern for conv2d/linear/activation backward testers)
- Confirms no pooling backward tester exists — nothing to audit there

## Changes Made

**`shared/testing/layer_testers.mojo` (lines 1150–1157)**

Replaced the vague 4-line comment with structured `NOTE` comments specifying:
- `epsilon=3e-4` for float32 (avoids precision loss in normalization ops, same as conv2d/linear — see #2704)
- `tolerance=1e-1` (10%) for all dtypes — consistent with conv2d backward (see #3090)
- `epsilon=1e-3` for other dtypes — same pattern as #3090

## Verification

- `pixi run pre-commit run --all-files` — all hooks pass (Mojo Format, markdown lint, trailing whitespace, etc.)

Closes #3208