### PR TITLE
refactor(serialization): replace Python pathlib with Mojo native os.listdir

### DIFF
--- a/shared/utils/serialization.mojo
+++ b/shared/utils/serialization.mojo
@@ -44,7 +44,7 @@ from memory import UnsafePointer
 from collections import List, Dict
 from collections.optional import Optional
 from shared.utils.file_io import create_directory
-from python import Python
+import os
 
 
 # ============================================================================
@@ -311,16 +311,28 @@ fn load_named_tensors(dirpath: String) raises -> List[NamedTensor]:
     var result: List[NamedTensor] = []
 
     try:
-        # Use Python to list directory contents
-        var _ = Python.import_module("os")
-        var pathlib = Python.import_module("pathlib")
-        var builtins = Python.import_module("builtins")
-        var p = pathlib.Path(dirpath)
-        var weight_files = builtins.sorted(p.glob("*.weights"))
+        # List directory contents using Mojo native os.listdir
+        var entries = os.listdir(dirpath)
+
+        # Collect .weights files and sort for deterministic ordering
+        var weight_files: List[String] = []
+        for i in range(len(entries)):
+            var entry = entries[i]
+            if entry.endswith(".weights"):
+                weight_files.append(entry)
+
+        # Sort filenames for deterministic ordering (insertion sort)
+        for i in range(1, len(weight_files)):
+            var key = weight_files[i]
+            var j = i - 1
+            while j >= 0 and weight_files[j] > key:
+                weight_files[j + 1] = weight_files[j]
+                j -= 1
+            weight_files[j + 1] = key
 
         # Load each weights file
-        for file in weight_files:
-            var filepath = String(file)
+        for i in range(len(weight_files)):
+            var filepath = dirpath + "/" + weight_files[i]
             var (name, tensor) = load_tensor_with_name(filepath)
             result.append(NamedTensor(name, tensor))
 


### PR DESCRIPTION
## Summary

- Replace `Python.import_module("pathlib")`, `Python.import_module("os")`, and `Python.import_module("builtins")` in `load_named_tensors()` with Mojo's native `os.listdir()`
- Filter results for `.weights` extension and sort with insertion sort for deterministic ordering
- Removes `from python import Python` import (no longer needed in this file)

## Changes Made

**`shared/utils/serialization.mojo`**:
- Replace `from python import Python` with `import os`
- Rewrite `load_named_tensors()` to use `os.listdir()` instead of Python interop

## Verification

- Pre-commit hooks pass (mojo format, deprecated syntax check, whitespace, etc.)
- Logic is equivalent: enumerate directory, filter `.weights` files, sort alphabetically, load each
- Tests would run in CI via `just test-group "tests/shared" "test_serialization.mojo"` and `just test-group "tests/shared/core" "test_extensor_serialization.mojo"`

Closes #3240

🤖 Generated with [Claude Code](https://claude.com/claude-code)