### PR TITLE
docs(adr): update ADR-004 helpers directory tree to reflect active files

### DIFF
--- a/docs/adr/ADR-004-testing-strategy.md
+++ b/docs/adr/ADR-004-testing-strategy.md
@@ -141,7 +141,11 @@ tests/
 │       ├── layer_testers.mojo            # Reusable test patterns
 │       └── gradient_checker.mojo         # Numerical gradient utils
 └── helpers/
-    └── fixtures.mojo                     # Test fixtures
+    ├── __init__.mojo                     # Package re-exports
+    ├── fixtures.mojo                     # Test fixture utilities
+    ├── utils.mojo                        # Tensor debugging utilities
+    ├── test_fixtures.mojo                # Self-tests for fixtures.mojo
+    └── test_utils.mojo                   # Self-tests for utils.mojo
 ```
 
 ## Rationale


### PR DESCRIPTION
## Summary

- Removes stale single-file listing (`fixtures.mojo` only) for `tests/helpers/` in ADR-004's directory tree
- Replaces with accurate listing of all 5 active helper files: `__init__.mojo`, `fixtures.mojo`, `utils.mojo`, `test_fixtures.mojo`, `test_utils.mojo`
- `gradient_checking.mojo` was already deleted; this corrects the documentation to reflect actual directory state

Closes #3252

## Test plan

- [x] `pixi run pre-commit run markdownlint-cli2 --files docs/adr/ADR-004-testing-strategy.md` passes
- [x] No functional code changes — documentation only
- [x] `tests/helpers/` directory contents verified to match updated listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)