### PR TITLE
fix(training): support N-D tensors in DataLoader.next()

### DIFF
--- a/shared/training/trainer_interface.mojo
+++ b/shared/training/trainer_interface.mojo
@@ -377,17 +377,11 @@ struct DataLoader(Copyable, Movable):
         var end_idx = min(start_idx + self.batch_size, self.num_samples)
         var actual_batch_size = end_idx - start_idx
 
-        # Extract batch slice
-        var batch_data_shape = List[Int]()
-        batch_data_shape.append(actual_batch_size)
-        batch_data_shape.append(self.data.shape()[1])
-        var batch_data = ExTensor(batch_data_shape, self.data.dtype())
+        # Extract batch slice — supports N-D tensors (2D, 3D, 4D, etc.)
+        var batch_data = self.data.slice(start_idx, end_idx)
 
-        var batch_labels_shape = List[Int]()
-        batch_labels_shape.append(actual_batch_size)
-        var batch_labels = ExTensor(batch_labels_shape, self.labels.dtype())
+        var batch_labels = self.labels.slice(start_idx, end_idx)
 
-        # Tensor slicing is implemented in ExTensor.slice() and __getitem__()
         # NOTE(#3076): Python data loader integration blocked by Track 4 (Python↔Mojo interop).
         # Tracked in #3076 (parent: #3059). Placeholder tensors used until Track 4 is ready.
 

--- a/tests/shared/training/test_training_loop.mojo
+++ b/tests/shared/training/test_training_loop.mojo
@@ -592,6 +592,111 @@ fn test_training_loop_property_loss_decreases_on_simple_problem() raises:
 
 
 # ============================================================================
+# DataLoader N-D Tensor Tests
+# ============================================================================
+
+from shared.training.trainer_interface import DataLoader
+
+
+fn test_dataloader_4d_batch_slicing() raises:
+    """Test DataLoader correctly slices 4D tensors (N, C, H, W).
+
+    Verifies that DataLoader.next() returns batches with all trailing
+    dimensions (C, H, W) preserved correctly for image data.
+    """
+    # Create (8, 2, 4, 4) float32 tensor simulating image data
+    var data = ones([8, 2, 4, 4], DType.float32)
+    var labels = zeros([8], DType.float32)
+    var loader = DataLoader(data^, labels^, 4)
+
+    # First batch
+    var batch1 = loader.next()
+    assert_equal(batch1.data.shape()[0], 4)
+    assert_equal(batch1.data.shape()[1], 2)
+    assert_equal(batch1.data.shape()[2], 4)
+    assert_equal(batch1.data.shape()[3], 4)
+    assert_equal(batch1.batch_size, 4)
+
+    # Second batch
+    var batch2 = loader.next()
+    assert_equal(batch2.data.shape()[0], 4)
+    assert_equal(batch2.data.shape()[1], 2)
+    assert_equal(batch2.data.shape()[2], 4)
+    assert_equal(batch2.data.shape()[3], 4)
+    assert_equal(batch2.batch_size, 4)
+
+    print("  test_dataloader_4d_batch_slicing: PASSED")
+
+
+fn test_dataloader_4d_partial_last_batch() raises:
+    """Test DataLoader handles partial last batch for 4D tensors.
+
+    With N=6 and batch_size=4, the second batch should have 2 samples
+    while preserving trailing dimensions (C, H, W).
+    """
+    var data = ones([6, 2, 4, 4], DType.float32)
+    var labels = zeros([6], DType.float32)
+    var loader = DataLoader(data^, labels^, 4)
+
+    # First full batch: shape (4, 2, 4, 4)
+    var batch1 = loader.next()
+    assert_equal(batch1.data.shape()[0], 4)
+    assert_equal(batch1.data.shape()[1], 2)
+    assert_equal(batch1.data.shape()[2], 4)
+    assert_equal(batch1.data.shape()[3], 4)
+    assert_equal(batch1.batch_size, 4)
+
+    # Partial last batch: shape (2, 2, 4, 4)
+    var batch2 = loader.next()
+    assert_equal(batch2.data.shape()[0], 2)
+    assert_equal(batch2.data.shape()[1], 2)
+    assert_equal(batch2.data.shape()[2], 4)
+    assert_equal(batch2.data.shape()[3], 4)
+    assert_equal(batch2.batch_size, 2)
+
+    print("  test_dataloader_4d_partial_last_batch: PASSED")
+
+
+fn test_dataloader_3d_batch_slicing() raises:
+    """Test DataLoader correctly slices 3D tensors (N, seq_len, features).
+
+    Verifies that DataLoader.next() works for sequence data where each
+    sample has shape (seq_len, features).
+    """
+    var data = ones([8, 10, 16], DType.float32)
+    var labels = zeros([8], DType.float32)
+    var loader = DataLoader(data^, labels^, 4)
+
+    var batch = loader.next()
+    assert_equal(batch.data.shape()[0], 4)
+    assert_equal(batch.data.shape()[1], 10)
+    assert_equal(batch.data.shape()[2], 16)
+    assert_equal(batch.batch_size, 4)
+
+    print("  test_dataloader_3d_batch_slicing: PASSED")
+
+
+fn test_dataloader_nd_shape_preserved() raises:
+    """Test that trailing dimensions are identical across all batches.
+
+    Iterates all batches of a (9, 3, 8, 8) tensor with batch_size=4
+    and asserts remaining dims (3, 8, 8) are preserved in every batch.
+    """
+    var data = ones([9, 3, 8, 8], DType.float32)
+    var labels = zeros([9], DType.float32)
+    var loader = DataLoader(data^, labels^, 4)
+
+    while loader.has_next():
+        var batch = loader.next()
+        # All batches must preserve trailing dims regardless of batch size
+        assert_equal(batch.data.shape()[1], 3)
+        assert_equal(batch.data.shape()[2], 8)
+        assert_equal(batch.data.shape()[3], 8)
+
+    print("  test_dataloader_nd_shape_preserved: PASSED")
+
+
+# ============================================================================
 # Test Main
 # ============================================================================
 
