### PR TITLE
fix(ci): split test_normalization.mojo (21 tests) into 3 files per ADR-009

### DIFF
--- a/tests/shared/core/test_normalization_part1.mojo
+++ b/tests/shared/core/test_normalization_part1.mojo
@@ -1,0 +1,602 @@
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_normalization.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for batch normalization (forward pass and first backward tests).
+
+Tests cover:
+- Batch normalization shapes
+- Batch normalization training mode
+- Batch normalization inference mode
+- Batch normalization scale/shift
+- Batch normalization zero variance
+- Batch normalization backward: gradient input (training)
+- Batch normalization backward: gradient input (inference)
+- Batch normalization backward: gradient gamma
+
+All tests use pure functional API.
+"""
+
+from tests.shared.conftest import (
+    assert_almost_equal,
+    assert_close_float,
+    assert_equal,
+    assert_equal_int,
+    assert_shape,
+    assert_shape_equal,
+    assert_true,
+)
+from tests.shared.conftest import TestFixtures
+from shared.testing import (
+    compute_numerical_gradient,
+    assert_gradients_close,
+)
+from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.normalization import (
+    batch_norm2d,
+    batch_norm2d_backward,
+    layer_norm,
+    layer_norm_backward,
+)
+from shared.core.arithmetic import add, subtract, multiply
+from shared.core.reduction import sum as reduce_sum
+
+
+# ============================================================================
+# Batch Normalization Tests
+# ============================================================================
+
+
+fn test_batch_norm2d_shapes() raises:
+    """Test that batch_norm2d returns correct output shape."""
+    var shape = List[Int]()
+    shape.append(2)  # batch
+    shape.append(3)  # channels
+    shape.append(4)  # height
+    shape.append(4)  # width
+    var x = ones(shape, DType.float32)
+
+    # Create gamma, beta, running_mean, running_var for 3 channels
+    var param_shape = List[Int]()
+    param_shape.append(3)
+    var gamma = ones(param_shape, DType.float32)
+    var beta = zeros(param_shape, DType.float32)
+    var running_mean = zeros(param_shape, DType.float32)
+    var running_var = ones(param_shape, DType.float32)
+
+    # Training mode
+    var result = batch_norm2d(
+        x,
+        gamma,
+        beta,
+        running_mean,
+        running_var,
+        training=True,
+        momentum=0.1,
+        epsilon=1e-5,
+    )
+    var output = result[0]
+    var new_mean = result[1]
+    var new_var = result[2]
+
+    # Check output shape
+    assert_equal(output.shape()[0], 2)
+    assert_equal(output.shape()[1], 3)
+    assert_equal(output.shape()[2], 4)
+    assert_equal(output.shape()[3], 4)
+
+    # Check statistics shapes
+    assert_equal(new_mean.shape()[0], 3)
+    assert_equal(new_var.shape()[0], 3)
+
+
+fn test_batch_norm2d_training_mode() raises:
+    """Test that batch_norm2d computes batch statistics in training mode."""
+    var shape = List[Int]()
+    shape.append(2)  # batch
+    shape.append(1)  # channels
+    shape.append(2)  # height
+    shape.append(2)  # width
+    var x = zeros(shape, DType.float32)
+
+    # Set specific values: [0, 1, 2, 3, 4, 5, 6, 7]
+    for i in range(8):
+        x._data.bitcast[Float32]()[i] = Float32(i)
+
+    # Mean should be 3.5, variance should be computed from data
+    var param_shape = List[Int]()
+    param_shape.append(1)
+    var gamma = ones(param_shape, DType.float32)
+    var beta = zeros(param_shape, DType.float32)
+    var running_mean = zeros(param_shape, DType.float32)
+    var running_var = ones(param_shape, DType.float32)
+
+    var result2 = batch_norm2d(
+        x,
+        gamma,
+        beta,
+        running_mean,
+        running_var,
+        training=True,
+        momentum=0.1,
+        epsilon=1e-5,
+    )
+    var output = result2[0]
+    var new_mean = result2[1]
+    var new_var = result2[2]
+
+    # In training mode, running stats should be updated
+    # new_running_mean = (1 - momentum) * old + momentum * batch_mean
+    # = 0.9 * 0.0 + 0.1 * 3.5 = 0.35
+    assert_almost_equal(
+        new_mean._data.bitcast[Float32]()[0], Float32(0.35), tolerance=1e-4
+    )
+
+
+fn test_batch_norm2d_inference_mode() raises:
+    """Test that batch_norm2d uses running statistics in inference mode."""
+    var shape = List[Int]()
+    shape.append(2)  # batch
+    shape.append(1)  # channels
+    shape.append(2)  # height
+    shape.append(2)  # width
+    var x = ones(shape, DType.float32)
+
+    var param_shape = List[Int]()
+    param_shape.append(1)
+    var gamma = ones(param_shape, DType.float32)
+    var beta = zeros(param_shape, DType.float32)
+
+    # Set running statistics
+    var running_mean = zeros(param_shape, DType.float32)
+    running_mean._data.bitcast[Float32]()[0] = 0.5
+
+    var running_var = ones(param_shape, DType.float32)
+    running_var._data.bitcast[Float32]()[0] = 0.25
+
+    # Inference mode
+    var result3 = batch_norm2d(
+        x,
+        gamma,
+        beta,
+        running_mean,
+        running_var,
+        training=False,
+        momentum=0.1,
+        epsilon=1e-5,
+    )
+    var output = result3[0]
+    var new_mean = result3[1]
+    var new_var = result3[2]
+
+    # Running statistics should be unchanged in inference mode
+    assert_almost_equal(
+        new_mean._data.bitcast[Float32]()[0], Float32(0.5), tolerance=1e-5
+    )
+    assert_almost_equal(
+        new_var._data.bitcast[Float32]()[0], Float32(0.25), tolerance=1e-5
+    )
+
+    # Output should use running statistics for normalization
+    # normalized = (x - running_mean) / sqrt(running_var + eps)
+    # = (1.0 - 0.5) / sqrt(0.25 + 1e-5) ≈ 0.5 / 0.5 = 1.0
+    # output = gamma * normalized + beta = 1.0 * 1.0 + 0.0 = 1.0
+    for i in range(8):
+        assert_almost_equal(
+            output._data.bitcast[Float32]()[i], Float32(1.0), tolerance=1e-3
+        )
+
+
+fn test_batch_norm2d_scale_shift() raises:
+    """Test that batch_norm2d applies gamma and beta correctly."""
+    var shape = List[Int]()
+    shape.append(1)  # batch
+    shape.append(2)  # channels
+    shape.append(2)  # height
+    shape.append(2)  # width
+    var x = zeros(shape, DType.float32)
+
+    var param_shape = List[Int]()
+    param_shape.append(2)
+
+    # Set gamma = [2.0, 3.0], beta = [1.0, -1.0]
+    var gamma = zeros(param_shape, DType.float32)
+    gamma._data.bitcast[Float32]()[0] = 2.0
+    gamma._data.bitcast[Float32]()[1] = 3.0
+
+    var beta = zeros(param_shape, DType.float32)
+    beta._data.bitcast[Float32]()[0] = 1.0
+    beta._data.bitcast[Float32]()[1] = -1.0
+
+    var running_mean = zeros(param_shape, DType.float32)
+    var running_var = ones(param_shape, DType.float32)
+
+    # Inference mode with zero input and zero mean
+    var result4 = batch_norm2d(
+        x,
+        gamma,
+        beta,
+        running_mean,
+        running_var,
+        training=False,
+        momentum=0.1,
+        epsilon=1e-5,
+    )
+    var output = result4[0]
+
+    # For zero input with zero mean: normalized = 0
+    # output = gamma * 0 + beta = beta
+    # Channel 0: beta[0] = 1.0
+    # Channel 1: beta[1] = -1.0
+
+    # Check channel 0 values (indices 0-3)
+    for i in range(4):
+        assert_almost_equal(
+            output._data.bitcast[Float32]()[i], Float32(1.0), tolerance=1e-4
+        )
+
+    # Check channel 1 values (indices 4-7)
+    for i in range(4, 8):
+        assert_almost_equal(
+            output._data.bitcast[Float32]()[i], Float32(-1.0), tolerance=1e-4
+        )
+
+
+fn test_batch_norm2d_zero_variance() raises:
+    """Test that batch_norm2d handles zero variance with epsilon."""
+    var shape = List[Int]()
+    shape.append(2)  # batch
+    shape.append(1)  # channels
+    shape.append(1)  # height
+    shape.append(1)  # width
+    var x = ones(shape, DType.float32)  # All values are 1.0 - zero variance
+
+    var param_shape = List[Int]()
+    param_shape.append(1)
+    var gamma = ones(param_shape, DType.float32)
+    var beta = zeros(param_shape, DType.float32)
+    var running_mean = zeros(param_shape, DType.float32)
+    var running_var = ones(param_shape, DType.float32)
+
+    # This should not crash due to division by zero
+    var result5 = batch_norm2d(
+        x,
+        gamma,
+        beta,
+        running_mean,
+        running_var,
+        training=True,
+        momentum=0.1,
+        epsilon=1e-5,
+    )
+    var output = result5[0]
+
+    # All outputs should be finite
+    for i in range(2):
+        var val = output._data.bitcast[Float32]()[i]
+        assert_true(val == val)  # Not NaN
+        assert_true(val > -1e10 and val < 1e10)  # Not infinite
+
+
+# ============================================================================
+# Batch Normalization Backward Pass Tests (GRADIENT CHECKING)
+# ============================================================================
+
+
+fn test_batch_norm2d_backward_gradient_input() raises:
+    """Test batch_norm2d_backward gradient w.r.t. input using numerical validation.
+
+    CRITICAL TEST: Validates mathematical correctness of batch norm backpropagation.
+    Uses central finite differences for gold-standard gradient validation.
+
+    Uses non-uniform grad_output to avoid the pathological case where
+    grad_output=ones gives analytically-zero gradients (sum(x_norm)=0 cancellation),
+    which would make the test sensitive to floating-point noise in the forward pass.
+    """
+    # Small tensor for gradient checking (computational cost is O(n²))
+    var shape = List[Int]()
+    shape.append(2)  # batch
+    shape.append(2)  # channels
+    shape.append(2)  # height
+    shape.append(2)  # width
+
+    # Create test input with varying values
+    var x = zeros(shape, DType.float32)
+    for i in range(16):
+        x._data.bitcast[Float32]()[i] = Float32(i) * 0.1
+
+    # Parameters
+    var param_shape = List[Int]()
+    param_shape.append(2)
+    var gamma = ones(param_shape, DType.float32)
+    gamma._data.bitcast[Float32]()[0] = 1.5
+    gamma._data.bitcast[Float32]()[1] = 2.0
+
+    var beta = zeros(param_shape, DType.float32)
+    var running_mean = zeros(param_shape, DType.float32)
+    var running_var = ones(param_shape, DType.float32)
+
+    # Forward pass
+    var result6 = batch_norm2d(
+        x, gamma, beta, running_mean, running_var, training=True, epsilon=1e-5
+    )
+    var output = result6[0]
+
+    # Use non-uniform grad_output to avoid the pathological cancellation case
+    # where grad_output=ones gives dL/dx ~ sum(x_norm)=0 (analytically zero gradient).
+    # Non-uniform weights break the symmetry, producing non-zero testable gradients.
+    var grad_output = zeros_like(output)
+    for i in range(16):
+        # Alternating pattern to avoid symmetry: [0.5, -0.3, 0.8, -0.2, ...]
+        var val = Float32(i % 4) * Float32(0.25) - Float32(0.3)
+        grad_output._data.bitcast[Float32]()[i] = val
+
+    # Backward pass
+    var result7 = batch_norm2d_backward(
+        grad_output,
+        x,
+        gamma,
+        running_mean,
+        running_var,
+        training=True,
+        epsilon=1e-5,
+    )
+    var grad_input = result7[0]
+
+    # Numerical gradient via finite differences.
+    # forward_for_grad computes weighted sum: sum(output * grad_output)
+    # so the numerical gradient matches what the backward should compute.
+    fn forward_for_grad(inp: ExTensor) raises -> ExTensor:
+        var result_nested = batch_norm2d(
+            inp,
+            gamma,
+            beta,
+            running_mean,
+            running_var,
+            training=True,
+            epsilon=1e-5,
+        )
+        var out = result_nested[0]
+        # Compute weighted sum: sum(output * grad_output)
+        # This matches the backward with our non-uniform grad_output
+        var weighted = multiply(out, grad_output)
+        var result = weighted
+        while result.dim() > 0:
+            result = reduce_sum(result, axis=0, keepdims=False)
+        return result
+
+    var numerical_grad = compute_numerical_gradient(
+        forward_for_grad, x, epsilon=1e-3
+    )
+
+    # Validate analytical gradient matches numerical gradient
+    # Looser tolerance for batch norm (complex operation with many intermediate steps)
+    # rtol=2e-2 (2%) to accommodate batch norm's compounding of floating-point errors
+    # across normalization, scale, and shift operations.
+    assert_gradients_close(
+        grad_input,
+        numerical_grad,
+        rtol=2e-2,
+        atol=1e-4,
+        message="Batch norm gradient w.r.t. input",
+    )
+
+    print("✓ Batch norm backward gradient (input) validated numerically")
+
+
+fn test_batch_norm2d_backward_gradient_input_inference_mode() raises:
+    """Numerical gradient validation for batch_norm2d_backward in inference mode.
+
+    Inference mode uses fixed running_mean/running_var, giving a simpler
+    linear gradient: grad_input = grad_output * gamma / sqrt(running_var + eps).
+    Validates the inference code path in batch_norm2d_backward independently
+    from training mode.
+    """
+    # Small tensor: batch=2, channels=2, height=2, width=2 (16 elements)
+    var shape = List[Int]()
+    shape.append(2)  # batch
+    shape.append(2)  # channels
+    shape.append(2)  # height
+    shape.append(2)  # width
+
+    # Input with varying values
+    var x = zeros(shape, DType.float32)
+    for i in range(16):
+        x._data.bitcast[Float32]()[i] = Float32(i) * 0.1
+
+    # Parameters: non-unit gamma, non-zero running stats per channel
+    var param_shape = List[Int]()
+    param_shape.append(2)
+    var gamma = ones(param_shape, DType.float32)
+    gamma._data.bitcast[Float32]()[0] = 1.5
+    gamma._data.bitcast[Float32]()[1] = 2.0
+
+    var beta = zeros(param_shape, DType.float32)
+
+    var running_mean = zeros(param_shape, DType.float32)
+    running_mean._data.bitcast[Float32]()[0] = 0.3
+    running_mean._data.bitcast[Float32]()[1] = 0.7
+
+    var running_var = ones(param_shape, DType.float32)
+    running_var._data.bitcast[Float32]()[0] = 0.5
+    running_var._data.bitcast[Float32]()[1] = 1.5
+
+    # Forward pass in inference mode (running stats frozen)
+    var result_fwd = batch_norm2d(
+        x,
+        gamma,
+        beta,
+        running_mean,
+        running_var,
+        training=False,
+        epsilon=1e-5,
+    )
+    var output = result_fwd[0]
+
+    # Use ones grad_output: in inference mode, grad_input = grad_output * gamma / std
+    # which is non-zero for grad_output=ones (no cancellation issue unlike training mode)
+    var grad_output = ones_like(output)
+
+    # Analytical backward pass in inference mode
+    var result_bwd = batch_norm2d_backward(
+        grad_output,
+        x,
+        gamma,
+        running_mean,
+        running_var,
+        training=False,
+        epsilon=1e-5,
+    )
+    var grad_input = result_bwd[0]
+
+    # Numerical gradient: closure uses training=False with fixed running stats
+    fn forward_for_grad_infer(inp: ExTensor) raises -> ExTensor:
+        var res = batch_norm2d(
+            inp,
+            gamma,
+            beta,
+            running_mean,
+            running_var,
+            training=False,
+            epsilon=1e-5,
+        )
+        var out = res[0]
+        # Weighted sum matching our grad_output=ones backward
+        var weighted = multiply(out, grad_output)
+        var result = weighted
+        while result.dim() > 0:
+            result = reduce_sum(result, axis=0, keepdims=False)
+        return result
+
+    var numerical_grad = compute_numerical_gradient(
+        forward_for_grad_infer, x, epsilon=3e-4
+    )
+
+    # Inference mode gradient is a simple linear rescaling; tolerances can be tight
+    assert_gradients_close(
+        grad_input,
+        numerical_grad,
+        rtol=1e-2,
+        atol=1e-5,
+        message="Batch norm inference mode gradient w.r.t. input",
+    )
+
+    print(
+        "✓ Batch norm backward gradient (input) inference mode validated"
+        " numerically"
+    )
+
+
+fn test_batch_norm2d_backward_gradient_gamma() raises:
+    """Test batch_norm2d_backward gradient w.r.t. gamma using numerical validation.
+
+    Perturbs gamma using finite differences and compares against analytical grad_gamma.
+    Uses non-uniform grad_output to test sensitivity across channels.
+    """
+    var shape = List[Int]()
+    shape.append(2)  # batch
+    shape.append(2)  # channels
+    shape.append(2)  # height
+    shape.append(2)  # width
+
+    var x = zeros(shape, DType.float32)
+    for i in range(16):
+        x._data.bitcast[Float32]()[i] = Float32(i) * 0.1
+
+    var param_shape = List[Int]()
+    param_shape.append(2)
+
+    var gamma = ones(param_shape, DType.float32)
+    gamma._data.bitcast[Float32]()[0] = 1.5
+    gamma._data.bitcast[Float32]()[1] = 2.0
+
+    var beta = zeros(param_shape, DType.float32)
+    var running_mean = zeros(param_shape, DType.float32)
+    var running_var = ones(param_shape, DType.float32)
+
+    # Forward pass to get output shape for grad_output
+    var result_fwd = batch_norm2d(
+        x, gamma, beta, running_mean, running_var, training=True, epsilon=1e-5
+    )
+    var output = result_fwd[0]
+
+    # Non-uniform grad_output to exercise per-channel sensitivity
+    var grad_output = zeros_like(output)
+    for i in range(16):
+        grad_output._data.bitcast[Float32]()[i] = Float32(i + 1) * 0.1
+
+    # Analytical gradient
+    var result_bwd = batch_norm2d_backward(
+        grad_output,
+        x,
+        gamma,
+        running_mean,
+        running_var,
+        training=True,
+        epsilon=1e-5,
+    )
+    var grad_gamma_analytical = result_bwd[1]
+
+    # Numerical gradient: perturb gamma
+    # The forward closure computes: sum(batch_norm2d(x, g, ...) * grad_output)
+    # so the numerical gradient matches what batch_norm2d_backward should produce.
+    fn forward_for_gamma(g: ExTensor) raises -> ExTensor:
+        var res = batch_norm2d(
+            x, g, beta, running_mean, running_var, training=True, epsilon=1e-5
+        )
+        var out = res[0]
+        var weighted = multiply(out, grad_output)
+        var result = weighted
+        while result.dim() > 0:
+            result = reduce_sum(result, axis=0, keepdims=False)
+        return result
+
+    var numerical_grad_gamma = compute_numerical_gradient(
+        forward_for_gamma, gamma, epsilon=1e-3
+    )
+
+    assert_gradients_close(
+        grad_gamma_analytical,
+        numerical_grad_gamma,
+        rtol=1e-2,
+        atol=1e-4,
+        message="Batch norm gradient w.r.t. gamma",
+    )
+    print("✓ Batch norm backward gradient (gamma) validated numerically")
+
+
+# ============================================================================
+# Main Test Runner
+# ============================================================================
+
+
+fn main() raises:
+    """Run batch normalization forward and first backward tests."""
+    print("Running normalization part1 tests...")
+
+    # Batch normalization tests
+    test_batch_norm2d_shapes()
+    print("✓ test_batch_norm2d_shapes")
+
+    test_batch_norm2d_training_mode()
+    print("✓ test_batch_norm2d_training_mode")
+
+    test_batch_norm2d_inference_mode()
+    print("✓ test_batch_norm2d_inference_mode")
+
+    test_batch_norm2d_scale_shift()
+    print("✓ test_batch_norm2d_scale_shift")
+
+    test_batch_norm2d_zero_variance()
+    print("✓ test_batch_norm2d_zero_variance")
+
+    # Batch normalization backward pass tests (gradient checking)
+    test_batch_norm2d_backward_gradient_input()
+    print("✓ test_batch_norm2d_backward_gradient_input")
+
+    test_batch_norm2d_backward_gradient_input_inference_mode()
+    print("✓ test_batch_norm2d_backward_gradient_input_inference_mode")
+
+    test_batch_norm2d_backward_gradient_gamma()
+    print("✓ test_batch_norm2d_backward_gradient_gamma")
+
+    print("\nAll normalization part1 tests passed!")

--- a/tests/shared/core/test_normalization_part2.mojo
+++ b/tests/shared/core/test_normalization_part2.mojo
@@ -1,0 +1,425 @@
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_normalization.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for batch normalization backward (continued) and layer normalization forward.
+
+Tests cover:
+- Batch normalization backward: gradient beta
+- Batch normalization backward: training vs inference
+- Batch normalization backward: shapes
+- Layer normalization shapes (2D and 4D inputs)
+- Layer normalization normalization correctness
+- Layer normalization scale/shift
+- Layer normalization zero variance
+- Layer normalization backward shapes (2D)
+
+All tests use pure functional API.
+"""
+
+from tests.shared.conftest import (
+    assert_almost_equal,
+    assert_close_float,
+    assert_equal,
+    assert_equal_int,
+    assert_shape,
+    assert_shape_equal,
+    assert_true,
+)
+from tests.shared.conftest import TestFixtures
+from shared.testing import (
+    compute_numerical_gradient,
+    assert_gradients_close,
+)
+from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.normalization import (
+    batch_norm2d,
+    batch_norm2d_backward,
+    layer_norm,
+    layer_norm_backward,
+)
+from shared.core.arithmetic import add, subtract, multiply
+from shared.core.reduction import sum as reduce_sum
+
+
+# ============================================================================
+# Batch Normalization Backward Pass Tests (continued)
+# ============================================================================
+
+
+fn test_batch_norm2d_backward_gradient_beta() raises:
+    """Test batch_norm2d_backward gradient w.r.t. beta using numerical validation.
+
+    Perturbs beta using finite differences and compares against analytical grad_beta.
+    beta contributes additively, so grad_beta = sum(grad_output) over batch and spatial dims.
+    """
+    var shape = List[Int]()
+    shape.append(2)  # batch
+    shape.append(2)  # channels
+    shape.append(2)  # height
+    shape.append(2)  # width
+
+    var x = zeros(shape, DType.float32)
+    for i in range(16):
+        x._data.bitcast[Float32]()[i] = Float32(i) * 0.1
+
+    var param_shape = List[Int]()
+    param_shape.append(2)
+
+    var gamma = ones(param_shape, DType.float32)
+    gamma._data.bitcast[Float32]()[0] = 1.5
+    gamma._data.bitcast[Float32]()[1] = 2.0
+
+    var beta = zeros(param_shape, DType.float32)
+    beta._data.bitcast[Float32]()[0] = 0.5
+    beta._data.bitcast[Float32]()[1] = -0.5
+
+    var running_mean = zeros(param_shape, DType.float32)
+    var running_var = ones(param_shape, DType.float32)
+
+    # Forward pass to get output shape for grad_output
+    var result_fwd = batch_norm2d(
+        x, gamma, beta, running_mean, running_var, training=True, epsilon=1e-5
+    )
+    var output = result_fwd[0]
+
+    # Non-uniform grad_output
+    var grad_output = zeros_like(output)
+    for i in range(16):
+        grad_output._data.bitcast[Float32]()[i] = Float32(i + 1) * 0.1
+
+    # Analytical gradient
+    var result_bwd = batch_norm2d_backward(
+        grad_output,
+        x,
+        gamma,
+        running_mean,
+        running_var,
+        training=True,
+        epsilon=1e-5,
+    )
+    var grad_beta_analytical = result_bwd[2]
+
+    # Numerical gradient: perturb beta
+    fn forward_for_beta(b: ExTensor) raises -> ExTensor:
+        var res = batch_norm2d(
+            x, gamma, b, running_mean, running_var, training=True, epsilon=1e-5
+        )
+        var out = res[0]
+        var weighted = multiply(out, grad_output)
+        var result = weighted
+        while result.dim() > 0:
+            result = reduce_sum(result, axis=0, keepdims=False)
+        return result
+
+    var numerical_grad_beta = compute_numerical_gradient(
+        forward_for_beta, beta, epsilon=1e-3
+    )
+
+    assert_gradients_close(
+        grad_beta_analytical,
+        numerical_grad_beta,
+        rtol=1e-2,
+        atol=1e-4,
+        message="Batch norm gradient w.r.t. beta",
+    )
+    print("✓ Batch norm backward gradient (beta) validated numerically")
+
+
+fn test_batch_norm2d_backward_training_vs_inference() raises:
+    """Test that batch_norm2d_backward behaves differently in training vs inference.
+
+    Training mode: Gradients flow through batch statistics
+    Inference mode: Gradients bypass statistics (use running stats).
+    """
+    var shape = List[Int]()
+    shape.append(2)  # batch
+    shape.append(1)  # channels
+    shape.append(2)  # height
+    shape.append(2)  # width
+
+    var x = zeros(shape, DType.float32)
+    for i in range(8):
+        x._data.bitcast[Float32]()[i] = Float32(i)
+
+    var param_shape = List[Int]()
+    param_shape.append(1)
+    var gamma = ones(param_shape, DType.float32)
+    gamma._data.bitcast[Float32]()[0] = 2.0
+
+    var beta = zeros(param_shape, DType.float32)
+    var running_mean = zeros(param_shape, DType.float32)
+    var running_var = ones(param_shape, DType.float32)
+
+    # Forward passes
+    var result8 = batch_norm2d(
+        x, gamma, beta, running_mean, running_var, training=True
+    )
+    var out_train = result8[0]
+    var result9 = batch_norm2d(
+        x, gamma, beta, running_mean, running_var, training=False
+    )
+    var out_infer = result9[0]
+
+    var grad_output = ones_like(out_train)
+
+    # Backward passes
+    var result10 = batch_norm2d_backward(
+        grad_output, x, gamma, running_mean, running_var, training=True
+    )
+    var grad_train = result10[0]
+    var result11 = batch_norm2d_backward(
+        grad_output, x, gamma, running_mean, running_var, training=False
+    )
+    var grad_infer = result11[0]
+
+    # Gradients should differ between training and inference modes
+    var diff_found = False
+    for i in range(8):
+        var diff = abs(
+            grad_train._data.bitcast[Float32]()[i]
+            - grad_infer._data.bitcast[Float32]()[i]
+        )
+        if diff > 1e-5:
+            diff_found = True
+            break
+
+    assert_true(diff_found, "Training and inference gradients should differ")
+    print("✓ Batch norm backward: training vs inference modes differ correctly")
+
+
+fn test_batch_norm2d_backward_shapes() raises:
+    """Test that batch_norm2d_backward returns correct gradient shapes."""
+    var shape = List[Int]()
+    shape.append(3)  # batch
+    shape.append(4)  # channels
+    shape.append(5)  # height
+    shape.append(5)  # width
+
+    var x = ones(shape, DType.float32)
+    var grad_output = ones(shape, DType.float32)
+
+    var param_shape = List[Int]()
+    param_shape.append(4)
+    var gamma = ones(param_shape, DType.float32)
+    var running_mean = zeros(param_shape, DType.float32)
+    var running_var = ones(param_shape, DType.float32)
+
+    var result12 = batch_norm2d_backward(
+        grad_output, x, gamma, running_mean, running_var, training=True
+    )
+    var grad_input = result12[0]
+    var grad_gamma = result12[1]
+    var grad_beta = result12[2]
+
+    # Validate shapes
+    assert_shape_equal(
+        grad_input.shape(), x.shape(), "grad_input should match input shape"
+    )
+    assert_shape_equal(
+        grad_gamma.shape(), gamma.shape(), "grad_gamma should match gamma shape"
+    )
+    assert_shape_equal(
+        grad_beta.shape(), gamma.shape(), "grad_beta should match beta shape"
+    )
+
+    # Check specific dimensions
+    assert_equal(grad_input.shape()[0], 3, "batch dimension")
+    assert_equal(grad_input.shape()[1], 4, "channels dimension")
+    assert_equal(grad_gamma.shape()[0], 4, "gamma channels")
+    assert_equal(grad_beta.shape()[0], 4, "beta channels")
+
+
+# ============================================================================
+# Layer Normalization Tests
+# ============================================================================
+
+
+fn test_layer_norm_shapes_2d() raises:
+    """Test that layer_norm returns correct shape for 2D input."""
+    var shape = List[Int]()
+    shape.append(4)  # batch
+    shape.append(10)  # features
+    var x = ones(shape, DType.float32)
+
+    var param_shape = List[Int]()
+    param_shape.append(10)
+    var gamma = ones(param_shape, DType.float32)
+    var beta = zeros(param_shape, DType.float32)
+
+    var output = layer_norm(x, gamma, beta, epsilon=1e-5)
+
+    # Check output shape
+    assert_equal(output.shape()[0], 4)
+    assert_equal(output.shape()[1], 10)
+
+
+fn test_layer_norm_shapes_4d() raises:
+    """Test that layer_norm returns correct shape for 4D input."""
+    var shape = List[Int]()
+    shape.append(2)  # batch
+    shape.append(3)  # channels
+    shape.append(4)  # height
+    shape.append(4)  # width
+    var x = ones(shape, DType.float32)
+
+    # For 4D input, normalize over C*H*W
+    var normalized_shape = 3 * 4 * 4  # 48
+    var param_shape = List[Int]()
+    param_shape.append(normalized_shape)
+    var gamma = ones(param_shape, DType.float32)
+    var beta = zeros(param_shape, DType.float32)
+
+    var output = layer_norm(x, gamma, beta, epsilon=1e-5)
+
+    # Check output shape
+    assert_equal(output.shape()[0], 2)
+    assert_equal(output.shape()[1], 3)
+    assert_equal(output.shape()[2], 4)
+    assert_equal(output.shape()[3], 4)
+
+
+fn test_layer_norm_normalization_2d() raises:
+    """Test that layer_norm normalizes each sample independently."""
+    var shape = List[Int]()
+    shape.append(2)  # batch
+    shape.append(4)  # features
+    var x = zeros(shape, DType.float32)
+
+    # Sample 1: [0, 1, 2, 3]
+    x._data.bitcast[Float32]()[0] = 0.0
+    x._data.bitcast[Float32]()[1] = 1.0
+    x._data.bitcast[Float32]()[2] = 2.0
+    x._data.bitcast[Float32]()[3] = 3.0
+
+    # Sample 2: [4, 5, 6, 7]
+    x._data.bitcast[Float32]()[4] = 4.0
+    x._data.bitcast[Float32]()[5] = 5.0
+    x._data.bitcast[Float32]()[6] = 6.0
+    x._data.bitcast[Float32]()[7] = 7.0
+
+    var param_shape = List[Int]()
+    param_shape.append(4)
+    var gamma = ones(param_shape, DType.float32)
+    var beta = zeros(param_shape, DType.float32)
+
+    var output = layer_norm(x, gamma, beta, epsilon=1e-5)
+
+    # For each sample, mean should be 0 and variance should be 1 (approximately)
+    # Sample 1 mean: (0+1+2+3)/4 = 1.5
+    # Sample 1 std: sqrt(((0-1.5)^2 + (1-1.5)^2 + (2-1.5)^2 + (3-1.5)^2)/4) ≈ 1.118
+
+    # After normalization: (x - mean) / std
+    # Sample 1[0]: (0 - 1.5) / 1.118 ≈ -1.34
+    # Sample 1[1]: (1 - 1.5) / 1.118 ≈ -0.45
+    # Sample 1[2]: (2 - 1.5) / 1.118 ≈ 0.45
+    # Sample 1[3]: (3 - 1.5) / 1.118 ≈ 1.34
+
+    # Check that first sample has approximately zero mean
+    var sum1 = Float32(0.0)
+    for i in range(4):
+        sum1 += output._data.bitcast[Float32]()[i]
+    var mean1 = sum1 / 4.0
+    assert_almost_equal(mean1, Float32(0.0), tolerance=1e-5)
+
+    # Check that second sample has approximately zero mean
+    var sum2 = Float32(0.0)
+    for i in range(4, 8):
+        sum2 += output._data.bitcast[Float32]()[i]
+    var mean2 = sum2 / 4.0
+    assert_almost_equal(mean2, Float32(0.0), tolerance=1e-5)
+
+
+fn test_layer_norm_scale_shift() raises:
+    """Test that layer_norm applies gamma and beta correctly."""
+    var shape = List[Int]()
+    shape.append(1)  # batch
+    shape.append(3)  # features
+    var x = zeros(shape, DType.float32)
+
+    var param_shape = List[Int]()
+    param_shape.append(3)
+
+    # Set gamma = [2.0, 3.0, 4.0], beta = [1.0, 0.0, -1.0]
+    var gamma = zeros(param_shape, DType.float32)
+    gamma._data.bitcast[Float32]()[0] = 2.0
+    gamma._data.bitcast[Float32]()[1] = 3.0
+    gamma._data.bitcast[Float32]()[2] = 4.0
+
+    var beta = zeros(param_shape, DType.float32)
+    beta._data.bitcast[Float32]()[0] = 1.0
+    beta._data.bitcast[Float32]()[1] = 0.0
+    beta._data.bitcast[Float32]()[2] = -1.0
+
+    var output = layer_norm(x, gamma, beta, epsilon=1e-5)
+
+    # For zero input with zero mean: normalized = 0
+    # output = gamma * 0 + beta = beta
+    assert_almost_equal(
+        output._data.bitcast[Float32]()[0], Float32(1.0), tolerance=1e-4
+    )
+    assert_almost_equal(
+        output._data.bitcast[Float32]()[1], Float32(0.0), tolerance=1e-4
+    )
+    assert_almost_equal(
+        output._data.bitcast[Float32]()[2], Float32(-1.0), tolerance=1e-4
+    )
+
+
+fn test_layer_norm_zero_variance() raises:
+    """Test that layer_norm handles zero variance with epsilon."""
+    var shape = List[Int]()
+    shape.append(2)  # batch
+    shape.append(3)  # features
+    var x = ones(shape, DType.float32)  # All values are 1.0 - zero variance
+
+    var param_shape = List[Int]()
+    param_shape.append(3)
+    var gamma = ones(param_shape, DType.float32)
+    var beta = zeros(param_shape, DType.float32)
+
+    # This should not crash due to division by zero
+    var output = layer_norm(x, gamma, beta, epsilon=1e-5)
+
+    # All outputs should be finite
+    for i in range(6):
+        var val = output._data.bitcast[Float32]()[i]
+        assert_true(val == val)  # Not NaN
+        assert_true(val > -1e10 and val < 1e10)  # Not infinite
+
+
+# ============================================================================
+# Main Test Runner
+# ============================================================================
+
+
+fn main() raises:
+    """Run batch normalization backward (continued) and layer norm forward tests."""
+    print("Running normalization part2 tests...")
+
+    # Batch normalization backward pass tests (continued)
+    test_batch_norm2d_backward_gradient_beta()
+    print("✓ test_batch_norm2d_backward_gradient_beta")
+
+    test_batch_norm2d_backward_training_vs_inference()
+    print("✓ test_batch_norm2d_backward_training_vs_inference")
+
+    test_batch_norm2d_backward_shapes()
+    print("✓ test_batch_norm2d_backward_shapes")
+
+    # Layer normalization tests
+    test_layer_norm_shapes_2d()
+    print("✓ test_layer_norm_shapes_2d")
+
+    test_layer_norm_shapes_4d()
+    print("✓ test_layer_norm_shapes_4d")
+
+    test_layer_norm_normalization_2d()
+    print("✓ test_layer_norm_normalization_2d")
+
+    test_layer_norm_scale_shift()
+    print("✓ test_layer_norm_scale_shift")
+
+    test_layer_norm_zero_variance()
+    print("✓ test_layer_norm_zero_variance")
+
+    print("\nAll normalization part2 tests passed!")

