### PR TITLE
refactor(tests): remove test_backward_compat_aliases.mojo from CI

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -205,7 +205,7 @@ jobs:
           - name: "Core Gradient"
             path: "tests/shared/core"
             # test_backward and test_gradient_checking split per ADR-009
-            pattern: "test_backward_linear.mojo test_backward_conv_pool.mojo test_backward_losses.mojo test_backward_compat_aliases.mojo test_gradient_checking_basic.mojo test_gradient_checking_dtype.mojo test_gradient_validation.mojo test_variable_backward.mojo"
+            pattern: "test_backward_linear.mojo test_backward_conv_pool.mojo test_backward_losses.mojo test_gradient_checking_basic.mojo test_gradient_checking_dtype.mojo test_gradient_validation.mojo test_variable_backward.mojo"
           - name: "Core Utilities"
             path: "tests/shared/core"
             pattern: "test_utilities.mojo test_utility.mojo test_utils.mojo test_validation.mojo test_validation_extended.mojo test_integration.mojo test_inplace_simd.mojo test_lazy_expression.mojo test_memory_pool.mojo test_constants.mojo test_extensor_getset_float32.mojo test_extensor_inplace_ops.mojo test_extensor_randn.mojo test_extensor_reflected_ops.mojo test_extensor_serialization.mojo test_extensor_slicing.mojo test_extensor_unary_ops.mojo test_memory_leaks.mojo test_initializers.mojo test_initializers_validation.mojo test_layers.mojo test_linear.mojo test_conv.mojo test_normalization.mojo test_dropout.mojo test_module.mojo test_composed_op.mojo"


### PR DESCRIPTION
## Summary

- Removes `test_backward_compat_aliases.mojo` from the CI workflow pattern string in `.github/workflows/comprehensive-tests.yml`
- The test file itself was already deleted; this removes the dangling reference

## Changes Made

The file `tests/shared/core/test_backward_compat_aliases.mojo` only tested `LinearBackwardResult`, `LinearNoBiasBackwardResult`, and `BenchmarkStatistics` aliases — all deprecated and removed in #3059. The file has been deleted; this PR removes the last reference from the CI "Core Gradient" test group pattern.

## Verification

- Zero references to `test_backward_compat_aliases` remain in any `.mojo`, `.toml`, or `.yml` files (excluding the prompt file)
- Pre-commit hooks pass

Closes #3266