### PR TITLE
feat(extensor,matrix): add view semantics to ravel() and transpose()

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -1054,6 +1054,62 @@ struct ExTensor(
 
         return result^
 
+    fn _nd_index_to_flat_offset(self, linear_idx: Int) -> Int:
+        """Convert a linear element index to a byte offset using strides.
+
+        For contiguous tensors this is equivalent to linear_idx * dtype_size.
+        For non-contiguous tensors (e.g. transpose views), the correct memory
+        position is obtained by mapping the linear index through the ND shape
+        and then applying per-dimension strides.
+
+        Args:
+            linear_idx: Linear element index in [0, numel).
+
+        Returns:
+            Byte offset into _data for the element.
+        """
+        var dtype_size = self._get_dtype_size()
+        var ndim = len(self._shape)
+        var remaining = linear_idx
+        var element_offset = 0
+        for i in range(ndim - 1, -1, -1):
+            var coord = remaining % self._shape[i]
+            remaining //= self._shape[i]
+            element_offset += coord * self._strides[i]
+        return element_offset * dtype_size
+
+    fn view_with_strides(
+        self, new_shape: List[Int], new_strides: List[Int]
+    ) -> ExTensor:
+        """Create a zero-copy view with custom shape and strides.
+
+        Shares the underlying data pointer and reference count with this
+        tensor. The caller is responsible for ensuring that new_shape and
+        new_strides are consistent with the original allocation.
+
+        Args:
+            new_shape: Shape for the view.
+            new_strides: Per-dimension strides (in elements) for the view.
+
+        Returns:
+            A new ExTensor sharing _data/_refcount with permuted shape/strides.
+        """
+        # Shallow-copy to share _data and _refcount (increments refcount)
+        var result = self
+        result._is_view = True
+        result._shape = List[Int]()
+        for i in range(len(new_shape)):
+            result._shape.append(new_shape[i])
+        result._strides = List[Int]()
+        for i in range(len(new_strides)):
+            result._strides.append(new_strides[i])
+        # Recompute numel from new_shape
+        var n = 1
+        for i in range(len(new_shape)):
+            n *= new_shape[i]
+        result._numel = n
+        return result^
+
     fn _get_float64(self, index: Int) -> Float64:
         """Internal: Get value at index as Float64 (assumes float-compatible dtype).
 
@@ -1063,8 +1119,12 @@ struct ExTensor(
         Returns:
             The value at the index as Float64.
         """
-        var dtype_size = self._get_dtype_size()
-        var offset = index * dtype_size
+        var offset: Int
+        if self.is_contiguous():
+            var dtype_size = self._get_dtype_size()
+            offset = index * dtype_size
+        else:
+            offset = self._nd_index_to_flat_offset(index)
 
         if self._dtype == DType.float16:
             var ptr = (self._data + offset).bitcast[Float16]()
@@ -1089,8 +1149,12 @@ struct ExTensor(
             index: The element index to set.
             value: The value to set (as Float64).
         """
-        var dtype_size = self._get_dtype_size()
-        var offset = index * dtype_size
+        var offset: Int
+        if self.is_contiguous():
+            var dtype_size = self._get_dtype_size()
+            offset = index * dtype_size
+        else:
+            offset = self._nd_index_to_flat_offset(index)
 
         if self._dtype == DType.float16:
             var ptr = (self._data + offset).bitcast[Float16]()
@@ -1118,8 +1182,12 @@ struct ExTensor(
             For Float64 and integer types, value is cast to Float32.
             For Float16, value is upcast to Float32.
         """
-        var dtype_size = self._get_dtype_size()
-        var offset = index * dtype_size
+        var offset: Int
+        if self.is_contiguous():
+            var dtype_size = self._get_dtype_size()
+            offset = index * dtype_size
+        else:
+            offset = self._nd_index_to_flat_offset(index)
 
         if self._dtype == DType.float16:
             var ptr = (self._data + offset).bitcast[Float16]()
@@ -1146,8 +1214,12 @@ struct ExTensor(
             For Float64, value is upcast to Float64.
             For integer types, value is truncated to integer.
         """
-        var dtype_size = self._get_dtype_size()
-        var offset = index * dtype_size
+        var offset: Int
+        if self.is_contiguous():
+            var dtype_size = self._get_dtype_size()
+            offset = index * dtype_size
+        else:
+            offset = self._nd_index_to_flat_offset(index)
 
         if self._dtype == DType.float16:
             var ptr = (self._data + offset).bitcast[Float16]()
@@ -1168,8 +1240,12 @@ struct ExTensor(
         Returns:
             The value at the index as Int64.
         """
-        var dtype_size = self._get_dtype_size()
-        var offset = index * dtype_size
+        var offset: Int
+        if self.is_contiguous():
+            var dtype_size = self._get_dtype_size()
+            offset = index * dtype_size
+        else:
+            offset = self._nd_index_to_flat_offset(index)
 
         if self._dtype == DType.int8:
             var ptr = (self._data + offset).bitcast[Int8]()
@@ -1208,8 +1284,12 @@ struct ExTensor(
             index: The element index to set.
             value: The value to set (as Int64).
         """
-        var dtype_size = self._get_dtype_size()
-        var offset = index * dtype_size
+        var offset: Int
+        if self.is_contiguous():
+            var dtype_size = self._get_dtype_size()
+            offset = index * dtype_size
+        else:
+            offset = self._nd_index_to_flat_offset(index)
 
         if self._dtype == DType.int8:
             var ptr = (self._data + offset).bitcast[Int8]()

--- a/shared/core/matrix.mojo
+++ b/shared/core/matrix.mojo
@@ -14,6 +14,7 @@ from collections import List
 from memory import memcpy
 from shared.core.extensor import ExTensor
 from shared.core.gradient_types import GradientPair
+from shared.core.shape import as_contiguous
 
 
 # ============================================================================
@@ -594,13 +595,28 @@ fn matmul(a: ExTensor, b: ExTensor) raises -> ExTensor:
             This function always allocates a new result tensor. Input tensors are only read,
             never modified, so aliasing between a and b is safe.
     """
+    # Ensure inputs are contiguous so that all dtype-specialized impls can
+    # use direct flat-buffer indexing. For already-contiguous tensors we take
+    # a shared-ownership copy (view) to avoid allocation; for non-contiguous
+    # tensors (e.g. transpose views) we materialize a fresh contiguous copy.
+    var a_cont: ExTensor
+    var b_cont: ExTensor
+    if a.is_contiguous():
+        a_cont = a
+    else:
+        a_cont = as_contiguous(a)
+    if b.is_contiguous():
+        b_cont = b
+    else:
+        b_cont = as_contiguous(b)
+
     # Check dtype compatibility
-    if a.dtype() != b.dtype():
+    if a_cont.dtype() != b_cont.dtype():
         raise Error("Cannot multiply matrices with different dtypes")
 
     # Check dimension compatibility
-    var a_shape = a.shape()
-    var b_shape = b.shape()
+    var a_shape = a_cont.shape()
+    var b_shape = b_cont.shape()
     var a_ndim = len(a_shape)
     var b_ndim = len(b_shape)
 
@@ -624,9 +640,9 @@ fn matmul(a: ExTensor, b: ExTensor) raises -> ExTensor:
         # Result is a vector of shape (m,)
         var result_shape = List[Int](capacity=1)
         result_shape.append(m)
-        var result = ExTensor(result_shape, a.dtype())
+        var result = ExTensor(result_shape, a_cont.dtype())
 
-        _dispatch_matmul_2d_1d(result, a, b, m, k)
+        _dispatch_matmul_2d_1d(result, a_cont, b_cont, m, k)
         return result^
 
     # Handle vector @ matrix (1D @ 2D)
@@ -649,9 +665,9 @@ fn matmul(a: ExTensor, b: ExTensor) raises -> ExTensor:
         # Result is a vector of shape (n,)
         var result_shape = List[Int](capacity=1)
         result_shape.append(n)
-        var result = ExTensor(result_shape, a.dtype())
+        var result = ExTensor(result_shape, a_cont.dtype())
 
-        _dispatch_matmul_1d_2d(result, a, b, m, n)
+        _dispatch_matmul_1d_2d(result, a_cont, b_cont, m, n)
         return result^
 
     # For 2D and higher, require at least 2D tensors
@@ -686,14 +702,14 @@ fn matmul(a: ExTensor, b: ExTensor) raises -> ExTensor:
     result_shape.append(b_cols)
 
     # Create result
-    var result = ExTensor(result_shape, a.dtype())
+    var result = ExTensor(result_shape, a_cont.dtype())
 
     # Implement matrix multiplication
     # For 2D case: result[i, j] = sum(a[i, k] * b[k, j] for k in range(a_cols))
     # For batched case: apply same logic to each batch
 
     if len(a_shape) == 2:
-        _dispatch_matmul_2d_2d(result, a, b, a_rows, a_cols, b_cols)
+        _dispatch_matmul_2d_2d(result, a_cont, b_cont, a_rows, a_cols, b_cols)
     else:
         # Batched matrix multiplication (3D+)
         var batch_size = 1
@@ -706,8 +722,8 @@ fn matmul(a: ExTensor, b: ExTensor) raises -> ExTensor:
 
         _dispatch_matmul_batched(
             result,
-            a,
-            b,
+            a_cont,
+            b_cont,
             batch_size,
             a_rows,
             a_cols,
@@ -793,35 +809,19 @@ fn transpose(
             raise Error("duplicate axis " + String(axis) + " in permutation")
         seen[axis] = True
 
-    # Build result shape using permutation
+    # Build result shape by permuting input dimensions
     var result_shape = List[Int](capacity=ndim)
     for axis in perm.value():
         result_shape.append(input_shape[axis])
 
-    var result = ExTensor(result_shape, tensor.dtype())
+    # Build result strides by permuting input strides (view semantics).
+    # The input tensor's strides are permuted according to axes so that
+    # element access through the view produces the transposed layout.
+    var result_strides = List[Int](capacity=ndim)
+    for axis in perm.value():
+        result_strides.append(tensor._strides[axis])
 
-    # Compute strides for input tensor (row-major order)
-    var input_strides = List[Int](capacity=ndim)
-    var stride = 1
-    for i in range(ndim - 1, -1, -1):
-        input_strides.append(stride)
-        stride *= input_shape[i]
-    # Reverse to get correct indexing order
-    var temp_strides = List[Int](capacity=ndim)
-    for i in range(len(input_strides) - 1, -1, -1):
-        temp_strides.append(input_strides[i])
-    input_strides = temp_strides^
-
-    _dispatch_transpose_copy(
-        result,
-        tensor,
-        ndim,
-        result_shape,
-        input_strides,
-        perm.value(),
-        result.numel(),
-    )
-    return result^
+    return tensor.view_with_strides(result_shape, result_strides)
 
 
 fn transpose_view(

--- a/tests/shared/core/test_matrix.mojo
+++ b/tests/shared/core/test_matrix.mojo
@@ -662,23 +662,24 @@ fn test_transpose_values() raises:
     var result = transpose(a)
 
     # A^T = [[1, 4], [2, 5], [3, 6]]
+    # Use stride-aware element access (_get_float32) to read logical values.
     assert_almost_equal(
-        result._data.bitcast[Float32]()[0], Float32(1.0), tolerance=1e-5
+        result._get_float32(0), Float32(1.0), tolerance=1e-5
     )
     assert_almost_equal(
-        result._data.bitcast[Float32]()[1], Float32(4.0), tolerance=1e-5
+        result._get_float32(1), Float32(4.0), tolerance=1e-5
     )
     assert_almost_equal(
-        result._data.bitcast[Float32]()[2], Float32(2.0), tolerance=1e-5
+        result._get_float32(2), Float32(2.0), tolerance=1e-5
     )
     assert_almost_equal(
-        result._data.bitcast[Float32]()[3], Float32(5.0), tolerance=1e-5
+        result._get_float32(3), Float32(5.0), tolerance=1e-5
     )
     assert_almost_equal(
-        result._data.bitcast[Float32]()[4], Float32(3.0), tolerance=1e-5
+        result._get_float32(4), Float32(3.0), tolerance=1e-5
     )
     assert_almost_equal(
-        result._data.bitcast[Float32]()[5], Float32(6.0), tolerance=1e-5
+        result._get_float32(5), Float32(6.0), tolerance=1e-5
     )
 
 
@@ -948,14 +949,15 @@ fn test_transpose_axes_2d_simple() raises:
 
     # Check actual values: result[i,j] = input[j,i]
     # result[0,0] = input[0,0] = 0, result[0,1] = input[1,0] = 4, result[0,2] = input[2,0] = 8
+    # Use stride-aware element access (_get_float32) to read logical values.
     assert_almost_equal(
-        result._data.bitcast[Float32]()[0], Float32(0.0), tolerance=1e-5
+        result._get_float32(0), Float32(0.0), tolerance=1e-5
     )
     assert_almost_equal(
-        result._data.bitcast[Float32]()[1], Float32(4.0), tolerance=1e-5
+        result._get_float32(1), Float32(4.0), tolerance=1e-5
     )
     assert_almost_equal(
-        result._data.bitcast[Float32]()[2], Float32(8.0), tolerance=1e-5
+        result._get_float32(2), Float32(8.0), tolerance=1e-5
     )
 
 
@@ -1252,6 +1254,101 @@ fn test_transpose_axes_double_permutation() raises:
             t_recovered._data.bitcast[Float32]()[i],
             t._data.bitcast[Float32]()[i],
             tolerance=1e-5,
+        )
+
+
+# ============================================================================
+# Transpose Tests - View Semantics (Issue #3236)
+# ============================================================================
+
+
+fn test_transpose_returns_view() raises:
+    """Test that transpose() returns a view (shares data, _is_view == True)."""
+    var shape = List[Int]()
+    shape.append(3)
+    shape.append(4)
+    var a = ones(shape, DType.float32)
+    var t = transpose(a)
+
+    assert_true(t._is_view, "transpose() result should be a view")
+
+
+fn test_transpose_view_strides() raises:
+    """Test that transpose view has correctly permuted strides."""
+    var shape = List[Int]()
+    shape.append(3)
+    shape.append(4)
+    var a = ones(shape, DType.float32)
+    # a is contiguous: strides [4, 1]
+    var t = transpose(a)
+    # t should have strides [1, 4] (permuted: a._strides reversed)
+    assert_equal(t._strides[0], 1, "Transposed stride[0] should be 1 (inner stride of input)")
+    assert_equal(t._strides[1], 4, "Transposed stride[1] should be 4 (outer stride of input)")
+
+
+fn test_transpose_view_values() raises:
+    """Test that stride-aware element access returns correct transposed values."""
+    var shape = List[Int]()
+    shape.append(2)
+    shape.append(3)
+    var a = zeros(shape, DType.float32)
+
+    # A = [[1, 2, 3], [4, 5, 6]]
+    a._data.bitcast[Float32]()[0] = 1.0
+    a._data.bitcast[Float32]()[1] = 2.0
+    a._data.bitcast[Float32]()[2] = 3.0
+    a._data.bitcast[Float32]()[3] = 4.0
+    a._data.bitcast[Float32]()[4] = 5.0
+    a._data.bitcast[Float32]()[5] = 6.0
+
+    var t = transpose(a)
+    # t shape [3, 2], strides [1, 3].
+    # t[0,0]=a[0,0]=1, t[0,1]=a[1,0]=4
+    # t[1,0]=a[0,1]=2, t[1,1]=a[1,1]=5
+    # t[2,0]=a[0,2]=3, t[2,1]=a[1,2]=6
+    # Linear order: 1, 4, 2, 5, 3, 6
+    assert_almost_equal(t._get_float32(0), Float32(1.0), tolerance=1e-5)
+    assert_almost_equal(t._get_float32(1), Float32(4.0), tolerance=1e-5)
+    assert_almost_equal(t._get_float32(2), Float32(2.0), tolerance=1e-5)
+    assert_almost_equal(t._get_float32(3), Float32(5.0), tolerance=1e-5)
+    assert_almost_equal(t._get_float32(4), Float32(3.0), tolerance=1e-5)
+    assert_almost_equal(t._get_float32(5), Float32(6.0), tolerance=1e-5)
+
+
+fn test_transpose_view_refcount() raises:
+    """Test that transposing increments the reference count."""
+    var shape = List[Int]()
+    shape.append(3)
+    shape.append(4)
+    var a = ones(shape, DType.float32)
+    var refcount_before = a._refcount[]
+    var t = transpose(a)
+    assert_equal(
+        t._refcount[],
+        refcount_before + 1,
+        "Refcount should increase by 1 after creating view",
+    )
+
+
+fn test_transpose_chained_views() raises:
+    """Test that chained transposes produce correct logical values."""
+    var shape = List[Int]()
+    shape.append(2)
+    shape.append(3)
+    shape.append(4)
+    var a = zeros(shape, DType.float32)
+    # Fill with sequential values 0..23
+    for i in range(24):
+        a._data.bitcast[Float32]()[i] = Float32(i)
+
+    # Double transpose should recover original shape and values
+    var t = transpose(transpose(a))
+    assert_equal(t.shape()[0], 2, "Double transpose dim 0 should be 2")
+    assert_equal(t.shape()[1], 3, "Double transpose dim 1 should be 3")
+    assert_equal(t.shape()[2], 4, "Double transpose dim 2 should be 4")
+    for i in range(24):
+        assert_almost_equal(
+            t._get_float32(i), Float32(i), tolerance=1e-5
         )
 
 
@@ -1719,6 +1816,19 @@ fn main() raises:
     print("✓ test_transpose_axes_backward_3d")
     test_transpose_axes_double_permutation()
     print("✓ test_transpose_axes_double_permutation")
+
+    # Transpose tests - view semantics (Issue #3236)
+    print("\n=== Transpose: View Semantics (Issue #3236) ===")
+    test_transpose_returns_view()
+    print("✓ test_transpose_returns_view")
+    test_transpose_view_strides()
+    print("✓ test_transpose_view_strides")
+    test_transpose_view_values()
+    print("✓ test_transpose_view_values")
+    test_transpose_view_refcount()
+    print("✓ test_transpose_view_refcount")
+    test_transpose_chained_views()
+    print("✓ test_transpose_chained_views")
 
     # Dot product tests
     print("\n=== Dot Product ===")

--- a/tests/shared/core/test_shape.mojo
+++ b/tests/shared/core/test_shape.mojo
@@ -25,6 +25,7 @@ from shared.core import (
 
 # Import test helpers
 from tests.shared.conftest import (
+    assert_true,
     assert_dtype,
     assert_numel,
     assert_dim,
@@ -174,15 +175,17 @@ fn test_flatten_c_order() raises:
 
 
 fn test_ravel_view() raises:
-    """Test ravel (should return view if possible)."""
+    """Test ravel returns a zero-copy view for contiguous tensors."""
     var shape = List[Int]()
     shape.append(3)
     shape.append(4)
     var a = ones(shape, DType.float32)
     var b = ravel(a)
 
-    # Currently returns a 1D copy (view semantics deferred to future work)
     assert_dim(b, 1, "Ravel should be 1D")
+    assert_numel(b, 12, "Ravel should have 12 elements")
+    # ravel() of a contiguous tensor is a view (_is_view == True)
+    assert_true(b._is_view, "ravel() of contiguous tensor should be a view")
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- `transpose()` now returns a zero-copy **view** with permuted strides instead of allocating a new tensor and copying all elements
- `ravel()` already returned a view for contiguous tensors — stale TODO comment removed, view assertion added to test
- `_get_float64`, `_set_float64`, `_get_float32`, `_set_float32`, `_get_int64`, `_set_int64` now use stride-aware indexing for non-contiguous tensors
- `matmul()` materialises non-contiguous inputs via `as_contiguous()` before flat-buffer kernel dispatch

## Changes Made

### `shared/core/extensor.mojo`
- Added `_nd_index_to_flat_offset(linear_idx)` — converts linear index → strided byte offset via ND coords
- Added `view_with_strides(new_shape, new_strides)` — shared-ownership view factory (increments refcount)
- Updated all `_get_*` / `_set_*` accessors to branch on `is_contiguous()` and call `_nd_index_to_flat_offset` for non-contiguous tensors

### `shared/core/matrix.mojo`
- `transpose()`: replaced `_dispatch_transpose_copy` with `tensor.view_with_strides(result_shape, result_strides)` — strides permuted, no data copy
- `matmul()`: added `as_contiguous()` check at the top so non-contiguous transpose views are materialised before flat-buffer SIMD kernels run
- Added `from shared.core.shape import as_contiguous`

### `tests/shared/core/test_shape.mojo`
- `test_ravel_view()`: removed stale "view semantics deferred" comment; added `assert_true(b._is_view)` to verify view is returned

### `tests/shared/core/test_matrix.mojo`
- Updated `test_transpose_values` and `test_transpose_axes_2d_simple` to use `_get_float32()` (stride-aware) instead of raw `_data.bitcast[]` on transpose results
- Added 5 new view-semantics tests: `test_transpose_returns_view`, `test_transpose_view_strides`, `test_transpose_view_values`, `test_transpose_view_refcount`, `test_transpose_chained_views`

## Verification

- All pre-commit hooks pass (mojo format, lint, test coverage validation)
- New tests verify: `_is_view == True`, strides are permuted (not row-major), element values correct via stride-aware access, refcount incremented, chained double-transpose recovers original values
- Existing matmul + transpose combination tests (A.T @ B, A @ B.T, etc.) continue to work via `as_contiguous()` materialisation path

Closes #3236