### PR TITLE
fix(scripts): add --target-dir flag and env var fallback for migrate_odyssey_skills

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -820,6 +820,51 @@ ProjectOdyssey/
 - **Packaging**: Objectives, integration requirements, integration steps, success criteria
 - **Cleanup**: Objectives, cleanup tasks, success criteria, notes
 
+### migrate_odyssey_skills.py
+
+- **Purpose**: Migrate Odyssey2 `.claude/skills/` skill definitions to ProjectMnemosyne plugin format
+- **Complexity**: High (YAML frontmatter parsing, category mapping, directory transformation)
+- **Key Features**:
+  - Transforms SKILL.md frontmatter and body to Mnemosyne conventions
+  - Generates `.claude-plugin/plugin.json` with category, tags, and version metadata
+  - Copies auxiliary subdirectories (`scripts/`, `templates/`, `references/`, etc.)
+  - Supports `--audit` mode for cross-referencing coverage between repos
+  - Dry-run mode (`--dry-run`) to preview changes without writing files
+
+**Required Setup**
+
+Before running, you need a local clone of ProjectMnemosyne. Specify its location using one of:
+
+1. `--target-dir PATH` CLI argument (highest priority)
+2. `MNEMOSYNE_DIR` environment variable
+3. Default: `/tmp/ProjectMnemosyne`
+
+**Usage Examples**
+
+```bash
+# Clone Mnemosyne if not already present
+git clone https://github.com/<org>/ProjectMnemosyne /tmp/ProjectMnemosyne
+
+# Migrate all skills (dry run first)
+python3 scripts/migrate_odyssey_skills.py --dry-run
+
+# Migrate all skills for real
+python3 scripts/migrate_odyssey_skills.py
+
+# Use a custom Mnemosyne path
+python3 scripts/migrate_odyssey_skills.py --target-dir /path/to/ProjectMnemosyne
+
+# Or set an environment variable
+export MNEMOSYNE_DIR=/path/to/ProjectMnemosyne
+python3 scripts/migrate_odyssey_skills.py
+
+# Migrate a single skill
+python3 scripts/migrate_odyssey_skills.py --skill gh-create-pr-linked
+
+# Check coverage (audit mode)
+python3 scripts/migrate_odyssey_skills.py --audit
+```
+
 ---
 
 ## Related Documentation

--- a/scripts/migrate_odyssey_skills.py
+++ b/scripts/migrate_odyssey_skills.py
@@ -20,6 +20,7 @@ Target structure (ProjectMnemosyne):
 
 import argparse
 import json
+import os
 import re
 import shutil
 import sys
@@ -32,8 +33,34 @@ from typing import Optional
 # Source Odyssey2 skills directory
 ODYSSEY_SKILLS_DIR = Path("/home/mvillmow/Odyssey2/.claude/skills")
 
-# Target ProjectMnemosyne directory
-MNEMOSYNE_DIR = Path("/home/mvillmow/Odyssey2/build/ProjectMnemosyne")
+# Default target ProjectMnemosyne directory (used when --target-dir is not specified
+# and the MNEMOSYNE_DIR environment variable is not set)
+DEFAULT_MNEMOSYNE_DIR = Path("/tmp/ProjectMnemosyne")  # nosec B108
+
+
+def resolve_mnemosyne_dir(target: Optional[str]) -> Path:
+    """Resolve the ProjectMnemosyne directory path.
+
+    Priority: --target-dir CLI arg > MNEMOSYNE_DIR env var > /tmp/ProjectMnemosyne default.
+
+    Args:
+        target: Value of the --target-dir CLI argument, or None if not provided.
+
+    Returns:
+        Resolved Path to the ProjectMnemosyne root directory.
+    """
+    if target is not None:
+        return Path(target)
+    env = os.environ.get("MNEMOSYNE_DIR")
+    if env:
+        return Path(env)
+    return DEFAULT_MNEMOSYNE_DIR
+
+
+# Module-level constants kept for backwards compatibility with existing tests
+# that patch MNEMOSYNE_SKILLS_DIR directly.  main() uses resolve_mnemosyne_dir()
+# instead of these constants at runtime.
+MNEMOSYNE_DIR = DEFAULT_MNEMOSYNE_DIR
 MNEMOSYNE_SKILLS_DIR = MNEMOSYNE_DIR / "skills"
 
 # Category mapping from Odyssey categories to Mnemosyne valid categories
