### PR TITLE
refactor(core): remove last deprecated alias reference from shared/core

### DIFF
--- a/tests/shared/core/test_conv.mojo
+++ b/tests/shared/core/test_conv.mojo
@@ -1112,7 +1112,7 @@ fn main() raises:
     test_conv2d_batched()
     print("✓ test_conv2d_batched")
 
-    # Backward pass tests (Conv2dBackwardResult is GradientTriple which is Copyable)
+    # Backward pass tests (return type is GradientTriple which is Copyable)
     test_conv2d_backward_shapes()
     print("✓ test_conv2d_backward_shapes")
 


### PR DESCRIPTION
## Summary

- Removed the last remaining reference to the deprecated `Conv2dBackwardResult` alias in a comment in `tests/shared/core/test_conv.mojo`
- All 8 deprecated type aliases (`LinearBackwardResult`, `LinearNoBiasBackwardResult`, and 6 `Conv2d*BackwardResult` variants) are now completely removed from `shared/core`
- This completes the cleanup started in #3064 and closes parent issue #3059

## Changes Made

- `tests/shared/core/test_conv.mojo:1115` — Updated comment to say `GradientTriple` instead of the removed `Conv2dBackwardResult` alias

## Verification

- `grep` confirms 0 remaining occurrences of all 8 deprecated alias names across all `.mojo` files
- All pre-commit hooks pass

Closes #3267