### PR TITLE
fix(file_io): implement remove_safely() using Python os.remove() interop

### DIFF
--- a/shared/utils/file_io.mojo
+++ b/shared/utils/file_io.mojo
@@ -660,22 +660,23 @@ fn create_backup(filepath: String) -> Bool:
 
 
 fn remove_safely(filepath: String) -> Bool:
-    """Remove file safely (move to trash vs permanent delete).
+    """Remove file using Python os.remove() interop.
 
     Args:
             filepath: File to remove.
 
     Returns:
-            True if removed, False if error.
+            True if removed successfully, False if file doesn't exist or error.
     """
-    # NOTE (Mojo v0.26.1): Mojo v0.26.1 doesn't have os.remove() or file system operations
-    # In production, this would move file to trash/trash directory
-    # For now, this is a placeholder that simulates successful removal
     if not file_exists(filepath):
         return False
 
-    # Placeholder - would call os.remove(filepath) or move to trash
-    return True
+    try:
+        var python = Python.import_module("os")
+        python.remove(filepath)
+        return True
+    except:
+        return False
 
 
 # ============================================================================

--- a/tests/shared/utils/test_io.mojo
+++ b/tests/shared/utils/test_io.mojo
@@ -230,14 +230,27 @@ fn test_write_with_backup():
     pass
 
 
-fn test_safe_remove():
-    """Test safe file removal (move to trash, not permanent delete)."""
-    # TODO(#44): Implement when safe_remove exists
-    # Create temp file
-    # Remove safely
-    # Verify file moved to trash directory
-    # Not permanently deleted
-    pass
+fn test_safe_remove() raises:
+    """Test remove_safely() actually deletes the file."""
+    from shared.utils.file_io import remove_safely, safe_write_file, file_exists
+
+    var test_path = "/tmp/test_remove_safely_3283.txt"
+
+    # Create file
+    var written = safe_write_file(test_path, "test content")
+    assert_true(written)
+    assert_true(file_exists(test_path))
+
+    # Remove it
+    var removed = remove_safely(test_path)
+    assert_true(removed)
+    assert_false(file_exists(test_path))
+
+    # Removing nonexistent file returns False
+    var removed_again = remove_safely(test_path)
+    assert_false(removed_again)
+
+    print("PASS: test_safe_remove")
 
 
 fn test_create_directory_safe():


### PR DESCRIPTION
## Summary

- Replace no-op `remove_safely()` placeholder (always returned `True` without deleting) with real implementation using Python `os.remove()` interop
- Uses the same `Python.import_module("os")` pattern already established in `safe_write_file()` for `os.rename()`
- Replace `test_safe_remove()` stub with a real test covering success and nonexistent-file cases

## Changes

- `shared/utils/file_io.mojo:662-679` — replaced placeholder body with Python interop call
- `tests/shared/utils/test_io.mojo:233-253` — replaced TODO stub with real test

## Test plan

- [x] Pre-commit hooks pass (mojo format, trailing whitespace, end-of-file, large files)
- [ ] CI: `pixi run mojo test tests/shared/utils/test_io.mojo` — `PASS: test_safe_remove`
- [ ] CI: `grep -n "placeholder" shared/utils/file_io.mojo` — no match in `remove_safely()`

Closes #3283

🤖 Generated with [Claude Code](https://claude.com/claude-code)