### PR TITLE
test(utility): verify error message in test_setitem_out_of_bounds

### DIFF
--- a/tests/shared/core/test_utility.mojo
+++ b/tests/shared/core/test_utility.mojo
@@ -321,13 +321,14 @@ fn test_setitem_out_of_bounds() raises:
     shape.append(3)
     var t = zeros(shape, DType.float32)
 
-    var raised = False
+    var error_raised = False
     try:
         t[5] = 1.0
-    except:
-        raised = True
+    except e:
+        error_raised = True
+        assert_equal(String(e), "Index out of bounds")
 
-    if not raised:
+    if not error_raised:
         raise Error("__setitem__ should raise error for out-of-bounds index")
 
 


### PR DESCRIPTION
## Summary

- Replace bare `except:` clause in `test_setitem_out_of_bounds` with `except e:`
- Add `assert_equal(String(e), "Index out of bounds")` to verify the exact error message
- Matches the `except e:` pattern used in `test_bool_requires_single_element`

## Changes Made

- `tests/shared/core/test_utility.mojo`: Updated `test_setitem_out_of_bounds` to use named exception binding and assert the error message text

## Verification

- Pre-commit hooks pass (mojo format, syntax checks, test coverage validation)
- Change is minimal and focused — test-only, no production code changes

Closes #3389