### PR TITLE
docs(ci): reference open GLIBC tracking issues in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
   # On older hosts (Debian 10/Buster, glibc 2.28) the wrapper script detects the
   # incompatibility and exits 0 with a warning instead of failing the commit.
   # CI runs on Ubuntu 24.04 (glibc 2.39) and always formats.
-  # See docs/dev/mojo-glibc-compatibility.md for details. Ref: #3170
+  # See docs/dev/mojo-glibc-compatibility.md for details. Tracked: #3170 (closed), #3253, #3365
   - repo: local
     hooks:
       - id: mojo-format


### PR DESCRIPTION
## Summary

- Verified that the mojo-format GLIBC mismatch is already tracked as an infrastructure issue (#3170 closed, #3253 and #3365 open)
- Updated the tracking reference in `.pre-commit-config.yaml` to list all open follow-up issues alongside the closed original

## Changes Made

Single-line update to `.pre-commit-config.yaml` line 9:

```diff
-  # See docs/dev/mojo-glibc-compatibility.md for details. Ref: #3170
+  # See docs/dev/mojo-glibc-compatibility.md for details. Tracked: #3170 (closed), #3253, #3365
```

## Verification

- Deduplication search confirmed three issues track this problem (#3170 closed, #3253 and #3365 open)
- `docs/dev/mojo-glibc-compatibility.md` already documents the full problem, workaround, and resolution path
- Pre-commit hooks pass (YAML check, whitespace checks)

Closes #3212

🤖 Generated with [Claude Code](https://claude.com/claude-code)