### PR TITLE
feat(extensor): add __bool__ for single-element truthiness

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -2748,6 +2748,27 @@ struct ExTensor(
             return 0
         return self._shape[0]
 
+    fn __bool__(self) raises -> Bool:
+        """Return the boolean value of a single-element tensor.
+
+        Follows PyTorch/NumPy convention: a single-element tensor can be
+        used in boolean context. Returns True if the value is non-zero.
+
+        Returns:
+            True if the single element is non-zero, False otherwise.
+
+        Raises:
+            Error: If tensor has more than one element.
+
+        Example:
+            ```mojo
+            var x = full([], 5.0, DType.float32)
+            if x:  # True
+                print("non-zero")
+            ```
+        """
+        return self.item() != 0.0
+
     fn __int__(self) raises -> Int:
         """Convert single-element tensor to Int.
 

--- a/tests/shared/core/test_utility.mojo
+++ b/tests/shared/core/test_utility.mojo
@@ -349,26 +349,21 @@ fn test_bool_single_element() raises:
     var t_zero = full(shape, 0.0, DType.float32)
     var t_nonzero = full(shape, 5.0, DType.float32)
 
-    # if t_zero:  # Should be False
-    #     raise Error("Zero tensor should be falsy")
-    # if not t_nonzero:  # Should be True
-    #     raise Error("Non-zero tensor should be truthy")
-    pass  # Placeholder
+    if t_zero:
+        raise Error("Zero tensor should be falsy")
+    if not t_nonzero:
+        raise Error("Non-zero tensor should be truthy")
 
 
 fn test_bool_requires_single_element() raises:
-    """Test that item() requires single-element tensor.
-
-    Note: Since __bool__ is not yet implemented, we test item() which
-    has the same single-element requirement and is used for scalar extraction.
-    """
+    """Test that __bool__ raises for multi-element tensor."""
     var shape = List[Int]()
     shape.append(5)
     var t = ones(shape, DType.float32)
 
     var error_raised = False
     try:
-        var val = item(t)  # Should raise error for multi-element tensor
+        var val = Bool(t)  # Should raise error for multi-element tensor
         _ = val  # Suppress unused warning
     except e:
         error_raised = True
@@ -383,7 +378,7 @@ fn test_bool_requires_single_element() raises:
             )
 
     if not error_raised:
-        raise Error("item() on multi-element tensor should raise error")
+        raise Error("__bool__ on multi-element tensor should raise error")
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Add `fn __bool__(self) raises -> Bool` to `ExTensor` in `shared/core/extensor.mojo`
- Delegates to `item()` and returns `item() != 0.0`, following PyTorch/NumPy conventions
- Update placeholder tests in `tests/shared/core/test_utility.mojo` to actually exercise `__bool__` via boolean context and `Bool(t)` calls

## Changes Made

- `shared/core/extensor.mojo`: Added `__bool__` method after `__len__`, before `__int__`
- `tests/shared/core/test_utility.mojo`: Replaced placeholder `pass` with real assertions; updated `test_bool_requires_single_element` to call `Bool(t)` directly

## Verification

- All pre-commit hooks pass (mojo format, deprecated syntax check, test coverage validation)
- Implementation follows the same pattern as `__int__` and `__float__` (delegates to `item()`)

Closes #3255

🤖 Generated with [Claude Code](https://claude.com/claude-code)