### PR TITLE
docs(dev): document Mojo JIT crash workaround for libKGENCompilerRTShared.so

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ gh pr merge --auto --rebase
 
 - [Mojo Syntax & Patterns](/.claude/shared/mojo-guidelines.md)
 - [Mojo Anti-Patterns](/.claude/shared/mojo-anti-patterns.md) - 64+ failure patterns
+- [Mojo JIT Crash Workaround](docs/dev/mojo-jit-crash-workaround.md) - `libKGENCompilerRTShared.so` flake
 - [PR Workflow](/.claude/shared/pr-workflow.md)
 - [GitHub Issue Workflow](/.claude/shared/github-issue-workflow.md)
 - [Common Constraints](/.claude/shared/common-constraints.md)

--- a/docs/dev/mojo-jit-crash-workaround.md
+++ b/docs/dev/mojo-jit-crash-workaround.md
@@ -1,0 +1,115 @@
+# Mojo JIT Crash: `libKGENCompilerRTShared.so` (Mojo v0.26.1)
+
+**Tracking**: Issue #3330, follow-up from #3120
+
+## Problem
+
+An intermittent crash in the Mojo JIT compiler causes `mojo test` to output `execution crashed`
+and exit non-zero. The crash originates in `libKGENCompilerRTShared.so`, the Mojo runtime/compiler
+shared library — it is **a Mojo v0.26.1 compiler bug, not a bug in test code**.
+
+Sample crash output:
+
+```text
+execution crashed
+```
+
+This single line is the entire output. No test names, no stack trace, no assertion failures.
+
+## Diagnosis: Compiler Flake vs. Test Bug
+
+The key diagnostic is **where the crash appears relative to test output**:
+
+| Symptom | Cause |
+|---------|-------|
+| `execution crashed` appears **before any test output** | Compiler flake — retry |
+| `execution crashed` or segfault appears **after test output** | Likely a real test bug |
+| Specific assertion failure message | Real test bug — investigate |
+
+### Sample: Compiler Flake (retry to fix)
+
+```text
+execution crashed
+```
+
+No test names printed. Nothing ran. This is the JIT crash.
+
+### Sample: Real Test Failure (investigate code)
+
+```text
+test_forward ... PASS
+test_backward ... FAIL: assertion failed at line 42
+  left:  0.5
+  right: 0.6
+```
+
+Tests started running, then a specific test failed with a meaningful message.
+
+## Workaround: CI Retry Pattern
+
+Because the crash is non-deterministic, a retry loop resolves it in practice. The crash rarely
+occurs twice in a row on the same test group.
+
+### Shell Retry Loop
+
+```bash
+for attempt in 1 2 3; do
+    if just test-group "$PATH" "$PATTERN"; then
+        break
+    fi
+    if [ $attempt -lt 3 ]; then
+        echo "Attempt $attempt failed, retrying in 30s..."
+        sleep 30
+    fi
+done
+```
+
+### GitHub Actions: `nick-fields/retry`
+
+```yaml
+- name: Run test group (with retry for JIT crash)
+  uses: nick-fields/retry@v3
+  with:
+    timeout_minutes: 15
+    max_attempts: 3
+    retry_wait_seconds: 30
+    command: just test-group "${{ matrix.test-group.path }}" "${{ matrix.test-group.pattern }}"
+```
+
+### Current CI Mitigation (as of Mojo v0.26.1)
+
+The `comprehensive-tests.yml` workflow currently uses `continue-on-error: true` for the known
+flaky test groups (Core Tensors, Integration Tests, Benchmarking) as a stopgap. Adding a retry
+action is the recommended long-term fix while still on Mojo v0.26.1.
+
+## Relationship to Heap Corruption Bug (ADR-009)
+
+This crash is **distinct** from the deterministic heap corruption crash described in
+[ADR-009](../adr/ADR-009-heap-corruption-workaround.md):
+
+| | JIT Crash (this doc) | Heap Corruption (ADR-009) |
+|-|---------------------|--------------------------|
+| **Trigger** | Non-deterministic, intermittent | After exactly ~15 cumulative tests in one file |
+| **Output** | `execution crashed` before any test runs | Crash mid-run after test output |
+| **Workaround** | Retry the test run | Split files to ≤10 tests each |
+| **CI fix** | `continue-on-error` or retry action | File splitting (already applied) |
+
+Both originate in `libKGENCompilerRTShared.so` but are separate bugs with different behaviors and
+different workarounds.
+
+## Long-Term Resolution
+
+This crash is expected to be fixed in a future Mojo release. When upgrading past v0.26.1:
+
+1. Remove the `continue-on-error` workarounds from `comprehensive-tests.yml`
+2. Remove any retry steps added for this crash
+3. Verify by running `just test-group` on Core Tensors, Integration Tests, and Benchmarking
+   groups 5+ times in a row — they should pass consistently without retries
+4. If the crash no longer appears, the Mojo runtime fix is confirmed
+
+## References
+
+- [Issue #3330](https://github.com/HomericIntelligence/ProjectOdyssey/issues/3330) — Document JIT crash workaround
+- [Issue #3120](https://github.com/HomericIntelligence/ProjectOdyssey/issues/3120) — Core Loss test crashes (follow-up context)
+- [ADR-009](../adr/ADR-009-heap-corruption-workaround.md) — Heap corruption workaround (related but distinct)
+- `.github/workflows/comprehensive-tests.yml` — Current `continue-on-error` mitigation

--- a/docs/dev/mojo-test-failure-patterns.md
+++ b/docs/dev/mojo-test-failure-patterns.md
@@ -4,6 +4,10 @@
 **Date**: 2025-11-26
 **Context**: Issue #2025 - Systematic analysis of all Mojo test failures
 
+> **Note**: For `execution crashed` errors that appear _before_ any test output, see
+> [Mojo JIT Crash Workaround](mojo-jit-crash-workaround.md) — this is a compiler flake,
+> not a test bug. Retry the test run to confirm.
+
 ## Executive Summary
 
 Analysis of 10 PRs revealed 7 major categories of errors affecting 50+ test files. The root


### PR DESCRIPTION
## Summary

- Add `docs/dev/mojo-jit-crash-workaround.md` documenting the intermittent Mojo v0.26.1 JIT
  crash (`execution crashed` / `libKGENCompilerRTShared.so`) so future developers recognize
  it as a compiler flake rather than a test bug
- Add Quick Links entry in `CLAUDE.md` for discoverability
- Add callout at the top of `docs/dev/mojo-test-failure-patterns.md` pointing to the new doc

## Changes Made

- **New**: `docs/dev/mojo-jit-crash-workaround.md` — covers: (1) what `execution crashed`
  means, (2) why it's a compiler bug not a test bug, (3) retry pattern fix (shell loop +
  GitHub Actions `nick-fields/retry`), (4) how to verify (crash before any test output = flake),
  (5) distinction from ADR-009 heap corruption, (6) long-term removal checklist
- **Modified**: `CLAUDE.md` — added link under Core Guidelines Quick Links
- **Modified**: `docs/dev/mojo-test-failure-patterns.md` — added blockquote callout after
  Executive Summary heading

## Verification

- [x] `pixi run pre-commit run markdownlint-cli2` passes on all three files
- [x] New doc contains all four required pieces from issue description
- [x] `libKGENCompilerRTShared.so` and `execution crashed` are present and searchable

Closes #3330