### PR TITLE
fix(docker): pin just version to 1.14.0 for reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
 RUN curl -fsSL https://claude.ai/install.sh | bash
 
 # Install just tool (pre-built binary, much faster than cargo install)
-RUN curl -fsSL https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+RUN curl -fsSL https://just.systems/install.sh | bash -s -- --to /usr/local/bin --tag 1.14.0
 
 # ---------------------------
 # Stage 1.5: Create dev user


### PR DESCRIPTION
## Summary

- Pin `just` installation to version 1.14.0 using `--tag 1.14.0` flag in the install script
- Ensures reproducible Docker builds by not always fetching latest version
- Mirrors the previous `cargo install just --version 1.14.0` pinning approach

## Changes Made

- `Dockerfile`: Added `--tag 1.14.0` to the `just.systems/install.sh` invocation

## Verification

The change is minimal and targeted — a single flag addition to the curl install command.

Closes #3349

🤖 Generated with [Claude Code](https://claude.com/claude-code)