### PR TITLE
feat(gradient_types): add Conv2dNoBiasGradient and DepthwiseConv2dNoBiasGradient structs

### DIFF
--- a/shared/core/__init__.mojo
+++ b/shared/core/__init__.mojo
@@ -207,6 +207,8 @@ from shared.core.gradient_types import (
     GradientPair,
     GradientTriple,
     GradientQuad,
+    Conv2dNoBiasGradient,
+    DepthwiseConv2dNoBiasGradient,
 )
 
 # ============================================================================

--- a/shared/core/conv.mojo
+++ b/shared/core/conv.mojo
@@ -16,6 +16,8 @@ from shared.core.gradient_types import (
     GradientPair,
     GradientTriple,
     GradientQuad,
+    Conv2dNoBiasGradient,
+    DepthwiseConv2dNoBiasGradient,
 )
 from shared.core.parallel_utils import should_parallelize
 
@@ -834,7 +836,7 @@ fn conv2d_no_bias_backward(
     kernel: ExTensor,
     stride: Int = 1,
     padding: Int = 0,
-) raises -> GradientPair:
+) raises -> Conv2dNoBiasGradient:
     """Backward pass for 2D convolution without bias.
 
     Args:
@@ -845,7 +847,7 @@ fn conv2d_no_bias_backward(
             padding: Padding used in forward pass.
 
     Returns:
-            GradientPair containing grad_input and grad_kernel.
+            Conv2dNoBiasGradient containing grad_input and grad_weights.
 
     Raises:
             Error: If tensor shapes are incompatible.
@@ -854,7 +856,7 @@ fn conv2d_no_bias_backward(
     # Copy needed fields before result is destroyed (ExTensor is ImplicitlyCopyable)
     var grad_input_copy = result.grad_input
     var grad_kernel_copy = result.grad_weights
-    return GradientPair(grad_input_copy^, grad_kernel_copy^)
+    return Conv2dNoBiasGradient(grad_input_copy^, grad_kernel_copy^)
 
 
 fn depthwise_conv2d(
@@ -1217,7 +1219,7 @@ fn depthwise_conv2d_no_bias_backward(
     kernel: ExTensor,
     stride: Int = 1,
     padding: Int = 0,
-) raises -> GradientPair:
+) raises -> DepthwiseConv2dNoBiasGradient:
     """Backward pass for depthwise 2D convolution without bias.
 
     Args:
