### PR TITLE
ci(retry): apply retry logic to all test/build workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -93,7 +93,25 @@ jobs:
               pixi run python "$SUITE_PATH/run_benchmark.py" --output benchmark-results/${{ matrix.benchmark-suite }}.json
             elif [ -f "$SUITE_PATH/run_benchmark.mojo" ]; then
               echo "Running Mojo benchmark..."
-              pixi run mojo -I . "$SUITE_PATH/run_benchmark.mojo" --output benchmark-results/${{ matrix.benchmark-suite }}.json
+              attempt=0
+              delay=1
+              bench_ok=0
+              while [ $attempt -lt 3 ]; do
+                attempt=$((attempt + 1))
+                if pixi run mojo -I . "$SUITE_PATH/run_benchmark.mojo" --output benchmark-results/${{ matrix.benchmark-suite }}.json; then
+                  bench_ok=1
+                  break
+                fi
+                if [ $attempt -lt 3 ]; then
+                  echo "⚠️  Attempt $attempt failed, retrying in ${delay}s..."
+                  sleep $delay
+                  delay=$((delay * 2))
+                fi
+              done
+              if [ $bench_ok -eq 0 ]; then
+                echo "❌ Benchmark failed after 3 attempts"
+                exit 1
+              fi
             else
               echo "⚠️  No benchmark runner found in $SUITE_PATH"
               echo '{"suite": "${{ matrix.benchmark-suite }}", "status": "not_implemented"}' > benchmark-results/${{ matrix.benchmark-suite }}.json

--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -111,11 +111,26 @@ jobs:
 
           # Build the shared package (compiles all modules properly with relative imports)
           export REPO_ROOT=$(pwd)
-          if pixi run mojo package -I "$REPO_ROOT" shared -o /tmp/shared.mojopkg 2>&1; then
+          attempt=0
+          delay=1
+          compiled=0
+          while [ $attempt -lt 3 ]; do
+            attempt=$((attempt + 1))
+            if pixi run mojo package -I "$REPO_ROOT" shared -o /tmp/shared.mojopkg 2>&1; then
+              compiled=1
+              break
+            fi
+            if [ $attempt -lt 3 ]; then
+              echo "⚠️  Attempt $attempt failed, retrying in ${delay}s..."
+              sleep $delay
+              delay=$((delay * 2))
+            fi
+          done
+          if [ $compiled -eq 1 ]; then
             echo "✅ PASSED: shared package compiled successfully"
             echo "compilation_status=success" >> $GITHUB_ENV
           else
-            echo "❌ FAILED: shared package compilation"
+            echo "❌ FAILED: shared package compilation after 3 attempts"
             echo ""
             echo "Fix compilation errors before merging to main."
             echo "compilation_status=failed" >> $GITHUB_ENV

--- a/.github/workflows/paper-validation.yml
+++ b/.github/workflows/paper-validation.yml
@@ -248,9 +248,23 @@ jobs:
                 pixi run pytest "$paper_dir/tests" --verbose || true
               fi
 
-              # Run Mojo tests if they exist
+              # Run Mojo tests if they exist (with retry for JIT crash resilience, issue #3329)
               if [ -n "$(find "$paper_dir/tests" -name 'test_*.mojo' 2>/dev/null)" ]; then
-                pixi run mojo test -I . "$paper_dir/tests" --verbose || true
+                attempt=0
+                delay=1
+                while [ $attempt -lt 3 ]; do
+                  attempt=$((attempt + 1))
+                  if pixi run mojo test -I . "$paper_dir/tests" --verbose; then
+                    break
+                  fi
+                  if [ $attempt -lt 3 ]; then
+                    echo "⚠️  Attempt $attempt failed, retrying in ${delay}s..."
+                    sleep $delay
+                    delay=$((delay * 2))
+                  else
+                    echo "⚠️  Mojo tests failed after 3 attempts (soft failure)"
+                  fi
+                done || true
               fi
             fi
           done
