### PR TITLE
feat(ci): automate test count badge to avoid drift

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,13 @@ repos:
         language: system
         files: (test_.*\.mojo|comprehensive-tests\.yml)$
         pass_filenames: false
+      - id: check-test-count-badge
+        name: Check Test Count Badge
+        description: Validate README.md test count badge matches actual test_*.mojo count
+        entry: python3 scripts/check_test_count_badge.py
+        language: system
+        files: ^README\.md$
+        pass_filenames: false
 
   # Markdown linting
   - repo: https://github.com/DavidAnson/markdownlint-cli2

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ maximum performance and type safety.
 
 [![Mojo](https://img.shields.io/badge/Mojo-0.26+-orange.svg)](https://www.modular.com/mojo)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-247%2B-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-223%2B-brightgreen.svg)](tests/)
 [![Coverage](https://img.shields.io/badge/coverage-pending-lightgrey.svg)](#coverage-status)
 
 ## What This Is
@@ -18,7 +18,7 @@ ML Odyssey is a research platform with two goals:
 2. **Provide a reusable shared library** of ML components that paper implementations build on
 
 The project currently has ~198K lines of Mojo code, 7 fully-implemented neural network
-architectures, and 247+ tests across layerwise unit tests and end-to-end integration tests.
+architectures, and 223+ tests across layerwise unit tests and end-to-end integration tests.
 
 ## Implemented Architectures
 

--- a/scripts/check_test_count_badge.py
+++ b/scripts/check_test_count_badge.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Check Test Count Badge — Validate README.md test count badge against actual test files.
+
+This script counts test_*.mojo files in the repository and compares the count
+against the shields.io badge URL in README.md. It fails if the badge is more than
+10% out of date, and can auto-update the badge with --fix.
+
+Exit codes:
+  0 - Badge is current (within tolerance)
+  1 - Badge is stale or validation error
+
+Usage:
+    python scripts/check_test_count_badge.py [--fix] [--tolerance FLOAT]
+
+Arguments:
+    --fix           Auto-update the badge in README.md to the actual count
+    --tolerance     Allowed fractional drift before failing (default: 0.10)
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Enable importing from scripts/common.py
+sys.path.insert(0, str(Path(__file__).parent))
+from common import get_repo_root
+
+# Directories to exclude from test file discovery (matches validate_test_coverage.py)
+_EXCLUDE_DIRS = [".pixi/", "build/", "dist/", ".git/", "worktrees/"]
+
+# Regex to extract the numeric count from a shields.io tests badge URL.
+# Matches patterns like: tests-247%2B, tests-122%2B, tests-300
+_BADGE_COUNT_RE = re.compile(r"tests-(\d[\d,]*?)(?:%2B|-brightgreen|\+|\.svg|-[a-z])")
+
+# Pattern that identifies the tests badge line in README.md
+_BADGE_LINE_RE = re.compile(r"(https://img\.shields\.io/badge/tests-)(\d[\d,]*)(%2B-brightgreen\.svg)")
+
+
+def count_test_files(repo_root: Path) -> int:
+    """Count test_*.mojo files, excluding build artifacts and known non-test directories.
+
+    Uses subprocess find to mirror the approach in validate_test_coverage.py and
+    handle large directory trees safely.  Exclusions are checked against the path
+    *relative to repo_root* so that worktree paths (which contain 'worktrees/' in
+    their absolute form) are not incorrectly filtered.
+
+    Args:
+        repo_root: Absolute path to the repository root.
+
+    Returns:
+        Number of test_*.mojo files found.
+    """
+    cmd = ["find", str(repo_root), "-name", "test_*.mojo", "-type", "f"]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+
+    if result.returncode != 0:
+        print(f"❌ find command failed: {result.stderr}", file=sys.stderr)
+        return 0
+
+    repo_prefix = str(repo_root) + "/"
+    count = 0
+    for path in result.stdout.splitlines():
+        # Build the relative path for exclusion checks so that worktree repo
+        # roots (e.g. .worktrees/issue-3307/) are not falsely excluded.
+        rel = path[len(repo_prefix) :] if path.startswith(repo_prefix) else path
+        if any(excl in rel for excl in _EXCLUDE_DIRS):
+            continue
+        count += 1
+
+    return count
+
+
+def parse_badge_count(readme_path: Path) -> Optional[int]:
+    """Extract the test count from the shields.io badge in README.md.
+
+    Args:
+        readme_path: Path to README.md.
+
+    Returns:
+        The integer count embedded in the badge URL, or None if not found.
+    """
+    if not readme_path.exists():
+        print(f"❌ README not found: {readme_path}", file=sys.stderr)
+        return None
+
+    content = readme_path.read_text(encoding="utf-8")
+    match = _BADGE_COUNT_RE.search(content)
+    if not match:
+        print("❌ Could not find tests badge in README.md", file=sys.stderr)
+        return None
+
+    raw = match.group(1).replace(",", "")
+    try:
+        return int(raw)
+    except ValueError:
+        print(f"❌ Could not parse badge count from '{raw}'", file=sys.stderr)
+        return None
+
+
+def check_badge_drift(actual: int, badge: int, tolerance: float = 0.10) -> bool:
+    """Return True if the badge count is within tolerance of the actual count.
+
+    Args:
+        actual: Real number of test files found.
+        badge: Count recorded in the README badge.
+        tolerance: Maximum allowed fractional deviation (default 10%).
+
+    Returns:
+        True if within tolerance, False if the badge is too stale.
+    """
+    if actual == 0:
+        return badge == 0
+    drift = abs(actual - badge) / actual
+    return drift <= tolerance
+
+
+def update_badge(readme_path: Path, new_count: int) -> None:
+    """Rewrite the tests badge URL in README.md with new_count.
+
+    Args:
+        readme_path: Path to README.md.
+        new_count: The count to embed in the badge URL.
+    """
+    content = readme_path.read_text(encoding="utf-8")
+    updated = _BADGE_LINE_RE.sub(
+        rf"\g<1>{new_count}\g<3>",
+        content,
+    )
+    readme_path.write_text(updated, encoding="utf-8")
+
+
+def main() -> int:
+    """Orchestrate badge count validation.
+
+    Returns:
+        0 if badge is current, 1 if stale or error.
+    """
+    args = sys.argv[1:]
+    fix_mode = "--fix" in args
+
+    tolerance = 0.10
+    if "--tolerance" in args:
+        idx = args.index("--tolerance")
+        try:
+            tolerance = float(args[idx + 1])
+        except (IndexError, ValueError):
+            print("❌ --tolerance requires a float argument", file=sys.stderr)
+            return 1
+
+    repo_root = get_repo_root()
+    readme_path = repo_root / "README.md"
+
+    actual = count_test_files(repo_root)
+    badge = parse_badge_count(readme_path)
+
+    if badge is None:
+        return 1
+
+    if check_badge_drift(actual, badge, tolerance):
+        print(f"✅ Test count badge is current: {badge}+ (actual: {actual})")
+        return 0
+
+    print(
+        f"❌ Test count badge is stale: badge={badge}+, actual={actual} "
+        f"(drift={abs(actual - badge) / actual:.1%}, tolerance={tolerance:.0%})"
+    )
+
+    if fix_mode:
+        update_badge(readme_path, actual)
+        print(f"✅ Updated badge to {actual}+ in README.md")
+        return 0
+
+    print("   Run with --fix to auto-update the badge.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_check_test_count_badge.py
+++ b/tests/scripts/test_check_test_count_badge.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/check_test_count_badge.py."""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Add scripts directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+from check_test_count_badge import (
+    check_badge_drift,
+    count_test_files,
+    main,
+    parse_badge_count,
+    update_badge,
+)
+
+
+# ---------------------------------------------------------------------------
+# count_test_files
+# ---------------------------------------------------------------------------
+
+
+def test_count_test_files_finds_mojo_files(tmp_path: Path) -> None:
+    """Should count test_*.mojo files in a directory tree."""
+    (tmp_path / "test_alpha.mojo").write_text("")
+    (tmp_path / "test_beta.mojo").write_text("")
+    (tmp_path / "not_a_test.mojo").write_text("")  # must be excluded by name
+    subdir = tmp_path / "nested"
+    subdir.mkdir()
+    (subdir / "test_gamma.mojo").write_text("")
+
+    count = count_test_files(tmp_path)
+    assert count == 3
+
+
+def test_count_test_files_excludes_pixi(tmp_path: Path) -> None:
+    """Files under .pixi/ should be excluded."""
+    pixi = tmp_path / ".pixi" / "lib"
+    pixi.mkdir(parents=True)
+    (pixi / "test_hidden.mojo").write_text("")
+    (tmp_path / "test_real.mojo").write_text("")
+
+    count = count_test_files(tmp_path)
+    assert count == 1
+
+
+def test_count_test_files_excludes_worktrees(tmp_path: Path) -> None:
+    """Files under worktrees/ should be excluded."""
+    wt = tmp_path / "worktrees" / "branch"
+    wt.mkdir(parents=True)
+    (wt / "test_branch.mojo").write_text("")
+    (tmp_path / "test_main.mojo").write_text("")
+
+    count = count_test_files(tmp_path)
+    assert count == 1
+
+
+def test_count_test_files_empty_dir(tmp_path: Path) -> None:
+    """Should return 0 for directories with no matching files."""
+    assert count_test_files(tmp_path) == 0
+
+
+# ---------------------------------------------------------------------------
+# parse_badge_count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "badge_url, expected",
+    [
+        ("[![Tests](https://img.shields.io/badge/tests-247%2B-brightgreen.svg)](tests/)", 247),
+        ("[![Tests](https://img.shields.io/badge/tests-122%2B-brightgreen.svg)](tests/)", 122),
+        ("[![Tests](https://img.shields.io/badge/tests-300%2B-brightgreen.svg)](tests/)", 300),
+        ("[![Tests](https://img.shields.io/badge/tests-1000%2B-brightgreen.svg)](tests/)", 1000),
+    ],
+)
+def test_parse_badge_count_various_values(tmp_path: Path, badge_url: str, expected: int) -> None:
+    """Should extract numeric count from various badge URL formats."""
+    readme = tmp_path / "README.md"
+    readme.write_text(f"# Title\n\n{badge_url}\n")
+    assert parse_badge_count(readme) == expected
+
+
+def test_parse_badge_count_missing_badge(tmp_path: Path) -> None:
+    """Should return None when no tests badge is present."""
+    readme = tmp_path / "README.md"
+    readme.write_text("# Title\n\nNo badge here.\n")
+    assert parse_badge_count(readme) is None
+
+
+def test_parse_badge_count_nonexistent_file(tmp_path: Path) -> None:
+    """Should return None for a non-existent README."""
+    assert parse_badge_count(tmp_path / "MISSING.md") is None
+
+
+# ---------------------------------------------------------------------------
+# check_badge_drift
+# ---------------------------------------------------------------------------
+
+
+def test_check_badge_drift_within_tolerance() -> None:
+    """Should return True when drift is within 10%."""
+    # 5% drift
+    assert check_badge_drift(actual=200, badge=190) is True
+
+
+def test_check_badge_drift_exactly_at_tolerance() -> None:
+    """Should return True when drift equals the tolerance boundary exactly."""
+    # 10% below
+    assert check_badge_drift(actual=200, badge=180, tolerance=0.10) is True
+
+
+def test_check_badge_drift_just_over_tolerance() -> None:
+    """Should return False when drift exceeds tolerance."""
+    # ~10.5% drift
+    assert check_badge_drift(actual=200, badge=179, tolerance=0.10) is False
+
+
+def test_check_badge_drift_zero_actual() -> None:
+    """Should handle zero actual count: matches only when badge is also zero."""
+    assert check_badge_drift(actual=0, badge=0) is True
+    assert check_badge_drift(actual=0, badge=1) is False
+
+
+def test_check_badge_drift_custom_tolerance() -> None:
+    """Should respect custom tolerance values."""
+    assert check_badge_drift(actual=100, badge=95, tolerance=0.05) is True
+    assert check_badge_drift(actual=100, badge=94, tolerance=0.05) is False
+
+
+# ---------------------------------------------------------------------------
+# update_badge
+# ---------------------------------------------------------------------------
+
+
+def test_update_badge_rewrites_count(tmp_path: Path) -> None:
+    """Should update the badge count in README.md."""
+    readme = tmp_path / "README.md"
+    readme.write_text("[![Tests](https://img.shields.io/badge/tests-122%2B-brightgreen.svg)](tests/)\n")
+    update_badge(readme, 300)
+    content = readme.read_text()
+    assert "tests-300%2B-brightgreen.svg" in content
+    assert "tests-122" not in content
+
+
+def test_update_badge_preserves_rest_of_file(tmp_path: Path) -> None:
+    """Should not modify any content outside the badge URL."""
+    readme = tmp_path / "README.md"
+    original = (
+        "# Title\n\n"
+        "[![Tests](https://img.shields.io/badge/tests-247%2B-brightgreen.svg)](tests/)\n\n"
+        "Some other content.\n"
+    )
+    readme.write_text(original)
+    update_badge(readme, 250)
+    content = readme.read_text()
+    assert "# Title" in content
+    assert "Some other content." in content
+    assert "tests-250%2B-brightgreen.svg" in content
+
+
+# ---------------------------------------------------------------------------
+# main() integration tests
+# ---------------------------------------------------------------------------
+
+
+def _write_readme(path: Path, count: int) -> None:
+    path.write_text(f"[![Tests](https://img.shields.io/badge/tests-{count}%2B-brightgreen.svg)](tests/)\n")
+
+
+def test_main_badge_current_exits_zero(tmp_path: Path) -> None:
+    """Should exit 0 when badge matches actual count within tolerance."""
+    readme = tmp_path / "README.md"
+    _write_readme(readme, 200)
+
+    with (
+        patch("check_test_count_badge.get_repo_root", return_value=tmp_path),
+        patch("check_test_count_badge.count_test_files", return_value=200),
+        patch("sys.argv", ["check_test_count_badge.py"]),
+    ):
+        assert main() == 0
+
+
+def test_main_badge_stale_exits_one(tmp_path: Path) -> None:
+    """Should exit 1 when badge is stale beyond tolerance."""
+    readme = tmp_path / "README.md"
+    _write_readme(readme, 100)
+
+    with (
+        patch("check_test_count_badge.get_repo_root", return_value=tmp_path),
+        patch("check_test_count_badge.count_test_files", return_value=200),
+        patch("sys.argv", ["check_test_count_badge.py"]),
+    ):
+        assert main() == 1
+
+
+def test_main_fix_mode_updates_badge(tmp_path: Path) -> None:
+    """Should update badge and exit 0 when --fix is passed."""
+    readme = tmp_path / "README.md"
+    _write_readme(readme, 100)
+
+    with (
+        patch("check_test_count_badge.get_repo_root", return_value=tmp_path),
+        patch("check_test_count_badge.count_test_files", return_value=200),
+        patch("sys.argv", ["check_test_count_badge.py", "--fix"]),
+    ):
+        result = main()
+
+    assert result == 0
+    content = readme.read_text()
+    assert "tests-200%2B-brightgreen.svg" in content
+
+
+def test_main_no_badge_in_readme_exits_one(tmp_path: Path) -> None:
+    """Should exit 1 when README has no tests badge."""
+    readme = tmp_path / "README.md"
+    readme.write_text("# No badge here\n")
+
+    with (
+        patch("check_test_count_badge.get_repo_root", return_value=tmp_path),
+        patch("check_test_count_badge.count_test_files", return_value=100),
+        patch("sys.argv", ["check_test_count_badge.py"]),
+    ):
+        assert main() == 1
+
+
+def test_main_custom_tolerance(tmp_path: Path) -> None:
+    """Should respect --tolerance argument."""
+    readme = tmp_path / "README.md"
+    _write_readme(readme, 190)  # 5% drift from 200
+
+    # With 3% tolerance, 5% drift should fail
+    with (
+        patch("check_test_count_badge.get_repo_root", return_value=tmp_path),
+        patch("check_test_count_badge.count_test_files", return_value=200),
+        patch("sys.argv", ["check_test_count_badge.py", "--tolerance", "0.03"]),
+    ):
+        assert main() == 1
+
+    # With 10% tolerance, 5% drift should pass
+    with (
+        patch("check_test_count_badge.get_repo_root", return_value=tmp_path),
+        patch("check_test_count_badge.count_test_files", return_value=200),
+        patch("sys.argv", ["check_test_count_badge.py", "--tolerance", "0.10"]),
+    ):
+        assert main() == 0


### PR DESCRIPTION
## Summary

- Add `scripts/check_test_count_badge.py` that counts `test_*.mojo` files and validates the shields.io badge in `README.md` is within 10% of the actual count
- Add `tests/scripts/test_check_test_count_badge.py` with 22 unit tests covering all public functions
- Add `check-test-count-badge` pre-commit hook scoped to `README.md` changes
- Update stale badge from `247+` to current `223+`

## Changes Made

- `scripts/check_test_count_badge.py` — `count_test_files`, `parse_badge_count`, `check_badge_drift`, `update_badge`, `main` with `--fix` / `--tolerance` flags
- `tests/scripts/test_check_test_count_badge.py` — 22 passing pytest tests
- `.pre-commit-config.yaml` — new `check-test-count-badge` hook after `validate-test-coverage`
- `README.md` — badge and prose updated to 223+

## Verification

```
python -m pytest tests/scripts/test_check_test_count_badge.py -v
# 22 passed in 1.11s

python3 scripts/check_test_count_badge.py
# ✅ Test count badge is current: 223+ (actual: 223)
```

All pre-commit hooks passed on commit.

Closes #3307

🤖 Generated with [Claude Code](https://claude.com/claude-code)