### PR TITLE
fix(ci): split Autograd & Benchmarking into separate test groups

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -217,9 +217,15 @@ jobs:
             pattern: "test_*.mojo datasets/test_*.mojo samplers/test_*.mojo transforms/test_*.mojo loaders/test_*.mojo formats/test_*.mojo"
             continue-on-error: true
           # ---- Autograd engine + shared benchmarking helpers ----
-          - name: "Autograd & Benchmarking"
-            path: "tests/shared"
-            pattern: "autograd/test_*.mojo benchmarking/test_*.mojo"
+          # Kept as separate entries (not merged under tests/shared parent path)
+          # to avoid silent pass-with-0-tests if a subdirectory is empty/renamed.
+          # See: https://github.com/homericintelligence/projectodyssey/issues/3356
+          - name: "Autograd"
+            path: "tests/shared/autograd"
+            pattern: "test_*.mojo"
+          - name: "Benchmarking"
+            path: "tests/shared/benchmarking"
+            pattern: "test_*.mojo"
           # ---- Integration tests (segfault-prone on CI, kept non-blocking) ----
           - name: "Integration Tests"
             path: "tests/shared/integration"

--- a/justfile
+++ b/justfile
@@ -492,8 +492,10 @@ test-group path pattern:
     done
 
     if [ -z "$test_files" ]; then
-        echo "⚠️  No test files found"
-        exit 0
+        echo "❌ ERROR: No test files found in {{path}} matching {{pattern}}"
+        echo "   This usually means the directory is empty or was renamed."
+        echo "   Fix: update the test group path/pattern in comprehensive-tests.yml"
+        exit 1
     fi
 
     # Run each test file


### PR DESCRIPTION
## Summary

- Split the merged `Autograd & Benchmarking` CI matrix entry into two separate entries (`Autograd` at `tests/shared/autograd`, `Benchmarking` at `tests/shared/benchmarking`) to eliminate the silent false-pass risk from the parent-path glob approach
- Fixed `just test-group` to exit 1 (not 0) when no test files are discovered, making zero-discovery failures loud and explicit

## Changes Made

- `.github/workflows/comprehensive-tests.yml`: Replace single merged entry with two separate entries, each with a specific directory path. Added explanatory comment referencing this issue.
- `justfile`: In `test-group` recipe, changed `exit 0` → `exit 1` with a descriptive error message when no test files are found.

## Verification

- `continue-on-error: ... || name == 'Benchmarking'` already matches the new standalone "Benchmarking" entry correctly — no additional change needed there.
- Pre-commit hooks passed (YAML syntax, trailing whitespace, end-of-file, test coverage validation).

Closes #3356