### PR TITLE
feat(ci): enforce checkout-first ordering for composite actions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -494,6 +494,52 @@ All CI workflows use justfile recipes for consistent command execution between l
 
 **See**: `/justfile` for complete implementation and `CLAUDE.md` for developer documentation.
 
+### Composite Action Checkout Invariant
+
+**Rule**: `actions/checkout` must appear as a step **before** any `uses: ./.github/actions/` reference
+within a job.
+
+**Why**: Local composite actions (`uses: ./.github/actions/X`) are resolved from the repository on
+disk. If the repository has not been checked out yet, GitHub Actions cannot find the action directory
+and the workflow fails with `Cannot find action './.github/actions/X'`.
+
+**Correct pattern**:
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code          # MUST come first
+        uses: actions/checkout@v4
+
+      - name: Set up Pixi            # composite action — safe because checkout already ran
+        uses: ./.github/actions/setup-pixi
+```
+
+**Incorrect pattern** (will fail):
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Pixi            # ERROR: checkout has not run yet
+        uses: ./.github/actions/setup-pixi
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+```
+
+**Run the check locally**:
+
+```bash
+python3 scripts/validate_workflow_checkout_order.py .github/workflows/
+```
+
+**CI enforcement**: The `validate-workflows.yml` workflow runs this check automatically on all pull
+requests that touch `.github/` files.
+
 ### Pixi-Based Environment Setup
 
 All workflows use the modern Pixi setup:

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -1,0 +1,37 @@
+name: Validate Workflow Checkout Order
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/**'
+      - 'scripts/validate_workflow_checkout_order.py'
+      - '.github/workflows/validate-workflows.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/**'
+      - 'scripts/validate_workflow_checkout_order.py'
+      - '.github/workflows/validate-workflows.yml'
+  workflow_dispatch:
+
+jobs:
+  validate-checkout-order:
+    name: Enforce Composite Action Checkout-First Ordering
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Validate checkout-first ordering for composite actions
+        run: |
+          echo "Checking that all jobs using ./.github/actions/ have actions/checkout as a preceding step..."
+          python3 scripts/validate_workflow_checkout_order.py .github/workflows/

--- a/scripts/validate_workflow_checkout_order.py
+++ b/scripts/validate_workflow_checkout_order.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Validate that composite action references follow checkout-first ordering.
+
+Local composite actions (uses: ./.github/actions/X) require the repository to
+be checked out before they can be referenced. This script enforces that
+actions/checkout always appears as a step before any ./.github/actions/ reference
+within every job of every scanned workflow file.
+
+Usage:
+    python scripts/validate_workflow_checkout_order.py [path ...]
+
+    path: One or more workflow YAML files or directories containing them.
+          Defaults to .github/workflows/ relative to the repo root.
+
+Exit codes:
+    0: All workflows pass the checkout-first invariant
+    1: One or more violations found
+"""
+
+import sys
+from pathlib import Path
+from typing import List, NamedTuple
+
+import yaml
+
+
+# Security limit: skip files larger than 1 MB
+MAX_FILE_SIZE = 1_048_576
+
+
+class Violation(NamedTuple):
+    """A single checkout-order violation."""
+
+    workflow_file: Path
+    job_name: str
+    step_index: int
+    step_name: str
+    composite_action: str
+
+
+def _is_checkout_step(step: object) -> bool:
+    """Return True if the step uses actions/checkout (any version or hash)."""
+    if not isinstance(step, dict):
+        return False
+    uses = step.get("uses", "")
+    return isinstance(uses, str) and uses.startswith("actions/checkout")
+
+
+def _is_composite_action_step(step: object) -> bool:
+    """Return True if the step references a local composite action."""
+    if not isinstance(step, dict):
+        return False
+    uses = step.get("uses", "")
+    return isinstance(uses, str) and uses.startswith("./.github/actions/")
+
+
+def validate_workflow(workflow_file: Path) -> List[Violation]:
+    """
+    Validate checkout-first ordering for all jobs in a workflow file.
+
+    Args:
+        workflow_file: Path to the workflow YAML file.
+
+    Returns:
+        List of Violation objects; empty list means the file passes.
+    """
+    if workflow_file.stat().st_size > MAX_FILE_SIZE:
+        print(f"WARNING: Skipping {workflow_file} (exceeds {MAX_FILE_SIZE} byte limit)")
+        return []
+
+    with open(workflow_file, encoding="utf-8") as fh:
+        try:
+            data = yaml.safe_load(fh)
+        except yaml.YAMLError as exc:
+            print(f"WARNING: Skipping {workflow_file} (YAML parse error: {exc})")
+            return []
+
+    if not isinstance(data, dict):
+        return []
+
+    jobs = data.get("jobs")
+    if not isinstance(jobs, dict):
+        return []
+
+    violations: List[Violation] = []
+
+    for job_name, job_data in jobs.items():
+        if not isinstance(job_data, dict):
+            continue
+
+        steps = job_data.get("steps")
+        if not isinstance(steps, list):
+            continue
+
+        checked_out = False
+        for idx, step in enumerate(steps):
+            if _is_checkout_step(step):
+                checked_out = True
+                continue
+
+            if _is_composite_action_step(step):
+                if not checked_out:
+                    step_name = (
+                        step.get("name", f"(unnamed step {idx + 1})") if isinstance(step, dict) else f"(step {idx + 1})"
+                    )
+                    composite_action = step.get("uses", "") if isinstance(step, dict) else ""
+                    violations.append(
+                        Violation(
+                            workflow_file=workflow_file,
+                            job_name=str(job_name),
+                            step_index=idx + 1,
+                            step_name=str(step_name),
+                            composite_action=str(composite_action),
+                        )
+                    )
+
+    return violations
+
+
+def collect_workflow_files(paths: List[str]) -> List[Path]:
+    """
+    Expand the given paths into a list of workflow YAML files.
+
+    Args:
+        paths: File paths or directory paths. Directories are searched for
+               *.yml and *.yaml files non-recursively.
+
+    Returns:
+        Deduplicated list of Path objects for each candidate file.
+    """
+    files: List[Path] = []
+    for raw in paths:
+        p = Path(raw)
+        if p.is_file():
+            files.append(p)
+        elif p.is_dir():
+            files.extend(sorted(p.glob("*.yml")))
+            files.extend(sorted(p.glob("*.yaml")))
+        else:
+            print(f"WARNING: Path not found: {p}", file=sys.stderr)
+
+    # Deduplicate while preserving order
+    seen: set = set()
+    result: List[Path] = []
+    for f in files:
+        key = f.resolve()
+        if key not in seen:
+            seen.add(key)
+            result.append(f)
+    return result
+
+
+def _default_workflow_dir() -> str:
+    """Return the default workflow directory relative to the repo root."""
+    # Walk up from this script's location to find the repo root
+    here = Path(__file__).resolve().parent
+    candidate = here.parent / ".github" / "workflows"
+    if candidate.is_dir():
+        return str(candidate)
+    return ".github/workflows"
+
+
+def main(argv: List[str] | None = None) -> int:
+    """
+    Entry point for the checkout-order validation script.
+
+    Args:
+        argv: Command-line arguments (defaults to sys.argv[1:]).
+
+    Returns:
+        Exit code: 0 for success, 1 for violations found.
+    """
+    args = argv if argv is not None else sys.argv[1:]
+
+    if not args:
+        args = [_default_workflow_dir()]
+
+    workflow_files = collect_workflow_files(args)
+
+    if not workflow_files:
+        print("No workflow files found to validate.")
+        return 0
+
+    all_violations: List[Violation] = []
+    for wf_file in workflow_files:
+        violations = validate_workflow(wf_file)
+        all_violations.extend(violations)
+
+    if all_violations:
+        for v in all_violations:
+            print(
+                f"\nERROR: {v.workflow_file} :: job '{v.job_name}' :: step {v.step_index} "
+                f"uses '{v.composite_action}'\n"
+                f"       but actions/checkout is not a preceding step.\n"
+                f"       Composite actions require the repository to be checked out first."
+            )
+        print(f"\nFound {len(all_violations)} violation(s) in {len(workflow_files)} file(s).")
+        return 1
+
+    print(f"OK: {len(workflow_files)} workflow file(s) checked. All pass checkout-first invariant.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_validate_workflow_checkout_order.py
+++ b/tests/scripts/test_validate_workflow_checkout_order.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Tests for scripts/validate_workflow_checkout_order.py.
+
+Verifies that the script correctly detects violations of the checkout-first
+invariant for local composite actions, and passes clean workflows.
+"""
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# Add scripts directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+from validate_workflow_checkout_order import (
+    collect_workflow_files,
+    main,
+    validate_workflow,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def write_workflow(tmp_path: Path, name: str, content: str) -> Path:
+    """Write a workflow YAML file to tmp_path and return its path."""
+    f = tmp_path / name
+    f.write_text(textwrap.dedent(content))
+    return f
+
+
+# ---------------------------------------------------------------------------
+# validate_workflow – clean cases
+# ---------------------------------------------------------------------------
+
+
+class TestValidateWorkflowClean:
+    """Workflows that should produce zero violations."""
+
+    def test_checkout_before_composite_action(self, tmp_path: Path) -> None:
+        """Checkout step precedes composite action — no violation."""
+        wf = write_workflow(
+            tmp_path,
+            "ok.yml",
+            """
+            jobs:
+              build:
+                steps:
+                  - name: Checkout
+                    uses: actions/checkout@v4
+                  - name: Setup pixi
+                    uses: ./.github/actions/setup-pixi
+            """,
+        )
+        assert validate_workflow(wf) == []
+
+    def test_no_composite_actions(self, tmp_path: Path) -> None:
+        """Workflow with no composite actions always passes."""
+        wf = write_workflow(
+            tmp_path,
+            "no_composite.yml",
+            """
+            jobs:
+              build:
+                steps:
+                  - name: Checkout
+                    uses: actions/checkout@v4
+                  - name: Run tests
+                    run: pytest
+            """,
+        )
+        assert validate_workflow(wf) == []
+
+    def test_checkout_with_pin_hash(self, tmp_path: Path) -> None:
+        """Pinned-hash checkout form is recognised."""
+        wf = write_workflow(
+            tmp_path,
+            "pinned.yml",
+            """
+            jobs:
+              build:
+                steps:
+                  - name: Checkout
+                    uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+                  - name: Setup pixi
+                    uses: ./.github/actions/setup-pixi
+            """,
+        )
+        assert validate_workflow(wf) == []
+
+    def test_multiple_jobs_both_clean(self, tmp_path: Path) -> None:
+        """All jobs checked out before composite references."""
+        wf = write_workflow(
+            tmp_path,
+            "multi_job.yml",
+            """
+            jobs:
+              job1:
+                steps:
+                  - uses: actions/checkout@v4
+                  - uses: ./.github/actions/setup-pixi
+              job2:
+                steps:
+                  - uses: actions/checkout@v4
+                  - uses: ./.github/actions/pr-comment
+                    with:
+                      report-file: report.md
+            """,
+        )
+        assert validate_workflow(wf) == []
+
+    def test_empty_jobs(self, tmp_path: Path) -> None:
+        """Workflow with no jobs produces no violations."""
+        wf = write_workflow(
+            tmp_path,
+            "empty_jobs.yml",
+            """
+            on: push
+            jobs: {}
+            """,
+        )
+        assert validate_workflow(wf) == []
+
+    def test_non_workflow_yaml(self, tmp_path: Path) -> None:
+        """YAML file without a 'jobs' key is silently ignored."""
+        wf = write_workflow(
+            tmp_path,
+            "config.yml",
+            """
+            foo: bar
+            baz: 42
+            """,
+        )
+        assert validate_workflow(wf) == []
+
+    def test_composite_at_end_after_checkout(self, tmp_path: Path) -> None:
+        """Composite action as the final step is fine as long as checkout came first."""
+        wf = write_workflow(
+            tmp_path,
+            "composite_end.yml",
+            """
+            jobs:
+              build:
+                steps:
+                  - uses: actions/checkout@v4
+                  - run: echo "middle step"
+                  - uses: ./.github/actions/pr-comment
+                    with:
+                      report-file: out.md
+            """,
+        )
+        assert validate_workflow(wf) == []
+
+
+# ---------------------------------------------------------------------------
+# validate_workflow – violation cases
+# ---------------------------------------------------------------------------
+
+
+class TestValidateWorkflowViolations:
+    """Workflows that should produce violations."""
+
+    def test_composite_before_checkout(self, tmp_path: Path) -> None:
+        """Composite action referenced before checkout — one violation."""
+        wf = write_workflow(
+            tmp_path,
+            "bad.yml",
+            """
+            jobs:
+              build:
+                steps:
+                  - name: Setup pixi
+                    uses: ./.github/actions/setup-pixi
+                  - name: Checkout
+                    uses: actions/checkout@v4
+            """,
+        )
+        violations = validate_workflow(wf)
+        assert len(violations) == 1
+        v = violations[0]
+        assert v.job_name == "build"
+        assert v.step_index == 1
+        assert v.composite_action == "./.github/actions/setup-pixi"
+        assert v.workflow_file == wf
+
+    def test_no_checkout_at_all(self, tmp_path: Path) -> None:
+        """Composite action in job that has no checkout — one violation."""
+        wf = write_workflow(
+            tmp_path,
+            "no_checkout.yml",
+            """
+            jobs:
+              build:
+                steps:
+                  - run: echo hello
+                  - uses: ./.github/actions/setup-pixi
+            """,
+        )
+        violations = validate_workflow(wf)
+        assert len(violations) == 1
+        assert violations[0].composite_action == "./.github/actions/setup-pixi"
+
+    def test_multiple_violations_in_one_job(self, tmp_path: Path) -> None:
+        """Two composite actions before checkout produce two violations."""
+        wf = write_workflow(
+            tmp_path,
+            "two_violations.yml",
+            """
+            jobs:
+              build:
+                steps:
+                  - uses: ./.github/actions/setup-pixi
+                  - uses: ./.github/actions/pr-comment
+                  - uses: actions/checkout@v4
+            """,
+        )
+        violations = validate_workflow(wf)
+        assert len(violations) == 2
+        actions = {v.composite_action for v in violations}
+        assert actions == {"./.github/actions/setup-pixi", "./.github/actions/pr-comment"}
+
+    def test_one_clean_job_one_violating_job(self, tmp_path: Path) -> None:
+        """Only the job without checkout produces a violation."""
+        wf = write_workflow(
+            tmp_path,
+            "mixed_jobs.yml",
+            """
+            jobs:
+              clean_job:
+                steps:
+                  - uses: actions/checkout@v4
+                  - uses: ./.github/actions/setup-pixi
+              bad_job:
+                steps:
+                  - uses: ./.github/actions/setup-pixi
+                  - uses: actions/checkout@v4
+            """,
+        )
+        violations = validate_workflow(wf)
+        assert len(violations) == 1
+        assert violations[0].job_name == "bad_job"
+
+    def test_violation_step_name_captured(self, tmp_path: Path) -> None:
+        """The violation records the step name correctly."""
+        wf = write_workflow(
+            tmp_path,
+            "named_step.yml",
+            """
+            jobs:
+              build:
+                steps:
+                  - name: My Special Setup
+                    uses: ./.github/actions/setup-pixi
+                  - uses: actions/checkout@v4
+            """,
+        )
+        violations = validate_workflow(wf)
+        assert len(violations) == 1
+        assert violations[0].step_name == "My Special Setup"
+
+
+# ---------------------------------------------------------------------------
+# collect_workflow_files
+# ---------------------------------------------------------------------------
+
+
+class TestCollectWorkflowFiles:
+    """Tests for path collection helpers."""
+
+    def test_directory_collects_yml_files(self, tmp_path: Path) -> None:
+        """Files with .yml extension in a directory are collected."""
+        (tmp_path / "a.yml").write_text("on: push\n")
+        (tmp_path / "b.yml").write_text("on: push\n")
+        (tmp_path / "c.txt").write_text("not yaml\n")
+        files = collect_workflow_files([str(tmp_path)])
+        names = {f.name for f in files}
+        assert names == {"a.yml", "b.yml"}
+
+    def test_directory_collects_yaml_files(self, tmp_path: Path) -> None:
+        """Files with .yaml extension are also collected."""
+        (tmp_path / "a.yaml").write_text("on: push\n")
+        files = collect_workflow_files([str(tmp_path)])
+        assert len(files) == 1
+        assert files[0].name == "a.yaml"
+
+    def test_explicit_file_path(self, tmp_path: Path) -> None:
+        """An explicit file path is collected directly."""
+        wf = tmp_path / "workflow.yml"
+        wf.write_text("on: push\n")
+        files = collect_workflow_files([str(wf)])
+        assert files == [wf]
+
+    def test_deduplication(self, tmp_path: Path) -> None:
+        """The same file referenced twice is deduplicated."""
+        wf = tmp_path / "workflow.yml"
+        wf.write_text("on: push\n")
+        files = collect_workflow_files([str(wf), str(wf)])
+        assert len(files) == 1
+
+    def test_missing_path_is_warned(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        """A non-existent path emits a warning but does not raise."""
+        files = collect_workflow_files([str(tmp_path / "nonexistent")])
+        assert files == []
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# main() integration
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    """Integration tests for the main() entry point."""
+
+    def test_main_passes_on_clean_workflows(self, tmp_path: Path) -> None:
+        """main() returns 0 when all workflows are clean."""
+        write_workflow(
+            tmp_path,
+            "clean.yml",
+            """
+            jobs:
+              build:
+                steps:
+                  - uses: actions/checkout@v4
+                  - uses: ./.github/actions/setup-pixi
+            """,
+        )
+        result = main([str(tmp_path)])
+        assert result == 0
+
+    def test_main_fails_on_violation(self, tmp_path: Path) -> None:
+        """main() returns 1 when a violation is detected."""
+        write_workflow(
+            tmp_path,
+            "bad.yml",
+            """
+            jobs:
+              build:
+                steps:
+                  - uses: ./.github/actions/setup-pixi
+                  - uses: actions/checkout@v4
+            """,
+        )
+        result = main([str(tmp_path)])
+        assert result == 1
+
+    def test_main_no_files(self, tmp_path: Path) -> None:
+        """main() returns 0 and prints a message when no YAML files found."""
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        result = main([str(empty_dir)])
+        assert result == 0
+
+    def test_main_real_workflows(self) -> None:
+        """main() passes against the actual .github/workflows/ directory."""
+        repo_root = Path(__file__).resolve().parent.parent.parent
+        workflows_dir = repo_root / ".github" / "workflows"
+        if not workflows_dir.is_dir():
+            pytest.skip(".github/workflows not found")
+        result = main([str(workflows_dir)])
+        assert result == 0, "Existing workflows violate the checkout-first invariant"
+
+    def test_main_multiple_paths(self, tmp_path: Path) -> None:
+        """main() accepts multiple explicit file paths."""
+        good = write_workflow(
+            tmp_path,
+            "good.yml",
+            """
+            jobs:
+              build:
+                steps:
+                  - uses: actions/checkout@v4
+                  - uses: ./.github/actions/setup-pixi
+            """,
+        )
+        bad = write_workflow(
+            tmp_path,
+            "bad.yml",
+            """
+            jobs:
+              build:
+                steps:
+                  - uses: ./.github/actions/setup-pixi
+            """,
+        )
+        result = main([str(good), str(bad)])
+        assert result == 1


### PR DESCRIPTION
## Summary

- Add `scripts/validate_workflow_checkout_order.py`: scans workflow YAML files and
  reports any job where a `./.github/actions/` step appears before `actions/checkout`
- Add `.github/workflows/validate-workflows.yml`: CI job that runs the check on PRs
  touching `.github/` files
- Update `.github/workflows/README.md`: new "Composite Action Checkout Invariant"
  section documenting the rule, the correct/incorrect patterns, and how to run the
  check locally
- Add `tests/scripts/test_validate_workflow_checkout_order.py`: 22 pytest tests
  covering clean workflows, violation detection, edge cases, and the real `.github/workflows/`

## Test plan

- [x] 22 unit/integration tests pass (`python -m pytest tests/scripts/test_validate_workflow_checkout_order.py -v`)
- [x] Script passes against all existing workflows (no false positives)
- [x] Pre-commit hooks pass (ruff format, ruff check, markdownlint, check-yaml)

Closes #3346

🤖 Generated with [Claude Code](https://claude.com/claude-code)