### PR TITLE
feat(mypy): add --check-untyped-defs for full body type coverage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
     hooks:
       - id: mypy
         files: ^scripts/.*\.py$
-        args: [--ignore-missing-imports, --no-strict-optional, --explicit-package-bases, --python-version, "3.10"]
+        args: [--ignore-missing-imports, --no-strict-optional, --explicit-package-bases, --check-untyped-defs, --python-version, "3.10"]
         additional_dependencies: [types-PyYAML]
 
   # Python formatting and linting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
+check_untyped_defs = true
 explicit_package_bases = true
 mypy_path = "."
 exclude = "generators/"

--- a/scripts/agents/tests/test_integration.py
+++ b/scripts/agents/tests/test_integration.py
@@ -362,7 +362,7 @@ description: test
         """Test frontmatter validation with unknown keys."""
         frontmatter = {"name": "test", "description": "test", "unknown_key": "value"}
         required = ["name", "description"]
-        optional = []
+        optional: list[str] = []
 
         errors = validate_frontmatter_keys(frontmatter, required, optional)
 

--- a/scripts/analyze_warnings.py
+++ b/scripts/analyze_warnings.py
@@ -70,7 +70,7 @@ def print_summary(categories):
     print()
 
     # Count warnings per file
-    file_counts = defaultdict(int)
+    file_counts: defaultdict[str, int] = defaultdict(int)
     for warnings in categories.values():
         for warning in warnings:
             # Extract file path

--- a/scripts/convert_image_to_idx.py
+++ b/scripts/convert_image_to_idx.py
@@ -36,9 +36,9 @@ def load_and_preprocess(image_path: Path, emnist_transform: bool) -> bytes:
         784 bytes of uint8 pixel values in row-major order.
     """
     img = Image.open(image_path).convert("L")
-    img = img.resize((28, 28), Image.LANCZOS)
+    img = img.resize((28, 28), Image.Resampling.LANCZOS)
     if emnist_transform:
-        img = img.transpose(Image.TRANSPOSE).transpose(Image.FLIP_LEFT_RIGHT)
+        img = img.transpose(Image.Transpose.TRANSPOSE).transpose(Image.Transpose.FLIP_LEFT_RIGHT)
     return bytes(img.getdata())
 
 


### PR DESCRIPTION
## Summary

- Add `check_untyped_defs = true` to `[tool.mypy]` in `pyproject.toml` for full body type-checking coverage
- Add `--check-untyped-defs` to the pre-commit mypy hook args
- Fix the 5 type errors surfaced by the flag across 3 files

## Changes Made

| File | Change |
|------|--------|
| `pyproject.toml` | Added `check_untyped_defs = true` under `[tool.mypy]` |
| `.pre-commit-config.yaml` | Added `--check-untyped-defs` to mypy hook args |
| `scripts/analyze_warnings.py` | Added `defaultdict[str, int]` type annotation |
| `scripts/agents/tests/test_integration.py` | Annotated empty list as `list[str]` |
| `scripts/convert_image_to_idx.py` | Replaced deprecated `Image.LANCZOS`/`Image.TRANSPOSE`/`Image.FLIP_LEFT_RIGHT` with `Image.Resampling.LANCZOS` and `Image.Transpose` enum values |

## Verification

- `pixi run mypy scripts/ --check-untyped-defs --exclude generators/` → Success: no issues found in 57 source files
- `pixi run pre-commit run mypy --all-files` → Passed
- `pixi run pre-commit run --all-files` → All hooks passed

Closes #3370

🤖 Generated with [Claude Code](https://claude.com/claude-code)