### PR TITLE
fix(docker): pin PIXI_VERSION in main Dockerfile development stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,8 +66,9 @@ ENV PIXI_CACHE_DIR=/home/${USER_NAME}/.cache/pixi
 RUN mkdir -p $PIXI_HOME $PIXI_CACHE_DIR $HOME/.cache/rattler && \
     chmod -R 700 $PIXI_HOME $PIXI_CACHE_DIR $HOME/.cache/rattler
 
-# Install Pixi as dev user
-RUN curl -fsSL https://pixi.sh/install.sh | bash
+# Install Pixi as dev user (pinned version for reproducible builds)
+ENV PIXI_VERSION=0.65.0
+RUN curl -fsSL https://pixi.sh/install.sh | PIXI_VERSION=${PIXI_VERSION} bash
 
 # Copy dependency manifests first for layer caching
 COPY --chown=${USER_NAME}:${USER_NAME} pixi.toml pixi.lock pyproject.toml requirements.txt requirements-dev.txt .pre-commit-config.yaml ./


### PR DESCRIPTION
## Summary

- Pins `PIXI_VERSION=0.65.0` in the `Dockerfile` development stage to match the pattern already used in `Dockerfile.ci`
- Passes the version via `PIXI_VERSION=${PIXI_VERSION}` environment variable to the install script for reproducible builds

## Changes Made

- `Dockerfile` line 70: replaced unpinned `curl -fsSL https://pixi.sh/install.sh | bash` with pinned version using `ENV PIXI_VERSION=0.65.0`

## Verification

- Change is consistent with `Dockerfile.ci` which already uses this pattern
- No functional change — same install script, now pinned to `0.65.0`

Closes #3350

🤖 Generated with [Claude Code](https://claude.com/claude-code)