### PR TITLE
test(conv): add multi-channel backward pass tests for Conv2D

### DIFF
--- a/tests/shared/core/test_conv.mojo
+++ b/tests/shared/core/test_conv.mojo
@@ -768,6 +768,159 @@ fn test_conv2d_no_bias_backward_shapes() raises:
     assert_equal(grad_kernel.shape()[3], kW)
 
 
+fn test_conv2d_backward_multichannel_shapes() raises:
+    """Test conv2d_backward returns correct gradient shapes for multi-channel config.
+
+    Tests in_channels=3, out_channels=8 — typical first conv layer configuration.
+    Verifies grad_weights shape is (out_channels, in_channels, kH, kW) and
+    grad_input shape is (batch, in_channels, H, W).
+    """
+    var batch = 1
+    var in_channels = 3
+    var out_channels = 8
+    var in_height = 6
+    var in_width = 6
+    var kH = 3
+    var kW = 3
+    var stride = 1
+    var padding = 1
+
+    var input_shape = List[Int]()
+    input_shape.append(batch)
+    input_shape.append(in_channels)
+    input_shape.append(in_height)
+    input_shape.append(in_width)
+    var x = ones(input_shape, DType.float32)
+
+    var kernel_shape = List[Int]()
+    kernel_shape.append(out_channels)
+    kernel_shape.append(in_channels)
+    kernel_shape.append(kH)
+    kernel_shape.append(kW)
+    var kernel = ones(kernel_shape, DType.float32)
+
+    var bias_shape = List[Int]()
+    bias_shape.append(out_channels)
+    var bias = zeros(bias_shape, DType.float32)
+
+    # Forward pass: output shape (1, 8, 6, 6) with padding=1
+    var output = conv2d(x, kernel, bias, stride, padding)
+    var grad_output = ones(output.shape(), DType.float32)
+
+    # Backward pass
+    var result = conv2d_backward(grad_output, x, kernel, stride, padding)
+    var grad_input = result.grad_input
+    var grad_kernel = result.grad_weights
+    var grad_bias = result.grad_bias
+
+    # grad_input should match input shape: (batch, in_channels, H, W)
+    assert_equal(grad_input.shape()[0], batch)
+    assert_equal(grad_input.shape()[1], in_channels)
+    assert_equal(grad_input.shape()[2], in_height)
+    assert_equal(grad_input.shape()[3], in_width)
+
+    # grad_weights should match kernel shape: (out_channels, in_channels, kH, kW)
+    assert_equal(grad_kernel.shape()[0], out_channels)
+    assert_equal(grad_kernel.shape()[1], in_channels)
+    assert_equal(grad_kernel.shape()[2], kH)
+    assert_equal(grad_kernel.shape()[3], kW)
+
+    # grad_bias should match bias shape: (out_channels,)
+    assert_equal(grad_bias.shape()[0], out_channels)
+
+
+fn test_conv2d_backward_multichannel_values() raises:
+    """Test conv2d_backward computes correct gradients for multi-channel config.
+
+    Uses analytically tractable configuration (all ones, single spatial output)
+    to verify gradient accumulation across input channels and output channels.
+
+    Config: batch=1, in_channels=3, out_channels=8
+    Input: (1, 3, 3, 3) all ones, kernel: (8, 3, 3, 3) all ones
+    stride=1, padding=0 -> output shape: (1, 8, 1, 1)
+    grad_output = ones((1, 8, 1, 1))
+
+    Analytical expected values:
+    - grad_weights[oc, ic, kh, kw] = sum over (batch, oh, ow) of
+        grad_output[b, oc, oh, ow] * x[b, ic, oh+kh, ow+kw]
+        = 1.0 * 1.0 = 1.0 for every weight position
+    - grad_input[b, ic, ih, iw] = sum over oc of
+        grad_output[b, oc, oh, ow] * kernel[oc, ic, kh, kw]
+        = 8 output channels * 1.0 * 1.0 = 8.0 for every input position
+    - grad_bias[oc] = sum over (batch, oh, ow) of grad_output[b, oc, oh, ow]
+        = 1.0 (single spatial position, single batch item)
+    """
+    var batch = 1
+    var in_channels = 3
+    var out_channels = 8
+    var kH = 3
+    var kW = 3
+    var stride = 1
+    var padding = 0
+
+    # Input: (1, 3, 3, 3) all ones
+    var input_shape = List[Int]()
+    input_shape.append(batch)
+    input_shape.append(in_channels)
+    input_shape.append(3)
+    input_shape.append(3)
+    var x = ones(input_shape, DType.float32)
+
+    # Kernel: (8, 3, 3, 3) all ones
+    var kernel_shape = List[Int]()
+    kernel_shape.append(out_channels)
+    kernel_shape.append(in_channels)
+    kernel_shape.append(kH)
+    kernel_shape.append(kW)
+    var kernel = ones(kernel_shape, DType.float32)
+
+    var bias_shape = List[Int]()
+    bias_shape.append(out_channels)
+    var bias = zeros(bias_shape, DType.float32)
+
+    # Forward pass: output shape (1, 8, 1, 1) - 3x3 input, 3x3 kernel, no padding
+    var output = conv2d(x, kernel, bias, stride, padding)
+    var grad_output = ones(output.shape(), DType.float32)
+
+    # Backward pass
+    var result = conv2d_backward(grad_output, x, kernel, stride, padding)
+    var grad_input = result.grad_input
+    var grad_kernel = result.grad_weights
+    var grad_bias = result.grad_bias
+
+    # Verify grad_weights values: each weight gradient = 1.0
+    # (single spatial output position, all ones input and grad_output)
+    var n_weights = out_channels * in_channels * kH * kW
+    var grad_weights_data = grad_kernel._data.bitcast[Float32]()
+    for i in range(n_weights):
+        assert_almost_equal(
+            grad_weights_data[i],
+            Float32(1.0),
+            tolerance=1e-4,
+        )
+
+    # Verify grad_input values: each input gradient = 8.0
+    # (8 output channels each contributing kernel=1.0 * grad_output=1.0)
+    var n_inputs = batch * in_channels * 3 * 3
+    var grad_input_data = grad_input._data.bitcast[Float32]()
+    for i in range(n_inputs):
+        assert_almost_equal(
+            grad_input_data[i],
+            Float32(out_channels),
+            tolerance=1e-4,
+        )
+
+    # Verify grad_bias values: each bias gradient = 1.0
+    # (1 batch * 1 spatial position * grad_output=1.0)
+    var grad_bias_data = grad_bias._data.bitcast[Float32]()
+    for oc in range(out_channels):
+        assert_almost_equal(
+            grad_bias_data[oc],
+            Float32(1.0),
+            tolerance=1e-4,
+        )
+
+
 # ============================================================================
 # Integration Tests
 # ============================================================================
