### PR TITLE
fix(docs): update agent-claude4-update-status to reflect consolidated review specialists

### DIFF
--- a/docs/dev/agent-claude4-update-status.md
+++ b/docs/dev/agent-claude4-update-status.md
@@ -66,19 +66,11 @@ These serve as templates for their respective categories.
 - `.claude/agents/security-specialist.md`
 - `.claude/agents/numerical-stability-specialist.md`
 
-**Review Specialists (10):**
+**Review Specialists (4):**
 
-- `.claude/agents/algorithm-review-specialist.md`
-- `.claude/agents/implementation-review-specialist.md`
-- `.claude/agents/architecture-review-specialist.md`
-- `.claude/agents/data-engineering-review-specialist.md`
-- `.claude/agents/dependency-review-specialist.md`
-- `.claude/agents/documentation-review-specialist.md`
+- `.claude/agents/general-review-specialist.md`
 - `.claude/agents/mojo-language-review-specialist.md`
-- `.claude/agents/paper-review-specialist.md`
-- `.claude/agents/performance-review-specialist.md`
-- `.claude/agents/research-review-specialist.md`
-- `.claude/agents/safety-review-specialist.md`
+- `.claude/agents/security-review-specialist.md`
 - `.claude/agents/test-review-specialist.md`
 
 **Pattern**: Review specialists rarely need sub-agents (they ARE the specialists)


### PR DESCRIPTION
## Summary

- Removed stale cross-references to 10 deleted review specialist agents from `docs/dev/agent-claude4-update-status.md`
- Updated the "Review Specialists" section from the 10 deleted agents to the 4 current agents: `general-review-specialist`, `mojo-language-review-specialist`, `security-review-specialist`, `test-review-specialist`

## Changes Made

- `docs/dev/agent-claude4-update-status.md`: Replaced 10 deleted agent references with `general-review-specialist` in the Review Specialists tracking section

## Verification

- Re-ran grep across all `.md` files: zero matches for any deleted agent names
- Pre-commit hooks passed (markdown lint, trailing whitespace, end-of-file)

Closes #3323