### PR TITLE
feat(extensor): add ExTensor.transpose(dim0, dim1) stride-view method

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -713,6 +713,54 @@ struct ExTensor(
 
         return result^
 
+    fn transpose(self, dim0: Int, dim1: Int) raises -> ExTensor:
+        """Return a non-contiguous view with dim0 and dim1 swapped.
+
+        Creates a stride-based view sharing the same underlying data — no
+        copying occurs. For any non-trivial swap (dim0 != dim1) the result
+        satisfies is_contiguous() == False.
+
+        Args:
+            dim0: First dimension to swap.
+            dim1: Second dimension to swap.
+
+        Returns:
+            A new ExTensor view with permuted shape and strides.
+
+        Raises:
+            Error: If tensor has fewer than 2 dimensions or dims are out of
+                bounds.
+
+        Example:
+            ```mojo
+            var shape = List[Int]()
+            shape.append(3)
+            shape.append(4)
+            var a = ones(shape, DType.float32)
+            var b = a.transpose(0, 1)  # shape (4, 3), non-contiguous view
+            ```
+        """
+        var ndim = self.dim()
+        if ndim < 2:
+            raise Error("transpose requires at least 2 dimensions")
+        if dim0 < 0 or dim0 >= ndim:
+            raise Error("transpose: dim0 out of range")
+        if dim1 < 0 or dim1 >= ndim:
+            raise Error("transpose: dim1 out of range")
+
+        var result = self.copy()
+        result._is_view = True
+
+        var tmp_shape = result._shape[dim0]
+        result._shape[dim0] = result._shape[dim1]
+        result._shape[dim1] = tmp_shape
+
+        var tmp_stride = result._strides[dim0]
+        result._strides[dim0] = result._strides[dim1]
+        result._strides[dim1] = tmp_stride
+
+        return result^
+
     fn __getitem__(self, index: Int) raises -> Float32:
         """Get element at flat index.
 

--- a/tests/shared/core/test_utility.mojo
+++ b/tests/shared/core/test_utility.mojo
@@ -15,7 +15,6 @@ from shared.core import (
     item,
     diff,
     as_contiguous,
-    transpose_view,
 )
 
 # Import test helpers
@@ -160,7 +159,7 @@ fn test_is_contiguous_after_transpose() raises:
     shape.append(3)
     shape.append(4)
     var a = ones(shape, DType.float32)
-    var b = transpose_view(a)
+    var b = a.transpose(0, 1)
     assert_false(
         b.is_contiguous(), "Transposed tensor should not be contiguous"
     )
@@ -178,7 +177,7 @@ fn test_contiguous_on_noncontiguous() raises:
     shape.append(4)
     var a = arange(0.0, 12.0, 1.0, DType.float32)
     var b = a.reshape(shape)
-    var t = transpose_view(b)
+    var t = b.transpose(0, 1)
     assert_false(
         t.is_contiguous(), "Transposed tensor should not be contiguous"
     )


### PR DESCRIPTION
## Summary

- Add `fn transpose(self, dim0: Int, dim1: Int) raises -> ExTensor` method to `ExTensor` in `shared/core/extensor.mojo`
- Method returns a non-contiguous view by swapping strides and shape dimensions without copying data
- Update `test_is_contiguous_after_transpose` and `test_contiguous_on_noncontiguous` to use `a.transpose(0, 1)` (method syntax) instead of `transpose_view(a)` (standalone function workaround)
- Remove unused `transpose_view` import from `test_utility.mojo`

## Changes Made

- `shared/core/extensor.mojo`: Added `transpose(dim0, dim1)` method after `slice()` (~line 716)
- `tests/shared/core/test_utility.mojo`: Updated two tests to use `ExTensor.transpose()` method

## Test plan

- [x] Pre-commit hooks pass (mojo format, deprecated-syntax check)
- [x] `test_is_contiguous_after_transpose` uses real `a.transpose(0, 1)` operation
- [x] `test_contiguous_on_noncontiguous` validates full `transpose → is_contiguous → as_contiguous` pipeline

Closes #3390

🤖 Generated with [Claude Code](https://claude.com/claude-code)