### PR TITLE
fix(ci): pin composite action versions to full SHAs

### DIFF
--- a/.github/actions/pr-comment/action.yml
+++ b/.github/actions/pr-comment/action.yml
@@ -17,7 +17,7 @@ runs:
   using: composite
   steps:
     - name: Post or update PR comment
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
       with:
         github-token: ${{ inputs.github-token }}
         script: |

--- a/.github/actions/setup-pixi/action.yml
+++ b/.github/actions/setup-pixi/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: Set up Pixi
-      uses: prefix-dev/setup-pixi@v0.9.4
+      uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e  # v0.9.4
       with:
         pixi-version: ${{ inputs.pixi-version }}
 


### PR DESCRIPTION
## Summary

- Pin `prefix-dev/setup-pixi@v0.9.4` to SHA `a0af7a228712d6121d37aba47adf55c1332c9c2e` in `.github/actions/setup-pixi/action.yml`
- Pin `actions/github-script@v8` to SHA `ed597411d8f924073f98dfc5c65a23a2325f34cd` in `.github/actions/pr-comment/action.yml`

Matches the SHA-pinning pattern already used elsewhere in the repo (e.g. `actions/checkout@8e8c483...`).

## Test plan

- [x] YAML syntax validated via pre-commit `check-yaml` hook (passes)
- [x] SHAs resolved via `gh api` against the upstream repos
- [x] No functional changes — only version reference format changed

Closes #3342