### PR TITLE
test(normalization): add numerical gradient test for batch_norm2d_backward inference mode

### DIFF
--- a/tests/shared/core/test_normalization.mojo
+++ b/tests/shared/core/test_normalization.mojo
@@ -378,6 +378,109 @@ fn test_batch_norm2d_backward_gradient_input() raises:
     print("✓ Batch norm backward gradient (input) validated numerically")
 
 
+fn test_batch_norm2d_backward_gradient_input_inference_mode() raises:
+    """Numerical gradient validation for batch_norm2d_backward in inference mode.
+
+    Inference mode uses fixed running_mean/running_var, giving a simpler
+    linear gradient: grad_input = grad_output * gamma / sqrt(running_var + eps).
+    Validates the inference code path in batch_norm2d_backward independently
+    from training mode.
+    """
+    # Small tensor: batch=2, channels=2, height=2, width=2 (16 elements)
+    var shape = List[Int]()
+    shape.append(2)  # batch
+    shape.append(2)  # channels
+    shape.append(2)  # height
+    shape.append(2)  # width
+
+    # Input with varying values
+    var x = zeros(shape, DType.float32)
+    for i in range(16):
+        x._data.bitcast[Float32]()[i] = Float32(i) * 0.1
+
+    # Parameters: non-unit gamma, non-zero running stats per channel
+    var param_shape = List[Int]()
+    param_shape.append(2)
+    var gamma = ones(param_shape, DType.float32)
+    gamma._data.bitcast[Float32]()[0] = 1.5
+    gamma._data.bitcast[Float32]()[1] = 2.0
+
+    var beta = zeros(param_shape, DType.float32)
+
+    var running_mean = zeros(param_shape, DType.float32)
+    running_mean._data.bitcast[Float32]()[0] = 0.3
+    running_mean._data.bitcast[Float32]()[1] = 0.7
+
+    var running_var = ones(param_shape, DType.float32)
+    running_var._data.bitcast[Float32]()[0] = 0.5
+    running_var._data.bitcast[Float32]()[1] = 1.5
+
+    # Forward pass in inference mode (running stats frozen)
+    var result_fwd = batch_norm2d(
+        x,
+        gamma,
+        beta,
+        running_mean,
+        running_var,
+        training=False,
+        epsilon=1e-5,
+    )
+    var output = result_fwd[0]
+
+    # Use ones grad_output: in inference mode, grad_input = grad_output * gamma / std
+    # which is non-zero for grad_output=ones (no cancellation issue unlike training mode)
+    var grad_output = ones_like(output)
+
+    # Analytical backward pass in inference mode
+    var result_bwd = batch_norm2d_backward(
+        grad_output,
+        x,
+        gamma,
+        running_mean,
+        running_var,
+        training=False,
+        epsilon=1e-5,
+    )
+    var grad_input = result_bwd[0]
+
+    # Numerical gradient: closure uses training=False with fixed running stats
+    fn forward_for_grad_infer(inp: ExTensor) raises -> ExTensor:
+        var res = batch_norm2d(
+            inp,
+            gamma,
+            beta,
+            running_mean,
+            running_var,
+            training=False,
+            epsilon=1e-5,
+        )
+        var out = res[0]
+        # Weighted sum matching our grad_output=ones backward
+        var weighted = multiply(out, grad_output)
+        var result = weighted
+        while result.dim() > 0:
+            result = reduce_sum(result, axis=0, keepdims=False)
+        return result
+
+    var numerical_grad = compute_numerical_gradient(
+        forward_for_grad_infer, x, epsilon=3e-4
+    )
+
+    # Inference mode gradient is a simple linear rescaling; tolerances can be tight
+    assert_gradients_close(
+        grad_input,
+        numerical_grad,
+        rtol=1e-2,
+        atol=1e-5,
+        message="Batch norm inference mode gradient w.r.t. input",
+    )
+
+    print(
+        "✓ Batch norm backward gradient (input) inference mode validated"
+        " numerically"
+    )
+
+
 fn test_batch_norm2d_backward_gradient_gamma() raises:
     """Test batch_norm2d_backward gradient w.r.t. gamma using numerical validation.
 
@@ -1044,6 +1147,9 @@ fn main() raises:
     # Batch normalization backward pass tests (gradient checking)
     test_batch_norm2d_backward_gradient_input()
     print("✓ test_batch_norm2d_backward_gradient_input")
+
+    test_batch_norm2d_backward_gradient_input_inference_mode()
+    print("✓ test_batch_norm2d_backward_gradient_input_inference_mode")
 
     test_batch_norm2d_backward_gradient_gamma()
     print("✓ test_batch_norm2d_backward_gradient_gamma")


### PR DESCRIPTION
## Summary

- Add `test_batch_norm2d_backward_gradient_input_inference_mode()` to `tests/shared/core/test_normalization.mojo`
- Validates the inference-mode code path in `batch_norm2d_backward` using central finite differences
- No implementation changes — pure test addition

## Changes Made

The new test exercises the inference branch of `batch_norm2d_backward` (`normalization.mojo:856–913`), which was previously covered only by a mode-comparison test (`test_batch_norm2d_backward_training_vs_inference`) but not by numerical gradient validation.

**Key design choices:**
- Uses `training=False` in both the forward closure and analytical backward call, keeping `running_mean`/`running_var` frozen as required by inference semantics
- Uses `grad_output=ones` (unlike the training-mode test which requires non-uniform weights to avoid cancellation — inference mode's linear formula `grad_input = grad_output * gamma / std` is non-zero for all-ones)
- Non-unit `gamma=[1.5, 2.0]`, `running_mean=[0.3, 0.7]`, `running_var=[0.5, 1.5]` to exercise per-channel scaling
- `epsilon=3e-4` for finite differences (project standard), `rtol=1e-2`, `atol=1e-5`

## Verification

- Pre-commit hooks pass (mojo format, trailing whitespace, end-of-file, large file check)
- CI will run `mojo test tests/shared/core/test_normalization.mojo` — all existing tests remain unchanged

Closes #3280