### PR TITLE
docs(extensor): add __hash__ to ExTensor docstring and public API docs

### DIFF
--- a/shared/core/__init__.mojo
+++ b/shared/core/__init__.mojo
@@ -12,7 +12,7 @@ Architecture:
     - Functions return new values, never mutate inputs
 
 Modules:
-    extensor: Core tensor type and creation functions
+    extensor: Core tensor type (ExTensor, implements Hashable via __hash__) and creation functions
     types: Custom data types (type aliases for FP8/BF8/BF16/FP4, MXFP4/NVFP4 blocked formats)
     arithmetic: Element-wise arithmetic operations (add, subtract, multiply, divide)
     matrix: Matrix operations (matmul, transpose, dot, outer)
@@ -140,6 +140,8 @@ from shared.core.optimizer_constants import (
 # ============================================================================
 # Core Tensor Type and Creation Functions
 # ============================================================================
+# ExTensor implements the Hashable trait (__hash__), allowing tensors to be
+# used as dictionary keys or in hash-based data structures via hash(tensor).
 
 from shared.core.extensor import (
     ExTensor,

--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -2867,16 +2867,34 @@ struct ExTensor(
     fn __hash__[H: Hasher](self, mut hasher: H):
         """Compute hash based on shape, dtype, and data.
 
+        ExTensor implements the `Hashable` trait, allowing tensors to be used as
+        dictionary keys or in hash-based data structures. Two tensors with identical
+        shape, dtype, and element values will produce the same hash.
+
         Parameters:
             H: The hasher type conforming to the Hasher trait.
 
         Args:
             hasher: The hasher to write values into.
 
+        Note:
+            The hash is computed from the tensor's shape dimensions, dtype ordinal,
+            and raw bit patterns of all element values. NaN values with different
+            bit representations will hash differently.
+
         Example:
             ```mojo
+            from hashlib import hash
             var x = ones([3], DType.float32)
             var h = hash(x)
+
+            # Tensors with identical shape, dtype, and values hash equally
+            var y = ones([3], DType.float32)
+            assert hash(x) == hash(y)
+
+            # Tensors with different shapes hash differently
+            var z = ones([4], DType.float32)
+            # hash(x) != hash(z)  (with overwhelming probability)
             ```
         """
         from shared.core.dtype_ordinal import dtype_to_ordinal


### PR DESCRIPTION
## Summary

- Expanded the `__hash__` docstring in `shared/core/extensor.mojo` to explain the `Hashable` trait implementation, add a `Note` on the hashing algorithm (shape dims + dtype ordinal + raw bit patterns), and provide a richer `Example` block showing equality and inequality cases
- Updated `shared/core/__init__.mojo` to surface `__hash__` / `Hashable` in the module-level `Modules` listing and in a comment above the Core Tensor import block

## Test plan

- [ ] Pre-commit hooks pass (Mojo format, trailing whitespace, end-of-file) ✅ verified locally
- [ ] No logic changes — documentation only; existing tests remain unaffected
- [ ] `__hash__` implementation unchanged — only its docstring was updated

Closes #3378

🤖 Generated with [Claude Code](https://claude.com/claude-code)