### PR TITLE
fix(security): move bandit B310/B202 skips to .bandit config file

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,8 @@
+[bandit]
+targets = scripts
+recursive = true
+skips = B310,B202
+# B310: urllib.request.urlopen — all URLs are internal, non-user-supplied constants
+#       (e.g., GHCR registry URLs in release scripts). No untrusted input reaches urlopen.
+# B202: tarfile.extractall — archives are CI-produced artifacts from trusted pipelines,
+#       not user-uploaded content. Path traversal risk does not apply here.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,13 +26,13 @@ repos:
 
   # Security checks - bandit for accurate Python security scanning
   # Replaces naive pygrep shell=True check with AST-based analysis
-  # Skips: B310 (urlopen with controlled URLs), B202 (tarfile in download scripts)
+  # Suppressions (B310, B202) are documented in .bandit [bandit] section
   - repo: local
     hooks:
       - id: bandit
         name: Bandit Security Scan
-        description: Scan Python files for security vulnerabilities using bandit
-        entry: pixi run bandit -ll --skip B310,B202
+        description: Scan Python files for security vulnerabilities using bandit (suppressions in .bandit)
+        entry: pixi run bandit -ll --ini .bandit
         language: system
         files: ^(scripts|tests)/.*\.py$
         types: [python]

--- a/pixi.toml
+++ b/pixi.toml
@@ -30,3 +30,6 @@ nbformat = ">=5.10.0,<6"
 nbconvert = ">=7.16.0,<8"
 flask = ">=3.0.0,<4"
 pydantic = ">=2.12.5,<3"
+
+[tasks]
+bandit = "bandit --ini .bandit"


### PR DESCRIPTION
## Summary

- Create `.bandit` INI config at repo root with `targets=scripts`, `recursive=true`, `skips=B310,B202`, and inline rationale comments for each suppression
- Update `.pre-commit-config.yaml` bandit hook to use `--ini .bandit` instead of `--skip B310,B202` CLI flags
- Add `[tasks] bandit = "bandit --ini .bandit"` to `pixi.toml` so `pixi run bandit` works for developers

## Problem

B310/B202 skip list was embedded as a `--skip` CLI flag in the pre-commit hook, invisible to developers running `bandit` directly. Running `bandit -r scripts/` manually produced false positives for B310 and B202 that don't exist in CI.

## Solution

A `.bandit` INI file (the format bandit natively supports via `--ini`) moves suppressions to a discoverable config file with documented rationale:

- **B310**: `urllib.request.urlopen` — all URLs are internal, non-user-supplied constants (GHCR registry URLs). No untrusted input reaches urlopen.
- **B202**: `tarfile.extractall` — archives are CI-produced artifacts from trusted pipelines. Path traversal risk does not apply.

## Test plan

- [x] `bandit --ini .bandit` shows `cli exclude tests: B310,B202` and exits 0 with no medium/high issues
- [x] `pixi run bandit` applies suppressions correctly via `--ini .bandit`
- [x] `pixi run pre-commit run --all-files bandit` passes

Closes #3361

🤖 Generated with [Claude Code](https://claude.com/claude-code)