### PR TITLE
fix(ci): split test_imports.mojo (24 tests) into 3 files per ADR-009

### DIFF
--- a/tests/shared/test_imports_part1.mojo
+++ b/tests/shared/test_imports_part1.mojo
@@ -1,0 +1,148 @@
+"""
+Import Validation Tests - Part 1: Core and Training Package Imports
+
+Tests that all public imports work correctly for the shared library.
+These tests verify both import functionality and basic component behavior.
+
+ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+high test load. Split from test_imports.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Run with: mojo test tests/shared/test_imports_part1.mojo
+"""
+
+from testing import assert_true
+
+# ============================================================================
+# Core Package Imports
+# ============================================================================
+
+
+fn test_core_imports() raises:
+    """Test core package imports work correctly."""
+    from shared.core import ExTensor, zeros, ones, randn
+    from shared.core import relu, sigmoid, tanh, softmax, gelu
+
+    # Test that functions are actually callable and work correctly
+    var test_tensor = zeros([3, 3], DType.float32)
+    assert_true(
+        test_tensor.dim() == 2, "zeros should create tensor with correct rank"
+    )
+    var test_shape = test_tensor.shape()
+    assert_true(
+        test_shape[0] == 3,
+        "zeros should create tensor with correct first dimension",
+    )
+    assert_true(
+        test_shape[1] == 3,
+        "zeros should create tensor with correct second dimension",
+    )
+
+    print("✓ Core imports test passed")
+
+
+fn test_core_layers_imports() raises:
+    """Test core layer operations imports."""
+    from shared.core import linear, conv2d, flatten
+    from shared.core import maxpool2d, avgpool2d
+
+    print("✓ Core layer operations imports test passed")
+
+
+fn test_core_activations_imports() raises:
+    """Test core activation function imports."""
+    from shared.core import (
+        relu,
+        sigmoid,
+        tanh,
+        softmax,
+        leaky_relu,
+        elu,
+        gelu,
+        swish,
+        mish,
+        selu,
+    )
+
+    print("✓ Core activation functions imports test passed")
+
+
+fn test_core_types_imports() raises:
+    """Test core types imports."""
+    from shared.core import ExTensor, FP8, BF8
+
+    print("✓ Core types imports test passed")
+
+
+# ============================================================================
+# Training Package Imports
+# ============================================================================
+
+
+fn test_training_imports() raises:
+    """Test training package imports work correctly."""
+    from shared.training import SGD, MSELoss
+    from shared.training import StepLR, CosineAnnealingLR, ExponentialLR
+    from shared.training import EarlyStopping, ModelCheckpoint
+
+    print("✓ Training imports test passed")
+
+
+fn test_training_optimizers_imports() raises:
+    """Test training optimizers imports."""
+    from shared.training import SGD
+
+    print("✓ Training optimizers imports test passed")
+
+
+fn test_training_schedulers_imports() raises:
+    """Test training schedulers imports."""
+    from shared.training import (
+        StepLR,
+        CosineAnnealingLR,
+        ExponentialLR,
+        WarmupLR,
+        MultiStepLR,
+        ReduceLROnPlateau,
+    )
+
+    print("✓ Training schedulers imports test passed")
+
+
+fn test_training_metrics_imports() raises:
+    """Test training metrics imports."""
+    # Metrics are in shared.training for now
+    from shared.training import base
+
+    print("✓ Training metrics imports test passed")
+
+
+# ============================================================================
+# Main Test Runner
+# ============================================================================
+
+
+fn main() raises:
+    """Run part 1 import validation tests."""
+    print("\n" + "=" * 70)
+    print("Running Import Validation Tests - Part 1 (Core & Training)")
+    print("=" * 70 + "\n")
+
+    # Core package tests
+    print("Testing Core Package...")
+    test_core_imports()
+    test_core_layers_imports()
+    test_core_activations_imports()
+    test_core_types_imports()
+
+    # Training package tests (first half)
+    print("\nTesting Training Package (Part 1)...")
+    test_training_imports()
+    test_training_optimizers_imports()
+    test_training_schedulers_imports()
+    test_training_metrics_imports()
+
+    # Summary
+    print("\n" + "=" * 70)
+    print("✅ Import Validation Tests - Part 1 Passed!")
+    print("=" * 70)