--- a/tests/shared/core/test_normalization_part3.mojo
+++ b/tests/shared/core/test_normalization_part3.mojo
@@ -1,0 +1,284 @@
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_normalization.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for layer normalization backward pass.
+
+Tests cover:
+- Layer normalization backward shapes (2D and 4D)
+- Layer normalization backward grad_beta
+- Layer normalization backward zero input edge case
+- Layer normalization backward gradient input (numerical validation)
+
+All tests use pure functional API.
+"""
+
+from tests.shared.conftest import (
+    assert_almost_equal,
+    assert_close_float,
+    assert_equal,
+    assert_equal_int,
+    assert_shape,
+    assert_shape_equal,
+    assert_true,
+)
+from tests.shared.conftest import TestFixtures
+from shared.testing import (
+    compute_numerical_gradient,
+    assert_gradients_close,
+)
+from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.normalization import (
+    batch_norm2d,
+    batch_norm2d_backward,
+    layer_norm,
+    layer_norm_backward,
+)
+from shared.core.arithmetic import add, subtract, multiply
+from shared.core.reduction import sum as reduce_sum
+
+
+# ============================================================================
+# Layer Normalization Backward Pass Tests
+# ============================================================================
+
+
+fn test_layer_norm_backward_shapes_2d() raises:
+    """Test that layer_norm_backward returns correct gradient shapes for 2D input.
+    """
+    var shape = List[Int]()
+    shape.append(4)  # batch
+    shape.append(10)  # features
+    var x = ones(shape, DType.float32)
+    var grad_output = ones(shape, DType.float32)
+
+    var param_shape = List[Int]()
+    param_shape.append(10)
+    var gamma = ones(param_shape, DType.float32)
+
+    var result13 = layer_norm_backward(grad_output, x, gamma, epsilon=1e-5)
+    var grad_input = result13[0]
+    var grad_gamma = result13[1]
+    var grad_beta = result13[2]
+
+    # Validate shapes
+    assert_shape_equal(
+        grad_input.shape(), x.shape(), "grad_input should match input shape"
+    )
+    assert_shape_equal(
+        grad_gamma.shape(), gamma.shape(), "grad_gamma should match gamma shape"
+    )
+    assert_shape_equal(
+        grad_beta.shape(), gamma.shape(), "grad_beta should match beta shape"
+    )
+
+    # Check specific dimensions
+    assert_equal(grad_input.shape()[0], 4, "batch dimension")
+    assert_equal(grad_input.shape()[1], 10, "features dimension")
+    assert_equal(grad_gamma.shape()[0], 10, "gamma features")
+    assert_equal(grad_beta.shape()[0], 10, "beta features")
+
+
+fn test_layer_norm_backward_shapes_4d() raises:
+    """Test that layer_norm_backward returns correct gradient shapes for 4D input.
+    """
+    var shape = List[Int]()
+    shape.append(2)  # batch
+    shape.append(3)  # channels
+    shape.append(4)  # height
+    shape.append(4)  # width
+    var x = ones(shape, DType.float32)
+    var grad_output = ones(shape, DType.float32)
+
+    # For 4D input, gamma has shape (C * H * W)
+    var normalized_size = 3 * 4 * 4  # 48
+    var param_shape = List[Int]()
+    param_shape.append(normalized_size)
+    var gamma = ones(param_shape, DType.float32)
+
+    var result14 = layer_norm_backward(grad_output, x, gamma, epsilon=1e-5)
+    var grad_input = result14[0]
+    var grad_gamma = result14[1]
+    var grad_beta = result14[2]
+
+    # Validate shapes
+    assert_shape_equal(
+        grad_input.shape(), x.shape(), "grad_input should match input shape"
+    )
+    assert_shape_equal(
+        grad_gamma.shape(), gamma.shape(), "grad_gamma should match gamma shape"
+    )
+    assert_shape_equal(
+        grad_beta.shape(), gamma.shape(), "grad_beta should match beta shape"
+    )
+
+
+fn test_layer_norm_backward_grad_beta() raises:
+    """Test that layer_norm_backward grad_beta equals sum of grad_output over batch.
+    """
+    var shape = List[Int]()
+    shape.append(3)  # batch
+    shape.append(4)  # features
+    var x = zeros(shape, DType.float32)
+
+    # Set varying input values
+    for i in range(12):
+        x._data.bitcast[Float32]()[i] = Float32(i) * 0.1
+
+    var param_shape = List[Int]()
+    param_shape.append(4)
+    var gamma = ones(param_shape, DType.float32)
+
+    # Create varying grad_output
+    var grad_output = zeros(shape, DType.float32)
+    for b in range(3):
+        for f in range(4):
+            var idx = b * 4 + f
+            grad_output._data.bitcast[Float32]()[idx] = (
+                Float32(b + 1) * Float32(f + 1) * 0.1
+            )
+
+    var result15 = layer_norm_backward(grad_output, x, gamma, epsilon=1e-5)
+    var grad_beta = result15[2]
+
+    # grad_beta should be sum over batch dimension
+    # For each feature f: grad_beta[f] = sum over b of grad_output[b, f]
+    for f in range(4):
+        var expected_sum = Float32(0.0)
+        for b in range(3):
+            expected_sum += Float32(b + 1) * Float32(f + 1) * 0.1
+        assert_almost_equal(
+            grad_beta._data.bitcast[Float32]()[f], expected_sum, tolerance=1e-4
+        )
+
+
+fn test_layer_norm_backward_zero_input() raises:
+    """Test layer_norm_backward with zero input (edge case)."""
+    var shape = List[Int]()
+    shape.append(2)  # batch
+    shape.append(4)  # features
+    var x = zeros(shape, DType.float32)  # All zeros - zero variance
+
+    var param_shape = List[Int]()
+    param_shape.append(4)
+    var gamma = ones(param_shape, DType.float32)
+    var grad_output = ones(shape, DType.float32)
+
+    # Should not crash with zero variance
+    var result16 = layer_norm_backward(grad_output, x, gamma, epsilon=1e-5)
+    var grad_input = result16[0]
+    var grad_gamma = result16[1]
+    var grad_beta = result16[2]
+
+    # All gradients should be finite
+    for i in range(8):
+        var val = grad_input._data.bitcast[Float32]()[i]
+        assert_true(val == val, "grad_input should not be NaN")
+        assert_true(val > -1e10 and val < 1e10, "grad_input should be finite")
+
+    for i in range(4):
+        var val_gamma = grad_gamma._data.bitcast[Float32]()[i]
+        var val_beta = grad_beta._data.bitcast[Float32]()[i]
+        assert_true(val_gamma == val_gamma, "grad_gamma should not be NaN")
+        assert_true(val_beta == val_beta, "grad_beta should not be NaN")
+
+
+fn test_layer_norm_backward_gradient_input() raises:
+    """Test layer_norm_backward gradient w.r.t. input using numerical validation.
+
+    CRITICAL TEST: Validates mathematical correctness of layer norm backpropagation.
+    Uses central finite differences for gold-standard gradient validation.
+    Uses non-uniform grad_output to prevent algebraic cancellation masking bugs.
+
+    When grad_output=ones, sum(grad_output * x_hat) = sum(x_hat) = 0 by normalization,
+    making the last term in the backward formula vanish. Non-uniform grad_output
+    ensures sum(grad_output * x_hat) != 0, exercising the full backward formula.
+    """
+    # Small 2D tensor: (batch=2, features=4)
+    var shape = List[Int]()
+    shape.append(2)
+    shape.append(4)
+
+    # Input with varying values (not uniform, not zero)
+    var x = zeros(shape, DType.float32)
+    for i in range(8):
+        x._data.bitcast[Float32]()[i] = Float32(i) * 0.1 + 0.05
+
+    # Parameters: non-trivial gamma, zero beta
+    var param_shape = List[Int]()
+    param_shape.append(4)
+    var gamma = ones(param_shape, DType.float32)
+    gamma._data.bitcast[Float32]()[0] = 1.5
+    gamma._data.bitcast[Float32]()[1] = 0.8
+    gamma._data.bitcast[Float32]()[2] = 1.2
+    gamma._data.bitcast[Float32]()[3] = 2.0
+    var beta = zeros(param_shape, DType.float32)
+
+    # Non-uniform grad_output: critical to avoid algebraic cancellation
+    var grad_output = zeros(shape, DType.float32)
+    grad_output._data.bitcast[Float32]()[0] = 0.3
+    grad_output._data.bitcast[Float32]()[1] = -0.5
+    grad_output._data.bitcast[Float32]()[2] = 1.2
+    grad_output._data.bitcast[Float32]()[3] = -0.8
+    grad_output._data.bitcast[Float32]()[4] = 0.7
+    grad_output._data.bitcast[Float32]()[5] = -0.2
+    grad_output._data.bitcast[Float32]()[6] = 0.9
+    grad_output._data.bitcast[Float32]()[7] = -1.1
+
+    # Analytical backward pass
+    var result = layer_norm_backward(grad_output, x, gamma, epsilon=1e-5)
+    var grad_input = result[0]
+
+    # Numerical gradient via finite differences.
+    # The scalar loss is sum(layer_norm(x) * grad_output), so the numerical
+    # gradient matches what layer_norm_backward(grad_output, x, gamma) computes.
+    fn forward_for_grad(inp: ExTensor) raises -> ExTensor:
+        var out = layer_norm(inp, gamma, beta, epsilon=1e-5)
+        # Weighted sum: sum(out * grad_output) matches backward with non-uniform grad_output
+        var weighted = multiply(out, grad_output)
+        var result_inner = weighted
+        while result_inner.dim() > 0:
+            result_inner = reduce_sum(result_inner, axis=0, keepdims=False)
+        return result_inner
+
+    var numerical_grad = compute_numerical_gradient(
+        forward_for_grad, x, epsilon=1e-4
+    )
+
+    # Validate analytical gradient matches numerical gradient
+    assert_gradients_close(
+        grad_input,
+        numerical_grad,
+        rtol=1e-2,
+        atol=1e-5,
+        message="Layer norm gradient w.r.t. input",
+    )
+
+    print("✓ Layer norm backward gradient (input) validated numerically")
+
+
+# ============================================================================
+# Main Test Runner
+# ============================================================================
+
+
+fn main() raises:
+    """Run layer normalization backward tests."""
+    print("Running normalization part3 tests...")
+
+    # Layer normalization backward pass tests
+    test_layer_norm_backward_shapes_2d()
+    print("✓ test_layer_norm_backward_shapes_2d")
+
+    test_layer_norm_backward_shapes_4d()
+    print("✓ test_layer_norm_backward_shapes_4d")
+
+    test_layer_norm_backward_grad_beta()
+    print("✓ test_layer_norm_backward_grad_beta")
+
+    test_layer_norm_backward_zero_input()
+    print("✓ test_layer_norm_backward_zero_input")
+
+    test_layer_norm_backward_gradient_input()
+    print("✓ test_layer_norm_backward_gradient_input")
+
+    print("\nAll normalization part3 tests passed!")


### PR DESCRIPTION
## Summary

- Splits `tests/shared/core/test_normalization.mojo` (21 `fn test_` functions, exceeding ADR-009 limit) into 3 files of ≤8 tests each
- Fixes intermittent heap corruption crashes (`libKGENCompilerRTShared.so` JIT fault) in the `Core NN Modules` CI group

## Changes Made

- **Deleted**: `tests/shared/core/test_normalization.mojo` (21 tests)
- **Created**: `tests/shared/core/test_normalization_part1.mojo` (8 tests — batch norm forward + first backward)
- **Created**: `tests/shared/core/test_normalization_part2.mojo` (8 tests — batch norm backward continued + layer norm forward)
- **Created**: `tests/shared/core/test_normalization_part3.mojo` (5 tests — layer norm backward pass)
- **Updated**: `.github/workflows/comprehensive-tests.yml` — `Core Utilities` group now references the 3 new filenames

Each new file includes the ADR-009 tracking comment header. All 21 original test cases are preserved.

## Verification

- All pre-commit hooks pass (Mojo format, YAML check, test coverage validation, etc.)
- Test count per file: 8, 8, 5 — all ≤ ADR-009 limit of 10

Closes #3461