### PR TITLE
fix(pre-commit): upgrade mirrors-mypy rev from v1.8.0 to v1.19.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
 
   # Python type checking
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.19.1
     hooks:
       - id: mypy
         files: ^scripts/.*\.py$


### PR DESCRIPTION
## Summary

- Align the `mirrors-mypy` pre-commit hook revision with the mypy version resolved by pixi (`>=1.19.1,<2`)
- Eliminates the version mismatch where `pixi run mypy` used v1.19.1 but the pre-commit hook used v1.8.0
- Ensures consistent type-checking behavior between local development and pre-commit hooks

## Changes Made

- `.pre-commit-config.yaml`: Updated `mirrors-mypy` rev from `v1.8.0` to `v1.19.1`

## Verification

- [x] Pre-commit hooks install and run successfully with new version
- [x] `pixi run mypy --version` confirms v1.19.1 is the resolved version
- [x] No behavior changes to mypy args or scope

Closes #3369

🤖 Generated with [Claude Code](https://claude.com/claude-code)