### PR TITLE
fix(ci): split test_layer_testers.mojo (14 tests) per ADR-009

### DIFF
--- a/tests/shared/testing/test_layer_testers_part1.mojo
+++ b/tests/shared/testing/test_layer_testers_part1.mojo
@@ -1,0 +1,130 @@
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_layer_testers.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for layer_testers module (Part 1 of 2)
+
+Tests LayerTester utility functions:
+- test_layer_dtype_consistency
+- test_layer_no_invalid_values
+- test_activation_layer_backward (relu, sigmoid)
+
+Split from test_layer_testers.mojo per ADR-009 (≤10 fn test_ per file).
+See test_layer_testers_part2.mojo for remaining tests.
+"""
+
+from math import isnan, isinf
+from shared.testing.layer_testers import LayerTester
+from shared.testing.special_values import (
+    create_ones_tensor,
+    create_special_value_tensor,
+    create_seeded_random_tensor,
+)
+from shared.testing.assertions import assert_true
+from shared.testing.tensor_factory import zeros_tensor
+from shared.core.extensor import ExTensor
+
+
+fn test_layer_dtype_consistency_passes() raises:
+    """Test that dtype consistency check passes when dtypes match."""
+    var input = create_ones_tensor([1, 3, 32, 32], DType.float32)
+    var output = create_ones_tensor([1, 64, 30, 30], DType.float32)
+
+    # Should not raise - dtypes match
+    LayerTester.test_layer_dtype_consistency(input, output, "TestLayer")
+
+
+fn test_layer_dtype_consistency_different_shapes() raises:
+    """Test that dtype consistency works with different shapes."""
+    var input = create_ones_tensor([1, 3], DType.float16)
+    var output = create_ones_tensor([1, 10], DType.float16)
+
+    # Should not raise - dtypes match even though shapes differ
+    LayerTester.test_layer_dtype_consistency(input, output, "TestFC")
+
+
+fn test_layer_no_invalid_values_passes() raises:
+    """Test that invalid value check passes when no NaN/Inf."""
+    var output = create_ones_tensor([2, 3, 4, 5], DType.float32)
+
+    # Should not raise - all values are 1.0 (finite)
+    LayerTester.test_layer_no_invalid_values(output, "TestLayer")
+
+
+fn test_layer_no_invalid_values_with_zeros() raises:
+    """Test that invalid value check passes with zero values."""
+    var output = create_special_value_tensor([3, 3], DType.float32, 0.0)
+
+    # Should not raise - zeros are valid
+    LayerTester.test_layer_no_invalid_values(output, "TestLayer")
+
+
+fn test_layer_no_invalid_values_with_halves() raises:
+    """Test that invalid value check passes with 0.5 values."""
+    var output = create_special_value_tensor([2, 2], DType.float32, 0.5)
+
+    # Should not raise - 0.5 is valid
+    LayerTester.test_layer_no_invalid_values(output, "TestLayer")
+
+
+fn test_layer_tester_utility_functions() raises:
+    """Test that LayerTester utility functions are accessible."""
+    # This test verifies that we can call the static methods without errors
+
+    var input = create_ones_tensor([1, 3, 32, 32], DType.float32)
+    var output = create_ones_tensor([1, 64, 30, 30], DType.float32)
+
+    # Test dtype consistency
+    LayerTester.test_layer_dtype_consistency(input, output, "Conv1")
+
+    # Test no invalid values
+    LayerTester.test_layer_no_invalid_values(output, "Conv1")
+
+
+fn test_activation_layer_backward_relu() raises:
+    """Test ReLU activation backward pass with gradient checking."""
+    # Use small shape to avoid timeout
+    LayerTester.test_activation_layer_backward(
+        shape=[2, 3, 4, 4], dtype=DType.float32, activation="relu"
+    )
+
+
+fn test_activation_layer_backward_sigmoid() raises:
+    """Test Sigmoid activation backward pass with gradient checking."""
+    # Use small shape to avoid timeout
+    LayerTester.test_activation_layer_backward(
+        shape=[2, 3, 4, 4], dtype=DType.float32, activation="sigmoid"
+    )
+
+
+fn main() raises:
+    print("Testing layer_testers module (Part 1)...")
+
+    # Test dtype consistency
+    test_layer_dtype_consistency_passes()
+    print("✓ test_layer_dtype_consistency_passes")
+
+    test_layer_dtype_consistency_different_shapes()
+    print("✓ test_layer_dtype_consistency_different_shapes")
+
+    # Test invalid value checking
+    test_layer_no_invalid_values_passes()
+    print("✓ test_layer_no_invalid_values_passes")
+
+    test_layer_no_invalid_values_with_zeros()
+    print("✓ test_layer_no_invalid_values_with_zeros")
+
+    test_layer_no_invalid_values_with_halves()
+    print("✓ test_layer_no_invalid_values_with_halves")
+
+    # Test utility functions
+    test_layer_tester_utility_functions()
+    print("✓ test_layer_tester_utility_functions")
+
+    # Test backward pass methods
+    test_activation_layer_backward_relu()
+    print("✓ test_activation_layer_backward_relu")
+
+    test_activation_layer_backward_sigmoid()
+    print("✓ test_activation_layer_backward_sigmoid")
+
+    print("\n✅ All layer_testers Part 1 tests passed!")

--- a/tests/shared/testing/test_layer_testers_part2.mojo
+++ b/tests/shared/testing/test_layer_testers_part2.mojo
@@ -1,17 +1,17 @@
-"""Tests for layer_testers module
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_layer_testers.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for layer_testers module (Part 2 of 2)
 