--- a/tests/shared/test_imports_part2.mojo
+++ b/tests/shared/test_imports_part2.mojo
@@ -1,0 +1,135 @@
+"""
+Import Validation Tests - Part 2: Training Callbacks, Data, and Utils Imports
+
+Tests that all public imports work correctly for the shared library.
+These tests verify both import functionality and basic component behavior.
+
+ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+high test load. Split from test_imports.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Run with: mojo test tests/shared/test_imports_part2.mojo
+"""
+
+from testing import assert_true
+
+# ============================================================================
+# Training Package Imports (continued)
+# ============================================================================
+
+
+fn test_training_callbacks_imports() raises:
+    """Test training callbacks imports."""
+    from shared.training import (
+        EarlyStopping,
+        ModelCheckpoint,
+        LoggingCallback,
+    )
+
+    print("✓ Training callbacks imports test passed")
+
+
+fn test_training_loops_imports() raises:
+    """Test training loops imports."""
+    from shared.training import TrainingState, Callback
+
+    print("✓ Training loops imports test passed")
+
+
+# ============================================================================
+# Data Package Imports
+# ============================================================================
+
+
+fn test_data_imports() raises:
+    """Test data package imports work correctly."""
+    from shared.data import (
+        Dataset,
+        ExTensorDataset,
+        CIFAR10Dataset,
+        EMNISTDataset,
+    )
+
+    print("✓ Data imports test passed")
+
+
+fn test_data_datasets_imports() raises:
+    """Test data datasets imports."""
+    from shared.data import Dataset, ExTensorDataset, FileDataset
+
+    print("✓ Data datasets imports test passed")
+
+
+fn test_data_loaders_imports() raises:
+    """Test data loaders imports."""
+    from shared.data import Batch
+
+    print("✓ Data loaders imports test passed")
+
+
+fn test_data_transforms_imports() raises:
+    """Test data transforms imports."""
+    # Data transforms are provided as utility functions, not classes
+    from shared.data import normalize_images, one_hot_encode
+
+    print("✓ Data transforms imports test passed")
+
+
+# ============================================================================
+# Utils Package Imports
+# ============================================================================
+
+
+fn test_utils_imports() raises:
+    """Test utils package imports work correctly."""
+    from shared.utils import Logger, LogLevel, get_logger
+    from shared.utils import load_config, save_config, Config
+
+    print("✓ Utils imports test passed")
+
+
+fn test_utils_logging_imports() raises:
+    """Test utils logging imports."""
+    from shared.utils import (
+        Logger,
+        LogLevel,
+        get_logger,
+        StreamHandler,
+        FileHandler,
+    )
+
+    print("✓ Utils logging imports test passed")
+
+
+# ============================================================================
+# Main Test Runner
+# ============================================================================
+
+
+fn main() raises:
+    """Run part 2 import validation tests."""
+    print("\n" + "=" * 70)
+    print("Running Import Validation Tests - Part 2 (Training Callbacks, Data & Utils)")
+    print("=" * 70 + "\n")
+
+    # Training package tests (second half)
+    print("Testing Training Package (Part 2)...")
+    test_training_callbacks_imports()
+    test_training_loops_imports()
+
+    # Data package tests
+    print("\nTesting Data Package...")
+    test_data_imports()
+    test_data_datasets_imports()
+    test_data_loaders_imports()
+    test_data_transforms_imports()
+
+    # Utils package tests (first half)
+    print("\nTesting Utils Package (Part 1)...")
+    test_utils_imports()
+    test_utils_logging_imports()
+
+    # Summary
+    print("\n" + "=" * 70)
+    print("✅ Import Validation Tests - Part 2 Passed!")
+    print("=" * 70)

