### PR TITLE
fix(extensor): canonicalize NaN bit patterns in __hash__ for stable hashing

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -2921,6 +2921,9 @@ struct ExTensor(
         ExTensor implements the `Hashable` trait, allowing tensors to be used as
         dictionary keys or in hash-based data structures. Two tensors with identical
         shape, dtype, and element values will produce the same hash.
+        NaN values are canonicalized to a single quiet NaN bit pattern before
+        hashing, ensuring that different NaN representations (signaling NaN,
+        negative NaN, different NaN payloads) all produce the same hash.
 
         Parameters:
             H: The hasher type conforming to the Hasher trait.
@@ -2950,15 +2953,26 @@ struct ExTensor(
         """
         from shared.core.dtype_ordinal import dtype_to_ordinal
 
+        # Canonical quiet NaN bit pattern for Float64 (IEEE 754: exponent all-ones,
+        # MSB of mantissa set, zero payload, positive sign).
+        alias CANONICAL_NAN_F64: UInt64 = 0x7FF8000000000000
+        # NaN detection mask for Float64: if (bits & 0x7FFFFFFFFFFFFFFF) > 0x7FF0000000000000,
+        # then exponent is all-ones and mantissa is non-zero => NaN.
+        alias F64_INF_BITS: UInt64 = 0x7FF0000000000000
+        alias F64_ABS_MASK: UInt64 = 0x7FFFFFFFFFFFFFFF
+
         # Hash shape
         for i in range(len(self._shape)):
             hasher.update(self._shape[i])
         # Hash dtype ordinal
         hasher.update(dtype_to_ordinal(self._dtype))
-        # Hash data
+        # Hash data: for float types, canonicalize NaN before contributing bits.
         for i in range(self._numel):
             var val = self._get_float64(i)
             var int_bits = UnsafePointer[Float64](to=val).bitcast[UInt64]()[]
+            # Canonicalize any NaN to a single stable bit pattern.
+            if (int_bits & F64_ABS_MASK) > F64_INF_BITS:
+                int_bits = CANONICAL_NAN_F64
             hasher.update(int_bits)
 
     fn contiguous(self) raises -> ExTensor:

--- a/tests/shared/core/test_hash.mojo
+++ b/tests/shared/core/test_hash.mojo
@@ -1,0 +1,374 @@
+"""Tests for ExTensor __hash__ NaN stability (issue #3382).
+
+Verifies that different NaN bit patterns (quiet NaN, signaling NaN, negative NaN,
+different NaN payloads) all produce the same hash, ensuring deterministic hash
+behavior for tensors containing NaN values.
+"""
+
+from memory import UnsafePointer
+from shared.core import (
+    ExTensor,
+    zeros,
+    ones,
+    full,
+    arange,
+    nan_tensor,
+)
+from tests.shared.conftest import (
+    assert_equal_int,
+)
+
+
+# ============================================================================
+# Helpers: inject specific NaN bit patterns into a tensor
+# ============================================================================
+
+
+fn make_f32_nan_tensor(bits: UInt32) raises -> ExTensor:
+    """Create a scalar float32 tensor whose single element has the given raw bits.
+
+    Args:
+        bits: The IEEE 754 bit pattern to store. Must represent a NaN.
+
+    Returns:
+        A scalar (0-D) ExTensor with DType.float32 containing that bit pattern.
+    """
+    var shape = List[Int]()
+    var t = ExTensor(shape, DType.float32)
+    t._data.bitcast[UInt32]()[] = bits
+    return t^
+
+
+fn make_f64_nan_tensor(bits: UInt64) raises -> ExTensor:
+    """Create a scalar float64 tensor whose single element has the given raw bits.
+
+    Args:
+        bits: The IEEE 754 bit pattern to store. Must represent a NaN.
+
+    Returns:
+        A scalar (0-D) ExTensor with DType.float64 containing that bit pattern.
+    """
+    var shape = List[Int]()
+    var t = ExTensor(shape, DType.float64)
+    t._data.bitcast[UInt64]()[] = bits
+    return t^
+
+
+fn make_f16_nan_tensor(bits: UInt16) raises -> ExTensor:
+    """Create a scalar float16 tensor whose single element has the given raw bits.
+
+    Args:
+        bits: The IEEE 754 bit pattern to store. Must represent a NaN.
+
+    Returns:
+        A scalar (0-D) ExTensor with DType.float16 containing that bit pattern.
+    """
+    var shape = List[Int]()
+    var t = ExTensor(shape, DType.float16)
+    t._data.bitcast[UInt16]()[] = bits
+    return t^
+
+
+# ============================================================================
+# Test: normal values hash consistently
+# ============================================================================
+
+
+fn test_hash_normal_values() raises:
+    """Equal tensors yield equal hashes."""
+    var a = arange(0.0, 4.0, 1.0, DType.float32)
+    var b = arange(0.0, 4.0, 1.0, DType.float32)
+    assert_equal_int(Int(hash(a)), Int(hash(b)), "Equal tensors must hash equal")
+
+
+fn test_hash_different_values() raises:
+    """Different-valued tensors should produce different hashes (probabilistic)."""
+    var shape = List[Int]()
+    shape.append(1)
+    var a = full(shape, 1.0, DType.float64)
+    var b = full(shape, 2.0, DType.float64)
+    if hash(a) == hash(b):
+        raise Error("Different-valued tensors should not collide on hash")
+
+
+# ============================================================================
+# Test: NaN canonicalization — float32
+# ============================================================================
+
+
+fn test_hash_f32_quiet_nan_equals_negative_nan() raises:
+    """Positive and negative quiet NaN (float32) hash identically.
+
+    Positive quiet NaN:  0x7FC00000
+    Negative quiet NaN:  0xFFC00000  (sign bit = 1)
+    """
+    # Positive quiet NaN (canonical)
+    var pos_nan = make_f32_nan_tensor(UInt32(0x7FC00000))
+    # Negative quiet NaN (sign bit flipped)
+    var neg_nan = make_f32_nan_tensor(UInt32(0xFFC00000))
+    assert_equal_int(
+        Int(hash(pos_nan)),
+        Int(hash(neg_nan)),
+        "Positive and negative quiet NaN (f32) must hash equal",
+    )
+
+
+fn test_hash_f32_nan_payload_irrelevant() raises:
+    """Two float32 NaNs with different mantissa payloads hash identically.
+
+    NaN with payload 1:  0x7FC00001
+    NaN with payload 2:  0x7FC00002
+    """
+    var nan_a = make_f32_nan_tensor(UInt32(0x7FC00001))
+    var nan_b = make_f32_nan_tensor(UInt32(0x7FC00002))
+    assert_equal_int(
+        Int(hash(nan_a)),
+        Int(hash(nan_b)),
+        "NaN payloads must not affect hash (f32)",
+    )
+
+
+fn test_hash_f32_signaling_nan_equals_quiet_nan() raises:
+    """Signaling NaN (f32) hashes the same as quiet NaN.
+
+    Quiet NaN:     0x7FC00000  (MSB of mantissa = 1)
+    Signaling NaN: 0x7F800001  (MSB of mantissa = 0, payload = 1)
+    """
+    var quiet = make_f32_nan_tensor(UInt32(0x7FC00000))
+    var signaling = make_f32_nan_tensor(UInt32(0x7F800001))
+    assert_equal_int(
+        Int(hash(quiet)),
+        Int(hash(signaling)),
+        "Signaling and quiet NaN (f32) must hash equal",
+    )
+
+
+# ============================================================================
+# Test: NaN canonicalization — float64
+# ============================================================================
+
+
+fn test_hash_f64_nan_sign_irrelevant() raises:
+    """Positive and negative quiet NaN (float64) hash identically.
+
+    Positive quiet NaN:  0x7FF8000000000000
+    Negative quiet NaN:  0xFFF8000000000000
+    """
+    var pos_nan = make_f64_nan_tensor(UInt64(0x7FF8000000000000))
+    var neg_nan = make_f64_nan_tensor(UInt64(0xFFF8000000000000))
+    assert_equal_int(
+        Int(hash(pos_nan)),
+        Int(hash(neg_nan)),
+        "Positive and negative quiet NaN (f64) must hash equal",
+    )
+
+
+fn test_hash_f64_nan_payload_irrelevant() raises:
+    """Two float64 NaNs with different payloads hash identically.
+
+    NaN with payload 1:  0x7FF8000000000001
+    NaN with payload 2:  0x7FF8000000000002
+    """
+    var nan_a = make_f64_nan_tensor(UInt64(0x7FF8000000000001))
+    var nan_b = make_f64_nan_tensor(UInt64(0x7FF8000000000002))
+    assert_equal_int(
+        Int(hash(nan_a)),
+        Int(hash(nan_b)),
+        "NaN payloads must not affect hash (f64)",
+    )
+
+
+fn test_hash_f64_signaling_nan_equals_quiet_nan() raises:
+    """Signaling NaN (f64) hashes the same as quiet NaN.
+
+    Quiet NaN:     0x7FF8000000000000
+    Signaling NaN: 0x7FF0000000000001
+    """
+    var quiet = make_f64_nan_tensor(UInt64(0x7FF8000000000000))
+    var signaling = make_f64_nan_tensor(UInt64(0x7FF0000000000001))
+    assert_equal_int(
+        Int(hash(quiet)),
+        Int(hash(signaling)),
+        "Signaling and quiet NaN (f64) must hash equal",
+    )
+
+
+# ============================================================================
+# Test: NaN canonicalization — float16
+# ============================================================================
+
+
+fn test_hash_f16_nan_sign_irrelevant() raises:
+    """Positive and negative quiet NaN (float16) hash identically.
+
+    Positive quiet NaN (f16):  0x7E00
+    Negative quiet NaN (f16):  0xFE00
+    """
+    var pos_nan = make_f16_nan_tensor(UInt16(0x7E00))
+    var neg_nan = make_f16_nan_tensor(UInt16(0xFE00))
+    assert_equal_int(
+        Int(hash(pos_nan)),
+        Int(hash(neg_nan)),
+        "Positive and negative quiet NaN (f16) must hash equal",
+    )
+
+
+fn test_hash_f16_nan_payload_irrelevant() raises:
+    """Two float16 NaNs with different payloads hash identically.
+
+    NaN with payload 1:  0x7E01
+    NaN with payload 2:  0x7E02
+    """
+    var nan_a = make_f16_nan_tensor(UInt16(0x7E01))
+    var nan_b = make_f16_nan_tensor(UInt16(0x7E02))
+    assert_equal_int(
+        Int(hash(nan_a)),
+        Int(hash(nan_b)),
+        "NaN payloads must not affect hash (f16)",
+    )
+
+
+# ============================================================================
+# Test: mixed NaN and normal values hash deterministically
+# ============================================================================
+
+
+fn test_hash_mixed_nan_normal_deterministic() raises:
+    """A tensor mixing NaN and normal values hashes the same across calls."""
+    var shape = List[Int]()
+    shape.append(3)
+    var a = nan_tensor(shape, DType.float32)
+    # Set non-NaN elements
+    a._data.bitcast[Float32]()[1] = Float32(1.0)
+    a._data.bitcast[Float32]()[2] = Float32(2.0)
+
+    var b = nan_tensor(shape, DType.float32)
+    b._data.bitcast[Float32]()[1] = Float32(1.0)
+    b._data.bitcast[Float32]()[2] = Float32(2.0)
+
+    assert_equal_int(
+        Int(hash(a)),
+        Int(hash(b)),
+        "Mixed NaN/normal tensor must hash consistently",
+    )
+
+
+fn test_hash_mixed_nan_different_nan_patterns() raises:
+    """Tensors with same logical content but different NaN bit patterns hash equal."""
+    var shape = List[Int]()
+    shape.append(2)
+
+    # First tensor: element 0 = positive quiet NaN, element 1 = 1.0
+    var a = ExTensor(shape, DType.float32)
+    a._data.bitcast[UInt32]()[0] = UInt32(0x7FC00000)  # +qNaN
+    a._data.bitcast[Float32]()[1] = Float32(1.0)
+
+    # Second tensor: element 0 = negative quiet NaN, element 1 = 1.0
+    var b = ExTensor(shape, DType.float32)
+    b._data.bitcast[UInt32]()[0] = UInt32(0xFFC00000)  # -qNaN
+    b._data.bitcast[Float32]()[1] = Float32(1.0)
+
+    assert_equal_int(
+        Int(hash(a)),
+        Int(hash(b)),
+        "Tensors differing only in NaN bit pattern must hash equal",
+    )
+
+
+# ============================================================================
+# Test: shape and dtype sensitivity
+# ============================================================================
+
+
+fn test_hash_shape_sensitivity() raises:
+    """Tensors with different shapes hash differently."""
+    var shape_a = List[Int]()
+    shape_a.append(2)
+    var shape_b = List[Int]()
+    shape_b.append(3)
+    var a = ones(shape_a, DType.float32)
+    var b = ones(shape_b, DType.float32)
+    if hash(a) == hash(b):
+        raise Error("Tensors with different shapes should not collide on hash")
+
+
+fn test_hash_dtype_sensitivity() raises:
+    """Tensors with same shape/values but different dtypes hash differently."""
+    var shape = List[Int]()
+    shape.append(1)
+    var a = full(shape, 1.0, DType.float32)
+    var b = full(shape, 1.0, DType.float64)
+    if hash(a) == hash(b):
+        raise Error("Tensors with different dtypes should not collide on hash")
+
+
+# ============================================================================
+# Test: integer types unaffected (no NaN concern)
+# ============================================================================
+
+
+fn test_hash_integer_types_consistent() raises:
+    """Integer tensors hash consistently (no NaN issue for integer dtypes)."""
+    var shape = List[Int]()
+    shape.append(4)
+    var a = arange(0.0, 4.0, 1.0, DType.int32)
+    var b = arange(0.0, 4.0, 1.0, DType.int32)
+    assert_equal_int(
+        Int(hash(a)), Int(hash(b)), "Equal int32 tensors must hash equal"
+    )
+
+
+# ============================================================================
+# Entry point
+# ============================================================================
+
+
+fn main() raises:
+    print("Running NaN hash stability tests (issue #3382)...")
+
+    print("  test_hash_normal_values...")
+    test_hash_normal_values()
+
+    print("  test_hash_different_values...")
+    test_hash_different_values()
+
+    print("  test_hash_f32_quiet_nan_equals_negative_nan...")
+    test_hash_f32_quiet_nan_equals_negative_nan()
+
+    print("  test_hash_f32_nan_payload_irrelevant...")
+    test_hash_f32_nan_payload_irrelevant()
+
+    print("  test_hash_f32_signaling_nan_equals_quiet_nan...")
+    test_hash_f32_signaling_nan_equals_quiet_nan()
+
+    print("  test_hash_f64_nan_sign_irrelevant...")
+    test_hash_f64_nan_sign_irrelevant()
+
+    print("  test_hash_f64_nan_payload_irrelevant...")
+    test_hash_f64_nan_payload_irrelevant()
+
+    print("  test_hash_f64_signaling_nan_equals_quiet_nan...")
+    test_hash_f64_signaling_nan_equals_quiet_nan()
+
+    print("  test_hash_f16_nan_sign_irrelevant...")
+    test_hash_f16_nan_sign_irrelevant()
+
+    print("  test_hash_f16_nan_payload_irrelevant...")
+    test_hash_f16_nan_payload_irrelevant()
+
+    print("  test_hash_mixed_nan_normal_deterministic...")
+    test_hash_mixed_nan_normal_deterministic()
+
+    print("  test_hash_mixed_nan_different_nan_patterns...")
+    test_hash_mixed_nan_different_nan_patterns()
+
+    print("  test_hash_shape_sensitivity...")
+    test_hash_shape_sensitivity()
+
+    print("  test_hash_dtype_sensitivity...")
+    test_hash_dtype_sensitivity()
+
+    print("  test_hash_integer_types_consistent...")
+    test_hash_integer_types_consistent()
+
+    print("All NaN hash stability tests passed!")


### PR DESCRIPTION
## Summary

- IEEE 754 allows many distinct NaN bit patterns (signaling vs quiet NaN, different payloads, sign bit). The previous `__hash__` implementation used a raw bitcast, producing different hashes for semantically-equivalent NaN values.
- Fix: detect NaN in Float64 space after element conversion, and substitute a canonical quiet NaN bit pattern (`0x7FF8000000000000`) before hashing. The stored tensor data is never modified.
- Covers float16, float32, float64, bfloat16 (all go through `_get_float64` which converts to float64 before the NaN check).

## Changes Made

- `shared/core/extensor.mojo`: Added NaN canonicalization in `__hash__` — after bitcasting the float64 value to UInt64, replace any NaN bit pattern with the canonical `0x7FF8000000000000`.
- `tests/shared/core/test_hash.mojo`: New dedicated test file with 15 tests covering all NaN scenarios (positive/negative NaN, signaling/quiet NaN, different payloads) for float16, float32, float64, plus mixed NaN/normal tensors, shape/dtype sensitivity, and integer types.

## Test plan

- [x] Mojo Format pre-commit hook passes
- [x] All pre-commit checks pass (ruff failure is pre-existing in unrelated file)
- [x] `tests/shared/core/test_hash.mojo` covers all cases from issue plan
- [ ] CI will run full test suite in Docker (local glibc too old to run Mojo)

Closes #3382

🤖 Generated with [Claude Code](https://claude.com/claude-code)