### PR TITLE
feat(ci): detect 0-file CI matrix patterns as coverage gaps

### DIFF
--- a/scripts/validate_test_coverage.py
+++ b/scripts/validate_test_coverage.py
@@ -4,9 +4,11 @@ Validate Test Coverage - Ensure all test_*.mojo files are covered by CI
 
 This script finds all test_*.mojo files in the repository and verifies they are
 included in the CI test matrix in .github/workflows/comprehensive-tests.yml.
+It also checks the inverse: that each CI matrix pattern matches at least one
+existing file, flagging stale patterns as warnings.
 
 Exit codes:
-  0 - All tests covered
+  0 - All tests covered (stale-pattern warnings do not affect exit code)
   1 - Uncovered tests found or validation errors
 
 Usage:
@@ -226,6 +228,25 @@ def check_coverage(
     return uncovered, coverage_by_group
 
 
+def check_stale_patterns(ci_groups: Dict[str, Dict[str, str]], root_dir: Path) -> List[str]:
+    """
+    Check for CI matrix patterns that match 0 existing test files.
+
+    Args:
+        ci_groups: Mapping of group name to path/pattern info from parse_ci_matrix().
+        root_dir: Repository root directory used for glob expansion.
+
+    Returns:
+        Sorted list of group names whose patterns match no existing files.
+    """
+    stale = []
+    for group_name, group_info in ci_groups.items():
+        matched = expand_pattern(group_info["path"], group_info["pattern"], root_dir)
+        if not matched:
+            stale.append(group_name)
+    return sorted(stale)
+
+
 def generate_report(
     uncovered: Set[Path],
     test_files: List[Path],
@@ -354,6 +375,32 @@ def main():
 
     # Check coverage
     uncovered, coverage_by_group = check_coverage(test_files, ci_groups, repo_root)
+
+    # Check for stale CI patterns (inverse check)
+    stale_patterns = check_stale_patterns(ci_groups, repo_root)
+    if stale_patterns:
+        print("=" * 70, file=sys.stderr)
+        print("Warning: Stale CI Patterns", file=sys.stderr)
+        print("=" * 70, file=sys.stderr)
+        print(file=sys.stderr)
+        print(
+            f"⚠️  Found {len(stale_patterns)} CI pattern(s) matching 0 files:",
+            file=sys.stderr,
+        )
+        print(file=sys.stderr)
+        for group_name in stale_patterns:
+            group_info = ci_groups[group_name]
+            print(
+                f"   • {group_name!r}  (path={group_info['path']!r}, pattern={group_info['pattern']!r})",
+                file=sys.stderr,
+            )
+        print(file=sys.stderr)
+        print(
+            "Remove or update these entries in .github/workflows/comprehensive-tests.yml",
+            file=sys.stderr,
+        )
+        print("=" * 70, file=sys.stderr)
+        print(file=sys.stderr)
 
     # Only print detailed report if tests are missing
     if uncovered:

--- a/tests/scripts/test_validate_test_coverage.py
+++ b/tests/scripts/test_validate_test_coverage.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Tests for validate_test_coverage.py — stale pattern detection (issue #3358).
+
+Verifies that check_stale_patterns() correctly identifies CI matrix entries
+that match zero existing test files.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+from validate_test_coverage import check_stale_patterns, expand_pattern
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def tmp_repo(tmp_path: Path) -> Path:
+    """Create a minimal repo-like directory tree with a few test files."""
+    (tmp_path / "tests" / "unit").mkdir(parents=True)
+    (tmp_path / "tests" / "unit" / "test_foo.mojo").touch()
+    (tmp_path / "tests" / "unit" / "test_bar.mojo").touch()
+    (tmp_path / "tests" / "integration").mkdir(parents=True)
+    (tmp_path / "tests" / "integration" / "test_baz.mojo").touch()
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# check_stale_patterns
+# ---------------------------------------------------------------------------
+
+
+class TestCheckStalePatterns:
+    """Unit tests for check_stale_patterns()."""
+
+    def test_no_stale_when_all_patterns_match(self, tmp_repo: Path) -> None:
+        """Groups that match existing files are not reported as stale."""
+        ci_groups = {
+            "Unit Tests": {"path": "tests/unit", "pattern": "test_*.mojo"},
+            "Integration Tests": {
+                "path": "tests/integration",
+                "pattern": "test_*.mojo",
+            },
+        }
+        stale = check_stale_patterns(ci_groups, tmp_repo)
+        assert stale == []
+
+    def test_stale_when_path_does_not_exist(self, tmp_repo: Path) -> None:
+        """A pattern whose base path does not exist is reported as stale."""
+        ci_groups = {
+            "Ghost Tests": {"path": "tests/nonexistent", "pattern": "test_*.mojo"},
+        }
+        stale = check_stale_patterns(ci_groups, tmp_repo)
+        assert stale == ["Ghost Tests"]
+
+    def test_stale_when_pattern_matches_no_files(self, tmp_repo: Path) -> None:
+        """A pattern that globs to zero files in an existing path is stale."""
+        ci_groups = {
+            "Unit Tests": {"path": "tests/unit", "pattern": "test_missing_*.mojo"},
+        }
+        stale = check_stale_patterns(ci_groups, tmp_repo)
+        assert stale == ["Unit Tests"]
+
+    def test_partial_stale(self, tmp_repo: Path) -> None:
+        """Only the groups with zero matches are returned."""
+        ci_groups = {
+            "Good Group": {"path": "tests/unit", "pattern": "test_*.mojo"},
+            "Stale Group": {"path": "tests/deleted", "pattern": "test_*.mojo"},
+        }
+        stale = check_stale_patterns(ci_groups, tmp_repo)
+        assert stale == ["Stale Group"]
+
+    def test_multiple_stale_groups_sorted(self, tmp_repo: Path) -> None:
+        """Multiple stale groups are returned in sorted order."""
+        ci_groups = {
+            "Zebra Tests": {"path": "tests/z_gone", "pattern": "test_*.mojo"},
+            "Alpha Tests": {"path": "tests/a_gone", "pattern": "test_*.mojo"},
+            "Good Tests": {"path": "tests/unit", "pattern": "test_*.mojo"},
+        }
+        stale = check_stale_patterns(ci_groups, tmp_repo)
+        assert stale == ["Alpha Tests", "Zebra Tests"]
+
+    def test_empty_ci_groups_returns_empty(self, tmp_repo: Path) -> None:
+        """An empty CI groups mapping yields no stale patterns."""
+        stale = check_stale_patterns({}, tmp_repo)
+        assert stale == []
+
+    def test_returns_list_of_strings(self, tmp_repo: Path) -> None:
+        """Return type is always a list of strings."""
+        ci_groups = {
+            "Unit Tests": {"path": "tests/unit", "pattern": "test_*.mojo"},
+        }
+        result = check_stale_patterns(ci_groups, tmp_repo)
+        assert isinstance(result, list)
+        assert all(isinstance(name, str) for name in result)
+
+    def test_specific_file_pattern_stale_after_rename(self, tmp_repo: Path) -> None:
+        """A group referencing a specific file that was renamed is stale."""
+        # tests/unit/test_renamed.mojo no longer exists
+        ci_groups = {
+            "Renamed Test": {
+                "path": "tests/unit",
+                "pattern": "test_renamed.mojo",
+            },
+        }
+        stale = check_stale_patterns(ci_groups, tmp_repo)
+        assert stale == ["Renamed Test"]
+
+    def test_specific_file_pattern_not_stale_when_file_exists(self, tmp_repo: Path) -> None:
+        """A group referencing a specific existing file is not stale."""
+        ci_groups = {
+            "Foo Test": {"path": "tests/unit", "pattern": "test_foo.mojo"},
+        }
+        stale = check_stale_patterns(ci_groups, tmp_repo)
+        assert stale == []
+
+
+# ---------------------------------------------------------------------------
+# expand_pattern (regression guard — unchanged behaviour)
+# ---------------------------------------------------------------------------
+
+
+class TestExpandPattern:
+    """Regression tests ensuring expand_pattern still works correctly."""
+
+    def test_wildcard_finds_files(self, tmp_repo: Path) -> None:
+        matched = expand_pattern("tests/unit", "test_*.mojo", tmp_repo)
+        assert len(matched) == 2
+
+    def test_wildcard_finds_no_files_in_missing_dir(self, tmp_repo: Path) -> None:
+        matched = expand_pattern("tests/missing", "test_*.mojo", tmp_repo)
+        assert matched == set()
+
+    def test_direct_file_found(self, tmp_repo: Path) -> None:
+        matched = expand_pattern("tests/unit", "test_foo.mojo", tmp_repo)
+        assert len(matched) == 1
+
+    def test_direct_file_missing(self, tmp_repo: Path) -> None:
+        matched = expand_pattern("tests/unit", "test_gone.mojo", tmp_repo)
+        assert matched == set()


### PR DESCRIPTION
## Summary

- Adds `check_stale_patterns()` to `scripts/validate_test_coverage.py` to detect CI matrix entries that match zero existing test files
- Stale patterns are printed to stderr as `⚠️` warnings without changing the exit code (only uncovered test files cause exit 1)
- Adds 13 unit tests in `tests/scripts/test_validate_test_coverage.py`

## Changes Made

- `scripts/validate_test_coverage.py`: new `check_stale_patterns()` function + call in `main()` + updated docstring
- `tests/scripts/test_validate_test_coverage.py`: new test file covering all scenarios

## Test plan

- [x] `check_stale_patterns()` returns empty list when all patterns match existing files
- [x] Reports stale when base path does not exist
- [x] Reports stale when wildcard matches zero files in existing dir
- [x] Reports stale when specific filename was renamed/deleted
- [x] Multiple stale groups returned in sorted order
- [x] Empty CI groups input returns empty list
- [x] Regression tests for `expand_pattern()` unchanged behaviour
- [x] All 13 new tests pass
- [x] Pre-commit hooks pass (ruff, mypy, bandit)

Closes #3358

🤖 Generated with [Claude Code](https://claude.com/claude-code)