### PR TITLE
fix(ci): split test_packaging.mojo (17 tests) into 3 files per ADR-009

### DIFF
--- a/tests/shared/integration/test_packaging_part1.mojo
+++ b/tests/shared/integration/test_packaging_part1.mojo
@@ -1,0 +1,154 @@
+"""
+Packaging Integration Tests - Part 1: Package Structure and Import Hierarchy
+
+Tests that verify the shared library package structure and import hierarchy.
+Split from test_packaging.mojo per ADR-009.
+
+Run with: mojo test tests/shared/integration/test_packaging_part1.mojo
+
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_packaging.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""
+
+from testing import assert_true, assert_equal
+
+# ============================================================================
+# Package Structure Tests
+# ============================================================================
+
+
+fn test_package_version() raises:
+    """Test package version is accessible and correct."""
+    from shared import VERSION, AUTHOR, LICENSE
+
+    # Critical validation - ensure values are not empty/None
+    assert_true(VERSION != "", "VERSION should not be empty")
+    assert_true(AUTHOR != "", "AUTHOR should not be empty")
+    assert_true(LICENSE != "", "LICENSE should not be empty")
+
+    # Test expected format and values
+    assert_equal(AUTHOR, "ML Odyssey Team")
+    assert_equal(LICENSE, "BSD")
+
+    # Additional critical tests - ensure these are actual string values, not None
+    assert_true(VERSION.__len__() > 0, "VERSION string should have length > 0")
+    assert_true(AUTHOR.__len__() > 0, "AUTHOR string should have length > 0")
+    assert_true(LICENSE.__len__() > 0, "LICENSE string should have length > 0")
+
+    print("✓ Package version test passed")
+
+
+fn test_subpackage_accessibility() raises:
+    """Test all subpackages can be imported and have expected exports."""
+    from shared import core, training, data, utils
+
+    # Verify subpackages are accessible by testing exports
+    from shared.core import ExTensor, zeros
+    from shared.training import SGD, MSELoss
+    from shared.data import Dataset, ExTensorDataset
+    from shared.utils import Logger, Config
+
+    # Test that we can actually call the functions
+    var test_tensor = zeros([2, 3], DType.float32)
+    assert_true(test_tensor.dim() == 2, "zeros should create 2D tensor")
+    var shape = test_tensor.shape()
+    assert_true(shape[0] == 2, "First dimension should be 2")
+    assert_true(shape[1] == 3, "Second dimension should be 3")
+
+    # Test that we can actually instantiate classes
+    var test_optimizer = SGD(learning_rate=0.01)
+    var test_loss = MSELoss()
+    var test_logger = Logger("test.log")
+
+    print("✓ Subpackage accessibility test passed")
+
+
+# ============================================================================
+# Import Hierarchy Tests
+# ============================================================================
+
+
+fn test_root_level_imports() raises:
+    """Test most commonly used components are available at root level."""
+    # Root package doesn't re-export all components directly
+    from shared.core import ExTensor
+    from shared.training import SGD
+    from shared.utils import Logger
+
+    print("✓ Root level imports test passed")
+
+
+fn test_module_level_imports() raises:
+    """Test importing from specific modules."""
+    from shared.core import ExTensor, relu, linear
+    from shared.training import SGD, MSELoss
+    from shared.data import ExTensorDataset, Batch
+
+    print("✓ Module level imports test passed")
+
+
+fn test_nested_imports() raises:
+    """Test importing from nested submodules."""
+    from shared.core import linear, conv2d
+    from shared.training import SGD
+    from shared.training import StepLR
+
+    print("✓ Nested imports test passed")
+
+
+fn test_core_training_integration() raises:
+    """Test integration between core and training modules."""
+    from shared.core import ExTensor, zeros
+    from shared.training import SGD, MSELoss
+
+    # Create tensors using core
+    var data = zeros([10, 5], DType.float32)
+
+    # Create optimizer using training
+    var optimizer = SGD(learning_rate=0.01)
+    var loss_fn = MSELoss()
+
+    # Verify types are correct and components can be instantiated
+    var data_shape = data.shape()
+    assert_true(data.dim() == 2, "Data should be 2D tensor")
+    assert_true(data_shape[0] == 10, "First dimension should be 10")
+    assert_true(data_shape[1] == 5, "Second dimension should be 5")
+    assert_true(
+        abs(optimizer.get_learning_rate() - 0.01) < 1e-9,
+        "Learning rate should be 0.01",
+    )
+
+    print("✓ Core-training integration test passed")
+
+
+# ============================================================================
+# Main Test Runner
+# ============================================================================
+
+
+fn main() raises:
+    """Run packaging integration tests - part 1."""
+    print("\n" + "=" * 70)
+    print("Running Packaging Integration Tests - Part 1")
+    print("=" * 70 + "\n")
+
+    # Package structure
+    print("Testing Package Structure...")
+    test_package_version()
+    test_subpackage_accessibility()
+
+    # Import hierarchy
+    print("\nTesting Import Hierarchy...")
+    test_root_level_imports()
+    test_module_level_imports()
+    test_nested_imports()
+
+    # Cross-module integration (first test)
+    print("\nTesting Cross-Module Integration...")
+    test_core_training_integration()
+
+    # Summary
+    print("\n" + "=" * 70)
+    print("✅ All Packaging Integration Tests - Part 1 Passed!")
+    print("=" * 70)

--- a/tests/shared/integration/test_packaging_part2.mojo
+++ b/tests/shared/integration/test_packaging_part2.mojo
@@ -1,0 +1,235 @@
+"""
+Packaging Integration Tests - Part 2: Data Integration, Workflows, and API Stability
+
+Tests that verify cross-module data integration, complete workflows, and API stability.
+Split from test_packaging.mojo per ADR-009.
+
+Run with: mojo test tests/shared/integration/test_packaging_part2.mojo
+
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_packaging.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""
+
+from testing import assert_true, assert_equal
+
+# ============================================================================
+# Cross-Module Integration Tests
+# ============================================================================
+
+
+fn test_core_data_integration() raises:
+    """Test integration between core and data modules."""
+    from shared.core import ExTensor, zeros, ones
+    from shared.data import ExTensorDataset
+
+    # Create tensors using core
+    var data = zeros([10, 5], DType.float32)
+    var labels = ones([10, 1], DType.float32)
+
+    # Create dataset using data
+    var dataset = ExTensorDataset(data, labels)
+
+    # Verify dataset was created and has correct properties
+    var data_shape = data.shape()
+    var labels_shape = labels.shape()
+    assert_true(data.dim() == 2, "Data should be 2D tensor")
+    assert_true(labels.dim() == 2, "Labels should be 2D tensor")
+    assert_true(data_shape[0] == 10, "First dimension should be 10")
+    assert_true(labels_shape[0] == 10, "Labels first dimension should be 10")
+    assert_true(len(dataset) == 10, "Dataset should have 10 samples")
+
+    print("✓ Core-data integration test passed")
+
+
+fn test_training_data_integration() raises:
+    """Test integration between training and data modules."""
+    from shared.training import SGD
+    from shared.data import ExTensorDataset
+    from shared.core import zeros, ones
+
+    # Create simple dataset
+    var data = zeros([10, 5], DType.float32)
+    var labels = ones([10, 1], DType.float32)
+    var dataset = ExTensorDataset(data, labels)
+
+    # Create optimizer
+    var optimizer = SGD(learning_rate=0.01)
+
+    # Verify integration by checking component properties
+    var data_shape = data.shape()
+    var labels_shape = labels.shape()
+    assert_true(data.dim() == 2, "Data should be 2D tensor")
+    assert_true(labels.dim() == 2, "Labels should be 2D tensor")
+    assert_true(
+        abs(optimizer.get_learning_rate() - 0.01) < 1e-9,
+        "Learning rate should be 0.01",
+    )
+    assert_true(len(dataset) > 0, "Dataset should have samples")
+
+    print("✓ Training-data integration test passed")
+
+
+# ============================================================================
+# Complete Workflow Tests
+# ============================================================================
+
+
+fn test_complete_training_workflow() raises:
+    """Test complete training workflow using all modules."""
+    from shared.core import zeros, ones, relu
+    from shared.training import SGD, MSELoss
+    from shared.data import ExTensorDataset
+    from shared.utils import Logger
+
+    # 1. Create model parameters (core)
+    var weights = zeros([5, 10], DType.float32)
+    var bias = zeros([5], DType.float32)
+
+    # 2. Create data (data)
+    var data = zeros([10, 10], DType.float32)
+    var labels = ones([10, 5], DType.float32)
+    var dataset = ExTensorDataset(data, labels)
+
+    # 3. Create optimizer and loss (training)
+    var optimizer = SGD(learning_rate=0.01)
+    var loss_fn = MSELoss()
+
+    # 4. Create logger (utils)
+    var logger = Logger("training.log")
+
+    # 5. Verify workflow components work together
+    var weights_shape = weights.shape()
+    var bias_shape = bias.shape()
+    var data_shape = data.shape()
+    var labels_shape = labels.shape()
+    assert_true(weights.dim() == 2, "Weights should be 2D tensor")
+    assert_true(bias.dim() == 1, "Bias should be 1D tensor")
+    assert_true(data.dim() == 2, "Data should be 2D tensor")
+    assert_true(labels.dim() == 2, "Labels should be 2D tensor")
+    assert_true(
+        abs(optimizer.get_learning_rate() - 0.01) < 1e-9,
+        "Learning rate should be 0.01",
+    )
+    assert_true(len(dataset) > 0, "Dataset should have samples")
+    # Logger is created successfully if no exception was raised
+
+    print("✓ Complete workflow test passed")
+
+
+fn test_paper_implementation_pattern() raises:
+    """Test typical usage pattern from paper implementation."""
+    # Simulates how a paper implementation would use the shared library
+
+    from shared.core import ExTensor, zeros, conv2d, flatten, relu
+    from shared.training import (
+        SGD,
+        CosineAnnealingLR,
+        EarlyStopping,
+        ModelCheckpoint,
+    )
+    from shared.data import ExTensorDataset
+
+    # Paper-specific tensors for conv operations
+    var input_data = zeros([1, 1, 28, 28], DType.float32)
+
+    # Training setup
+    var optimizer = SGD(learning_rate=0.001)
+    var scheduler = CosineAnnealingLR(0.001, 50)
+
+    # Callbacks
+    var early_stop = EarlyStopping()
+    var checkpoint = ModelCheckpoint()
+
+    # Create dataset
+    var data = zeros([10, 1, 28, 28], DType.float32)
+    var labels = zeros([10, 10], DType.float32)
+    var dataset = ExTensorDataset(data, labels)
+
+    # Verify all components are properly instantiated
+    assert_true(input_data.dim() == 4, "Input data should be 4D tensor")
+    assert_true(
+        abs(optimizer.get_learning_rate() - 0.001) < 1e-9,
+        "Learning rate should be 0.001",
+    )
+    assert_true(len(dataset) > 0, "Dataset should have samples")
+
+    print("✓ Paper implementation pattern test passed")
+
+
+# ============================================================================
+# API Stability Tests
+# ============================================================================
+
+
+# SKIPPED: Mojo v0.26.1 doesn't support __all__
+# See shared/__init__.mojo lines 138-141 for explanation
+# fn test_public_api_exports() raises:
+#     """Test that __all__ exports are consistent."""
+#     from shared import __all__
+#
+#     # Verify __all__ exists and is non-empty
+#     # var expected_exports = [
+#     #     "Linear", "Conv2D", "ReLU",
+#     #     "SGD", "Adam",
+#     #     "Accuracy",
+#     #     "DataLoader",
+#     #     "Logger",
+#     # ]
+
+#     # for export in expected_exports:
+#     #     assert_true(export in __all__)
+#
+#     print("✓ Public API exports test passed (placeholder)")
+
+
+fn test_no_private_exports() raises:
+    """Test that private modules are not exported at root level."""
+    # Test that private modules are not accessible through public imports
+    # Mojo v0.26.1 doesn't support __all__, so we verify by checking
+    # that public symbols are available and documenting expected behavior
+
+    # Verify public symbols are available (confirming public API is working)
+    from shared import core, training, data, utils
+
+    # Document that the following should NOT be accessible:
+    # - Private modules like _internal, _private, _utils_private
+    # - Private symbols prefixed with _
+    # - Internal implementation details
+
+    # The fact that we can only import public symbols (core, training, data, utils)
+    # and not private ones proves the public API is properly isolated
+
+    print("✓ No private exports test passed - public API properly isolated")
+
+
+# ============================================================================
+# Main Test Runner
+# ============================================================================
+
+
+fn main() raises:
+    """Run packaging integration tests - part 2."""
+    print("\n" + "=" * 70)
+    print("Running Packaging Integration Tests - Part 2")
+    print("=" * 70 + "\n")
+
+    # Cross-module integration
+    print("Testing Cross-Module Integration...")
+    test_core_data_integration()
+    test_training_data_integration()
+
+    # Complete workflows
+    print("\nTesting Complete Workflows...")
+    test_complete_training_workflow()
+    test_paper_implementation_pattern()
+
+    # API stability
+    print("\nTesting API Stability...")
+    # test_public_api_exports()  # SKIPPED: Mojo v0.26.1 doesn't support __all__
+    test_no_private_exports()
+
+    # Summary
+    print("\n" + "=" * 70)
+    print("✅ All Packaging Integration Tests - Part 2 Passed!")
+    print("=" * 70)

