### PR TITLE
fix(extensor): add bfloat16 support to _set_float64/_get_float64

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -477,6 +477,8 @@ struct ExTensor(
         """
         if dtype == DType.float16:
             return 2
+        elif dtype == DType.bfloat16:
+            return 2
         elif dtype == DType.float32:
             return 4
         elif dtype == DType.float64:
@@ -1016,6 +1018,9 @@ struct ExTensor(
         if self._dtype == DType.float16:
             var ptr = (self._data + offset).bitcast[Float16]()
             return ptr[].cast[DType.float64]()
+        elif self._dtype == DType.bfloat16:
+            var ptr = (self._data + offset).bitcast[BFloat16]()
+            return Float64(Float32(ptr[]))
         elif self._dtype == DType.float32:
             var ptr = (self._data + offset).bitcast[Float32]()
             return ptr[].cast[DType.float64]()
@@ -1039,6 +1044,9 @@ struct ExTensor(
         if self._dtype == DType.float16:
             var ptr = (self._data + offset).bitcast[Float16]()
             ptr[] = value.cast[DType.float16]()
+        elif self._dtype == DType.bfloat16:
+            var ptr = (self._data + offset).bitcast[BFloat16]()
+            ptr[] = BFloat16(Float32(value))
         elif self._dtype == DType.float32:
             var ptr = (self._data + offset).bitcast[Float32]()
             ptr[] = value.cast[DType.float32]()

--- a/tests/shared/testing/test_special_values.mojo
+++ b/tests/shared/testing/test_special_values.mojo
@@ -262,10 +262,9 @@ fn test_dtypes_bfloat16() raises:
 
     Reference: shared.core.types.bf16 module for current BF16 implementation
     """
-    # var tensor = create_special_value_tensor([2, 2], DType.bfloat16, 1.0)
-    # assert_dtype(tensor, DType.bfloat16, "Should be bfloat16")
-    # verify_special_value_invariants(tensor, 1.0)
-    pass  # Placeholder - BFloat16 DType not yet supported in Mojo's runtime
+    var tensor = create_special_value_tensor([2, 2], DType.bfloat16, 1.0)
+    assert_dtype(tensor, DType.bfloat16, "Should be bfloat16")
+    verify_special_value_invariants(tensor, 1.0)
 
 
 fn test_create_seeded_random_tensor_reproducibility() raises:
@@ -479,9 +478,8 @@ fn main() raises:
     test_dtypes_float16()
     print("✓ test_dtypes_float16")
 
-    # BF16 dtype not yet supported in Mojo
     test_dtypes_bfloat16()
-    print("✓ test_dtypes_bfloat16 (skipped - DType.bfloat16 not supported)")
+    print("✓ test_dtypes_bfloat16")
 
     # Test seeded random tensor (for gradient checking reproducibility)
     test_create_seeded_random_tensor_reproducibility()


### PR DESCRIPTION
## Summary

- Add `DType.bfloat16` branch to `_get_float64`: reads via `BFloat16` pointer, casts through `Float32` intermediary to `Float64` (two-step cast avoids direct bf16↔f64 conversion issues in Mojo 0.26.1)
- Add `DType.bfloat16` branch to `_set_float64`: casts `Float64` → `Float32` → `BFloat16` before storing
- Add `DType.bfloat16` case in `_get_dtype_size_static` returning 2 bytes (previously fell through to 4-byte default, causing incorrect memory access)
- Re-enable `test_dtypes_bfloat16()` in `tests/shared/testing/test_special_values.mojo`: uncomment 3 test lines, remove `pass` placeholder, update print message

## Test plan

- [x] Pre-commit hooks pass (mojo format, markdown lint, trailing whitespace)
- [ ] `pixi run mojo test tests/shared/testing/test_special_values.mojo` passes in CI (requires Docker due to GLIBC version mismatch on local host)
- [ ] Full `tests/shared/core/` suite passes in CI (no regressions)

Closes #3300

🤖 Generated with [Claude Code](https://claude.com/claude-code)