### PR TITLE
docs(training): audit and document import limitations for shared/training submodules

### DIFF
--- a/shared/training/loops/__init__.mojo
+++ b/shared/training/loops/__init__.mojo
@@ -24,6 +24,17 @@ Example Usage:
         compute_batch_loss=my_batch_fn,
         epoch=1, total_epochs=100
     )
+
+Note:
+    All symbols in this module are re-exported cleanly through the parent
+    `shared.training` package. You may import directly from either location:
+
+    ```mojo
+    from shared.training.loops import TrainingLoop
+    from shared.training import TrainingLoop  # also works
+    ```
+
+    No Mojo re-export limitation applies here (unlike `shared.training.callbacks`).
 """
 
 # Export training loop implementations

--- a/shared/training/metrics/__init__.mojo
+++ b/shared/training/metrics/__init__.mojo
@@ -12,6 +12,17 @@ Includes:
 - Recall (Recall metric)
 
 All metrics implement the Metric trait for consistent interface
+
+Note:
+    All symbols in this module are re-exported cleanly through the parent
+    `shared.training` package. You may import directly from either location:
+
+    ```mojo
+    from shared.training.metrics import AccuracyMetric
+    from shared.training import AccuracyMetric  # also works
+    ```
+
+    No Mojo re-export limitation applies here (unlike `shared.training.callbacks`).
 """
 
 # Export base metric interface and utilities

--- a/shared/training/optimizers/__init__.mojo
+++ b/shared/training/optimizers/__init__.mojo
@@ -11,6 +11,17 @@ Includes:
 - LARS (Layer-wise Adaptive Rate Scaling)
 
 All optimizers follow pure functional design - caller manages state
+
+Note:
+    All symbols in this module are re-exported cleanly through the parent
+    `shared.training` package. You may import directly from either location:
+
+    ```mojo
+    from shared.training.optimizers import sgd_step
+    from shared.training import sgd_step  # also works
+    ```
+
+    No Mojo re-export limitation applies here (unlike `shared.training.callbacks`).
 """
 
 # Export optimizer implementations

--- a/shared/training/schedulers/__init__.mojo
+++ b/shared/training/schedulers/__init__.mojo
@@ -13,6 +13,17 @@ Includes:
 - WarmupStepLR: Combined warmup and step decay
 
 All schedulers are struct-based implementations of the LRScheduler trait
+
+Note:
+    All symbols in this module are re-exported cleanly through the parent
+    `shared.training` package. You may import directly from either location:
+
+    ```mojo
+    from shared.training.schedulers import StepLR
+    from shared.training import StepLR  # also works
+    ```
+
+    No Mojo re-export limitation applies here (unlike `shared.training.callbacks`).
 """
 
 # Export scheduler implementations


### PR DESCRIPTION
## Summary

- Audited all `__init__.mojo` files in `shared/training/` for `# NOTE:` re-export limitation comments (follow-up to #3091, part of #3059 cleanup sweep)
- Found that only `shared/training/__init__.mojo` had a callbacks re-export limitation — already documented in #3091
- Added `Note:` sections to `optimizers`, `schedulers`, `metrics`, and `loops` submodule docstrings confirming their symbols are cleanly re-exported through the parent package and distinguishing them from the callbacks limitation

## Changes Made

- `shared/training/optimizers/__init__.mojo`: Added `Note:` section confirming clean re-export
- `shared/training/schedulers/__init__.mojo`: Added `Note:` section confirming clean re-export
- `shared/training/metrics/__init__.mojo`: Added `Note:` section confirming clean re-export
- `shared/training/loops/__init__.mojo`: Added `Note:` section confirming clean re-export

## Verification

- All pre-commit hooks pass (mojo format, trailing whitespace, end-of-file)
- No functional changes — documentation only
- Audit confirmed: no additional re-export limitations exist beyond the callbacks limitation already documented

Closes #3210