### PR TITLE
test(foundation): add static regression tests for cargo-free Dockerfiles

### DIFF
--- a/tests/foundation/test_dockerfile_cargo_free.py
+++ b/tests/foundation/test_dockerfile_cargo_free.py
@@ -1,0 +1,40 @@
+"""Static regression tests asserting cargo is absent from Dockerfiles.
+
+Guards against re-introduction of the cargo apt dependency or cargo install
+after the optimization to use pre-built binaries instead.
+
+Follow-up from #3152.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[2]
+DOCKERFILES = [REPO_ROOT / "Dockerfile", REPO_ROOT / "Dockerfile.ci"]
+
+
+@pytest.mark.parametrize("dockerfile", DOCKERFILES, ids=["Dockerfile", "Dockerfile.ci"])
+class TestCargoAbsent:
+    """Assert cargo does not appear in apt-get install or as cargo install."""
+
+    def test_cargo_not_in_apt_get_install(self, dockerfile: Path) -> None:
+        """Assert cargo is not listed as an apt-get install dependency.
+
+        Args:
+            dockerfile: Path to the Dockerfile under test.
+        """
+        content = dockerfile.read_text()
+        match = re.search(r"apt-get install[^\n]*\bcargo\b", content)
+        assert match is None, f"Found 'cargo' in apt-get install in {dockerfile.name}: {match.group()!r}"
+
+    def test_cargo_install_not_present(self, dockerfile: Path) -> None:
+        """Assert 'cargo install' does not appear anywhere in the Dockerfile.
+
+        Args:
+            dockerfile: Path to the Dockerfile under test.
+        """
+        content = dockerfile.read_text()
+        match = re.search(r"\bcargo\s+install\b", content)
+        assert match is None, f"Found 'cargo install' in {dockerfile.name}: {match.group()!r}"


### PR DESCRIPTION
## Summary

- Add `tests/foundation/test_dockerfile_cargo_free.py` with parametrized pytest tests asserting `cargo` is absent from `apt-get install` lines and `cargo install` does not appear in `Dockerfile` or `Dockerfile.ci`
- Add `no-cargo-in-dockerfile` pygrep pre-commit hook to `.pre-commit-config.yaml` to block future re-introduction at commit time
- Update `Dockerfile` comment (line 37) to not contain the phrase "cargo install" — which would have triggered the new regression test

## Test plan

- [x] `test_cargo_not_in_apt_get_install[Dockerfile]` — PASSED
- [x] `test_cargo_not_in_apt_get_install[Dockerfile.ci]` — PASSED
- [x] `test_cargo_install_not_present[Dockerfile]` — PASSED
- [x] `test_cargo_install_not_present[Dockerfile.ci]` — PASSED
- [x] All pre-commit hooks pass (including the new `no-cargo-in-dockerfile` hook)

Closes #3351

🤖 Generated with [Claude Code](https://claude.com/claude-code)