--- a/tests/shared/integration/test_packaging_part3.mojo
+++ b/tests/shared/integration/test_packaging_part3.mojo
@@ -1,0 +1,312 @@
+"""
+Packaging Integration Tests - Part 3: Backward Compatibility and Critical Integration
+
+Tests that verify backward compatibility and critical cross-module integration.
+Split from test_packaging.mojo per ADR-009.
+
+Run with: mojo test tests/shared/integration/test_packaging_part3.mojo
+
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_packaging.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""
+
+from testing import assert_true, assert_equal
+
+# ============================================================================
+# Backward Compatibility Tests
+# ============================================================================
+
+
+fn test_deprecated_imports() raises:
+    """Test that deprecated imports still work with warnings."""
+    # Currently no deprecated APIs exist in this codebase
+    # When deprecated APIs are added, this test should:
+    # 1. Test that deprecated imports still work (backward compatibility)
+    # 2. Optionally test that deprecation warnings are issued
+    # 3. Document the migration path to new APIs
+
+    # Example of what this test should do when deprecated APIs exist:
+    # ```mojo
+    # # Test deprecated import still works
+    # from shared.deprecated import old_function  # Should still work
+    #
+    # # Test that replacement is available
+    # from shared.new import new_function  # Should work as replacement
+    # ```
+
+    # For now, we verify the test framework itself works by importing from shared
+    from shared import VERSION  # This import should always work
+
+    assert_true(VERSION != "", "Version should be accessible")
+
+    print(
+        "✓ Deprecated imports test passed - no deprecated APIs currently exist"
+    )
+
+
+fn test_api_version_compatibility() raises:
+    """Test API version compatibility."""
+    from shared import VERSION
+
+    # Verify version follows semantic versioning (major.minor.patch format)
+    var version_parts = VERSION.split(".")
+    assert_equal(
+        version_parts.__len__(),
+        3,
+        "Version should have 3 parts (major.minor.patch)",
+    )
+
+    # Verify each part is numeric
+    var major = version_parts[0]
+    var minor = version_parts[1]
+    var patch = version_parts[2]
+
+    # Basic format validation (should be digits)
+    try:
+        var major_int = atol(major)
+        assert_true(major_int >= 0, "Major version should be non-negative")
+    except:
+        assert_true(False, "Major version should be numeric")
+
+    try:
+        var minor_int = atol(minor)
+        assert_true(minor_int >= 0, "Minor version should be non-negative")
+    except:
+        assert_true(False, "Minor version should be numeric")
+
+    try:
+        var patch_int = atol(patch)
+        assert_true(patch_int >= 0, "Patch version should be non-negative")
+    except:
+        assert_true(False, "Patch version should be numeric")
+
+    print("✓ API version compatibility test passed")
+
+
+# ============================================================================
+# Critical Integration Tests - Catching Real Failures
+# ============================================================================
+
+
+fn test_cross_module_computation() raises:
+    """Test that components actually work together in real computations."""
+    from shared.core import zeros, ones, relu
+    from shared.core.matrix import matmul
+    from shared.training import SGD, MSELoss
+    from shared.data import ExTensorDataset
+
+    # Create realistic tensors
+    var data = zeros([32, 64], DType.float32)  # Batch of 32, features of 64
+    var labels = zeros([32, 10], DType.float32)  # 32 samples, 10 classes
+
+    # Create dataset
+    var dataset = ExTensorDataset(data, labels)
+
+    # Create a simple network forward pass
+    var weights1 = zeros([64, 128], DType.float32)  # Input layer
+    var bias1 = zeros([128], DType.float32)
+    var weights2 = zeros([128, 10], DType.float32)  # Output layer
+    var bias2 = zeros([10], DType.float32)
+
+    # Forward pass - this is where integration failures would occur
+    var hidden = matmul(data, weights1)  # (32,64) × (64,128) = (32,128)
+    var hidden_activated = relu(hidden)
+    var logits = matmul(
+        hidden_activated, weights2
+    )  # (32,128) × (128,10) = (32,10)
+
+    # Critical assertions that would catch shape/dtype errors
+    var logits_shape = logits.shape()
+    assert_true(logits.dim() == 2, "Logits should be 2D tensor")
+    assert_true(logits_shape[0] == 32, "Batch size should be preserved")
+    assert_true(logits_shape[1] == 10, "Output classes should match labels")
+    assert_true(logits.dtype() == DType.float32, "DType should be preserved")
+
+    # Test with training components
+    var optimizer = SGD(learning_rate=0.001)
+    var loss_fn = MSELoss()
+
+    # Compute loss
+    var loss = loss_fn.compute(logits, labels)
+    # Loss reduction depends on MSELoss configuration (mean/sum/none)
+    # Just verify loss is computed successfully
+    assert_true(loss.numel() > 0, "Loss should be computed")
+
+    print("✓ Cross-module computation test passed")
+
+
+fn test_tensor_operations_safety() raises:
+    """Test that tensor operations handle edge cases safely."""
+    from shared.core import zeros, ones, full
+
+    # Test zero-sized tensors
+    var empty_data = zeros([0, 5], DType.float32)
+    var empty_labels = zeros([0, 3], DType.float32)
+    assert_true(
+        empty_data.num_elements() == 0, "Empty tensor should have 0 elements"
+    )
+
+    # Test single-element tensors
+    var single_data = zeros([1], DType.float32)
+    var single_labels = zeros([1], DType.float32)
+    assert_true(
+        single_data.num_elements() == 1,
+        "Single element tensor should have 1 element",
+    )
+
+    # Test large tensors (memory safety)
+    try:
+        var large_tensor = zeros([1000, 1000], DType.float32)
+        assert_true(
+            large_tensor.num_elements() == 1000000,
+            "Large tensor should have 1M elements",
+        )
+    except:
+        # If allocation fails, that's actually a valid failure case
+        print("✓ Large tensor allocation failed (acceptable)")
+
+    # Test different dtypes
+    var int_tensor = zeros([2, 2], DType.int32)
+    var float_tensor = zeros([2, 2], DType.float32)
+    var bool_tensor = zeros([2, 2], DType.bool)
+
+    assert_true(
+        int_tensor.dtype() == DType.int32, "Int tensor should maintain dtype"
+    )
+    assert_true(
+        float_tensor.dtype() == DType.float32,
+        "Float tensor should maintain dtype",
+    )
+    assert_true(
+        bool_tensor.dtype() == DType.bool, "Bool tensor should maintain dtype"
+    )
+
+    print("✓ Tensor operations safety test passed")
+
+
+fn test_error_propagation() raises:
+    """Test that errors propagate correctly between modules."""
+    from shared.core import zeros
+    from shared.training import SGD
+    from shared.data import ExTensorDataset
+
+    # Test that incompatible tensor shapes fail appropriately
+    var good_data = zeros([10, 5], DType.float32)
+    var good_labels = zeros([10, 3], DType.float32)
+
+    # This should work
+    var good_dataset = ExTensorDataset(good_data, good_labels)
+    assert_true(len(good_dataset) > 0, "Valid dataset should be created")
+
+    # Test optimizer with edge case learning rates
+    var fast_optimizer = SGD(learning_rate=1000.0)  # Very large
+    var slow_optimizer = SGD(learning_rate=0.000001)  # Very small
+
+    assert_true(
+        abs(fast_optimizer.get_learning_rate() - 1000.0) < 1e-6,
+        "Large learning rate should be preserved",
+    )
+    assert_true(
+        abs(slow_optimizer.get_learning_rate() - 0.000001) < 1e-12,
+        "Small learning rate should be preserved",
+    )
+
+    print("✓ Error propagation test passed")
+
+
+fn test_integration_stress() raises:
+    """Stress test with realistic deep learning workload."""
+    from shared.core import zeros, ones, relu
+    from shared.core.matrix import matmul
+    from shared.training import SGD, MSELoss
+    from shared.data import ExTensorDataset
+
+    # Create a realistic batch size
+    var batch_size = 128
+    var input_dim = 784  # MNIST-like
+    var hidden_dim = 256
+    var output_dim = 10  # 10 classes
+
+    # Create data
+    var train_data = zeros([batch_size, input_dim], DType.float32)
+    var train_labels = zeros([batch_size, output_dim], DType.float32)
+
+    # Create dataset
+    var dataset = ExTensorDataset(train_data, train_labels)
+
+    # Create network parameters
+    var w1 = zeros([input_dim, hidden_dim], DType.float32)
+    var b1 = zeros([hidden_dim], DType.float32)
+    var w2 = zeros([hidden_dim, hidden_dim], DType.float32)
+    var b2 = zeros([hidden_dim], DType.float32)
+    var w3 = zeros([hidden_dim, output_dim], DType.float32)
+    var b3 = zeros([output_dim], DType.float32)
+
+    # Forward pass through 3-layer network
+    var x1 = matmul(train_data, w1)  # (128,784) × (784,256) = (128,256)
+    var x1_activated = relu(x1)
+
+    var x2 = matmul(x1_activated, w2)  # (128,256) × (256,256) = (128,256)
+    var x2_activated = relu(x2)
+
+    var x3 = matmul(x2_activated, w3)  # (128,256) × (256,10) = (128,10)
+
+    # Verify all shapes are correct
+    var x1_shape = x1_activated.shape()
+    var x2_shape = x2_activated.shape()
+    var x3_shape = x3.shape()
+    assert_true(x1_activated.dim() == 2, "First layer output should be 2D")
+    assert_true(
+        x1_shape[0] == batch_size and x1_shape[1] == hidden_dim,
+        "First layer should match expected shape",
+    )
+    assert_true(x2_activated.dim() == 2, "Second layer output should be 2D")
+    assert_true(
+        x2_shape[0] == batch_size, "Second layer batch size should match"
+    )
+    assert_true(x3.dim() == 2, "Final output should be 2D")
+    assert_true(
+        x3_shape[0] == batch_size, "Final output batch size should match"
+    )
+    assert_true(x3_shape[1] == output_dim, "Final output classes should match")
+
+    # Test with training components
+    var optimizer = SGD(learning_rate=0.01)
+    var loss_fn = MSELoss()
+
+    # Compute loss
+    var loss = loss_fn.compute(x3, train_labels)
+    # Loss reduction depends on MSELoss configuration
+    assert_true(loss.numel() > 0, "Loss should be computed")
+
+    print("✓ Integration stress test passed")
+
+
+# ============================================================================
+# Main Test Runner
+# ============================================================================
+
+
+fn main() raises:
+    """Run packaging integration tests - part 3."""
+    print("\n" + "=" * 70)
+    print("Running Packaging Integration Tests - Part 3")
+    print("=" * 70 + "\n")
+
+    # Backward compatibility
+    print("Testing Backward Compatibility...")
+    test_deprecated_imports()
+    test_api_version_compatibility()
+
+    # Critical integration tests
+    print("\nTesting Critical Integration...")
+    test_cross_module_computation()
+    test_tensor_operations_safety()
+    test_error_propagation()
+    test_integration_stress()
+
+    # Summary
+    print("\n" + "=" * 70)
+    print("✅ All Packaging Integration Tests - Part 3 Passed!")
+    print("=" * 70)


### PR DESCRIPTION
## Summary

- Splits `tests/shared/integration/test_packaging.mojo` (17 `fn test_` functions) into 3 files of ≤8 tests each, complying with ADR-009's limit to prevent Mojo v0.26.1 heap corruption crashes
- All 17 original test cases preserved — no tests deleted
- Each new file includes the ADR-009 tracking comment in the header
- CI workflow already uses `test_*.mojo` glob pattern, so no workflow changes needed

## Files Changed

- `tests/shared/integration/test_packaging.mojo` — deleted
- `tests/shared/integration/test_packaging_part1.mojo` — 6 tests (package structure + import hierarchy)
- `tests/shared/integration/test_packaging_part2.mojo` — 5 tests (data integration + workflows + API stability)
- `tests/shared/integration/test_packaging_part3.mojo` — 6 tests (backward compatibility + critical integration)

## Test Plan

- [x] All 17 original test functions preserved across the 3 new files
- [x] Each file has ≤8 `fn test_` functions (ADR-009 compliant)
- [x] Each file includes ADR-009 header comment
- [x] Pre-commit hooks pass (mojo format, validate test coverage, etc.)
- [x] CI `Integration Tests` group uses `test_*.mojo` glob — automatically picks up new files

Closes #3460

🤖 Generated with [Claude Code](https://claude.com/claude-code)