--- a/tests/shared/test_imports_part3.mojo
+++ b/tests/shared/test_imports_part3.mojo
@@ -1,0 +1,165 @@
+"""
+Import Validation Tests - Part 3: Utils, Root, Nested, and Version Imports
+
+Tests that all public imports work correctly for the shared library.
+These tests verify both import functionality and basic component behavior.
+
+ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+high test load. Split from test_imports.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Run with: mojo test tests/shared/test_imports_part3.mojo
+"""
+
+from testing import assert_true
+
+# ============================================================================
+# Utils Package Imports (continued)
+# ============================================================================
+
+
+fn test_utils_visualization_imports() raises:
+    """Test utils visualization imports."""
+    # Visualization functions require Python interop
+    # For now, just verify utils imports work
+    from shared.utils import Logger
+
+    print("✓ Utils visualization imports test passed")
+
+
+fn test_utils_config_imports() raises:
+    """Test utils config imports."""
+    from shared.utils import Config, load_config, save_config, ConfigValidator
+
+    print("✓ Utils config imports test passed")
+
+
+# ============================================================================
+# Root Package Imports
+# ============================================================================
+
+
+fn test_root_imports() raises:
+    """Test root package convenience imports work."""
+    # Root package doesn't re-export all components
+    # Users should import from subpackages
+    from shared.core import ExTensor
+    from shared.training import SGD
+    from shared.utils import Logger
+
+    print("✓ Root imports test passed")
+
+
+fn test_subpackage_imports() raises:
+    """Test importing subpackages themselves."""
+    from shared import core, training, data, utils
+
+    print("✓ Subpackage imports test passed")
+
+
+# ============================================================================
+# Nested Imports
+# ============================================================================
+
+
+fn test_nested_optimizer_imports() raises:
+    """Test nested imports from optimizer subpackages."""
+    from shared.training import SGD
+
+    print("✓ Nested optimizer imports test passed")
+
+
+fn test_nested_scheduler_imports() raises:
+    """Test nested imports from scheduler subpackages."""
+    from shared.training import StepLR, CosineAnnealingLR
+
+    print("✓ Nested scheduler imports test passed")
+
+
+fn test_nested_metric_imports() raises:
+    """Test nested imports from metrics subpackages."""
+    # Metrics are in shared.training
+    from shared.training import Callback
+
+    print("✓ Nested metric imports test passed")
+
+
+# ============================================================================
+# Version Info
+# ============================================================================
+
+
+fn test_version_info() raises:
+    """Test version info is accessible and has proper format."""
+    from shared import VERSION, AUTHOR, LICENSE
+
+    # Critical validation - ensure values are not empty/None
+    assert_true(VERSION != "", "VERSION should not be empty")
+    assert_true(AUTHOR != "", "AUTHOR should not be empty")
+    assert_true(LICENSE != "", "LICENSE should not be empty")
+
+    # Ensure these are actual string values, not None
+    assert_true(VERSION.__len__() > 0, "VERSION string should have length > 0")
+    assert_true(AUTHOR.__len__() > 0, "AUTHOR string should have length > 0")
+    assert_true(LICENSE.__len__() > 0, "LICENSE string should have length > 0")
+
+    # Test version format follows semantic versioning (major.minor.patch)
+    var version_parts = VERSION.split(".")
+    assert_true(
+        version_parts.__len__() == 3,
+        "Version should have 3 parts (major.minor.patch)",
+    )
+
+    # Test that version parts are numeric by checking they only contain digits
+    for i in range(version_parts.__len__()):
+        var part = version_parts[i]
+        assert_true(part.__len__() > 0, "Version part should not be empty")
+
+        # Check each character is a digit (0-9)
+        var is_numeric = True
+        for j in range(part.__len__()):
+            var ch = part[j]
+            if ch < "0" or ch > "9":
+                is_numeric = False
+                break
+
+        assert_true(is_numeric, "Version part should contain only digits")
+
+    print("✓ Version info test passed")
+
+
+# ============================================================================
+# Main Test Runner
+# ============================================================================
+
+
+fn main() raises:
+    """Run part 3 import validation tests."""
+    print("\n" + "=" * 70)
+    print("Running Import Validation Tests - Part 3 (Utils, Root, Nested & Version)")
+    print("=" * 70 + "\n")
+
+    # Utils package tests (second half)
+    print("Testing Utils Package (Part 2)...")
+    test_utils_visualization_imports()
+    test_utils_config_imports()
+
+    # Root package tests
+    print("\nTesting Root Package...")
+    test_root_imports()
+    test_subpackage_imports()
+
+    # Nested imports tests
+    print("\nTesting Nested Imports...")
+    test_nested_optimizer_imports()
+    test_nested_scheduler_imports()
+    test_nested_metric_imports()
+
+    # Version info test
+    print("\nTesting Version Info...")
+    test_version_info()
+
+    # Summary
+    print("\n" + "=" * 70)
+    print("✅ Import Validation Tests - Part 3 Passed!")
+    print("=" * 70)


### PR DESCRIPTION
## Summary

- Splits `tests/shared/test_imports.mojo` (24 `fn test_` functions) into 3 files of 8 tests each
- Eliminates intermittent Mojo v0.26.1 heap corruption crashes in the Shared Infra CI group
- Updates CI workflow pattern to reference the new filenames

## Changes Made

- `tests/shared/test_imports_part1.mojo` — Core package + Training (schedulers/optimizers/metrics) imports (8 tests)
- `tests/shared/test_imports_part2.mojo` — Training callbacks/loops, Data, Utils logging imports (8 tests)
- `tests/shared/test_imports_part3.mojo` — Utils config/viz, Root, Nested, Version imports (8 tests)
- `tests/shared/test_imports.mojo` — deleted (replaced by the 3 files above)
- `.github/workflows/comprehensive-tests.yml` — Shared Infra pattern updated to use new filenames

Each new file includes the ADR-009 header comment and has ≤8 `fn test_` functions.
All 24 original test cases are preserved with no modifications.

## Verification

- All pre-commit hooks pass (Mojo format, validate-test-coverage, YAML check, etc.)
- Test count per file: part1=8, part2=8, part3=8 (all ≤ ADR-009 limit of 10)

Closes #3427

🤖 Generated with [Claude Code](https://claude.com/claude-code)