### PR TITLE
test(extensor): add test_hash_empty_tensor for 0-element tensor

### DIFF
--- a/tests/shared/core/test_utility.mojo
+++ b/tests/shared/core/test_utility.mojo
@@ -582,6 +582,27 @@ fn test_hash_different_dtypes_differ() raises:
             "float32 and float64 tensors with same values should have different"
             " hashes"
         )
+fn test_hash_empty_tensor() raises:
+    """Test __hash__ for 0-element tensor hashes without error and consistently.
+
+    A tensor with shape [0] has _numel=0, so the data loop is skipped.
+    The hash is determined only by shape and dtype, but must still be stable.
+    """
+    var shape = List[Int]()
+    shape.append(0)
+    var a = zeros(shape, DType.float32)
+    var b = zeros(shape, DType.float32)
+
+    # Should not raise - the empty data loop must be safe
+    var hash_a = hash(a)
+    var hash_b = hash(b)
+
+    # Two empty tensors with identical shape and dtype must hash the same
+    assert_equal_int(
+        Int(hash_a),
+        Int(hash_b),
+        "Empty tensors with same shape/dtype should have equal hashes",
+    )
 
 
 # ============================================================================
@@ -687,6 +708,7 @@ fn main() raises:
     test_hash_large_values()
     test_hash_small_values_distinguish()
     test_hash_different_dtypes_differ()
+    test_hash_empty_tensor()
 
     # diff()
     print("  Testing diff()...")


### PR DESCRIPTION
## Summary

- Added `test_hash_empty_tensor` to `tests/shared/core/test_utility.mojo`
- Verifies that `__hash__` on a tensor with shape `[0]` (numel=0) completes without raising an error
- Verifies that two empty tensors with identical shape and dtype produce the same hash value

## Changes Made

The `__hash__` implementation loops over `self._numel` elements. For a 0-element tensor that loop
does nothing, so the hash is determined solely by shape and dtype. This edge case had no test.

**File modified:** `tests/shared/core/test_utility.mojo`
- Added `test_hash_empty_tensor()` function after `test_hash_small_values_distinguish()`
- Added `test_hash_empty_tensor()` call in `main()`

## Verification

Pre-commit hooks pass (mojo format, deprecated-list-check, trim-whitespace, etc.).

Closes #3384