### PR TITLE
docs(contributing): document mojo-format GLIBC incompatibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -301,6 +301,32 @@ If a hook itself is broken (not your code):
 - Document reason in commit message
 - Create issue to fix the broken hook
 
+#### Known Hook Incompatibility: mojo-format on Debian Buster / glibc < 2.32
+
+The `mojo-format` hook requires **glibc 2.32+** (Debian 12 / Ubuntu 22.04 or newer).
+On Debian 10 (Buster) or other hosts with glibc < 2.32, the hook automatically detects
+the incompatibility and **skips with a warning** instead of failing your commit.
+
+You will see output like:
+
+```text
+WARNING: mojo-format skipped: host glibc is incompatible with Mojo binary.
+         Mojo requires GLIBC_2.32+. Your system has an older glibc.
+         Files were NOT reformatted. Run inside Docker for full formatting.
+         See docs/dev/mojo-glibc-compatibility.md for details.
+```
+
+CI always runs on Ubuntu 24.04 (glibc 2.39) and enforces formatting before merge, so your
+code will still be format-checked. To format locally on an incompatible host, use Docker:
+
+```bash
+just shell
+# Inside container:
+pixi run mojo format path/to/file.mojo
+```
+
+See [docs/dev/mojo-glibc-compatibility.md](docs/dev/mojo-glibc-compatibility.md) for full details.
+
 ## Pull Request Process
 
 ### Before You Start


### PR DESCRIPTION
## Summary

- Adds a named subsection under **Pre-commit Hooks → Hook Failure Policy** in `CONTRIBUTING.md`
  documenting the `mojo-format` GLIBC < 2.32 limitation on Debian 10/Buster hosts
- Explains that the hook auto-skips with a warning (via `scripts/mojo-format-compat.sh`) instead
  of failing commits on incompatible hosts
- Links to `docs/dev/mojo-glibc-compatibility.md` for full details

The wrapper script and compatibility doc were already in place from #3170. This PR makes the
behaviour discoverable for contributors who encounter the warning.

## Changes Made

- `CONTRIBUTING.md`: Added `#### Known Hook Incompatibility: mojo-format on Debian Buster / glibc < 2.32`
  subsection with the warning message, Docker workaround, and link to the full doc

## Verification

- `SKIP=mojo-format pixi run pre-commit run markdownlint-cli2 --all-files` → **Passed**
- All other pre-commit hooks → **Passed**

Closes #3253

🤖 Generated with [Claude Code](https://claude.com/claude-code)