### PR TITLE
feat(shared): add LossTracker and AccuracyMetric as top-level shared exports

### DIFF
--- a/shared/__init__.mojo
+++ b/shared/__init__.mojo
@@ -68,8 +68,11 @@ from shared.version import VERSION, AUTHOR, LICENSE
 # Training schedulers (most commonly used)
 # from .training.schedulers import StepLR, CosineAnnealingLR
 
-# Training metrics (most commonly used)
-# from .training.metrics import Accuracy, LossTracker
+# Training metrics (most commonly used) — Issue #3221
+from shared.training.metrics import LossTracker, AccuracyMetric
+
+# Expose plan-canonical alias: Accuracy = AccuracyMetric
+alias Accuracy = AccuracyMetric
 
 # Training callbacks (most commonly used)
 # from .training.callbacks import EarlyStopping, ModelCheckpoint

--- a/shared/training/__init__.mojo
+++ b/shared/training/__init__.mojo
@@ -474,6 +474,17 @@ from shared.training.precision_config import PrecisionConfig, PrecisionMode
 # Export training configuration (Issue #2602)
 from shared.training.config import TrainingConfig
 
+# Export training metrics (Issue #3221)
+from shared.training.metrics import (
+    LossTracker,
+    Statistics,
+    ComponentTracker,
+    AccuracyMetric,
+    top1_accuracy,
+    topk_accuracy,
+    per_class_accuracy,
+)
+
 
 # Export CrossEntropyLoss wrapper (wraps core.loss.cross_entropy)
 struct CrossEntropyLoss(Loss, Movable):


### PR DESCRIPTION
## Summary

- Re-export `LossTracker`, `AccuracyMetric`, `Statistics`, `ComponentTracker`, and accuracy utility functions from `shared/training/__init__.mojo`
- Re-export `LossTracker` and `AccuracyMetric` from `shared/__init__.mojo`
- Add `alias Accuracy = AccuracyMetric` at the `shared` package level for plan-canonical naming

## Changes Made

- `shared/training/__init__.mojo`: Added `from shared.training.metrics import (LossTracker, Statistics, ComponentTracker, AccuracyMetric, top1_accuracy, topk_accuracy, per_class_accuracy)` block
- `shared/__init__.mojo`: Replaced commented-out metrics line with live imports and `alias Accuracy = AccuracyMetric`

## Approach

- **No struct renames** — `AccuracyMetric` stays as the concrete struct name to avoid breaking existing callers
- **Type alias** — `alias Accuracy = AccuracyMetric` satisfies the plan's canonical name with zero blast radius
- **No new files** — the implementation gap was purely missing re-exports

## Verification

- Pre-commit hooks pass (Mojo format, syntax checks, trailing whitespace)
- Existing tests import from `shared.training.metrics` directly and are unaffected
- CI will validate compilation in Docker (GLIBC mismatch prevents local `mojo build`)

Closes #3221