### PR TITLE
fix(ci): split test_image_transforms.mojo (15 tests) per ADR-009

### DIFF
--- a/tests/shared/data/transforms/test_image_transforms_part1.mojo
+++ b/tests/shared/data/transforms/test_image_transforms_part1.mojo
@@ -1,7 +1,11 @@
-"""Tests for image-specific transforms.
+"""Tests for image-specific transforms (Part 1 of 2).
 
-Tests image transforms including resize, crop, normalize, and other
-common preprocessing operations for image datasets.
+Tests image transforms including resize, crop, and basic normalize operations.
+Split from test_image_transforms.mojo per ADR-009 (≤10 fn test_ per file).
+
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_image_transforms.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
 from tests.shared.conftest import (
@@ -143,7 +147,7 @@ fn test_random_crop_padding():
 
 
 # ============================================================================
-# Normalize Transform Tests
+# Normalize Transform Tests (basic)
 # ============================================================================
 
 
@@ -162,149 +166,14 @@ fn test_normalize_basic():
     pass
 
 
-fn test_normalize_per_channel():
-    """Test per-channel normalization for RGB images.
-
-    Should support different mean/std for each channel,
-    common for ImageNet preprocessing.
-    """
-    # var image = Tensor.ones(28, 28, 3)
-    # var normalize = Normalize(
-    #     mean=[0.485, 0.456, 0.406],
-    #     std=[0.229, 0.224, 0.225]
-    # )
-    # var result = normalize(image)
-    #
-    # # Each channel should be normalized differently
-    # assert_not_equal(result[0, 0, 0], result[0, 0, 1])
-    pass
-
-
-fn test_normalize_range():
-    """Test normalization to specific range.
-
-    Common patterns: [0, 1] → [-1, 1] for tanh,
-    or [0, 255] → [0, 1] for uint8 images.
-    """
-    # # Scale [0, 255] to [0, 1]
-    # var image = Tensor.ones(28, 28, 1) * 255.0
-    # var normalize = Normalize(mean=0.0, std=255.0)
-    # var result = normalize(image)
-    #
-    # assert_almost_equal(result[0, 0, 0], 1.0)
-    pass
-
-
-# ============================================================================
-# ColorJitter Transform Tests
-# ============================================================================
-
-
-fn test_color_jitter_brightness():
-    """Test random brightness adjustment.
-
-    Should randomly adjust image brightness within specified range,
-    deterministic with fixed seed.
-    """
-    # var image = Tensor.ones(28, 28, 3) * 0.5
-    #
-    # TestFixtures.set_seed()
-    # var jitter = ColorJitter(brightness=0.2)
-    # var result = jitter(image)
-    #
-    # # Brightness should be adjusted (not equal to original)
-    # # but within valid range [0, 1]
-    # assert_true(result[0, 0, 0] >= 0.0)
-    # assert_true(result[0, 0, 0] <= 1.0)
-    pass
-
-
-fn test_color_jitter_all_params():
-    """Test ColorJitter with brightness, contrast, saturation.
-
-    Should apply all adjustments when specified,
-    in consistent order.
-    """
-    # var image = Tensor.ones(28, 28, 3)
-    # var jitter = ColorJitter(
-    #     brightness=0.2,
-    #     contrast=0.2,
-    #     saturation=0.2
-    # )
-    # var result = jitter(image)
-    #
-    # assert_true(result is not None)
-    pass
-
-
-# ============================================================================
-# Flip Transform Tests
-# ============================================================================
-
-
-fn test_horizontal_flip():
-    """Test horizontal (left-right) flip.
-
-    Should mirror image along vertical axis,
-    preserving height and channels.
-    """
-    # var image = Tensor([[1.0, 2.0], [3.0, 4.0]])
-    # var flip = HorizontalFlip()
-    # var result = flip(image)
-    #
-    # # Should be [[2.0, 1.0], [4.0, 3.0]]
-    # assert_almost_equal(result[0, 0], 2.0)
-    # assert_almost_equal(result[0, 1], 1.0)
-    pass
-
-
-fn test_vertical_flip():
-    """Test vertical (up-down) flip.
-
-    Should mirror image along horizontal axis,
-    preserving width and channels.
-    """
-    # var image = Tensor([[1.0, 2.0], [3.0, 4.0]])
-    # var flip = VerticalFlip()
-    # var result = flip(image)
-    #
-    # # Should be [[3.0, 4.0], [1.0, 2.0]]
-    # assert_almost_equal(result[0, 0], 3.0)
-    # assert_almost_equal(result[1, 0], 1.0)
-    pass
-
-
-fn test_random_flip():
-    """Test random horizontal flip.
-
-    Should flip with 50% probability (deterministic with seed),
-    common augmentation for training.
-    """
-    # var image = Tensor.ones(28, 28, 3)
-    #
-    # TestFixtures.set_seed()
-    # var flip = RandomHorizontalFlip(p=0.5)
-    #
-    # # Apply multiple times to verify randomness
-    # var flipped_count = 0
-    # for _ in range(100):
-    #     var result = flip(image)
-    #     if not result.equals(image):
-    #         flipped_count += 1
-    #
-    # # Should be approximately 50 out of 100
-    # assert_true(flipped_count > 30 and flipped_count < 70)
-    pass
-
-
 # ============================================================================
 # Main Test Runner
 # ============================================================================
 
 
 fn main() raises:
-    """Run all image transform tests."""
-    print("Running image transform tests...")
+    """Run image transform tests (Part 1): resize, crop, and basic normalize."""
+    print("Running image transform tests (Part 1)...")
 
     # Resize tests
     test_resize_basic()
@@ -317,18 +186,7 @@ fn main() raises:
     test_random_crop()
     test_random_crop_padding()
 
-    # Normalize tests
+    # Normalize tests (basic)
     test_normalize_basic()
-    test_normalize_per_channel()
-    test_normalize_range()
 
-    # ColorJitter tests
-    test_color_jitter_brightness()
-    test_color_jitter_all_params()
-
-    # Flip tests
-    test_horizontal_flip()
-    test_vertical_flip()
-    test_random_flip()
-
-    print("✓ All image transform tests passed!")
+    print("✓ All image transform tests (Part 1) passed!")

--- a/tests/shared/data/transforms/test_image_transforms_part2.mojo
+++ b/tests/shared/data/transforms/test_image_transforms_part2.mojo
@@ -1,0 +1,181 @@
+"""Tests for image-specific transforms (Part 2 of 2).
+
+Tests image transforms including per-channel normalize, color jitter, and flip.
+Split from test_image_transforms.mojo per ADR-009 (≤10 fn test_ per file).
+
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_image_transforms.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""
+
+from tests.shared.conftest import (
+    assert_true,
+    assert_equal,
+    assert_almost_equal,
+    TestFixtures,
+)
+
+
+# ============================================================================
+# Normalize Transform Tests (advanced)
+# ============================================================================
+
+
+fn test_normalize_per_channel():
+    """Test per-channel normalization for RGB images.
+
+    Should support different mean/std for each channel,
+    common for ImageNet preprocessing.
+    """
+    # var image = Tensor.ones(28, 28, 3)
+    # var normalize = Normalize(
+    #     mean=[0.485, 0.456, 0.406],
+    #     std=[0.229, 0.224, 0.225]
+    # )
+    # var result = normalize(image)
+    #
+    # # Each channel should be normalized differently
+    # assert_not_equal(result[0, 0, 0], result[0, 0, 1])
+    pass
+
+
+fn test_normalize_range():
+    """Test normalization to specific range.
+
+    Common patterns: [0, 1] → [-1, 1] for tanh,
+    or [0, 255] → [0, 1] for uint8 images.
+    """
+    # # Scale [0, 255] to [0, 1]
+    # var image = Tensor.ones(28, 28, 1) * 255.0
+    # var normalize = Normalize(mean=0.0, std=255.0)
+    # var result = normalize(image)
+    #
+    # assert_almost_equal(result[0, 0, 0], 1.0)
+    pass
+
+
+# ============================================================================
+# ColorJitter Transform Tests
+# ============================================================================
+
+
+fn test_color_jitter_brightness():
+    """Test random brightness adjustment.
+
+    Should randomly adjust image brightness within specified range,
+    deterministic with fixed seed.
+    """
+    # var image = Tensor.ones(28, 28, 3) * 0.5
+    #
+    # TestFixtures.set_seed()
+    # var jitter = ColorJitter(brightness=0.2)
+    # var result = jitter(image)
+    #
+    # # Brightness should be adjusted (not equal to original)
+    # # but within valid range [0, 1]
+    # assert_true(result[0, 0, 0] >= 0.0)
+    # assert_true(result[0, 0, 0] <= 1.0)
+    pass
+
+
+fn test_color_jitter_all_params():
+    """Test ColorJitter with brightness, contrast, saturation.
+
+    Should apply all adjustments when specified,
+    in consistent order.
+    """
+    # var image = Tensor.ones(28, 28, 3)
+    # var jitter = ColorJitter(
+    #     brightness=0.2,
+    #     contrast=0.2,
+    #     saturation=0.2
+    # )
+    # var result = jitter(image)
+    #
+    # assert_true(result is not None)
+    pass
+
+
+# ============================================================================
+# Flip Transform Tests
+# ============================================================================
+
+
+fn test_horizontal_flip():
+    """Test horizontal (left-right) flip.
+
+    Should mirror image along vertical axis,
+    preserving height and channels.
+    """
+    # var image = Tensor([[1.0, 2.0], [3.0, 4.0]])
+    # var flip = HorizontalFlip()
+    # var result = flip(image)
+    #
+    # # Should be [[2.0, 1.0], [4.0, 3.0]]
+    # assert_almost_equal(result[0, 0], 2.0)
+    # assert_almost_equal(result[0, 1], 1.0)
+    pass
+
+
+fn test_vertical_flip():
+    """Test vertical (up-down) flip.
+
+    Should mirror image along horizontal axis,
+    preserving width and channels.
+    """
+    # var image = Tensor([[1.0, 2.0], [3.0, 4.0]])
+    # var flip = VerticalFlip()
+    # var result = flip(image)
+    #
+    # # Should be [[3.0, 4.0], [1.0, 2.0]]
+    # assert_almost_equal(result[0, 0], 3.0)
+    # assert_almost_equal(result[1, 0], 1.0)
+    pass
+
+
+fn test_random_flip():
+    """Test random horizontal flip.
+
+    Should flip with 50% probability (deterministic with seed),
+    common augmentation for training.
+    """
+    # var image = Tensor.ones(28, 28, 3)
+    #
+    # TestFixtures.set_seed()
+    # var flip = RandomHorizontalFlip(p=0.5)
+    #
+    # # Apply multiple times to verify randomness
+    # var flipped_count = 0
+    # for _ in range(100):
+    #     var result = flip(image)
+    #     if not result.equals(image):
+    #         flipped_count += 1
+    #
+    # # Should be approximately 50 out of 100
+    # assert_true(flipped_count > 30 and flipped_count < 70)
+    pass
+
+
+# ============================================================================
+# Main Test Runner
+# ============================================================================
+
+
+fn main() raises:
+    """Run image transform tests (Part 2): normalize, color jitter, and flip."""
+    print("Running image transform tests (Part 2)...")
+
+    # Normalize tests (advanced)
+    test_normalize_per_channel()
+    test_normalize_range()
+
+    # ColorJitter tests
+    test_color_jitter_brightness()
+    test_color_jitter_all_params()
+
+    # Flip tests
+    test_horizontal_flip()
+    test_vertical_flip()
+    test_random_flip()
+
+    print("✓ All image transform tests (Part 2) passed!")


### PR DESCRIPTION
## Summary

- Split `tests/shared/data/transforms/test_image_transforms.mojo` (15 `fn test_` functions, exceeding ADR-009 limit of 10) into two files
- `test_image_transforms_part1.mojo`: 8 tests — resize, crop, normalize (basic)
- `test_image_transforms_part2.mojo`: 7 tests — normalize (advanced), color jitter, flip
- All 15 original test cases preserved; each new file has the ADR-009 tracking comment
- CI workflow unchanged — wildcard `transforms/test_*.mojo` auto-discovers both files
- Pre-commit hook `Validate Test Coverage` passed, confirming CI coverage is intact

## Test plan

- [x] Both new files have ≤8 `fn test_` functions (8 and 7 respectively)
- [x] All 15 original test cases are present across the two files
- [x] Each file contains the ADR-009 header comment
- [x] Pre-commit hooks pass (mojo format, validate test coverage, trailing whitespace, etc.)
- [x] CI workflow `Data` test group uses wildcard pattern that picks up both new files automatically

Closes #3473

🤖 Generated with [Claude Code](https://claude.com/claude-code)