### PR TITLE
docs(pre-commit): document intentional pass_filenames: false for validate-test-coverage hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,9 @@ repos:
         entry: python3 scripts/validate_test_coverage.py
         language: system
         files: (test_.*\.mojo|comprehensive-tests\.yml)$
+        # pass_filenames: false is intentional — this script performs a whole-repo
+        # coverage scan against the CI workflow YAML, not per-file validation.
+        # The files: pattern handles efficient triggering; the script ignores file args.
         pass_filenames: false
       - id: check-test-count-badge
         name: Check Test Count Badge


### PR DESCRIPTION
## Summary

- Evaluated whether `validate-test-coverage` pre-commit hook should use `pass_filenames: true`
- Confirmed the script performs a **whole-repo coverage scan** (not per-file validation) and ignores positional file arguments
- Added inline comment to `.pre-commit-config.yaml` documenting the intentional `pass_filenames: false` design

## Changes Made

- `.pre-commit-config.yaml`: Added 3-line comment above `pass_filenames: false` for the `validate-test-coverage` hook explaining the rationale

## Verification

- `pixi run pre-commit run validate-test-coverage --all-files` → Passed
- Pre-commit hooks on commit → All passed
- No functional changes — documentation only

Closes #3352

🤖 Generated with [Claude Code](https://claude.com/claude-code)