### PR TITLE
feat(docs): audit .claude/shared/ links and add missing Quick Links entries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,6 +85,17 @@ repos:
         types: [python]
         pass_filenames: true
 
+  # Audit .claude/shared/ link-backs in CLAUDE.md
+  - repo: local
+    hooks:
+      - id: audit-shared-links
+        name: Audit shared/ links in CLAUDE.md
+        description: Ensure every .claude/shared/*.md file is listed in CLAUDE.md Quick Links
+        entry: python scripts/audit_shared_links.py
+        language: system
+        files: ^(CLAUDE\.md|\.claude/shared/.*)$
+        pass_filenames: false
+
   # Test coverage validation
   - repo: local
     hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,9 @@ gh pr merge --auto --rebase
 - [Common Constraints](/.claude/shared/common-constraints.md)
 - [Documentation Rules](/.claude/shared/documentation-rules.md)
 - [Error Handling](/.claude/shared/error-handling.md)
+- [Git Commit Policy](/.claude/shared/git-commit-policy.md)
+- [Output Style Guidelines](/.claude/shared/output-style-guidelines.md)
+- [Tool Use Optimization](/.claude/shared/tool-use-optimization.md)
 
 ### Agent System & Skills
 

--- a/scripts/audit_shared_links.py
+++ b/scripts/audit_shared_links.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+Audit .claude/shared/ files for missing link-backs in CLAUDE.md
+
+Verifies that every file in .claude/shared/ is listed in the Quick Links
+section of CLAUDE.md. Exits non-zero if any shared file is missing.
+
+Usage:
+    python scripts/audit_shared_links.py [--claude-md PATH] [--shared-dir PATH]
+
+Exit codes:
+    0: All shared files are linked in CLAUDE.md Quick Links
+    1: One or more shared files are missing from Quick Links
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import List, Set, Tuple
+
+from common import get_repo_root
+
+
+def list_shared_files(shared_dir: Path) -> List[str]:
+    """
+    List all .md files in the shared directory.
+
+    Args:
+        shared_dir: Path to .claude/shared/ directory
+
+    Returns:
+        List of relative paths like '.claude/shared/foo.md'
+    """
+    return sorted(f".claude/shared/{p.name}" for p in shared_dir.iterdir() if p.is_file() and p.suffix == ".md")
+
+
+def extract_quick_links_section(claude_md_content: str) -> str:
+    """
+    Extract the Quick Links section from CLAUDE.md content.
+
+    Captures text from '## Quick Links' up to (but not including) the next
+    level-2 heading.
+
+    Args:
+        claude_md_content: Full content of CLAUDE.md
+
+    Returns:
+        The Quick Links section as a string, or empty string if not found
+    """
+    match = re.search(
+        r"^## Quick Links\b(.*?)(?=^## |\Z)",
+        claude_md_content,
+        re.MULTILINE | re.DOTALL,
+    )
+    return match.group(0) if match else ""
+
+
+def extract_linked_shared_paths(section: str) -> Set[str]:
+    """
+    Extract .claude/shared/... paths referenced as markdown links in a section.
+
+    Handles both absolute links (/.claude/shared/foo.md) and relative links
+    (.claude/shared/foo.md).
+
+    Args:
+        section: Markdown text to search
+
+    Returns:
+        Set of normalised paths like '.claude/shared/foo.md'
+    """
+    # Match markdown links: [text](url) or bare references in table cells.
+    # Capture the filename, ignoring any trailing #anchor fragment.
+    link_pattern = re.compile(r"\(/?\.claude/shared/([^)#\s]+)(?:#[^)]*)?\)")
+    return {f".claude/shared/{m.group(1)}" for m in link_pattern.finditer(section)}
+
+
+def audit(
+    claude_md_content: str,
+    shared_dir: Path,
+) -> Tuple[List[str], List[str]]:
+    """
+    Audit shared files against CLAUDE.md Quick Links.
+
+    Args:
+        claude_md_content: Full text of CLAUDE.md
+        shared_dir: Path to .claude/shared/ directory
+
+    Returns:
+        Tuple of (missing_files, present_files) where each element is a list
+        of '.claude/shared/...' path strings
+    """
+    shared_files = list_shared_files(shared_dir)
+    quick_links_section = extract_quick_links_section(claude_md_content)
+    linked_paths = extract_linked_shared_paths(quick_links_section)
+
+    missing = [f for f in shared_files if f not in linked_paths]
+    present = [f for f in shared_files if f in linked_paths]
+    return missing, present
+
+
+def main(argv: List[str] | None = None) -> int:
+    """
+    Run the audit and print results.
+
+    Returns:
+        0 if all shared files are linked, 1 otherwise
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    repo_root = get_repo_root()
+    parser.add_argument(
+        "--claude-md",
+        type=Path,
+        default=repo_root / "CLAUDE.md",
+        help="Path to CLAUDE.md (default: repo root)",
+    )
+    parser.add_argument(
+        "--shared-dir",
+        type=Path,
+        default=repo_root / ".claude" / "shared",
+        help="Path to .claude/shared/ directory (default: repo root)",
+    )
+    args = parser.parse_args(argv)
+
+    claude_md_path: Path = args.claude_md
+    shared_dir: Path = args.shared_dir
+
+    if not claude_md_path.exists():
+        print(f"ERROR: CLAUDE.md not found: {claude_md_path}", file=sys.stderr)
+        return 1
+
+    if not shared_dir.exists():
+        print(f"ERROR: shared dir not found: {shared_dir}", file=sys.stderr)
+        return 1
+
+    content = claude_md_path.read_text(encoding="utf-8")
+    missing, present = audit(content, shared_dir)
+
+    if missing:
+        print("AUDIT FAILED: The following .claude/shared/ files are not linked")
+        print("in the Quick Links section of CLAUDE.md:\n")
+        for path in missing:
+            print(f"  - {path}")
+        print(f"\n{len(missing)} file(s) missing, {len(present)} file(s) present.")
+        print("\nAdd the missing files to the '### Core Guidelines' list in CLAUDE.md.")
+        return 1
+
+    print(f"AUDIT PASSED: All {len(present)} .claude/shared/ file(s) are linked in CLAUDE.md Quick Links.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_audit_shared_links.py
+++ b/tests/test_audit_shared_links.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""
+Unit tests for scripts/audit_shared_links.py
+
+Tests use synthetic in-memory content strings rather than real file I/O,
+ensuring fast, hermetic tests that don't depend on the repo layout.
+"""
+
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import List
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from audit_shared_links import (
+    audit,
+    extract_linked_shared_paths,
+    extract_quick_links_section,
+    list_shared_files,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_shared_dir(tmp: Path, filenames: List[str]) -> Path:
+    """Create a fake .claude/shared/ directory with the given .md files."""
+    shared = tmp / ".claude" / "shared"
+    shared.mkdir(parents=True)
+    for name in filenames:
+        (shared / name).write_text(f"# {name}")
+    return shared
+
+
+def _make_claude_md(tmp: Path, content: str) -> Path:
+    """Write synthetic CLAUDE.md content to a temp file."""
+    path = tmp / "CLAUDE.md"
+    path.write_text(content)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# list_shared_files
+# ---------------------------------------------------------------------------
+
+
+class TestListSharedFiles:
+    def test_returns_md_files_only(self):
+        with TemporaryDirectory() as tmpdir:
+            shared = Path(tmpdir) / ".claude" / "shared"
+            shared.mkdir(parents=True)
+            (shared / "foo.md").write_text("# foo")
+            (shared / "bar.md").write_text("# bar")
+            (shared / "not-md.txt").write_text("ignored")
+
+            result = list_shared_files(shared)
+            assert ".claude/shared/foo.md" in result
+            assert ".claude/shared/bar.md" in result
+            assert ".claude/shared/not-md.txt" not in result
+
+    def test_returns_sorted_list(self):
+        with TemporaryDirectory() as tmpdir:
+            shared = Path(tmpdir) / ".claude" / "shared"
+            shared.mkdir(parents=True)
+            for name in ["zzz.md", "aaa.md", "mmm.md"]:
+                (shared / name).write_text("")
+
+            result = list_shared_files(shared)
+            assert result == sorted(result)
+
+    def test_empty_dir_returns_empty_list(self):
+        with TemporaryDirectory() as tmpdir:
+            shared = Path(tmpdir) / ".claude" / "shared"
+            shared.mkdir(parents=True)
+            assert list_shared_files(shared) == []
+
+
+# ---------------------------------------------------------------------------
+# extract_quick_links_section
+# ---------------------------------------------------------------------------
+
+
+class TestExtractQuickLinksSection:
+    def test_extracts_section_content(self):
+        content = """\
+## Other Section
+
+Some content.
+
+## Quick Links
+
+### Core Guidelines
+
+- [Foo](/.claude/shared/foo.md)
+
+## Another Section
+
+More content.
+"""
+        section = extract_quick_links_section(content)
+        assert "foo.md" in section
+        assert "Another Section" not in section
+
+    def test_returns_empty_string_when_missing(self):
+        content = "## Only Section\n\nNo quick links here.\n"
+        assert extract_quick_links_section(content) == ""
+
+    def test_captures_to_end_of_file_when_last_section(self):
+        content = "## Quick Links\n\n- [Bar](/.claude/shared/bar.md)\n"
+        section = extract_quick_links_section(content)
+        assert "bar.md" in section
+
+
+# ---------------------------------------------------------------------------
+# extract_linked_shared_paths
+# ---------------------------------------------------------------------------
+
+
+class TestExtractLinkedSharedPaths:
+    def test_absolute_link_extracted(self):
+        section = "- [Foo](/.claude/shared/foo.md)\n"
+        assert extract_linked_shared_paths(section) == {".claude/shared/foo.md"}
+
+    def test_relative_link_extracted(self):
+        section = "- [Bar](.claude/shared/bar.md)\n"
+        assert extract_linked_shared_paths(section) == {".claude/shared/bar.md"}
+
+    def test_anchor_stripped_from_path(self):
+        section = "- [Baz](/.claude/shared/baz.md#section)\n"
+        assert extract_linked_shared_paths(section) == {".claude/shared/baz.md"}
+
+    def test_multiple_links(self):
+        section = "- [A](/.claude/shared/a.md)\n- [B](/.claude/shared/b.md)\n- [C](/.claude/shared/c.md)\n"
+        result = extract_linked_shared_paths(section)
+        assert result == {
+            ".claude/shared/a.md",
+            ".claude/shared/b.md",
+            ".claude/shared/c.md",
+        }
+
+    def test_non_shared_links_ignored(self):
+        section = "- [Docs](/docs/some-doc.md)\n- [Foo](/.claude/shared/foo.md)\n"
+        result = extract_linked_shared_paths(section)
+        assert result == {".claude/shared/foo.md"}
+
+    def test_empty_section_returns_empty_set(self):
+        assert extract_linked_shared_paths("") == set()
+
+
+# ---------------------------------------------------------------------------
+# audit
+# ---------------------------------------------------------------------------
+
+
+FULL_CLAUDE_MD_TEMPLATE = """\
+## Quick Links
+
+### Core Guidelines
+
+{links}
+
+## Next Section
+
+Other content.
+"""
+
+
+class TestAudit:
+    def test_clean_state_passes(self):
+        with TemporaryDirectory() as tmpdir:
+            shared = _make_shared_dir(Path(tmpdir), ["foo.md", "bar.md", "baz.md"])
+            links = (
+                "- [Foo](/.claude/shared/foo.md)\n- [Bar](/.claude/shared/bar.md)\n- [Baz](/.claude/shared/baz.md)\n"
+            )
+            content = FULL_CLAUDE_MD_TEMPLATE.format(links=links)
+            missing, present = audit(content, shared)
+            assert missing == []
+            assert sorted(present) == [
+                ".claude/shared/bar.md",
+                ".claude/shared/baz.md",
+                ".claude/shared/foo.md",
+            ]
+
+    def test_missing_file_detected(self):
+        with TemporaryDirectory() as tmpdir:
+            shared = _make_shared_dir(Path(tmpdir), ["foo.md", "bar.md", "missing.md"])
+            links = (
+                "- [Foo](/.claude/shared/foo.md)\n- [Bar](/.claude/shared/bar.md)\n"
+                # missing.md intentionally absent
+            )
+            content = FULL_CLAUDE_MD_TEMPLATE.format(links=links)
+            missing, present = audit(content, shared)
+            assert missing == [".claude/shared/missing.md"]
+            assert ".claude/shared/foo.md" in present
+            assert ".claude/shared/bar.md" in present
+
+    def test_extra_link_in_claude_md_no_false_positive(self):
+        """Links in CLAUDE.md that don't correspond to shared files are fine."""
+        with TemporaryDirectory() as tmpdir:
+            shared = _make_shared_dir(Path(tmpdir), ["foo.md"])
+            links = "- [Foo](/.claude/shared/foo.md)\n- [Extra](/.claude/shared/extra-not-on-disk.md)\n"
+            content = FULL_CLAUDE_MD_TEMPLATE.format(links=links)
+            missing, present = audit(content, shared)
+            assert missing == []
+            assert present == [".claude/shared/foo.md"]
+
+    def test_all_missing_when_quick_links_absent(self):
+        with TemporaryDirectory() as tmpdir:
+            shared = _make_shared_dir(Path(tmpdir), ["foo.md", "bar.md"])
+            content = "## Some Other Section\n\nNo quick links.\n"
+            missing, present = audit(content, shared)
+            assert sorted(missing) == [
+                ".claude/shared/bar.md",
+                ".claude/shared/foo.md",
+            ]
+            assert present == []
+
+
+# ---------------------------------------------------------------------------
+# main (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_returns_0_on_clean_state(self):
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            shared = _make_shared_dir(tmppath, ["foo.md"])
+            content = FULL_CLAUDE_MD_TEMPLATE.format(links="- [Foo](/.claude/shared/foo.md)\n")
+            claude_md = _make_claude_md(tmppath, content)
+            rc = main(["--claude-md", str(claude_md), "--shared-dir", str(shared)])
+            assert rc == 0
+
+    def test_returns_1_on_missing_link(self):
+        with TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            shared = _make_shared_dir(tmppath, ["foo.md", "bar.md"])
+            content = FULL_CLAUDE_MD_TEMPLATE.format(
+                links="- [Foo](/.claude/shared/foo.md)\n"
+                # bar.md missing
+            )
+            claude_md = _make_claude_md(tmppath, content)
+            rc = main(["--claude-md", str(claude_md), "--shared-dir", str(shared)])
+            assert rc == 1
+
+    def test_returns_1_when_claude_md_missing(self, tmp_path: Path):
+        shared = tmp_path / ".claude" / "shared"
+        shared.mkdir(parents=True)
+        rc = main(
+            [
+                "--claude-md",
+                str(tmp_path / "NONEXISTENT.md"),
+                "--shared-dir",
+                str(shared),
+            ]
+        )
+        assert rc == 1
+
+    def test_returns_1_when_shared_dir_missing(self, tmp_path: Path):
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text("## Quick Links\n")
+        rc = main(
+            [
+                "--claude-md",
+                str(claude_md),
+                "--shared-dir",
+                str(tmp_path / "nonexistent"),
+            ]
+        )
+        assert rc == 1


### PR DESCRIPTION
## Summary

- Adds `output-style-guidelines.md`, `tool-use-optimization.md`, and `git-commit-policy.md` to the Quick Links / Core Guidelines list in `CLAUDE.md` (all 3 were present in `.claude/shared/` but absent from Quick Links)
- Adds `scripts/audit_shared_links.py` — detects drift between `.claude/shared/*.md` and `CLAUDE.md` Quick Links section, exits 1 on violations
- Adds `tests/test_audit_shared_links.py` — 20 unit tests using synthetic in-memory content
- Adds `audit-shared-links` pre-commit hook that fires whenever `CLAUDE.md` or `.claude/shared/` files are staged

## Test plan

- [x] 20/20 unit tests pass (`pixi run python -m pytest tests/test_audit_shared_links.py -v`)
- [x] Audit script passes against current repo (`python scripts/audit_shared_links.py` → exit 0)
- [x] All pre-commit hooks pass on changed files

Closes #3366

🤖 Generated with [Claude Code](https://claude.com/claude-code)