@@ -968,6 +1121,12 @@ fn main() raises:
 
     test_conv2d_no_bias_backward_shapes()
     print("✓ test_conv2d_no_bias_backward_shapes")
+
+    test_conv2d_backward_multichannel_shapes()
+    print("✓ test_conv2d_backward_multichannel_shapes")
+
+    test_conv2d_backward_multichannel_values()
+    print("✓ test_conv2d_backward_multichannel_values")
 
     # Integration tests
     test_conv2d_forward_backward_consistency()


### PR DESCRIPTION
## Summary

- Add `test_conv2d_backward_multichannel_shapes`: verifies gradient shapes for `in_channels=3, out_channels=8` (typical first conv layer) — confirms `grad_input` is `(batch, in_channels, H, W)` and `grad_weights` is `(out_channels, in_channels, kH, kW)`
- Add `test_conv2d_backward_multichannel_values`: verifies gradient values using analytically tractable all-ones config, confirming `grad_weights=1.0`, `grad_input=8.0` (accumulation from all 8 output channels), and `grad_bias=1.0`

Follow-up from #3085 which only tested single-channel backward passes.

Closes #3235

## Test plan

- [x] `test_conv2d_backward_multichannel_shapes` — shape assertions for all 3 gradient tensors with 3-channel input, 8-channel output
- [x] `test_conv2d_backward_multichannel_values` — value assertions using analytically computable all-ones configuration
- [x] All existing tests continue to pass (pre-commit hooks: Mojo Format, Validate Test Coverage, all passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)