### PR TITLE
test(security): add smoke tests to prevent regression of #3143 security gaps

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,10 +49,10 @@ jobs:
 
           if [ -f .gitleaks.toml ]; then
             echo "Using .gitleaks.toml configuration"
-            ./gitleaks detect --source=. --config=.gitleaks.toml --verbose --no-git --exit-code=1
+            ./gitleaks detect --source=. --config=.gitleaks.toml --verbose --exit-code=1
           else
             echo "No .gitleaks.toml found, using default configuration"
-            ./gitleaks detect --source=. --verbose --no-git --exit-code=1
+            ./gitleaks detect --source=. --verbose --exit-code=1
           fi
 
   # ============================================================================

--- a/.github/workflows/workflow-smoke-test.yml
+++ b/.github/workflows/workflow-smoke-test.yml
@@ -1,0 +1,63 @@
+name: Workflow Smoke Tests
+
+# Fast-fail gate that validates security workflow properties without heavy setup.
+# Guards against regression of gaps fixed in #3143:
+#   - pull_request trigger present in security.yml
+#   - Semgrep step has no continue-on-error: true
+#   - Gitleaks has no --no-git flag
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/security.yml'
+      - 'tests/smoke/test_security_workflow_properties.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test-security-workflows:
+    name: Security Workflow Property Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
+      # Fast-fail grep checks before any heavy setup
+      - name: Check pull_request trigger present
+        run: |
+          if ! grep -qP '^\s+pull_request\b' .github/workflows/security.yml; then
+            echo "ERROR: security.yml is missing pull_request trigger"
+            exit 1
+          fi
+          echo "OK: pull_request trigger present"
+
+      - name: Check Semgrep has no continue-on-error
+        run: |
+          # Extract lines around Semgrep action and check for continue-on-error
+          if grep -A20 'semgrep-action' .github/workflows/security.yml | grep -q 'continue-on-error: true'; then
+            echo "ERROR: Semgrep step has continue-on-error: true"
+            exit 1
+          fi
+          echo "OK: Semgrep step has no continue-on-error: true"
+
+      - name: Check Gitleaks has no --no-git flag
+        run: |
+          if grep -q -- '--no-git' .github/workflows/security.yml; then
+            echo "ERROR: Gitleaks uses --no-git in security.yml"
+            exit 1
+          fi
+          echo "OK: Gitleaks has no --no-git flag"
+
+      # Full pytest run for comprehensive assertions
+      - name: Set up Pixi
+        uses: ./.github/actions/setup-pixi
+
+      - name: Run security workflow smoke tests
+        run: pixi run python -m pytest tests/smoke/test_security_workflow_properties.py -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,17 @@ repos:
         files: ^(benchmarks|examples|papers|scripts|shared|tests)/.*\.(mojo|🔥)$
         types: [text]
 
+  # Security workflow property checks - prevents regression of gaps fixed in #3143
+  # Runs only when security workflow files are staged
+  - repo: local
+    hooks:
+      - id: check-security-workflow-no-git
+        name: Check Gitleaks has no --no-git flag
+        description: Prevent regression of #3143 - Gitleaks must not use --no-git
+        entry: 'gitleaks detect.*\-\-no\-git'
+        language: pygrep
+        files: ^\.github/workflows/security\.yml$
+
   # Security checks - bandit for accurate Python security scanning
   # Replaces naive pygrep shell=True check with AST-based analysis
   # Skips: B310 (urlopen with controlled URLs), B202 (tarfile in download scripts)

