### PR TITLE
fix(tests): update test_packaging.mojo placeholders to actual API names

### DIFF
--- a/shared/__init__.mojo
+++ b/shared/__init__.mojo
@@ -9,7 +9,7 @@ This package provides reusable ML/AI components including:
 
 Usage:
     # Import commonly used components directly
-    from shared import Linear, Conv2D, ReLU, SGD, Adam, Tensor
+    from shared import linear, Conv2dLayer, ReLULayer, SGD, Adam, ExTensor
 
     # Import from specific modules for less common items
     from shared.core.layers import MaxPool2D, Dropout
@@ -18,16 +18,12 @@ Usage:
 
 Example:
     ```mojo
-    from shared import Linear, ReLU, Sequential, SGD
+    from shared.core.layers import Conv2dLayer, ReLULayer
+    from shared.training import SGD
 
-    # Build a simple model
-    model = Sequential([
-        Linear(784, 256),
-        ReLU(),
-        Linear(256, 128),
-        ReLU(),
-        Linear(128, 10),
-    ])
+    # Build a simple model using layer components
+    var conv = Conv2dLayer(1, 32, 3, 3)
+    var relu = ReLULayer()
 
     # Create optimizer
     optimizer = SGD(learning_rate=0.01, momentum=0.9)
@@ -51,7 +47,7 @@ from shared.version import VERSION, AUTHOR, LICENSE
 # These imports are commented out pending full layer implementation.
 
 # Core layers (most commonly used)
-# from .core.layers import Linear, Conv2D, ReLU, MaxPool2D, Dropout, Flatten
+# from .core.layers import Conv2dLayer, ReLULayer, MaxPool2D, Dropout, Flatten
 
 # Core activations (function form)
 # from .core.activations import relu, sigmoid, tanh, softmax
@@ -60,7 +56,7 @@ from shared.version import VERSION, AUTHOR, LICENSE
 # from .core.module import Module, Sequential
 
 # Core tensors
-# from .core.tensors import Tensor, zeros, ones, randn
+# from .core.extensor import ExTensor, zeros, ones, randn
 
 # Training optimizers (most commonly used)
 # from .training.optimizers import SGD, Adam, AdamW
@@ -73,6 +69,8 @@ from shared.training.metrics import LossTracker, AccuracyMetric
 
 # Expose plan-canonical alias: Accuracy = AccuracyMetric
 alias Accuracy = AccuracyMetric
+# Training metrics (most commonly used)
+# from .training.metrics import AccuracyMetric, LossTracker
 
 # Training callbacks (most commonly used)
 # from .training.callbacks import EarlyStopping, ModelCheckpoint
@@ -81,8 +79,8 @@ alias Accuracy = AccuracyMetric
 # from .training.loops import train_epoch, validate_epoch
 
 # Data components (most commonly used)
-# from .data.datasets import TensorDataset, ImageDataset
-# from .data.loaders import DataLoader
+# from .data.datasets import ExTensorDataset, ImageDataset
+# from .data.loaders import BatchLoader
 # from .data.transforms import Normalize, ToTensor, Compose
 
 # Data transforms (available now — re-exported from shared.data)
@@ -101,22 +99,22 @@ from shared.data import Normalize, Compose
 #
 # Users can import in multiple ways:
 #   from shared import core, training, data, utils  # Import modules
-#   from shared.core.layers import Linear           # Import specific items
+#   from shared.core.layers import Conv2dLayer       # Import specific items
 #   import shared                                     # Import whole package
 #
 # The following components will be available once implementation completes:
 #
 # Version info: VERSION, AUTHOR, LICENSE
-# Core - Layers: Linear, Conv2D, ReLU, MaxPool2D, Dropout, Flatten
+# Core - Layers: Conv2dLayer, ReLULayer, MaxPool2D, Dropout, Flatten
 # Core - Activations: relu, sigmoid, tanh, softmax
 # Core - Module system: Module, Sequential
-# Core - Tensors: Tensor, zeros, ones, randn
+# Core - Tensors: ExTensor, zeros, ones, randn
 # Training - Optimizers: SGD, Adam, AdamW
 # Training - Schedulers: StepLR, CosineAnnealingLR
-# Training - Metrics: Accuracy, LossTracker
+# Training - Metrics: AccuracyMetric, LossTracker
 # Training - Callbacks: EarlyStopping, ModelCheckpoint
 # Training - Loops: train_epoch, validate_epoch
-# Data - Datasets: TensorDataset, ImageDataset, DataLoader
+# Data - Datasets: ExTensorDataset, ImageDataset, BatchLoader
 # Data - Transforms: Normalize, ToTensor, Compose
 # Utils: Logger, plot_training_curves
 # Autograd: Automatic differentiation utilities (when available)

--- a/tests/shared/integration/test_packaging.mojo
+++ b/tests/shared/integration/test_packaging.mojo
@@ -275,10 +275,10 @@ fn test_paper_implementation_pattern() raises:
 #
 #     # Verify __all__ exists and is non-empty
 #     # var expected_exports = [
-#     #     "Linear", "Conv2D", "ReLU",
+#     #     "linear", "Conv2dLayer", "ReLULayer",
 #     #     "SGD", "Adam",
-#     #     "Accuracy",
-#     #     "DataLoader",
+#     #     "AccuracyMetric",
+#     #     "BatchLoader",
 #     #     "Logger",
 #     # ]
 


### PR DESCRIPTION
## Summary

- Update commented-out `test_public_api_exports` body in `test_packaging.mojo` to use actual API names
- Update `shared/__init__.mojo` documentation comments and example code to use actual implemented names instead of original planned names

## Changes Made

| Old (planned) | New (actual) |
|---|---|
| `Conv2D` | `Conv2dLayer` |
| `ReLU` | `ReLULayer` |
| `Tensor` | `ExTensor` |
| `Accuracy` | `AccuracyMetric` |
| `DataLoader` | `BatchLoader` |
| `TensorDataset` | `ExTensorDataset` |
| `Linear` (in usage example) | `Conv2dLayer`, `ReLULayer` |

## Files Modified

- `tests/shared/integration/test_packaging.mojo` — updated commented `test_public_api_exports` body (lines 277-283)
- `shared/__init__.mojo` — updated docstring, usage example, and all API name references in comments

## Verification

- All pre-commit hooks pass (mojo format, markdown lint, trailing whitespace, etc.)
- Changes are comment/documentation only — no functional code changes
- Mojo binary not available locally (GLIBC mismatch), CI will verify no regressions

Closes #3222