### PR TITLE
feat(ci): add pre-commit hook performance benchmark

### DIFF
--- a/.github/workflows/precommit-benchmark.yml
+++ b/.github/workflows/precommit-benchmark.yml
@@ -1,0 +1,76 @@
+name: Pre-commit Hook Benchmark
+
+# Measure pre-commit hook runtime to catch performance regressions.
+# Non-blocking: emits a warning annotation but never fails CI.
+
+on:
+  workflow_dispatch:
+
+  push:
+    paths:
+      - .pre-commit-config.yaml
+      - pyproject.toml
+
+  pull_request:
+    paths:
+      - .pre-commit-config.yaml
+      - pyproject.toml
+
+permissions:
+  contents: read
+
+jobs:
+  precommit-benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Pixi
+        uses: ./.github/actions/setup-pixi
+
+      - name: Install pre-commit
+        run: |
+          pixi run pip install pre-commit
+
+      - name: Cache pre-commit environments
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-
+
+      - name: Count tracked files
+        id: count-files
+        run: |
+          FILE_COUNT=$(git ls-files | wc -l | tr -d ' ')
+          echo "file_count=$FILE_COUNT" >> "$GITHUB_OUTPUT"
+
+      - name: Time pre-commit hooks
+        id: time-hooks
+        run: |
+          START=$SECONDS
+          pixi run pre-commit run --all-files --show-diff-on-failure
+          HOOK_EXIT=$?
+          ELAPSED=$((SECONDS - START))
+          echo "elapsed=$ELAPSED" >> "$GITHUB_OUTPUT"
+          if [ "$HOOK_EXIT" -eq 0 ]; then
+            echo "status=passed" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=failed" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Write benchmark summary
+        if: always()
+        env:
+          ELAPSED: ${{ steps.time-hooks.outputs.elapsed }}
+          FILE_COUNT: ${{ steps.count-files.outputs.file_count }}
+          HOOK_STATUS: ${{ steps.time-hooks.outputs.status }}
+        run: |
+          python3 scripts/bench_precommit.py \
+            --elapsed "${ELAPSED:-0}" \
+            --files "${FILE_COUNT:-0}" \
+            --status "${HOOK_STATUS:-unknown}"

--- a/justfile
+++ b/justfile
@@ -426,6 +426,17 @@ pre-commit:
 pre-commit-all:
     @pre-commit run --all-files
 
+# Time pre-commit hooks on all files (for local benchmarking)
+bench-precommit:
+    #!/usr/bin/env bash
+    set -e
+    START=$SECONDS
+    pixi run pre-commit run --all-files
+    ELAPSED=$((SECONDS - START))
+    echo ""
+    echo "Hook runtime: ${ELAPSED}s"
+    python3 scripts/bench_precommit.py --elapsed "$ELAPSED" --status passed
+
 # CI: Full validation (build + package + test)
 validate:
     @echo "Validating configuration..."