@@ -303,7 +317,21 @@ jobs:
             if [ -f "$paper_dir/train.py" ]; then
               pixi run python "$paper_dir/train.py" --quick-validation --epochs 1 || true
             elif [ -f "$paper_dir/train.mojo" ]; then
-              pixi run mojo -I . "$paper_dir/train.mojo" --quick-validation --epochs 1 || true
+              attempt=0
+              delay=1
+              while [ $attempt -lt 3 ]; do
+                attempt=$((attempt + 1))
+                if pixi run mojo -I . "$paper_dir/train.mojo" --quick-validation --epochs 1; then
+                  break
+                fi
+                if [ $attempt -lt 3 ]; then
+                  echo "⚠️  Attempt $attempt failed, retrying in ${delay}s..."
+                  sleep $delay
+                  delay=$((delay * 2))
+                else
+                  echo "⚠️  Training script failed after 3 attempts (soft failure)"
+                fi
+              done || true
             fi
           done
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,10 +136,28 @@ jobs:
           if [ -d "src" ] && [ -n "$(find src -name '*.mojo' -o -name '*.🔥' 2>/dev/null)" ]; then
             echo "Building Mojo packages..."
 
-            # Build all Mojo packages
+            # Build all Mojo packages (with retry for JIT crash resilience, issue #3329)
             find src -name "*.mojo" -o -name "*.🔥" | while read -r file; do
               echo "Building: $file"
-              pixi run mojo build -I . "$file" -o "dist/mojo/$(basename "$file" .mojo)"
+              attempt=0
+              delay=1
+              built=0
+              while [ $attempt -lt 3 ]; do
+                attempt=$((attempt + 1))
+                if pixi run mojo build -I . "$file" -o "dist/mojo/$(basename "$file" .mojo)"; then
+                  built=1
+                  break
+                fi
+                if [ $attempt -lt 3 ]; then
+                  echo "⚠️  Attempt $attempt failed, retrying in ${delay}s..."
+                  sleep $delay
+                  delay=$((delay * 2))
+                fi
+              done
+              if [ $built -eq 0 ]; then
+                echo "❌ Build failed for $file after 3 attempts"
+                exit 1
+              fi
             done
 
             echo "✅ Mojo packages built successfully"
@@ -248,7 +266,22 @@ jobs:
           # Run Mojo tests if they exist
           if [ -d "tests/unit" ] && [ -n "$(find tests/unit -name '*.mojo' -o -name '*.🔥' 2>/dev/null)" ]; then
             echo "Running Mojo unit tests..."
-            pixi run mojo test -I . tests/unit/ --verbose
+            attempt=0
+            delay=1
+            while [ $attempt -lt 3 ]; do
+              attempt=$((attempt + 1))
+              if pixi run mojo test -I . tests/unit/ --verbose; then
+                break
+              fi
+              if [ $attempt -lt 3 ]; then
+                echo "⚠️  Attempt $attempt failed, retrying in ${delay}s..."
+                sleep $delay
+                delay=$((delay * 2))
+              else
+                echo "❌ Mojo unit tests failed after 3 attempts"
+                exit 1
+              fi
+            done
           fi
 
           # Run Python tests if they exist
@@ -265,7 +298,22 @@ jobs:
           if [ -d "tests/integration" ]; then
             if [ -n "$(find tests/integration -name '*.mojo' -o -name '*.🔥' 2>/dev/null)" ]; then
               echo "Running Mojo integration tests..."
-              pixi run mojo test -I . tests/integration/ --verbose
+              attempt=0
+              delay=1
+              while [ $attempt -lt 3 ]; do
+                attempt=$((attempt + 1))
+                if pixi run mojo test -I . tests/integration/ --verbose; then
+                  break
+                fi
+                if [ $attempt -lt 3 ]; then
+                  echo "⚠️  Attempt $attempt failed, retrying in ${delay}s..."
+                  sleep $delay
+                  delay=$((delay * 2))
+                else
+                  echo "❌ Mojo integration tests failed after 3 attempts"
+                  exit 1
+                fi
+              done
             fi
 
             if [ -n "$(find tests/integration -name 'test_*.py' 2>/dev/null)" ]; then

