### PR TITLE
test(utility): add __str__/__repr__ tests for int32 and bool dtypes

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -2878,6 +2878,32 @@ struct ExTensor(
         """
         return self.item()
 
+    fn _format_element(self, i: Int) -> String:
+        """Format a single element as a string based on dtype.
+
+        Args:
+            i: The element index.
+
+        Returns:
+            String representation: "True"/"False" for bool, integer string for
+            integral types, float string for floating-point types.
+        """
+        if self._dtype == DType.bool:
+            return "True" if self._get_int64(i) != 0 else "False"
+        elif (
+            self._dtype == DType.int8
+            or self._dtype == DType.int16
+            or self._dtype == DType.int32
+            or self._dtype == DType.int64
+            or self._dtype == DType.uint8
+            or self._dtype == DType.uint16
+            or self._dtype == DType.uint32
+            or self._dtype == DType.uint64
+        ):
+            return String(self._get_int64(i))
+        else:
+            return String(self._get_float64(i))
+
     fn __str__(self) -> String:
         """Human-readable string representation.
 
@@ -2888,7 +2914,7 @@ struct ExTensor(
         for i in range(self._numel):
             if i > 0:
                 result += ", "
-            result += String(self._get_float64(i))
+            result += self._format_element(i)
         result += "], dtype=" + String(self._dtype) + ")"
         return result
 
@@ -2911,7 +2937,7 @@ struct ExTensor(
         for i in range(self._numel):
             if i > 0:
                 result += ", "
-            result += String(self._get_float64(i))
+            result += self._format_element(i)
         result += "])"
         return result
 

--- a/tests/shared/core/test_utility.mojo
+++ b/tests/shared/core/test_utility.mojo
@@ -503,6 +503,61 @@ fn test_repr_complete() raises:
     )
 
 
+fn test_str_int32_no_decimals() raises:
+    """Test __str__ renders int32 values without decimal points."""
+    var shape = List[Int]()
+    shape.append(3)
+    var t = zeros(shape, DType.int32)
+    t[1] = 1.0
+    t[2] = 2.0
+    var s = String(t)
+    assert_equal(s, "ExTensor([0, 1, 2], dtype=int32)", "__str__ int32 format")
+
+
+fn test_str_bool_true_false() raises:
+    """Test __str__ renders bool values as True/False."""
+    var shape = List[Int]()
+    shape.append(3)
+    var t = zeros(shape, DType.bool)
+    t[1] = 1.0
+    var s = String(t)
+    assert_equal(
+        s, "ExTensor([False, True, False], dtype=bool)", "__str__ bool format"
+    )
+
+
+fn test_repr_int32_no_decimals() raises:
+    """Test __repr__ renders int32 values without decimal points."""
+    var shape = List[Int]()
+    shape.append(3)
+    var t = zeros(shape, DType.int32)
+    t[1] = 1.0
+    t[2] = 2.0
+    var r = repr(t)
+    assert_equal(
+        r,
+        "ExTensor(shape=[3], dtype=int32, numel=3, data=[0, 1, 2])",
+        "__repr__ int32 format",
+    )
+
+
+fn test_repr_bool_true_false() raises:
+    """Test __repr__ renders bool values as True/False."""
+    var shape = List[Int]()
+    shape.append(3)
+    var t = zeros(shape, DType.bool)
+    t[1] = 1.0
+    var r = repr(t)
+    assert_equal(
+        r,
+        (
+            "ExTensor(shape=[3], dtype=bool, numel=3,"
+            " data=[False, True, False])"
+        ),
+        "__repr__ bool format",
+    )
+
+
 # ============================================================================
 # Test __hash__
 # ============================================================================
@@ -679,6 +734,10 @@ fn main() raises:
     print("  Testing __str__ and __repr__...")
     test_str_readable()
     test_repr_complete()
+    test_str_int32_no_decimals()
+    test_str_bool_true_false()
+    test_repr_int32_no_decimals()
+    test_repr_bool_true_false()
 
     # __hash__
     print("  Testing __hash__...")


### PR DESCRIPTION
## Summary

- Added `_format_element()` helper to `ExTensor` that dispatches element formatting based on dtype: `bool` → `True`/`False`, integer types → no decimal points, float types → existing decimal format
- Fixed `__str__` and `__repr__` to use `_format_element()` instead of always calling `_get_float64()`
- Added four new test functions for int32 and bool dtype rendering in `test_utility.mojo`

## Changes Made

- `shared/core/extensor.mojo`: Added `_format_element(i: Int) -> String` private helper; updated `__str__` and `__repr__` to call it
- `tests/shared/core/test_utility.mojo`: Added `test_str_int32_no_decimals`, `test_str_bool_true_false`, `test_repr_int32_no_decimals`, `test_repr_bool_true_false`; registered all four in `main()`

## Verification

- All pre-commit hooks passed (mojo format, trailing whitespace, EOF, large files check)
- Tests follow existing patterns (zeros + setitem for controlled values)

Closes #3376