### PR TITLE
fix(serialization): use dtype_to_string() instead of String(dtype) in save_tensor

### DIFF
--- a/shared/utils/serialization.mojo
+++ b/shared/utils/serialization.mojo
@@ -117,7 +117,7 @@ fn save_tensor(tensor: ExTensor, filepath: String, name: String = "") raises:
     var numel = local_tensor.numel()
 
     # Build metadata line: dtype and shape dimensions
-    var dtype_str = String(dtype)
+    var dtype_str = dtype_to_string(dtype)
     var metadata = dtype_str + " "
     for i in range(len(shape)):
         metadata += String(shape[i])


### PR DESCRIPTION
## Summary

- Replace `String(dtype)` with `dtype_to_string(dtype)` in `save_tensor()` to ensure the serialized dtype string consistently matches what `parse_dtype()` expects during load
- `dtype_to_string()` is the canonical serialization function; `String(DType)` relies on Mojo's built-in `__str__` which may produce different output

## Changes Made

- `shared/utils/serialization.mojo:120`: Changed `var dtype_str = String(dtype)` → `var dtype_str = dtype_to_string(dtype)`

## Root Cause Analysis

The `test_serialization.mojo` CI failure was caused by two pre-existing issues:

1. **dtype serialization mismatch (this PR)**: `save_tensor()` used `String(dtype)` which may not produce the same format (`"float32"`, `"float64"`, etc.) as `parse_dtype()` expects. `dtype_to_string()` is the explicit, authoritative conversion that guarantees roundtrip consistency.

2. **Python pathlib ordering crash**: `load_named_tensors()` previously used Python interop with `pathlib.glob()`, which caused runtime crashes in CI. This was already fixed in commit `666302ea` (native Mojo `os.listdir` with insertion sort for deterministic ordering). This PR rebases on top of that fix.

## Verification

- Pre-commit hooks pass (mojo format, trailing whitespace, etc.)
- CI was previously passing after the `os.listdir` refactor; this PR adds the dtype fix on top
- Test assertions in `test_serialization.mojo` already expect alphabetical order (`bias` before `weights`) which matches the sorted `os.listdir` output

Closes #3257