--- a/.github/workflows/simd-benchmarks-weekly.yml
+++ b/.github/workflows/simd-benchmarks-weekly.yml
@@ -41,16 +41,24 @@ jobs:
           # Create results directory
           mkdir -p benchmark-results
 
-          # Run the SIMD benchmark and capture output
-          pixi run mojo run -I . benchmarks/bench_simd.mojo | tee benchmark-results/simd-output.txt
-
-          # Check if benchmark succeeded
-          if [ ${PIPESTATUS[0]} -eq 0 ]; then
-            echo "✅ SIMD benchmarks completed successfully"
-          else
-            echo "❌ SIMD benchmarks failed"
-            exit 1
-          fi
+          # Run the SIMD benchmark with retry for JIT crash resilience (issue #3329)
+          attempt=0
+          delay=1
+          while [ $attempt -lt 3 ]; do
+            attempt=$((attempt + 1))
+            if pixi run mojo run -I . benchmarks/bench_simd.mojo | tee benchmark-results/simd-output.txt; then
+              echo "✅ SIMD benchmarks completed successfully"
+              break
+            fi
+            if [ $attempt -lt 3 ]; then
+              echo "⚠️  Attempt $attempt failed, retrying in ${delay}s..."
+              sleep $delay
+              delay=$((delay * 2))
+            else
+              echo "❌ SIMD benchmarks failed after 3 attempts"
+              exit 1
+            fi
+          done
 
       - name: Generate benchmark summary
         if: success()

--- a/.github/workflows/test-data-utilities.yml
+++ b/.github/workflows/test-data-utilities.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Set up Pixi
         uses: ./.github/actions/setup-pixi
 
+      - name: Install Just
+        uses: extractions/setup-just@v3
+
       - name: Verify Mojo installation
         run: |
           pixi run mojo --version
@@ -42,47 +45,27 @@ jobs:
       - name: Run Dataset Tests
         if: steps.check-tests.outputs.tests_exist == 'true'
         run: |
-          echo "Running base dataset tests..."
-          if [ -f "tests/shared/data/datasets/test_base_dataset.mojo" ]; then
-            pixi run mojo -I . tests/shared/data/datasets/test_base_dataset.mojo
-          fi
-
-          echo "Running tensor dataset tests..."
-          if [ -f "tests/shared/data/datasets/test_tensor_dataset.mojo" ]; then
-            pixi run mojo -I . tests/shared/data/datasets/test_tensor_dataset.mojo
-          fi
+          just test-group "tests/shared/data/datasets" "test_base_dataset.mojo test_tensor_dataset.mojo"
 
       - name: Run Loader Tests
         if: steps.check-tests.outputs.tests_exist == 'true'
         run: |
-          echo "Running base loader tests..."
-          if [ -f "tests/shared/data/loaders/test_base_loader.mojo" ]; then
-            pixi run mojo -I . tests/shared/data/loaders/test_base_loader.mojo
-          fi
+          just test-group "tests/shared/data/loaders" "test_base_loader.mojo"
 
       - name: Run Transform Tests
         if: steps.check-tests.outputs.tests_exist == 'true'
         run: |
-          echo "Running transform pipeline tests..."
-          if [ -f "tests/shared/data/transforms/test_pipeline.mojo" ]; then
-            pixi run mojo -I . tests/shared/data/transforms/test_pipeline.mojo
-          fi
+          just test-group "tests/shared/data/transforms" "test_pipeline.mojo"
 
       - name: Run Sampler Tests
         if: steps.check-tests.outputs.tests_exist == 'true'
         run: |
-          echo "Running sequential sampler tests..."
-          if [ -f "tests/shared/data/samplers/test_sequential.mojo" ]; then
-            pixi run mojo -I . tests/shared/data/samplers/test_sequential.mojo
-          fi
+          just test-group "tests/shared/data/samplers" "test_sequential.mojo"
 
       - name: Run All Data Tests
         if: steps.check-tests.outputs.tests_exist == 'true'
         run: |
