### PR TITLE
feat(lint): ban .__matmul__() call sites via pre-commit hook and CI

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -42,6 +42,16 @@ jobs:
         run: |
           pixi run pre-commit run --all-files --show-diff-on-failure
 
+      - name: Enforce no .__matmul__() call sites
+        run: |
+          violations=$(grep -rn "\.__matmul__(" . --include="*.mojo" --exclude-dir=".pixi" --exclude-dir=".git" | grep -v "fn __matmul__(" | grep -v "# __matmul__" | grep -v "__matmul__.*deprecated")
+          if [ -n "$violations" ]; then
+            echo "::error::Found .__matmul__() call site(s). Use matmul(A, B) instead."
+            echo "$violations"
+            exit 1
+          fi
+          echo "No .__matmul__() call sites found."
+
       - name: Display helpful message on failure
         if: failure()
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,13 @@ repos:
         language: pygrep
         files: ^(benchmarks|examples|papers|scripts|shared|tests)/.*\.(mojo|🔥)$
         types: [text]
+      - id: no-matmul-call-sites
+        name: Enforce no .__matmul__() call sites
+        description: Ban .__matmul__( call sites in Mojo files (use matmul(A, B) instead). Ref #3215
+        entry: bash -c 'violations=$(grep -rn "\.__matmul__(" . --include="*.mojo" --exclude-dir=".pixi" --exclude-dir=".git" | grep -v "fn __matmul__(" | grep -v "# __matmul__" | grep -v "__matmul__.*deprecated"); if [ -n "$violations" ]; then echo "Found .__matmul__() call sites (use matmul(A, B) instead):"; echo "$violations"; exit 1; fi'
+        language: system
+        pass_filenames: false
+        always_run: true
 
   # Security checks - bandit for accurate Python security scanning
   # Replaces naive pygrep shell=True check with AST-based analysis


### PR DESCRIPTION
## Summary

- Adds a `no-matmul-call-sites` local pre-commit hook in `.pre-commit-config.yaml` that fails if any `.__matmul__(` call site appears in `.mojo` files
- Adds a matching CI step in `.github/workflows/pre-commit.yml` for belt-and-suspenders enforcement
- Excludes function definition lines (`fn __matmul__(`) and documentation references from both checks

## Test plan

- [x] Verified zero current violations before enabling enforcement
- [x] Confirmed the grep chain catches a real call site (`a.__matmul__(b)`)
- [x] Confirmed function definition lines (`fn __matmul__(self, ...)`) are correctly excluded
- [x] Pre-commit hooks passed on commit (new hook ran and passed)

Closes #3215

🤖 Generated with [Claude Code](https://claude.com/claude-code)