-Tests LayerTester utility functions:
-- test_layer_dtype_consistency
-- test_layer_no_invalid_values
-- test_conv_layer_backward
+Tests LayerTester backward pass functions:
+- test_activation_layer_backward (tanh)
 - test_linear_layer_backward
-- test_activation_layer_backward
+- test_conv_layer_backward
 - test_batchnorm_layer
 - test_batchnorm_layer_backward
 
-Note: Full layer tests (conv, linear, pooling, activation) will be tested
-in model-specific test files where actual layers with weights exist.
-This file focuses on testing the utility/helper functions in LayerTester.
+Split from test_layer_testers.mojo per ADR-009 (≤10 fn test_ per file).
+See test_layer_testers_part1.mojo for remaining tests.
 """
 
 from math import isnan, isinf
@@ -24,78 +24,6 @@ from shared.testing.special_values import (
 from shared.testing.assertions import assert_true
 from shared.testing.tensor_factory import zeros_tensor
 from shared.core.extensor import ExTensor
-
-
-fn test_layer_dtype_consistency_passes() raises:
-    """Test that dtype consistency check passes when dtypes match."""
-    var input = create_ones_tensor([1, 3, 32, 32], DType.float32)
-    var output = create_ones_tensor([1, 64, 30, 30], DType.float32)
-
-    # Should not raise - dtypes match
-    LayerTester.test_layer_dtype_consistency(input, output, "TestLayer")
-
-
-fn test_layer_dtype_consistency_different_shapes() raises:
-    """Test that dtype consistency works with different shapes."""
-    var input = create_ones_tensor([1, 3], DType.float16)
-    var output = create_ones_tensor([1, 10], DType.float16)
-
-    # Should not raise - dtypes match even though shapes differ
-    LayerTester.test_layer_dtype_consistency(input, output, "TestFC")
-
-
-fn test_layer_no_invalid_values_passes() raises:
-    """Test that invalid value check passes when no NaN/Inf."""
-    var output = create_ones_tensor([2, 3, 4, 5], DType.float32)
-
-    # Should not raise - all values are 1.0 (finite)
-    LayerTester.test_layer_no_invalid_values(output, "TestLayer")
-
-
-fn test_layer_no_invalid_values_with_zeros() raises:
-    """Test that invalid value check passes with zero values."""
-    var output = create_special_value_tensor([3, 3], DType.float32, 0.0)
-
-    # Should not raise - zeros are valid
-    LayerTester.test_layer_no_invalid_values(output, "TestLayer")
-
-
-fn test_layer_no_invalid_values_with_halves() raises:
-    """Test that invalid value check passes with 0.5 values."""
-    var output = create_special_value_tensor([2, 2], DType.float32, 0.5)
-
-    # Should not raise - 0.5 is valid
-    LayerTester.test_layer_no_invalid_values(output, "TestLayer")
-
-
-fn test_layer_tester_utility_functions() raises:
-    """Test that LayerTester utility functions are accessible."""
-    # This test verifies that we can call the static methods without errors
-
-    var input = create_ones_tensor([1, 3, 32, 32], DType.float32)
-    var output = create_ones_tensor([1, 64, 30, 30], DType.float32)
-
-    # Test dtype consistency
-    LayerTester.test_layer_dtype_consistency(input, output, "Conv1")
-
-    # Test no invalid values
-    LayerTester.test_layer_no_invalid_values(output, "Conv1")
-
-
-fn test_activation_layer_backward_relu() raises:
-    """Test ReLU activation backward pass with gradient checking."""
-    # Use small shape to avoid timeout
-    LayerTester.test_activation_layer_backward(
-        shape=[2, 3, 4, 4], dtype=DType.float32, activation="relu"
-    )
-
-
-fn test_activation_layer_backward_sigmoid() raises:
-    """Test Sigmoid activation backward pass with gradient checking."""
-    # Use small shape to avoid timeout
-    LayerTester.test_activation_layer_backward(
-        shape=[2, 3, 4, 4], dtype=DType.float32, activation="sigmoid"
-    )
 
 
 fn test_activation_layer_backward_tanh() raises:
@@ -226,36 +154,9 @@ fn test_batchnorm_layer_backward_fp32() raises:
 
 
 fn main() raises:
-    print("Testing layer_testers module...")
-
-    # Test dtype consistency
-    test_layer_dtype_consistency_passes()
-    print("✓ test_layer_dtype_consistency_passes")
-
-    test_layer_dtype_consistency_different_shapes()
-    print("✓ test_layer_dtype_consistency_different_shapes")
-
-    # Test invalid value checking
-    test_layer_no_invalid_values_passes()
-    print("✓ test_layer_no_invalid_values_passes")
-
-    test_layer_no_invalid_values_with_zeros()
-    print("✓ test_layer_no_invalid_values_with_zeros")
-
-    test_layer_no_invalid_values_with_halves()
-    print("✓ test_layer_no_invalid_values_with_halves")
-
-    # Test utility functions
-    test_layer_tester_utility_functions()
-    print("✓ test_layer_tester_utility_functions")
+    print("Testing layer_testers module (Part 2)...")
 
     # Test backward pass methods
-    test_activation_layer_backward_relu()
-    print("✓ test_activation_layer_backward_relu")
-
-    test_activation_layer_backward_sigmoid()
-    print("✓ test_activation_layer_backward_sigmoid")
-
     test_activation_layer_backward_tanh()
     print("✓ test_activation_layer_backward_tanh")
 
@@ -274,7 +175,7 @@ fn main() raises:
     test_batchnorm_layer_backward_fp32()
     print("✓ test_batchnorm_layer_backward_fp32")
 
-    print("\n✅ All layer_testers tests passed!")
+    print("\n✅ All layer_testers Part 2 tests passed!")
     print("\nBackward pass testing:")
     print("- Uses seeded random tensors for reproducibility")
     print("- Validates numerical gradients via finite differences")


### PR DESCRIPTION
## Summary

- Split `tests/shared/testing/test_layer_testers.mojo` (14 `fn test_` functions) into two files of ≤8 tests each, per ADR-009 heap corruption workaround
- All 14 original test cases preserved — no tests deleted
- Each new file includes the ADR-009 header comment
- CI workflow unchanged — existing `testing/test_*.mojo` glob pattern covers both new files automatically

## Changes Made

- **Deleted**: `tests/shared/testing/test_layer_testers.mojo` (14 tests — exceeded ADR-009 limit)
- **Created**: `tests/shared/testing/test_layer_testers_part1.mojo` (8 tests)
  - dtype consistency checks, invalid value checks, utility functions, relu/sigmoid backward
- **Created**: `tests/shared/testing/test_layer_testers_part2.mojo` (6 tests)
  - tanh backward, linear backward, conv backward, batchnorm training/inference/backward

## Verification

- [x] Pre-commit hooks pass (Mojo format, deprecated syntax check, test coverage validation)
- [x] Each file has ≤8 `fn test_` functions (ADR-009 compliant)
- [x] All 14 original test cases preserved
- [x] ADR-009 header comment in each new file
- [x] CI workflow pattern `testing/test_*.mojo` covers both new files without modification

Closes #3483

🤖 Generated with [Claude Code](https://claude.com/claude-code)