@@ -1228,7 +1230,7 @@ fn depthwise_conv2d_no_bias_backward(
             padding: Padding used in forward pass.
 
     Returns:
-            GradientPair containing grad_input and grad_kernel.
+            DepthwiseConv2dNoBiasGradient containing grad_input and grad_weights.
 
     Raises:
             Error: If tensor shapes are incompatible.
@@ -1239,7 +1241,7 @@ fn depthwise_conv2d_no_bias_backward(
     # Copy needed fields before result is destroyed (ExTensor is ImplicitlyCopyable)
     var grad_input_copy = result.grad_input
     var grad_kernel_copy = result.grad_weights
-    return GradientPair(grad_input_copy^, grad_kernel_copy^)
+    return DepthwiseConv2dNoBiasGradient(grad_input_copy^, grad_kernel_copy^)
 
 
 # ============================================================================
@@ -1400,8 +1402,8 @@ fn depthwise_separable_conv2d_backward(
     var depthwise_result = depthwise_conv2d_no_bias_backward(
         grad_depthwise_output, x, depthwise_kernel, stride, padding
     )
-    var grad_input = depthwise_result.grad_a
-    var grad_depthwise_kernel = depthwise_result.grad_b
+    var grad_input = depthwise_result.grad_input
+    var grad_depthwise_kernel = depthwise_result.grad_weights
 
     return GradientQuad(
         grad_input^, grad_depthwise_kernel^, grad_pointwise_kernel^, grad_bias^
@@ -1441,8 +1443,8 @@ fn depthwise_separable_conv2d_no_bias_backward(
     var pointwise_result = conv2d_no_bias_backward(
         grad_output, depthwise_output, pointwise_kernel, stride=1, padding=0
     )
-    var grad_depthwise_output = pointwise_result.grad_a
-    var grad_pointwise_kernel = pointwise_result.grad_b
+    var grad_depthwise_output = pointwise_result.grad_input
+    var grad_pointwise_kernel = pointwise_result.grad_weights
 
     # Backward through depthwise convolution
     var depthwise_result = depthwise_conv2d_no_bias_backward(
@@ -1450,8 +1452,8 @@ fn depthwise_separable_conv2d_no_bias_backward(
     )
 
     # Extract fields before constructing result
-    var grad_input = depthwise_result.grad_a
-    var grad_depthwise_kernel = depthwise_result.grad_b
+    var grad_input = depthwise_result.grad_input
+    var grad_depthwise_kernel = depthwise_result.grad_weights
 
     return GradientTriple(
         grad_input^,

--- a/shared/core/gradient_types.mojo
+++ b/shared/core/gradient_types.mojo
@@ -6,6 +6,8 @@ return types which are not fully supported in the current Mojo version.
 This module defines:
 - GradientPair: For binary operations returning 2 gradients.
 - GradientTriple: For ternary operations returning 3 gradients.
+- Conv2dNoBiasGradient: For conv2d_no_bias_backward with semantic field names.
+- DepthwiseConv2dNoBiasGradient: For depthwise_conv2d_no_bias_backward.
 """
 
 from shared.core.extensor import ExTensor
@@ -140,3 +142,71 @@ struct GradientQuad(Copyable, Movable):
         self.grad_b = grad_b^
         self.grad_c = grad_c^
         self.grad_d = grad_d^
+
+
+struct Conv2dNoBiasGradient(Copyable, Movable):
+    """Container for gradients from conv2d_no_bias_backward.
+
+    Uses the same field naming convention as GradientTriple to align with
+    conv2d_backward, making no-bias and biased conv backward results consistent.
+
+    Attributes:
+        grad_input: Gradient with respect to input activation.
+        grad_weights: Gradient with respect to convolution kernel.
+
+    Examples:
+        ```mojo
+        var grads = conv2d_no_bias_backward(grad_output, x, kernel)
+        var grad_input = grads.grad_input
+        var grad_weights = grads.grad_weights
+        ```
+    """
+
+    var grad_input: ExTensor
+    """Gradient with respect to input activation."""
+    var grad_weights: ExTensor
+    """Gradient with respect to convolution kernel."""
+
+    fn __init__(out self, var grad_input: ExTensor, var grad_weights: ExTensor):
+        """Initialize conv2d no-bias gradient.
+
+        Args:
+            grad_input: Gradient tensor for input.
+            grad_weights: Gradient tensor for kernel weights.
+        """
+        self.grad_input = grad_input^
+        self.grad_weights = grad_weights^
+
+
+struct DepthwiseConv2dNoBiasGradient(Copyable, Movable):
+    """Container for gradients from depthwise_conv2d_no_bias_backward.
+
+    Uses the same field naming convention as GradientTriple to align with
+    depthwise_conv2d_backward.
+
+    Attributes:
+        grad_input: Gradient with respect to input activation.
+        grad_weights: Gradient with respect to depthwise convolution kernel.
+
+    Examples:
+        ```mojo
+        var grads = depthwise_conv2d_no_bias_backward(grad_output, x, kernel)
+        var grad_input = grads.grad_input
+        var grad_weights = grads.grad_weights
+        ```
+    """
+
+    var grad_input: ExTensor
+    """Gradient with respect to input activation."""
+    var grad_weights: ExTensor
+    """Gradient with respect to depthwise convolution kernel."""
+
+    fn __init__(out self, var grad_input: ExTensor, var grad_weights: ExTensor):
+        """Initialize depthwise conv2d no-bias gradient.
+
+        Args:
+            grad_input: Gradient tensor for input.
+            grad_weights: Gradient tensor for kernel weights.
+        """
+        self.grad_input = grad_input^
+        self.grad_weights = grad_weights^

--- a/tests/shared/core/test_conv.mojo
+++ b/tests/shared/core/test_conv.mojo
@@ -752,8 +752,8 @@ fn test_conv2d_no_bias_backward_shapes() raises:
     var result = conv2d_no_bias_backward(
         grad_output, x, kernel, stride, padding
     )
-    var grad_input = result.grad_a
-    var grad_kernel = result.grad_b
+    var grad_input = result.grad_input
+    var grad_kernel = result.grad_weights
 
     # grad_input should match input shape
     assert_equal(grad_input.shape()[0], batch)


### PR DESCRIPTION
## Summary

- Add `Conv2dNoBiasGradient` and `DepthwiseConv2dNoBiasGradient` structs to `gradient_types.mojo` with semantically named fields (`grad_input`, `grad_weights`)
- Update `conv2d_no_bias_backward` and `depthwise_conv2d_no_bias_backward` to return the new domain-specific types instead of the generic `GradientPair`
- Update all 6 call sites in `conv.mojo` that accessed `.grad_a`/`.grad_b` to use `.grad_input`/`.grad_weights`
- `GradientPair` remains unchanged — still used for non-conv binary ops where `grad_a`/`grad_b` are semantically appropriate

## Changes Made

- `shared/core/gradient_types.mojo`: Add two new structs following `GradientTriple` naming convention
- `shared/core/conv.mojo`: Update imports, return types, docstrings, and call sites
- `shared/core/__init__.mojo`: Export new types
- `tests/shared/core/test_conv.mojo`: Update field access from `.grad_a`/`.grad_b` to `.grad_input`/`.grad_weights`

## Verification

- All pre-commit hooks passed (mojo format, trailing whitespace, end-of-file, large files)
- No remaining `.grad_a`/`.grad_b` accesses on conv no-bias backward results
- New types consistently use `grad_input`/`grad_weights` matching `GradientTriple`

Closes #3234