--- a/tests/smoke/test_security_workflow_properties.py
+++ b/tests/smoke/test_security_workflow_properties.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Smoke tests for security workflow properties.
+
+Validates that .github/workflows/security.yml has correct trigger coverage and
+security properties, preventing regression of gaps fixed in #3143:
+  1. pull_request trigger is present
+  2. Semgrep step has no continue-on-error: true
+  3. Gitleaks does not use --no-git
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+SECURITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "security.yml"
+
+
+@pytest.fixture(scope="module")
+def security_workflow_content() -> str:
+    """Read the security workflow file once for all tests in this module."""
+    assert SECURITY_WORKFLOW.exists(), f"security.yml not found at {SECURITY_WORKFLOW}"
+    return SECURITY_WORKFLOW.read_text(encoding="utf-8")
+
+
+class TestSecurityWorkflowTriggers:
+    """Verify trigger coverage for security.yml."""
+
+    def test_pull_request_trigger_present(self, security_workflow_content: str) -> None:
+        """security.yml must trigger on pull_request events.
+
+        Without this trigger, security scanning is skipped on PRs,
+        allowing vulnerabilities to merge undetected.
+        """
+        # Match 'pull_request:' or 'pull_request' (with optional trailing colon/whitespace)
+        # under the 'on:' block
+        assert re.search(r"^\s+pull_request\b", security_workflow_content, re.MULTILINE), (
+            "security.yml is missing a pull_request trigger. Add 'pull_request:' under the 'on:' block to scan all PRs."
+        )
+
+    def test_push_trigger_present(self, security_workflow_content: str) -> None:
+        """security.yml must trigger on push to main."""
+        assert re.search(r"^\s+push\b", security_workflow_content, re.MULTILINE), (
+            "security.yml is missing a push trigger."
+        )
+
+
+class TestSemgrepStep:
+    """Verify Semgrep SAST step configuration."""
+
+    def test_semgrep_has_no_continue_on_error(self, security_workflow_content: str) -> None:
+        """Semgrep step must not have continue-on-error: true.
+
+        Setting continue-on-error: true silences SAST failures, allowing
+        vulnerabilities to pass CI undetected.
+        """
+        # Find the Semgrep action block and verify continue-on-error is absent
+        semgrep_pattern = re.compile(
+            r"(returntocorp/semgrep-action|semgrep/semgrep-action).*?(?=\n\s*-\s+name:|\Z)",
+            re.DOTALL,
+        )
+        semgrep_match = semgrep_pattern.search(security_workflow_content)
+        assert semgrep_match is not None, (
+            "Could not find Semgrep action step in security.yml. "
+            "Expected a step using 'returntocorp/semgrep-action' or 'semgrep/semgrep-action'."
+        )
+
+        semgrep_block = semgrep_match.group(0)
+        assert "continue-on-error: true" not in semgrep_block, (
+            "Semgrep step has 'continue-on-error: true'. Remove it so SAST failures block the PR."
+        )
+
+    def test_semgrep_action_used(self, security_workflow_content: str) -> None:
+        """Semgrep action must be present in the workflow."""
+        assert re.search(r"uses:\s+(?:returntocorp|semgrep)/semgrep-action", security_workflow_content), (
+            "No Semgrep action found in security.yml. "
+            "Expected 'uses: returntocorp/semgrep-action' or 'uses: semgrep/semgrep-action'."
+        )
+
+
+class TestGitleaksStep:
+    """Verify Gitleaks secret scanning step configuration."""
+
+    def test_gitleaks_has_no_no_git_flag(self, security_workflow_content: str) -> None:
+        """Gitleaks must not use the --no-git flag.
+
+        --no-git scans only the working directory as a flat filesystem,
+        bypassing git history. This misses secrets committed in past commits
+        and then removed from the working tree.
+        """
+        assert "--no-git" not in security_workflow_content, (
+            "Gitleaks is invoked with '--no-git' in security.yml. "
+            "Remove '--no-git' so Gitleaks scans the full git history for secrets."
+        )
+
+    def test_gitleaks_present(self, security_workflow_content: str) -> None:
+        """Gitleaks must be present in the workflow for secret scanning."""
+        assert re.search(r"gitleaks", security_workflow_content, re.IGNORECASE), (
+            "No Gitleaks step found in security.yml. Secret scanning via Gitleaks is required."
+        )
+
+    def test_gitleaks_has_exit_code(self, security_workflow_content: str) -> None:
+        """Gitleaks must use --exit-code=1 to fail CI on secret detection."""
+        assert "--exit-code=1" in security_workflow_content, (
+            "Gitleaks is not configured with '--exit-code=1'. Without this, secret detection does not fail CI."
+        )


### PR DESCRIPTION
## Summary

- Remove `--no-git` from both Gitleaks invocations in `security.yml` so full git history is scanned for secrets
- Add 7 pytest smoke tests verifying: `pull_request` trigger present, Semgrep has no `continue-on-error: true`, Gitleaks has no `--no-git`
- Add CI workflow `workflow-smoke-test.yml` with fast grep gate + pytest run on all PRs
- Add pygrep pre-commit hook to catch `gitleaks detect.*--no-git` regressions locally

## Test plan

- [x] All 7 smoke tests pass locally: `pixi run python -m pytest tests/smoke/test_security_workflow_properties.py -v`
- [x] Pre-commit hooks pass on staged files
- [x] `workflow-smoke-test.yml` runs fast grep checks before pixi setup for quick feedback

Closes #3318

🤖 Generated with [Claude Code](https://claude.com/claude-code)