### PR TITLE
test(normalization): add numerical gradient test for layer_norm_backward

### DIFF
--- a/tests/shared/core/test_normalization.mojo
+++ b/tests/shared/core/test_normalization.mojo
@@ -785,6 +785,80 @@ fn test_layer_norm_backward_zero_input() raises:
         assert_true(val_beta == val_beta, "grad_beta should not be NaN")
 
 
+fn test_layer_norm_backward_gradient_input() raises:
+    """Test layer_norm_backward gradient w.r.t. input using numerical validation.
+
+    CRITICAL TEST: Validates mathematical correctness of layer norm backpropagation.
+    Uses central finite differences for gold-standard gradient validation.
+    Uses non-uniform grad_output to prevent algebraic cancellation masking bugs.
+
+    When grad_output=ones, sum(grad_output * x_hat) = sum(x_hat) = 0 by normalization,
+    making the last term in the backward formula vanish. Non-uniform grad_output
+    ensures sum(grad_output * x_hat) != 0, exercising the full backward formula.
+    """
+    # Small 2D tensor: (batch=2, features=4)
+    var shape = List[Int]()
+    shape.append(2)
+    shape.append(4)
+
+    # Input with varying values (not uniform, not zero)
+    var x = zeros(shape, DType.float32)
+    for i in range(8):
+        x._data.bitcast[Float32]()[i] = Float32(i) * 0.1 + 0.05
+
+    # Parameters: non-trivial gamma, zero beta
+    var param_shape = List[Int]()
+    param_shape.append(4)
+    var gamma = ones(param_shape, DType.float32)
+    gamma._data.bitcast[Float32]()[0] = 1.5
+    gamma._data.bitcast[Float32]()[1] = 0.8
+    gamma._data.bitcast[Float32]()[2] = 1.2
+    gamma._data.bitcast[Float32]()[3] = 2.0
+    var beta = zeros(param_shape, DType.float32)
+
+    # Non-uniform grad_output: critical to avoid algebraic cancellation
+    var grad_output = zeros(shape, DType.float32)
+    grad_output._data.bitcast[Float32]()[0] = 0.3
+    grad_output._data.bitcast[Float32]()[1] = -0.5
+    grad_output._data.bitcast[Float32]()[2] = 1.2
+    grad_output._data.bitcast[Float32]()[3] = -0.8
+    grad_output._data.bitcast[Float32]()[4] = 0.7
+    grad_output._data.bitcast[Float32]()[5] = -0.2
+    grad_output._data.bitcast[Float32]()[6] = 0.9
+    grad_output._data.bitcast[Float32]()[7] = -1.1
+
+    # Analytical backward pass
+    var result = layer_norm_backward(grad_output, x, gamma, epsilon=1e-5)
+    var grad_input = result[0]
+
+    # Numerical gradient via finite differences.
+    # The scalar loss is sum(layer_norm(x) * grad_output), so the numerical
+    # gradient matches what layer_norm_backward(grad_output, x, gamma) computes.
+    fn forward_for_grad(inp: ExTensor) raises -> ExTensor:
+        var out = layer_norm(inp, gamma, beta, epsilon=1e-5)
+        # Weighted sum: sum(out * grad_output) matches backward with non-uniform grad_output
+        var weighted = multiply(out, grad_output)
+        var result_inner = weighted
+        while result_inner.dim() > 0:
+            result_inner = reduce_sum(result_inner, axis=0, keepdims=False)
+        return result_inner
+
+    var numerical_grad = compute_numerical_gradient(
+        forward_for_grad, x, epsilon=1e-4
+    )
+
+    # Validate analytical gradient matches numerical gradient
+    assert_gradients_close(
+        grad_input,
+        numerical_grad,
+        rtol=1e-2,
+        atol=1e-5,
+        message="Layer norm gradient w.r.t. input",
+    )
+
+    print("✓ Layer norm backward gradient (input) validated numerically")
+
+
 # ============================================================================
 # Main Test Runner
 # ============================================================================
@@ -848,5 +922,8 @@ fn main() raises:
 
     test_layer_norm_backward_zero_input()
     print("✓ test_layer_norm_backward_zero_input")
+
+    test_layer_norm_backward_gradient_input()
+    print("✓ test_layer_norm_backward_gradient_input")
 
     print("\nAll normalization tests passed!")


### PR DESCRIPTION
## Summary

- Adds `test_layer_norm_backward_gradient_input` to `tests/shared/core/test_normalization.mojo`
- Validates `layer_norm_backward` grad_input against central finite differences
- Uses non-uniform `grad_output` to prevent algebraic cancellation that masks bugs when `grad_output=ones`

## Changes Made

**`tests/shared/core/test_normalization.mojo`**
- New test function `test_layer_norm_backward_gradient_input` (follows the pattern of `test_batch_norm2d_backward_gradient_input`)
- Added call in `fn main()` after `test_layer_norm_backward_zero_input`

## Why Non-Uniform grad_output

When `grad_output=ones`, `sum(grad_output * x_hat) = sum(x_hat) = 0` by normalization — the last term in the layer norm backward formula vanishes, allowing incorrect implementations to pass. Non-uniform `grad_output` ensures `sum(grad_output * x_hat) != 0`, exercising the full formula.

## Verification

Pre-commit hooks pass (Mojo format, syntax validation, test coverage checks). The test cannot be run locally due to GLIBC version requirements; CI will validate correctness.

Closes #3247