### PR TITLE
docs(readme): add CI badge for comprehensive-tests workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ maximum performance and type safety.
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](LICENSE)
 [![Tests](https://img.shields.io/badge/tests-247%2B-brightgreen.svg)](tests/)
 [![Coverage](https://img.shields.io/badge/coverage-pending-lightgrey.svg)](#coverage-status)
+[![CI](https://github.com/HomericIntelligence/ProjectOdyssey/actions/workflows/comprehensive-tests.yml/badge.svg?branch=main)](https://github.com/HomericIntelligence/ProjectOdyssey/actions/workflows/comprehensive-tests.yml)
 
 ## What This Is
 


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow status badge for `comprehensive-tests.yml` to the README badge block
- Badge uses GitHub's native `/badge.svg` URL which auto-reflects live CI state
- No maintenance required — badge updates automatically with each workflow run

## Changes

**`README.md`** — Added one badge line after the Coverage badge:

```markdown
[![CI](https://github.com/HomericIntelligence/ProjectOdyssey/actions/workflows/comprehensive-tests.yml/badge.svg?branch=main)](https://github.com/HomericIntelligence/ProjectOdyssey/actions/workflows/comprehensive-tests.yml)
```

## Test plan

- [x] `comprehensive-tests.yml` workflow file confirmed present at `.github/workflows/comprehensive-tests.yml`
- [x] All pre-commit hooks pass on `README.md` (markdownlint, trailing whitespace, end-of-file)
- [x] Badge block now contains 5 badges: Mojo, License, Tests, Coverage, CI

Closes #3306