### PR TITLE
fix(comments): remove NOTE: prefix from test/example comment markers

### DIFF
--- a/benchmarks/scripts/compare_results.mojo
+++ b/benchmarks/scripts/compare_results.mojo
@@ -592,7 +592,7 @@ fn main() raises:
     var current_file = "benchmarks/results/benchmark_results.json"
 
     # Parse command line arguments
-    # NOTE (Mojo v0.26.1): Hardcoded paths are intentional. While Mojo's sys.argv provides
+    # Hardcoded paths are intentional (Mojo v0.26.1). While Mojo's sys.argv provides
     # basic argv access, comprehensive argument parsing (flags, options,
     # help text) would require a custom parser. For internal benchmarking
     # tooling, hardcoded defaults are sufficient and simpler to maintain.

--- a/examples/googlenet-cifar10/train.mojo
+++ b/examples/googlenet-cifar10/train.mojo
@@ -94,7 +94,7 @@ fn train_epoch(
 
     print("Epoch " + String(epoch + 1) + ": lr=" + String(learning_rate))
 
-    # NOTE(#3084): Full backward pass implementation for GoogLeNet would require ~3500 lines:
+    # Full backward pass implementation for GoogLeNet would require ~3500 lines (#3084):
     #   - Forward pass with activation caching: ~600 lines (9 Inception modules × ~60 lines)
     #   - Backward pass through all layers: ~2500 lines
     #   - Parameter updates with momentum: ~400 lines

--- a/examples/lenet-emnist/run_infer.mojo
+++ b/examples/lenet-emnist/run_infer.mojo
@@ -337,7 +337,7 @@ fn main() raises:
         print("Loading image from", config.image_path, "...")
 
         # Load image (currently supports IDX format only)
-        # NOTE (Mojo v0.26.1): PNG/JPEG image loading requires external image processing libraries.
+        # PNG/JPEG image loading requires external image processing libraries (Mojo v0.26.1).
         # Mojo does not yet have native image decoding support in its stdlib.
         # For now, convert images to IDX format using Python preprocessing scripts.
         var image = load_image(config.image_path)

--- a/scripts/verify_installation.mojo
+++ b/scripts/verify_installation.mojo
@@ -39,7 +39,7 @@ fn main():
     # ========================================================================
     print("\nTest 2: Checking core package...")
     try:
-        # NOTE: These imports are commented until implementation completes
+        # These imports are commented until implementation completes
         # from shared.core import Linear, ReLU, Tensor
 
         print(

--- a/shared/__init__.mojo
+++ b/shared/__init__.mojo
@@ -48,7 +48,7 @@ from shared.version import VERSION, AUTHOR, LICENSE
 # ============================================================================
 # Core Exports - Most commonly used components
 # ============================================================================
-# NOTE: These imports are commented out pending full layer implementation.
+# These imports are commented out pending full layer implementation.
 
 # Core layers (most commonly used)
 # from .core.layers import Linear, Conv2D, ReLU, MaxPool2D, Dropout, Flatten
@@ -125,7 +125,7 @@ alias Accuracy = AccuracyMetric
 # This allows users to do: from shared import core, training, data, utils
 # Then access via: shared.core.layers.Linear, shared.training.optimizers.SGD
 #
-# NOTE: Mojo v0.26.1+ does not support __all__ module-level assignments.
+# Mojo v0.26.1+ does not support __all__ module-level assignments.
 # In Mojo, all public symbols (those not prefixed with _) are automatically
 # exported when the module is imported. The public API documentation below
 # describes what should be exposed at this package level:

--- a/tests/models/test_alexnet_layers.mojo
+++ b/tests/models/test_alexnet_layers.mojo
@@ -1116,7 +1116,7 @@ fn main() raises:
     test_conv1_forward_float32()
     print(" OK")
 
-    # NOTE: Float16 precision insufficient for 11x11 kernel accumulation
+    # Float16 precision insufficient for 11x11 kernel accumulation
     # (363 multiplications per output element). Known limitation - see #3009.
     print("  test_conv1_forward_float16... SKIPPED (float16 precision)")
 
@@ -1129,7 +1129,7 @@ fn main() raises:
     test_conv2_forward_float32()
     print(" OK")
 
-    # NOTE: Float16 precision insufficient for 5x5 kernel with 64 input channels
+    # Float16 precision insufficient for 5x5 kernel with 64 input channels
     # (1600 multiplications per output element). Known limitation - see #3009.
     print("  test_conv2_forward_float16... SKIPPED (float16 precision)")
 
@@ -1143,7 +1143,7 @@ fn main() raises:
     test_conv3_forward_float32()
     print(" OK")
 
-    # NOTE: Float16 precision insufficient for 3x3 kernel with 192 input channels
+    # Float16 precision insufficient for 3x3 kernel with 192 input channels
     # (1728 multiplications per output element). Known limitation - see #3009.
     print("  test_conv3_forward_float16... SKIPPED (float16 precision)")
 


### PR DESCRIPTION
## Summary

- Removes `# NOTE:` / `# NOTE(...):` prefix from 9 comment markers across test, example, benchmark, and script files
- Pure comment-only changes — no functional or behavioral impact
- Follow-up from #3072 which handled production source files

## Files Modified

| File | NOTEs removed |
|------|--------------|
| `tests/models/test_alexnet_layers.mojo` | 3 (Float16 skip explanations) |
| `examples/lenet-emnist/run_infer.mojo` | 1 (PNG/JPEG limitation) |
| `examples/googlenet-cifar10/train.mojo` | 1 (backward pass scope) |
| `shared/__init__.mojo` | 2 (pending imports, `__all__` limitation) |
| `benchmarks/scripts/compare_results.mojo` | 1 (hardcoded paths) |
| `scripts/verify_installation.mojo` | 1 (pending imports) |

## Verification

- `grep -rn "# NOTE" <scoped files>` returns zero results
- All pre-commit hooks passed (mojo format, trailing whitespace, end-of-file, large files)

Closes #3289