@@ -625,5 +730,11 @@ fn main() raises:
 
     print("Running property-based tests...")
     test_training_loop_property_loss_decreases_on_simple_problem()
+
+    print("Running DataLoader N-D Tensor Tests...")
+    test_dataloader_4d_batch_slicing()
+    test_dataloader_4d_partial_last_batch()
+    test_dataloader_3d_batch_slicing()
+    test_dataloader_nd_shape_preserved()
 
     print("\nAll training loop tests passed!")


### PR DESCRIPTION
## Summary

- Replace hardcoded 2D shape assumption (`self.data.shape()[1]`) in `DataLoader.next()` with `ExTensor.slice()`, which preserves all trailing dimensions for N-D tensors
- Fix labels slicing to use `slice()` consistently instead of building a 1D placeholder shape
- Add 4 new tests in `tests/shared/training/test_training_loop.mojo` covering 4D, 3D, and partial-batch scenarios

## Changes Made

**`shared/training/trainer_interface.mojo`** — `DataLoader.next()`:
- Removed manual shape construction with `shape()[1]` (2D-only assumption)
- Now uses `self.data.slice(start_idx, end_idx)` — dimension-agnostic, works for 2D/3D/4D/N-D
- Same fix applied to labels slice

**`tests/shared/training/test_training_loop.mojo`**:
- `test_dataloader_4d_batch_slicing` — (8, 2, 4, 4) tensor, verifies shape preserved in both batches
- `test_dataloader_4d_partial_last_batch` — (6, 2, 4, 4) tensor, verifies partial batch shape (2, 2, 4, 4)
- `test_dataloader_3d_batch_slicing` — (8, 10, 16) tensor, verifies (4, 10, 16) slices
- `test_dataloader_nd_shape_preserved` — iterates all batches of (9, 3, 8, 8), asserts dims (3, 8, 8) invariant

## Verification

All pre-commit hooks passed. Tests will be validated by CI.

Closes #3277

🤖 Generated with [Claude Code](https://claude.com/claude-code)