--- a/scripts/bench_precommit.py
+++ b/scripts/bench_precommit.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Pre-commit hook performance benchmark helper.
+
+Accepts elapsed time, file count, and hook status; emits a Markdown summary
+table and a GitHub Actions warning annotation if runtime exceeds the threshold.
+
+Usage:
+    python scripts/bench_precommit.py --elapsed 45 --files 300 --status passed
+    python scripts/bench_precommit.py --elapsed 150 --files 300 --status passed --threshold 120
+"""
+
+import argparse
+import os
+import sys
+from typing import Optional
+
+
+def format_summary_table(elapsed_s: int, file_count: int, hook_status: str) -> str:
+    """
+    Format a Markdown table summarising the pre-commit benchmark run.
+
+    Args:
+        elapsed_s: Wall-clock seconds the hooks took to complete.
+        file_count: Number of files processed.
+        hook_status: Result string, e.g. ``"passed"`` or ``"failed"``.
+
+    Returns:
+        Markdown-formatted table string including a trailing newline.
+    """
+    status_icon = "✅" if hook_status == "passed" else "❌"
+    return (
+        "## Pre-commit Hook Benchmark\n\n"
+        "| Metric | Value |\n"
+        "|--------|-------|\n"
+        f"| Hook status | {status_icon} {hook_status} |\n"
+        f"| Elapsed time | {elapsed_s}s |\n"
+        f"| Files processed | {file_count} |\n"
+    )
+
+
+def check_threshold(elapsed_s: int, threshold_s: int = 120) -> bool:
+    """
+    Return ``True`` if the elapsed time exceeds the threshold.
+
+    Args:
+        elapsed_s: Measured runtime in seconds.
+        threshold_s: Maximum acceptable runtime in seconds (default 120).
+
+    Returns:
+        ``True`` when slow (elapsed_s > threshold_s), ``False`` otherwise.
+    """
+    return elapsed_s > threshold_s
+
+
+def emit_warning(message: str) -> None:
+    """
+    Emit a GitHub Actions warning annotation to stdout.
+
+    Args:
+        message: Warning text to emit.
+    """
+    print(f"::warning::{message}")
+
+
+def write_step_summary(content: str, summary_path: Optional[str] = None) -> None:
+    """
+    Append content to the GitHub Actions step summary file if the path is set.
+
+    Args:
+        content: Markdown content to write.
+        summary_path: Path to the summary file; defaults to ``$GITHUB_STEP_SUMMARY``.
+    """
+    path = summary_path or os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    with open(path, "a") as fh:
+        fh.write(content)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """
+    CLI entry-point for the pre-commit benchmark helper.
+
+    Accepts --elapsed, --files, --status, and --threshold arguments, writes
+    a Markdown table to $GITHUB_STEP_SUMMARY (when set), emits a warning if
+    the run was slow, and always exits 0.
+
+    Args:
+        argv: Argument list; defaults to ``sys.argv[1:]``.
+
+    Returns:
+        Always 0 — timing regressions are non-blocking.
+    """
+    parser = argparse.ArgumentParser(description="Report pre-commit hook benchmark results.")
+    parser.add_argument(
+        "--elapsed",
+        type=int,
+        required=True,
+        help="Elapsed time in seconds.",
+    )
+    parser.add_argument(
+        "--files",
+        type=int,
+        default=0,
+        help="Number of files processed.",
+    )
+    parser.add_argument(
+        "--status",
+        default="passed",
+        help='Hook exit status string, e.g. "passed" or "failed".',
+    )
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=120,
+        help="Warning threshold in seconds (default: 120).",
+    )
+
+    args = parser.parse_args(argv)
+
+    table = format_summary_table(args.elapsed, args.files, args.status)
+    print(table)
+    write_step_summary(table)
+
+    if check_threshold(args.elapsed, args.threshold):
+        emit_warning(
+            f"Pre-commit hooks took {args.elapsed}s, "
+            f"which exceeds the {args.threshold}s threshold. "
+            "Consider reviewing hook configuration for performance regressions."
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_bench_precommit.py
+++ b/tests/scripts/test_bench_precommit.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Tests for scripts/bench_precommit.py."""
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from bench_precommit import (
+    check_threshold,
+    emit_warning,
+    format_summary_table,
+    main,
+    write_step_summary,
+)
+
+
+class TestFormatSummaryTable:
+    """Tests for format_summary_table()."""
+
+    def test_contains_elapsed(self) -> None:
+        result = format_summary_table(45, 100, "passed")
+        assert "45s" in result
+
+    def test_contains_file_count(self) -> None:
+        result = format_summary_table(45, 300, "passed")
+        assert "300" in result
+
+    def test_contains_passed_status(self) -> None:
+        result = format_summary_table(45, 100, "passed")
+        assert "passed" in result
+
+    def test_contains_failed_status(self) -> None:
+        result = format_summary_table(45, 100, "failed")
+        assert "failed" in result
+
+    def test_passed_has_checkmark(self) -> None:
+        result = format_summary_table(45, 100, "passed")
+        assert "✅" in result
+
+    def test_failed_has_cross(self) -> None:
+        result = format_summary_table(45, 100, "failed")
+        assert "❌" in result
+
+    def test_is_markdown_table(self) -> None:
+        result = format_summary_table(45, 100, "passed")
+        assert "|" in result
+        assert "---" in result
+
+    def test_ends_with_newline(self) -> None:
+        result = format_summary_table(45, 100, "passed")
+        assert result.endswith("\n")
+
+
+class TestCheckThreshold:
+    """Tests for check_threshold()."""
+
+    def test_fast_returns_false(self) -> None:
+        assert check_threshold(60, threshold_s=120) is False
+
+    def test_slow_returns_true(self) -> None:
+        assert check_threshold(150, threshold_s=120) is True
+
+    def test_exactly_at_threshold_returns_false(self) -> None:
+        assert check_threshold(120, threshold_s=120) is False
+
+    def test_default_threshold_is_120(self) -> None:
+        assert check_threshold(119) is False
+        assert check_threshold(121) is True
+
+
+class TestEmitWarning:
+    """Tests for emit_warning()."""
+
+    def test_warning_prefix(self, capsys: pytest.CaptureFixture[str]) -> None:
+        emit_warning("Hook is slow")
+        captured = capsys.readouterr()
+        assert captured.out.startswith("::warning::")
+
+    def test_message_included(self, capsys: pytest.CaptureFixture[str]) -> None:
+        emit_warning("Hook is slow")
+        captured = capsys.readouterr()
+        assert "Hook is slow" in captured.out
+
+
+class TestWriteStepSummary:
+    """Tests for write_step_summary()."""
+
+    def test_writes_to_file(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="r", suffix=".md", delete=False) as f:
+            path = f.name
+        write_step_summary("## Summary\n", summary_path=path)
+        content = Path(path).read_text()
+        assert "## Summary" in content
+
+    def test_no_file_when_path_empty(self) -> None:
+        # Should not raise even when no path is configured
+        write_step_summary("content", summary_path=None)
+
+    def test_appends_to_existing_content(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write("existing\n")
+            path = f.name
+        write_step_summary("appended\n", summary_path=path)
+        content = Path(path).read_text()
+        assert "existing" in content
+        assert "appended" in content
+
+
+class TestMain:
+    """Tests for the main() CLI entry-point."""
+
+    def test_exits_zero_when_fast(self) -> None:
+        rc = main(["--elapsed", "30", "--files", "100", "--status", "passed"])
+        assert rc == 0
+
+    def test_exits_zero_even_when_slow(self) -> None:
+        rc = main(["--elapsed", "200", "--files", "100", "--status", "passed"])
+        assert rc == 0
+
+    def test_exits_zero_when_failed_status(self) -> None:
+        rc = main(["--elapsed", "30", "--files", "100", "--status", "failed"])
+        assert rc == 0
+
+    def test_warning_emitted_when_slow(self, capsys: pytest.CaptureFixture[str]) -> None:
+        main(["--elapsed", "200", "--threshold", "120", "--status", "passed"])
+        captured = capsys.readouterr()
+        assert "::warning::" in captured.out
+
+    def test_no_warning_when_fast(self, capsys: pytest.CaptureFixture[str]) -> None:
+        main(["--elapsed", "50", "--threshold", "120", "--status", "passed"])
+        captured = capsys.readouterr()
+        assert "::warning::" not in captured.out
+
+    def test_custom_threshold_respected(self, capsys: pytest.CaptureFixture[str]) -> None:
+        main(["--elapsed", "60", "--threshold", "30", "--status", "passed"])
+        captured = capsys.readouterr()
+        assert "::warning::" in captured.out
+
+    def test_subprocess_exits_zero(self) -> None:
+        """Verify script exits 0 even when slow, via subprocess."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(Path(__file__).parent.parent.parent / "scripts" / "bench_precommit.py"),
+                "--elapsed",
+                "200",
+                "--files",
+                "100",
+                "--status",
+                "passed",
+            ],
+            capture_output=True,
+        )
+        assert result.returncode == 0


### PR DESCRIPTION
## Summary

- Adds `scripts/bench_precommit.py` — a pure-Python helper that formats a Markdown summary table, checks runtime against a configurable threshold (default 120 s), emits a `::warning::` GitHub Actions annotation when slow, and always exits 0 (non-blocking)
- Adds `tests/scripts/test_bench_precommit.py` — 24 unit tests covering all public functions including a subprocess exit-code check
- Adds `.github/workflows/precommit-benchmark.yml` — CI workflow that triggers on changes to `.pre-commit-config.yaml` / `pyproject.toml` and `workflow_dispatch`; times `pixi run pre-commit run --all-files` and writes results to `$GITHUB_STEP_SUMMARY`
- Adds `bench-precommit` justfile recipe for local reproduction of the same measurement

## Test plan

- [x] `pixi run python -m pytest tests/scripts/test_bench_precommit.py -v` — 24 passed
- [x] Pre-commit hooks pass (ruff format, ruff check, mypy, bandit)
- [x] YAML workflow file passes `check-yaml` hook

Closes #3353