### PR TITLE
fix(gradient_checker): replace shallow copy with deep copy in check_gradients

### DIFF
--- a/shared/testing/gradient_checker.mojo
+++ b/shared/testing/gradient_checker.mojo
@@ -117,8 +117,8 @@ fn check_gradients(
 
     # Step 2: Compute numerical gradient using finite differences
     var numerical_grad = zeros_like(input)
-    var input_copy_plus = input.copy()
-    var input_copy_minus = input.copy()
+    var input_copy_plus = _deep_copy(input)
+    var input_copy_minus = _deep_copy(input)
 
     for i in range(input.numel()):
         # Save original value
@@ -226,8 +226,8 @@ fn check_gradients_verbose(
         var analytical_grad = backward_fn(grad_output, input)
 
         var numerical_grad = zeros_like(input)
-        var input_copy_plus = input.copy()
-        var input_copy_minus = input.copy()
+        var input_copy_plus = _deep_copy(input)
+        var input_copy_minus = _deep_copy(input)
 
         for i in range(input.numel()):
             var original_val = input._get_float64(i)

--- a/tests/shared/testing/test_gradient_checker_meta.mojo
+++ b/tests/shared/testing/test_gradient_checker_meta.mojo
@@ -540,6 +540,49 @@ fn test_gradient_checker_large_epsilon() raises:
 
 
 # ============================================================================
+# Memory Safety Tests
+# ============================================================================
+
+
+fn test_check_gradients_does_not_mutate_input() raises:
+    """Regression test: check_gradients must not mutate the original input tensor.
+
+    Verifies that the deep-copy fix for the shallow-copy memory hazard is in
+    place. Before the fix, `input.copy()` (a `__copyinit__` shallow copy) shared
+    the `_data` buffer with the original tensor, so `_set_float64` calls inside
+    check_gradients corrupted the caller's tensor. After the fix, `_deep_copy`
+    allocates an independent buffer and the original is never modified.
+    """
+    print("Memory safety: check_gradients does not mutate input...")
+
+    var x = full([2, 2], 1.0, DType.float32)
+
+    # Snapshot all values before the call
+    var before = List[Float64]()
+    for i in range(x.numel()):
+        before.append(x._get_float64(i))
+
+    fn forward(t: ExTensor) raises escaping -> ExTensor:
+        return square_forward(t)^
+
+    fn backward(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+        return square_backward_correct(grad, inp)^
+
+    _ = check_gradients(forward, backward, x, epsilon=1e-5, tolerance=1e-2)
+
+    # Assert every element is unchanged
+    for i in range(x.numel()):
+        var after_val = x._get_float64(i)
+        assert_equal(
+            after_val,
+            before[i],
+            "check_gradients mutated input at index " + String(i),
+        )
+
+    print("  OK: check_gradients does not mutate the original input tensor")
+
+
+# ============================================================================
 # Main Test Runner
 # ============================================================================
 
@@ -583,6 +626,10 @@ fn main() raises:
     print("-" * 70)
     test_gradient_checker_small_epsilon()
     test_gradient_checker_large_epsilon()
+
+    print("\n[6] Memory Safety Tests")
+    print("-" * 70)
+    test_check_gradients_does_not_mutate_input()
 
     print("\n" + "=" * 70)
     print("ALL GRADIENT CHECKER META-TESTS PASSED!")


### PR DESCRIPTION
## Summary

- `check_gradients` and `check_gradients_verbose` used `input.copy()` (`__copyinit__`) which is a **shallow copy** sharing the underlying `_data` pointer with the original tensor
- Mutating the copy inside the finite-difference loop corrupted the caller's tensor (memory hazard)
- Fixed by replacing both `input.copy()` calls in each function with `_deep_copy(input)`, matching the existing pattern in `check_gradient` (singular) at lines 766/775

## Changes Made

- `shared/testing/gradient_checker.mojo`: lines 120–121 and 229–230 — `input.copy()` → `_deep_copy(input)` (4 lines changed)
- `tests/shared/testing/test_gradient_checker_meta.mojo`: added `test_check_gradients_does_not_mutate_input()` regression test that snapshots input values before the call and asserts they are unchanged after

## Test Plan

- [x] Pre-commit hooks pass (mojo format, coverage validation, lint)
- [x] New regression test `test_check_gradients_does_not_mutate_input` directly covers the bug
- [ ] CI: `pixi run mojo test tests/shared/testing/test_gradient_checker_meta.mojo`
- [ ] CI: `pixi run mojo test tests/shared/core/test_gradient_checking.mojo`
- [ ] CI: `pixi run mojo test tests/shared/core/test_gradient_validation.mojo`
- [ ] CI: `pixi run mojo test tests/shared/testing/test_gradient_check.mojo`

Closes #3225

🤖 Generated with [Claude Code](https://claude.com/claude-code)