-          echo "Running complete data utilities test suite..."
-          if [ -f "tests/shared/data/run_all_tests.mojo" ]; then
-            pixi run mojo -I . tests/shared/data/run_all_tests.mojo
-          fi
+          just test-group "tests/shared/data" "run_all_tests.mojo"
 
       - name: Report Results
         if: always()

--- a/.github/workflows/test-gradients.yml
+++ b/.github/workflows/test-gradients.yml
@@ -33,11 +33,14 @@ jobs:
       - name: Set up Pixi
         uses: ./.github/actions/setup-pixi
 
+      - name: Install Just
+        uses: extractions/setup-just@v3
+
       - name: Run gradient checking tests
         run: |
           # Split per ADR-009: test_gradient_checking.mojo split to avoid Mojo 0.26.1 heap corruption
-          pixi run mojo -I . tests/shared/core/test_gradient_checking_basic.mojo
-          pixi run mojo -I . tests/shared/core/test_gradient_checking_dtype.mojo
+          # Routed through just test-group for JIT crash retry protection (issue #3329)
+          just test-group "tests/shared/core" "test_gradient_checking_basic.mojo test_gradient_checking_dtype.mojo"
 
       - name: Check test results
         if: failure()

--- a/justfile
+++ b/justfile
@@ -503,19 +503,33 @@ test-group path pattern:
             echo "Running: $test_file"
             test_count=$((test_count + 1))
 
-            if pixi run mojo -I "$REPO_ROOT" -I . "$test_file"; then
-                echo "✅ PASSED: $test_file"
+            attempt=0
+            max_attempts=3
+            delay=1
+            test_passed=0
+            while [ $attempt -lt $max_attempts ]; do
+                attempt=$((attempt + 1))
+                if pixi run mojo -I "$REPO_ROOT" -I . "$test_file"; then
+                    test_passed=1
+                    break
+                fi
+                if [ $attempt -lt $max_attempts ]; then
+                    echo "⚠️  FAILED (attempt $attempt), retrying in ${delay}s: $test_file"
+                    sleep $delay
+                    delay=$((delay * 2))
+                fi
+            done
+            if [ $test_passed -eq 1 ]; then
+                if [ $attempt -eq 1 ]; then
+                    echo "✅ PASSED: $test_file"
+                else
+                    echo "✅ PASSED on attempt $attempt: $test_file"
+                fi
                 passed_count=$((passed_count + 1))
             else
-                echo "⚠️  FAILED (attempt 1), retrying: $test_file"
-                if pixi run mojo -I "$REPO_ROOT" -I . "$test_file"; then
-                    echo "✅ PASSED on retry: $test_file"
-                    passed_count=$((passed_count + 1))
-                else
-                    echo "❌ FAILED: $test_file"
-                    failed_count=$((failed_count + 1))
-                    failed_tests="$failed_tests\n  - $test_file"
-                fi
+                echo "❌ FAILED: $test_file"
+                failed_count=$((failed_count + 1))
+                failed_tests="$failed_tests\n  - $test_file"
             fi
         fi
     done


### PR DESCRIPTION
## Summary

- Upgraded `just test-group` from 2 to 3 attempts with exponential backoff (1s, 2s delays)
- Added 3-attempt retry to `comprehensive-tests.yml` `mojo package` compilation step
- Routed `test-gradients.yml` bare `pixi run mojo` calls through `just test-group` (gets retry for free)
- Routed `test-data-utilities.yml` bare `pixi run mojo` calls through `just test-group`
- Added inline 3-attempt retry loops to `simd-benchmarks-weekly.yml`, `benchmark.yml`, `release.yml`, and `paper-validation.yml`

Follows standard retry pattern: max 3 attempts, 1s base, 2× exponential backoff per `.claude/shared/error-handling.md`.

## Test plan

- [x] Pre-commit hooks pass (YAML validated, whitespace, EOF checks)
- [x] All 8 changed files committed cleanly
- [ ] CI comprehensive-tests, test-gradients, test-data-utilities workflows pass on PR

Closes #3329
Follow-up from #3120

🤖 Generated with [Claude Code](https://claude.com/claude-code)