### PR TITLE
test(extensor): add test_setitem_negative_index for bounds check coverage

### DIFF
--- a/tests/shared/core/test_utility.mojo
+++ b/tests/shared/core/test_utility.mojo
@@ -331,6 +331,22 @@ fn test_setitem_out_of_bounds() raises:
         raise Error("__setitem__ should raise error for out-of-bounds index")
 
 
+fn test_setitem_negative_index() raises:
+    """Test that __setitem__ raises error for negative index."""
+    var shape = List[Int]()
+    shape.append(3)
+    var t = zeros(shape, DType.float32)
+
+    var raised = False
+    try:
+        t[-1] = 1.0
+    except:
+        raised = True
+
+    if not raised:
+        raise Error("__setitem__ should raise error for negative index")
+
+
 # ============================================================================
 # Test __bool__
 # ============================================================================
@@ -569,6 +585,7 @@ fn main() raises:
     test_setitem_valid_index()
     test_setitem_integer_dtype()
     test_setitem_out_of_bounds()
+    test_setitem_negative_index()
 
     # __bool__
     print("  Testing __bool__...")


### PR DESCRIPTION
## Summary

- Adds `test_setitem_negative_index` to `tests/shared/core/test_utility.mojo`
- Verifies that `t[-1] = 1.0` raises an `Error`, covering the `index < 0` branch of `__setitem__`'s bounds check
- Follows the exact same pattern as the existing `test_setitem_out_of_bounds` test

## Test plan

- [x] New test `test_setitem_negative_index` added and called in `main()`
- [x] Pre-commit hooks pass (mojo format, test count validation, trailing whitespace)
- [x] CI will run `test_utility.mojo` and validate both boundary conditions

Closes #3387

🤖 Generated with [Claude Code](https://claude.com/claude-code)