### PR TITLE
feat(extensor): add __setitem__ with multi-dimensional List[Int] index support

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -882,7 +882,7 @@ struct ExTensor(
             if indices[i] < 0 or indices[i] >= self._shape[i]:
                 raise Error("Index out of bounds at dimension " + String(i))
             flat_idx += indices[i] * self._strides[i]
-        self[flat_idx] = value
+        self.__setitem__(flat_idx, value)
 
     fn __getitem__(self, slice: Slice) raises -> Self:
         """Get slice of 1D tensor [start:end] or [start:end:step].

--- a/tests/shared/core/test_extensor_setitem.mojo
+++ b/tests/shared/core/test_extensor_setitem.mojo
@@ -27,7 +27,9 @@ fn test_setitem_flat_float32() raises:
     """Test flat __setitem__ (Float32) on a 2D tensor."""
     var t = zeros([3, 4], DType.float32)
     t[5] = Float32(3.14)
-    assert_almost_equal(t._get_float64(5), Float64(Float32(3.14)), tolerance=1e-6)
+    assert_almost_equal(
+        t._get_float64(5), Float64(Float32(3.14)), tolerance=1e-6
+    )
 
 
 fn test_setitem_flat_int64() raises:


### PR DESCRIPTION
## Summary

- Adds `__setitem__(mut self, indices: List[Int], value: Float64)` overload to `ExTensor`
- Converts per-dimension indices to flat index via existing `_strides` field
- Bounds checking: rank mismatch and per-dimension out-of-range both raise `Error`
- Delegates to the existing flat `__setitem__(Int, Float64)` overload

## Changes Made

- `shared/core/extensor.mojo`: new `__setitem__` overload at line ~802
- `tests/shared/core/test_extensor_setitem.mojo`: 17 tests covering flat index overloads, multi-dim 2D/3D, dtype variants, all error cases, and round-trip correctness

## Verification

- All pre-commit hooks pass (`mojo format`, trailing whitespace, etc.)
- Test file validates stride arithmetic: `t[[1, 2]] = 5.0` on shape `[3,4]` → flat index 6
- Error cases confirmed: rank mismatch, per-dim bounds, negative indices

Closes #3275