### PR TITLE
fix(ci): split test_advanced_activations.mojo into 3 files (ADR-009)

### DIFF
--- a/tests/shared/core/test_advanced_activations_part1.mojo
+++ b/tests/shared/core/test_advanced_activations_part1.mojo
@@ -1,0 +1,145 @@
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_advanced_activations.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for advanced activation functions - Part 1: Swish/SiLU.
+
+Tests cover:
+- Swish/SiLU activation forward pass
+- Swish/SiLU activation backward pass
+
+All tests use pure functional API.
+"""
+
+from tests.shared.conftest import (
+    assert_almost_equal,
+    assert_close_float,
+    assert_equal,
+    assert_equal_int,
+    assert_shape,
+    assert_true,
+)
+from tests.shared.conftest import TestFixtures
+from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.activation import (
+    swish,
+    swish_backward,
+)
+from shared.core.elementwise import exp
+from shared.core.arithmetic import add, multiply
+from math import sqrt
+
+
+# ============================================================================
+# Swish/SiLU Tests
+# ============================================================================
+
+
+fn test_swish_shapes() raises:
+    """Test that swish returns correct output shape."""
+    var shape = List[Int]()
+    shape.append(4)
+    shape.append(10)
+    var x = ones(shape, DType.float32)
+
+    var output = swish(x)
+
+    # Check shape
+    assert_equal(output.shape()[0], 4)
+    assert_equal(output.shape()[1], 10)
+
+
+fn test_swish_values() raises:
+    """Test that swish computes correct values."""
+    var shape = List[Int]()
+    shape.append(5)
+    var x = zeros(shape, DType.float32)
+
+    # Test values: [-2, -1, 0, 1, 2]
+    x._data.bitcast[Float32]()[0] = -2.0
+    x._data.bitcast[Float32]()[1] = -1.0
+    x._data.bitcast[Float32]()[2] = 0.0
+    x._data.bitcast[Float32]()[3] = 1.0
+    x._data.bitcast[Float32]()[4] = 2.0
+
+    var output = swish(x)
+
+    # swish(x) = x * sigmoid(x)
+    # swish(-2) = -2 * sigmoid(-2) = -2 * 0.119 ≈ -0.238
+    # swish(-1) = -1 * sigmoid(-1) = -1 * 0.269 ≈ -0.269
+    # swish(0) = 0 * sigmoid(0) = 0 * 0.5 = 0.0
+    # swish(1) = 1 * sigmoid(1) = 1 * 0.731 ≈ 0.731
+    # swish(2) = 2 * sigmoid(2) = 2 * 0.881 ≈ 1.762
+
+    assert_almost_equal(
+        output._data.bitcast[Float32]()[0], Float32(-0.238), tolerance=0.01
+    )
+    assert_almost_equal(
+        output._data.bitcast[Float32]()[1], Float32(-0.269), tolerance=0.01
+    )
+    assert_almost_equal(
+        output._data.bitcast[Float32]()[2], Float32(0.0), tolerance=1e-5
+    )
+    assert_almost_equal(
+        output._data.bitcast[Float32]()[3], Float32(0.731), tolerance=0.01
+    )
+    assert_almost_equal(
+        output._data.bitcast[Float32]()[4], Float32(1.762), tolerance=0.01
+    )
+
+
+fn test_swish_backward_shapes() raises:
+    """Test that swish_backward returns correct gradient shape."""
+    var shape = List[Int]()
+    shape.append(3)
+    shape.append(5)
+    var x = ones(shape, DType.float32)
+
+    var output = swish(x)
+    var grad_output = ones(shape, DType.float32)
+    var grad_input = swish_backward(grad_output, x)
+
+    # Check shape
+    assert_equal(grad_input.shape()[0], 3)
+    assert_equal(grad_input.shape()[1], 5)
+
+
+fn test_swish_backward_zero() raises:
+    """Test swish backward at x=0."""
+    var shape = List[Int]()
+    shape.append(1)
+    var x = zeros(shape, DType.float32)
+
+    var grad_output = ones(shape, DType.float32)
+    var grad_input = swish_backward(grad_output, x)
+
+    # At x=0: sigmoid(0) = 0.5
+    # d/dx[x * sigmoid(x)] = sigmoid(x) + x * sigmoid(x) * (1 - sigmoid(x))
+    # = 0.5 + 0 * 0.5 * 0.5 = 0.5
+    assert_almost_equal(
+        grad_input._data.bitcast[Float32]()[0], Float32(0.5), tolerance=1e-5
+    )
+
+
+# ============================================================================
+# Main Test Runner
+# ============================================================================
+
+
+fn main() raises:
+    """Run Swish/SiLU advanced activation tests."""
+    print("Running advanced activation tests (Part 1: Swish/SiLU)...")
+
+    # Swish tests
+    test_swish_shapes()
+    print("✓ test_swish_shapes")
+
+    test_swish_values()
+    print("✓ test_swish_values")
+
+    test_swish_backward_shapes()
+    print("✓ test_swish_backward_shapes")
+
+    test_swish_backward_zero()
+    print("✓ test_swish_backward_zero")
+
+    print("\nAll Swish/SiLU tests passed!")

--- a/tests/shared/core/test_advanced_activations_part2.mojo
+++ b/tests/shared/core/test_advanced_activations_part2.mojo
@@ -1,12 +1,12 @@
-"""Tests for advanced activation functions.
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_advanced_activations.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for advanced activation functions - Part 2: Mish and ELU forward.
 
 Tests cover:
-- Swish/SiLU activation
-- Mish activation
-- ELU activation
-- Forward pass correctness
-- Backward pass correctness
-- Shape validation
+- Mish activation forward pass
+- Mish activation backward pass
+- ELU activation forward pass (shapes and values)
 
 All tests use pure functional API.
 """
@@ -22,109 +22,13 @@ from tests.shared.conftest import (
 from tests.shared.conftest import TestFixtures
 from shared.core.extensor import ExTensor, zeros, ones
 from shared.core.activation import (
-    swish,
-    swish_backward,
     mish,
     mish_backward,
     elu,
-    elu_backward,
-    sigmoid,
-    tanh,
 )
 from shared.core.elementwise import exp
 from shared.core.arithmetic import add, multiply
 from math import sqrt
-
-
-# ============================================================================
-# Swish/SiLU Tests
-# ============================================================================
-
-
-fn test_swish_shapes() raises:
-    """Test that swish returns correct output shape."""
-    var shape = List[Int]()
-    shape.append(4)
-    shape.append(10)
-    var x = ones(shape, DType.float32)
-
-    var output = swish(x)
-
-    # Check shape
-    assert_equal(output.shape()[0], 4)
-    assert_equal(output.shape()[1], 10)
-
-
-fn test_swish_values() raises:
-    """Test that swish computes correct values."""
-    var shape = List[Int]()
-    shape.append(5)
-    var x = zeros(shape, DType.float32)
-
-    # Test values: [-2, -1, 0, 1, 2]
-    x._data.bitcast[Float32]()[0] = -2.0
-    x._data.bitcast[Float32]()[1] = -1.0
-    x._data.bitcast[Float32]()[2] = 0.0
-    x._data.bitcast[Float32]()[3] = 1.0
-    x._data.bitcast[Float32]()[4] = 2.0
-
-    var output = swish(x)
-
-    # swish(x) = x * sigmoid(x)
-    # swish(-2) = -2 * sigmoid(-2) = -2 * 0.119 ≈ -0.238
-    # swish(-1) = -1 * sigmoid(-1) = -1 * 0.269 ≈ -0.269
-    # swish(0) = 0 * sigmoid(0) = 0 * 0.5 = 0.0
-    # swish(1) = 1 * sigmoid(1) = 1 * 0.731 ≈ 0.731
-    # swish(2) = 2 * sigmoid(2) = 2 * 0.881 ≈ 1.762
-
-    assert_almost_equal(
-        output._data.bitcast[Float32]()[0], Float32(-0.238), tolerance=0.01
-    )
-    assert_almost_equal(
-        output._data.bitcast[Float32]()[1], Float32(-0.269), tolerance=0.01
-    )
-    assert_almost_equal(
-        output._data.bitcast[Float32]()[2], Float32(0.0), tolerance=1e-5
-    )
-    assert_almost_equal(
-        output._data.bitcast[Float32]()[3], Float32(0.731), tolerance=0.01
-    )
-    assert_almost_equal(
-        output._data.bitcast[Float32]()[4], Float32(1.762), tolerance=0.01
-    )
-
-
-fn test_swish_backward_shapes() raises:
-    """Test that swish_backward returns correct gradient shape."""
-    var shape = List[Int]()
-    shape.append(3)
-    shape.append(5)
-    var x = ones(shape, DType.float32)
-
-    var output = swish(x)
-    var grad_output = ones(shape, DType.float32)
-    var grad_input = swish_backward(grad_output, x)
-
-    # Check shape
-    assert_equal(grad_input.shape()[0], 3)
-    assert_equal(grad_input.shape()[1], 5)
-
-
-fn test_swish_backward_zero() raises:
-    """Test swish backward at x=0."""
-    var shape = List[Int]()
-    shape.append(1)
-    var x = zeros(shape, DType.float32)
-
-    var grad_output = ones(shape, DType.float32)
-    var grad_input = swish_backward(grad_output, x)
-
-    # At x=0: sigmoid(0) = 0.5
-    # d/dx[x * sigmoid(x)] = sigmoid(x) + x * sigmoid(x) * (1 - sigmoid(x))
-    # = 0.5 + 0 * 0.5 * 0.5 = 0.5
-    assert_almost_equal(
-        grad_input._data.bitcast[Float32]()[0], Float32(0.5), tolerance=1e-5
-    )
 
 
 # ============================================================================
@@ -206,7 +110,7 @@ fn test_mish_backward_positive() raises:
 
 
 # ============================================================================
-# ELU Tests
+# ELU Forward Tests
 # ============================================================================
 
 
@@ -294,107 +198,14 @@ fn test_elu_alpha_parameter() raises:
     )
 
 
-fn test_elu_at_zero() raises:
-    """Test that elu is continuous at zero."""
-    var shape = List[Int]()
-    shape.append(1)
-    var x = zeros(shape, DType.float32)
-    x._data.bitcast[Float32]()[0] = 0.0
-
-    var output = elu(x, alpha=1.0)
-
-    # At x=0: elu(0) = 0
-    assert_almost_equal(
-        output._data.bitcast[Float32]()[0], Float32(0.0), tolerance=1e-5
-    )
-
-
-fn test_elu_backward_shapes() raises:
-    """Test that elu_backward returns correct gradient shape."""
-    var shape = List[Int]()
-    shape.append(3)
-    shape.append(5)
-    var x = ones(shape, DType.float32)
-
-    var output = elu(x, alpha=1.0)
-    var grad_output = ones(shape, DType.float32)
-    var grad_input = elu_backward(grad_output, x, alpha=1.0)
-
-    # Check shape
-    assert_equal(grad_input.shape()[0], 3)
-    assert_equal(grad_input.shape()[1], 5)
-
-
-fn test_elu_backward_positive() raises:
-    """Test elu backward gradient for positive inputs."""
-    var shape = List[Int]()
-    shape.append(1)
-    var x = ones(shape, DType.float32)
-    x._data.bitcast[Float32]()[0] = 1.0
-
-    var grad_output = ones(shape, DType.float32)
-    var grad_input = elu_backward(grad_output, x, alpha=1.0)
-
-    # For x > 0: d/dx[elu(x)] = 1
-    assert_almost_equal(
-        grad_input._data.bitcast[Float32]()[0], Float32(1.0), tolerance=1e-5
-    )
-
-
-fn test_elu_backward_negative() raises:
-    """Test elu backward gradient for negative inputs."""
-    var shape = List[Int]()
-    shape.append(1)
-    var x = zeros(shape, DType.float32)
-    x._data.bitcast[Float32]()[0] = -1.0
-
-    var grad_output = ones(shape, DType.float32)
-    var grad_input = elu_backward(grad_output, x, alpha=1.0)
-
-    # For x < 0: d/dx[elu(x)] = alpha * exp(x)
-    # d/dx[elu(-1)] = 1.0 * exp(-1) = 0.368
-    assert_almost_equal(
-        grad_input._data.bitcast[Float32]()[0], Float32(0.368), tolerance=0.01
-    )
-
-
-fn test_elu_backward_at_zero() raises:
-    """Test elu backward gradient at zero."""
-    var shape = List[Int]()
-    shape.append(1)
-    var x = zeros(shape, DType.float32)
-    x._data.bitcast[Float32]()[0] = 0.0
-
-    var grad_output = ones(shape, DType.float32)
-    var grad_input = elu_backward(grad_output, x, alpha=1.0)
-
-    # At x=0: d/dx[elu(x)] = 1
-    assert_almost_equal(
-        grad_input._data.bitcast[Float32]()[0], Float32(1.0), tolerance=1e-5
-    )
-
-
 # ============================================================================
 # Main Test Runner
 # ============================================================================
 
 
 fn main() raises:
-    """Run all advanced activation tests."""
-    print("Running advanced activation tests...")
-
-    # Swish tests
-    test_swish_shapes()
-    print("✓ test_swish_shapes")
-
-    test_swish_values()
-    print("✓ test_swish_values")
-
-    test_swish_backward_shapes()
-    print("✓ test_swish_backward_shapes")
-
-    test_swish_backward_zero()
-    print("✓ test_swish_backward_zero")
+    """Run Mish and ELU forward advanced activation tests."""
+    print("Running advanced activation tests (Part 2: Mish and ELU forward)...")
 
     # Mish tests
     test_mish_shapes()
@@ -409,7 +220,7 @@ fn main() raises:
     test_mish_backward_positive()
     print("✓ test_mish_backward_positive")
 
-    # ELU tests
+    # ELU forward tests
     test_elu_shapes()
     print("✓ test_elu_shapes")
 
@@ -422,19 +233,4 @@ fn main() raises:
     test_elu_alpha_parameter()
     print("✓ test_elu_alpha_parameter")
 
-    test_elu_at_zero()
-    print("✓ test_elu_at_zero")
-
-    test_elu_backward_shapes()
-    print("✓ test_elu_backward_shapes")
-
-    test_elu_backward_positive()
-    print("✓ test_elu_backward_positive")
-
-    test_elu_backward_negative()
-    print("✓ test_elu_backward_negative")
-
-    test_elu_backward_at_zero()
-    print("✓ test_elu_backward_at_zero")
-
-    print("\nAll advanced activation tests passed!")
+    print("\nAll Mish and ELU forward tests passed!")

--- a/tests/shared/core/test_advanced_activations_part3.mojo
+++ b/tests/shared/core/test_advanced_activations_part3.mojo
@@ -1,0 +1,142 @@
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_advanced_activations.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for advanced activation functions - Part 3: ELU backward pass.
+
+Tests cover:
+- ELU activation continuity at zero
+- ELU backward pass correctness
+
+All tests use pure functional API.
+"""
+
+from tests.shared.conftest import (
+    assert_almost_equal,
+    assert_close_float,
+    assert_equal,
+    assert_equal_int,
+    assert_shape,
+    assert_true,
+)
+from tests.shared.conftest import TestFixtures
+from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.activation import (
+    elu,
+    elu_backward,
+)
+from shared.core.elementwise import exp
+from shared.core.arithmetic import add, multiply
+from math import sqrt
+
+
+# ============================================================================
+# ELU Continuity and Backward Tests
+# ============================================================================
+
+
+fn test_elu_at_zero() raises:
+    """Test that elu is continuous at zero."""
+    var shape = List[Int]()
+    shape.append(1)
+    var x = zeros(shape, DType.float32)
+    x._data.bitcast[Float32]()[0] = 0.0
+
+    var output = elu(x, alpha=1.0)
+
+    # At x=0: elu(0) = 0
+    assert_almost_equal(
+        output._data.bitcast[Float32]()[0], Float32(0.0), tolerance=1e-5
+    )
+
+
+fn test_elu_backward_shapes() raises:
+    """Test that elu_backward returns correct gradient shape."""
+    var shape = List[Int]()
+    shape.append(3)
+    shape.append(5)
+    var x = ones(shape, DType.float32)
+
+    var output = elu(x, alpha=1.0)
+    var grad_output = ones(shape, DType.float32)
+    var grad_input = elu_backward(grad_output, x, alpha=1.0)
+
+    # Check shape
+    assert_equal(grad_input.shape()[0], 3)
+    assert_equal(grad_input.shape()[1], 5)
+
+
+fn test_elu_backward_positive() raises:
+    """Test elu backward gradient for positive inputs."""
+    var shape = List[Int]()
+    shape.append(1)
+    var x = ones(shape, DType.float32)
+    x._data.bitcast[Float32]()[0] = 1.0
+
+    var grad_output = ones(shape, DType.float32)
+    var grad_input = elu_backward(grad_output, x, alpha=1.0)
+
+    # For x > 0: d/dx[elu(x)] = 1
+    assert_almost_equal(
+        grad_input._data.bitcast[Float32]()[0], Float32(1.0), tolerance=1e-5
+    )
+
+
+fn test_elu_backward_negative() raises:
+    """Test elu backward gradient for negative inputs."""
+    var shape = List[Int]()
+    shape.append(1)
+    var x = zeros(shape, DType.float32)
+    x._data.bitcast[Float32]()[0] = -1.0
+
+    var grad_output = ones(shape, DType.float32)
+    var grad_input = elu_backward(grad_output, x, alpha=1.0)
+
+    # For x < 0: d/dx[elu(x)] = alpha * exp(x)
+    # d/dx[elu(-1)] = 1.0 * exp(-1) = 0.368
+    assert_almost_equal(
+        grad_input._data.bitcast[Float32]()[0], Float32(0.368), tolerance=0.01
+    )
+
+
+fn test_elu_backward_at_zero() raises:
+    """Test elu backward gradient at zero."""
+    var shape = List[Int]()
+    shape.append(1)
+    var x = zeros(shape, DType.float32)
+    x._data.bitcast[Float32]()[0] = 0.0
+
+    var grad_output = ones(shape, DType.float32)
+    var grad_input = elu_backward(grad_output, x, alpha=1.0)
+
+    # At x=0: d/dx[elu(x)] = 1
+    assert_almost_equal(
+        grad_input._data.bitcast[Float32]()[0], Float32(1.0), tolerance=1e-5
+    )
+
+
+# ============================================================================
+# Main Test Runner
+# ============================================================================
+
+
+fn main() raises:
+    """Run ELU backward advanced activation tests."""
+    print("Running advanced activation tests (Part 3: ELU backward)...")
+
+    # ELU continuity and backward tests
+    test_elu_at_zero()
+    print("✓ test_elu_at_zero")
+
+    test_elu_backward_shapes()
+    print("✓ test_elu_backward_shapes")
+
+    test_elu_backward_positive()
+    print("✓ test_elu_backward_positive")
+
+    test_elu_backward_negative()
+    print("✓ test_elu_backward_negative")
+
+    test_elu_backward_at_zero()
+    print("✓ test_elu_backward_at_zero")
+
+    print("\nAll ELU backward tests passed!")


### PR DESCRIPTION
## Summary

- Split `tests/shared/core/test_advanced_activations.mojo` (17 tests) into 3 files of ≤8 tests each to comply with ADR-009 heap corruption workaround
- Each new file includes the required ADR-009 header comment
- Updated `.github/workflows/comprehensive-tests.yml` to reference the 3 new filenames

## Changes Made

| File | Tests | Content |
|------|-------|---------|
| `test_advanced_activations_part1.mojo` | 4 | Swish/SiLU forward + backward |
| `test_advanced_activations_part2.mojo` | 8 | Mish forward/backward + ELU forward |
| `test_advanced_activations_part3.mojo` | 5 | ELU continuity + backward |

## Verification

- All 17 original test cases preserved across the 3 files
- Each file has ≤8 `fn test_` functions (ADR-009 limit: ≤10)
- All pre-commit hooks passed (mojo format, test coverage validator, YAML check)
- CI workflow updated: `test_advanced_activations.mojo` → 3 new filenames

Closes #3462

🤖 Generated with [Claude Code](https://claude.com/claude-code)