@@ -585,9 +612,18 @@ def find_all_skills(source_dir: Optional[Path] = None) -> list[tuple[str, Path, 
     return skills
 
 
-def skill_already_exists(skill_name: str) -> bool:
-    """Check if a skill already exists in ProjectMnemosyne."""
-    for category_dir in MNEMOSYNE_SKILLS_DIR.iterdir():
+def skill_already_exists(skill_name: str, mnemosyne_skills_dir: Optional[Path] = None) -> bool:
+    """Check if a skill already exists in ProjectMnemosyne.
+
+    Args:
+        skill_name: Name of the skill to check.
+        mnemosyne_skills_dir: Path to the Mnemosyne skills directory.
+            Defaults to the module-level MNEMOSYNE_SKILLS_DIR constant.
+    """
+    skills_dir = mnemosyne_skills_dir if mnemosyne_skills_dir is not None else MNEMOSYNE_SKILLS_DIR
+    if not skills_dir.exists():
+        return False
+    for category_dir in skills_dir.iterdir():
         if not category_dir.is_dir():
             continue
         skill_path = category_dir / skill_name
@@ -801,13 +837,13 @@ def main() -> int:
     parser.add_argument(
         "--target-dir",
         metavar="DIR",
-        default=str(MNEMOSYNE_DIR),
-        help=f"ProjectMnemosyne root directory (default: {MNEMOSYNE_DIR})",
+        default=None,
+        help=("Path to ProjectMnemosyne clone (default: $MNEMOSYNE_DIR env var or /tmp/ProjectMnemosyne)"),
     )
     args = parser.parse_args()
 
     source_dir = Path(args.source_dir)
-    target_dir = Path(args.target_dir)
+    target_dir = resolve_mnemosyne_dir(args.target_dir)
     target_skills_dir = target_dir / "skills"
 
     if not source_dir.exists():
@@ -815,7 +851,11 @@ def main() -> int:
         return 1
 
     if not target_dir.exists():
-        print(f"ERROR: ProjectMnemosyne directory not found: {target_dir}")
+        print(
+            f"ERROR: ProjectMnemosyne directory not found: {target_dir}\n"
+            f"Use --target-dir PATH or set MNEMOSYNE_DIR env var.",
+            file=sys.stderr,
+        )
         return 1
 
     all_skills = find_all_skills(source_dir=source_dir)
@@ -841,7 +881,7 @@ def main() -> int:
 
     for skill_name, skill_md_path, tier in all_skills:
         # Check if already exists
-        if not args.force and skill_already_exists(skill_name):
+        if not args.force and skill_already_exists(skill_name, target_skills_dir):
             print(f"SKIP: {skill_name} (already exists in Mnemosyne)")
             skipped += 1
             continue

--- a/tests/scripts/test_migrate_odyssey_skills.py
+++ b/tests/scripts/test_migrate_odyssey_skills.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python3
-"""Tests for migrate_odyssey_skills.py - auxiliary subdirectory copying."""
+"""Tests for migrate_odyssey_skills.py - auxiliary subdirectory copying and path resolution."""
 
+import importlib.util
 from pathlib import Path
 from typing import Optional
 from unittest.mock import patch
 
 import pytest
-
-# Import the module under test
-import importlib.util
 
 SCRIPT_PATH = Path(__file__).parent.parent.parent / "scripts" / "migrate_odyssey_skills.py"
 
@@ -414,3 +412,89 @@ class TestMigrateSkillAuxiliaryDirs:
         # Both files should exist (merge, not overwrite)
         assert (pre_existing / "run.sh").exists()
         assert (pre_existing / "existing_file.sh").exists()
+
+
+class TestResolveMnemosyneDir:
+    """Tests for resolve_mnemosyne_dir() path resolution priority."""
+
+    def test_explicit_target_takes_priority(self, migrate_module, tmp_path: Path) -> None:
+        """--target-dir value is used even when MNEMOSYNE_DIR env var is set."""
+        env_path = str(tmp_path / "env_path")
+        explicit_path = str(tmp_path / "explicit_path")
+        with patch.dict("os.environ", {"MNEMOSYNE_DIR": env_path}):
+            result = migrate_module.resolve_mnemosyne_dir(explicit_path)
+        assert result == Path(explicit_path)
+
+    def test_env_var_used_when_no_target(self, migrate_module, tmp_path: Path) -> None:
+        """MNEMOSYNE_DIR env var is used when --target-dir is not provided."""
+        env_path = str(tmp_path / "from_env")
+        with patch.dict("os.environ", {"MNEMOSYNE_DIR": env_path}):
+            result = migrate_module.resolve_mnemosyne_dir(None)
+        assert result == Path(env_path)
+
+    def test_default_used_when_neither_set(self, migrate_module) -> None:
+        """Default /tmp/ProjectMnemosyne is used when neither arg nor env var is set."""
+        env = {k: v for k, v in __import__("os").environ.items() if k != "MNEMOSYNE_DIR"}
+        with patch.dict("os.environ", env, clear=True):
+            result = migrate_module.resolve_mnemosyne_dir(None)
+        assert result == Path("/tmp/ProjectMnemosyne")  # nosec B108
+
+    def test_empty_env_var_falls_back_to_default(self, migrate_module) -> None:
+        """An unset MNEMOSYNE_DIR env var falls back to the default."""
+        env = {k: v for k, v in __import__("os").environ.items() if k != "MNEMOSYNE_DIR"}
+        with patch.dict("os.environ", env, clear=True):
+            result = migrate_module.resolve_mnemosyne_dir(None)
+        assert result == migrate_module.DEFAULT_MNEMOSYNE_DIR
+
+
+class TestSkillAlreadyExistsWithPath:
+    """Tests for skill_already_exists() with explicit mnemosyne_skills_dir."""
+
+    def test_returns_false_when_skills_dir_missing(self, migrate_module, tmp_path: Path) -> None:
+        """Returns False (not an error) when the skills directory does not exist."""
+        nonexistent = tmp_path / "no_such_dir" / "skills"
+        assert migrate_module.skill_already_exists("my-skill", nonexistent) is False
+
+    def test_returns_true_when_skill_present(self, migrate_module, tmp_path: Path) -> None:
+        """Returns True when the skill exists under any category."""
+        skills_dir = tmp_path / "skills"
+        (skills_dir / "tooling" / "my-skill").mkdir(parents=True)
+        assert migrate_module.skill_already_exists("my-skill", skills_dir) is True
+
+    def test_returns_false_when_skill_absent(self, migrate_module, tmp_path: Path) -> None:
+        """Returns False when the skill does not exist in any category."""
+        skills_dir = tmp_path / "skills"
+        (skills_dir / "tooling").mkdir(parents=True)
+        assert migrate_module.skill_already_exists("absent-skill", skills_dir) is False
+
+
+class TestMainErrorMessage:
+    """Tests for improved error messages in main() when target dir is missing."""
+
+    def test_missing_target_dir_prints_hint(
+        self, migrate_module, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """main() prints --target-dir hint when target directory does not exist."""
+        source_dir = tmp_path / "source_skills"
+        source_dir.mkdir()
+        missing_target = str(tmp_path / "nonexistent_mnemosyne")
+
+        # Call main via sys.argv patch
+        import sys
+
+        orig_argv = sys.argv
+        try:
+            sys.argv = [
+                "migrate_odyssey_skills.py",
+                "--source-dir",
+                str(source_dir),
+                "--target-dir",
+                missing_target,
+            ]
+            result = migrate_module.main()
+        finally:
+            sys.argv = orig_argv
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "--target-dir" in captured.err or "MNEMOSYNE_DIR" in captured.err


### PR DESCRIPTION
## Summary

- Add `resolve_mnemosyne_dir()` helper with three-level priority: `--target-dir` CLI arg → `$MNEMOSYNE_DIR` env var → `/tmp/ProjectMnemosyne` default
- Update `skill_already_exists()` to accept an explicit `mnemosyne_skills_dir` parameter so it uses the resolved path rather than the module-level constant
- Improve error message when target directory is missing (now shows `--target-dir` / `MNEMOSYNE_DIR` hint)
- Document required setup and usage examples in `scripts/README.md`
- Add 8 new tests covering path resolution priority, skill existence checks, and error message output

## Changes Made

- `scripts/migrate_odyssey_skills.py` — added `resolve_mnemosyne_dir()`, updated `main()` and `skill_already_exists()`
- `tests/scripts/test_migrate_odyssey_skills.py` — 8 new tests in 3 new test classes
- `scripts/README.md` — new `migrate_odyssey_skills.py` section with setup and usage examples

## Verification

- All 19 tests pass (`python -m pytest tests/scripts/test_migrate_odyssey_skills.py -v`)
- All pre-commit hooks pass (Bandit, mypy, Ruff format, Ruff check, markdownlint)

Closes #3311