### PR TITLE
fix(ci): split test_tensor_transforms.mojo per ADR-009 (14→8+6 tests)

### DIFF
--- a/tests/shared/data/transforms/test_tensor_transforms_part1.mojo
+++ b/tests/shared/data/transforms/test_tensor_transforms_part1.mojo
@@ -1,7 +1,9 @@
-"""Tests for tensor-specific transforms.
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_tensor_transforms.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for tensor-specific transforms (part 1): reshape and type conversion.
 
-Tests tensor transforms including reshape, type conversion, and
-other general tensor manipulations used in data preprocessing.
+Tests tensor transforms including reshape and type conversion used in data preprocessing.
 """
 
 from tests.shared.conftest import (
@@ -149,131 +151,13 @@ fn test_scale_float_to_uint8():
 
 
 # ============================================================================
-# Transpose Transform Tests
-# ============================================================================
-
-
-fn test_transpose_2d():
-    """Test transposing 2D tensor.
-
-    Should swap dimensions: (H, W) → (W, H),
-    useful for matrix operations.
-    """
-    # var data = Tensor.arange(0, 12).reshape(3, 4)
-    # var transpose = Transpose()
-    # var result = transpose(data)
-    #
-    # assert_equal(result.shape()[0], 4)
-    # assert_equal(result.shape()[1], 3)
-    # assert_equal(result[0, 0], data[0, 0])
-    # assert_equal(result[1, 0], data[0, 1])
-    pass
-
-
-fn test_permute_dimensions():
-    """Test permuting dimensions with custom order.
-
-    Should reorder dimensions: (H, W, C) → (C, H, W),
-    common for converting between channel formats.
-    """
-    # var data = Tensor.ones(28, 28, 3)  # HWC format
-    # var permute = Permute([2, 0, 1])  # To CHW format
-    # var result = permute(data)
-    #
-    # assert_equal(result.shape()[0], 3)   # Channels
-    # assert_equal(result.shape()[1], 28)  # Height
-    # assert_equal(result.shape()[2], 28)  # Width
-    pass
-
-
-fn test_channel_first_to_last():
-    """Test converting CHW to HWC format.
-
-    PyTorch uses CHW, TensorFlow uses HWC,
-    so conversion is needed for interop.
-    """
-    # var data = Tensor.ones(3, 28, 28)  # CHW
-    # var convert = ChannelFirstToLast()
-    # var result = convert(data)
-    #
-    # assert_equal(result.shape()[0], 28)  # Height
-    # assert_equal(result.shape()[1], 28)  # Width
-    # assert_equal(result.shape()[2], 3)   # Channels
-    pass
-
-
-# ============================================================================
-# Lambda Transform Tests
-# ============================================================================
-
-
-fn test_lambda_basic():
-    """Test applying custom function as transform.
-
-    Should allow arbitrary function to be used as transform,
-    enabling flexible custom preprocessing.
-    """
-    # fn square(x: Tensor) -> Tensor:
-    #     return x * x
-    #
-    # var data = Tensor([1.0, 2.0, 3.0])
-    # var transform = Lambda(square)
-    # var result = transform(data)
-    #
-    # assert_almost_equal(result[0], 1.0)
-    # assert_almost_equal(result[1], 4.0)
-    # assert_almost_equal(result[2], 9.0)
-    pass
-
-
-fn test_lambda_with_closure():
-    """Test Lambda with captured variables.
-
-    Should support closures for parameterized custom transforms,
-    useful for one-off preprocessing steps.
-    """
-    # var scale_factor = 2.0
-    # fn scale(x: Tensor) -> Tensor:
-    #     return x * scale_factor
-    #
-    # var data = Tensor([1.0, 2.0, 3.0])
-    # var transform = Lambda(scale)
-    # var result = transform(data)
-    #
-    # assert_almost_equal(result[0], 2.0)
-    # assert_almost_equal(result[1], 4.0)
-    pass
-
-
-# ============================================================================
-# Clamp Transform Tests
-# ============================================================================
-
-
-fn test_clamp_range():
-    """Test clamping values to valid range.
-
-    Should clip values outside [min, max] range,
-    useful for ensuring valid input ranges.
-    """
-    # var data = Tensor([-1.0, 0.5, 2.0])
-    # var clamp = Clamp(min=0.0, max=1.0)
-    # var result = clamp(data)
-    #
-    # assert_almost_equal(result[0], 0.0)  # Clamped from -1.0
-    # assert_almost_equal(result[1], 0.5)  # Unchanged
-    # assert_almost_equal(result[2], 1.0)  # Clamped from 2.0
-    pass
-
-
-# ============================================================================
 # Main Test Runner
 # ============================================================================
 
 
 fn main() raises:
-    """Run all tensor transform tests."""
-    print("Running tensor transform tests...")
+    """Run tensor transform tests part 1 (reshape and type conversion)."""
+    print("Running tensor transform tests (part 1)...")
 
     # Reshape tests
     test_reshape_basic()
@@ -287,16 +171,4 @@ fn main() raises:
     test_scale_uint8_to_float()
     test_scale_float_to_uint8()
 
-    # Transpose tests
-    test_transpose_2d()
-    test_permute_dimensions()
-    test_channel_first_to_last()
-
-    # Lambda tests
-    test_lambda_basic()
-    test_lambda_with_closure()
-
-    # Clamp tests
-    test_clamp_range()
-
-    print("✓ All tensor transform tests passed!")
+    print("✓ All tensor transform tests (part 1) passed!")

--- a/tests/shared/data/transforms/test_tensor_transforms_part2.mojo
+++ b/tests/shared/data/transforms/test_tensor_transforms_part2.mojo
@@ -1,0 +1,156 @@
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_tensor_transforms.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for tensor-specific transforms (part 2): transpose, lambda, and clamp.
+
+Tests tensor transforms including transpose, permute, lambda, and clamp used in data preprocessing.
+"""
+
+from tests.shared.conftest import (
+    assert_true,
+    assert_equal,
+    assert_almost_equal,
+    TestFixtures,
+)
+
+
+# ============================================================================
+# Transpose Transform Tests
+# ============================================================================
+
+
+fn test_transpose_2d():
+    """Test transposing 2D tensor.
+
+    Should swap dimensions: (H, W) → (W, H),
+    useful for matrix operations.
+    """
+    # var data = Tensor.arange(0, 12).reshape(3, 4)
+    # var transpose = Transpose()
+    # var result = transpose(data)
+    #
+    # assert_equal(result.shape()[0], 4)
+    # assert_equal(result.shape()[1], 3)
+    # assert_equal(result[0, 0], data[0, 0])
+    # assert_equal(result[1, 0], data[0, 1])
+    pass
+
+
+fn test_permute_dimensions():
+    """Test permuting dimensions with custom order.
+
+    Should reorder dimensions: (H, W, C) → (C, H, W),
+    common for converting between channel formats.
+    """
+    # var data = Tensor.ones(28, 28, 3)  # HWC format
+    # var permute = Permute([2, 0, 1])  # To CHW format
+    # var result = permute(data)
+    #
+    # assert_equal(result.shape()[0], 3)   # Channels
+    # assert_equal(result.shape()[1], 28)  # Height
+    # assert_equal(result.shape()[2], 28)  # Width
+    pass
+
+
+fn test_channel_first_to_last():
+    """Test converting CHW to HWC format.
+
+    PyTorch uses CHW, TensorFlow uses HWC,
+    so conversion is needed for interop.
+    """
+    # var data = Tensor.ones(3, 28, 28)  # CHW
+    # var convert = ChannelFirstToLast()
+    # var result = convert(data)
+    #
+    # assert_equal(result.shape()[0], 28)  # Height
+    # assert_equal(result.shape()[1], 28)  # Width
+    # assert_equal(result.shape()[2], 3)   # Channels
+    pass
+
+
+# ============================================================================
+# Lambda Transform Tests
+# ============================================================================
+
+
+fn test_lambda_basic():
+    """Test applying custom function as transform.
+
+    Should allow arbitrary function to be used as transform,
+    enabling flexible custom preprocessing.
+    """
+    # fn square(x: Tensor) -> Tensor:
+    #     return x * x
+    #
+    # var data = Tensor([1.0, 2.0, 3.0])
+    # var transform = Lambda(square)
+    # var result = transform(data)
+    #
+    # assert_almost_equal(result[0], 1.0)
+    # assert_almost_equal(result[1], 4.0)
+    # assert_almost_equal(result[2], 9.0)
+    pass
+
+
+fn test_lambda_with_closure():
+    """Test Lambda with captured variables.
+
+    Should support closures for parameterized custom transforms,
+    useful for one-off preprocessing steps.
+    """
+    # var scale_factor = 2.0
+    # fn scale(x: Tensor) -> Tensor:
+    #     return x * scale_factor
+    #
+    # var data = Tensor([1.0, 2.0, 3.0])
+    # var transform = Lambda(scale)
+    # var result = transform(data)
+    #
+    # assert_almost_equal(result[0], 2.0)
+    # assert_almost_equal(result[1], 4.0)
+    pass
+
+
+# ============================================================================
+# Clamp Transform Tests
+# ============================================================================
+
+
+fn test_clamp_range():
+    """Test clamping values to valid range.
+
+    Should clip values outside [min, max] range,
+    useful for ensuring valid input ranges.
+    """
+    # var data = Tensor([-1.0, 0.5, 2.0])
+    # var clamp = Clamp(min=0.0, max=1.0)
+    # var result = clamp(data)
+    #
+    # assert_almost_equal(result[0], 0.0)  # Clamped from -1.0
+    # assert_almost_equal(result[1], 0.5)  # Unchanged
+    # assert_almost_equal(result[2], 1.0)  # Clamped from 2.0
+    pass
+
+
+# ============================================================================
+# Main Test Runner
+# ============================================================================
+
+
+fn main() raises:
+    """Run tensor transform tests part 2 (transpose, lambda, and clamp)."""
+    print("Running tensor transform tests (part 2)...")
+
+    # Transpose tests
+    test_transpose_2d()
+    test_permute_dimensions()
+    test_channel_first_to_last()
+
+    # Lambda tests
+    test_lambda_basic()
+    test_lambda_with_closure()
+
+    # Clamp tests
+    test_clamp_range()
+
+    print("✓ All tensor transform tests (part 2) passed!")


### PR DESCRIPTION
## Summary

- Split `tests/shared/data/transforms/test_tensor_transforms.mojo` (14 tests) into 2 files per ADR-009 limit of ≤10 `fn test_` functions per file
- `test_tensor_transforms_part1.mojo`: 8 tests (reshape + type conversion)
- `test_tensor_transforms_part2.mojo`: 6 tests (transpose + lambda + clamp)
- Each new file includes the required ADR-009 tracking comment in its header
- CI workflow pattern `transforms/test_*.mojo` already covers new filenames — no workflow changes needed

## Test plan

- [x] Part 1 has 8 `fn test_` functions (≤8 limit met)
- [x] Part 2 has 6 `fn test_` functions (≤8 limit met)
- [x] All 14 original test cases preserved (none deleted)
- [x] ADR-009 header comment present in both files
- [x] Pre-commit hooks pass (Mojo format, validate test coverage, etc.)
- [x] CI workflow `Data Transforms` group picks up new files via existing glob pattern

Closes #3485

🤖 Generated with [Claude Code](https://claude.com/claude-code)