### PR TITLE
fix(ci): split test_datasets.mojo (13 tests) to fix heap corruption (ADR-009)

### DIFF
--- a/tests/shared/README.md
+++ b/tests/shared/README.md
@@ -62,7 +62,8 @@ tests/shared/
 │   ├── test_callbacks.mojo          # Training callbacks
 │   └── test_loops.mojo              # Training loops
 ├── data/                            # Data module tests
-│   ├── test_datasets.mojo           # Dataset implementations
+│   ├── test_datasets_part1.mojo     # Dataset implementations (Part 1, ADR-009 split)
+│   ├── test_datasets_part2.mojo     # Dataset implementations (Part 2, ADR-009 split)
 │   ├── test_loaders.mojo            # Data loaders
 │   └── test_transforms.mojo         # Data transforms
 ├── utils/                           # Utils module tests

--- a/tests/shared/data/test_datasets_part1.mojo
+++ b/tests/shared/data/test_datasets_part1.mojo
@@ -1,13 +1,16 @@
-"""High-level integration tests for dataset abstractions.
+"""High-level integration tests for dataset abstractions (Part 1 of 2).
 
 Tests cover cross-component interactions between datasets, loaders, and samplers.
 Individual unit tests exist in datasets/ subdirectory.
+
+ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+high test load. Split from test_datasets.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 
 Integration Points:
 - TensorDataset + BatchLoader access patterns
 - Dataset trait conformance and interface consistency
 - Metadata properties (length, shape consistency)
-- Edge cases: empty datasets, bounds checking
 """
 
 from tests.shared.conftest import (
@@ -325,186 +328,13 @@ fn test_dataset_interface_protocol() raises:
 
 
 # ============================================================================
-# Dataset Edge Case Tests
-# ============================================================================
-
-
-fn test_dataset_small_size() raises:
-    """Test ExTensorDataset with very small number of samples.
-
-    Should handle minimal datasets (2-5 samples) correctly.
-
-    Integration Points:
-        - Small dataset initialization
-        - Indexing for minimal samples
-
-    Success Criteria:
-        - Can create 2-sample dataset
-        - Can access both samples
-        - Length reported correctly
-    """
-    TestFixtures.set_seed()
-
-    var data_list = List[Float32]()
-    data_list.append(1.0)
-    data_list.append(2.0)
-    var data = ExTensor(data_list^)
-
-    var labels_list = List[Int]()
-    labels_list.append(0)
-    labels_list.append(1)
-    var labels = ExTensor(labels_list^)
-
-    var dataset = ExTensorDataset(data^, labels^)
-    assert_equal(dataset.__len__(), 2)
-
-
-fn test_dataset_single_sample() raises:
-    """Test ExTensorDataset with single sample (minimal edge case).
-
-    Should handle 1-sample datasets correctly.
-
-    Integration Points:
-        - Minimal dataset size
-        - Single-sample access
-
-    Success Criteria:
-        - 1-sample dataset initializes
-        - Can access via index 0
-        - Can access via index -1
-        - Length is 1
-    """
-    TestFixtures.set_seed()
-
-    var data_list = List[Float32]()
-    data_list.append(42.0)
-    var data = ExTensor(data_list^)
-
-    var labels_list = List[Int]()
-    labels_list.append(99)
-    var labels = ExTensor(labels_list^)
-
-    var dataset = ExTensorDataset(data^, labels^)
-
-    assert_equal(dataset.__len__(), 1)
-    var s0 = dataset.__getitem__(0)
-    var s_neg = dataset.__getitem__(-1)
-
-
-fn test_dataset_large_size() raises:
-    """Test ExTensorDataset with larger number of samples.
-
-    Should scale to thousands of samples without issues.
-
-    Integration Points:
-        - Large dataset creation
-        - Memory efficiency
-        - Indexing performance
-
-    Success Criteria:
-        - Can create 1000-sample dataset
-        - Length reported correctly
-        - Access patterns still work
-    """
-    TestFixtures.set_seed()
-
-    var data_list = List[Float32]()
-    for i in range(1000):
-        data_list.append(Float32(i % 100) / 100.0)
-    var data = ExTensor(data_list^)
-
-    var labels_list = List[Int]()
-    for i in range(1000):
-        labels_list.append(i % 10)
-    var labels = ExTensor(labels_list^)
-
-    var dataset = ExTensorDataset(data^, labels^)
-    assert_equal(dataset.__len__(), 1000)
-
-
-fn test_dataset_repeated_access() raises:
-    """Test ExTensorDataset handles repeated access to same sample.
-
-    Accessing the same index multiple times should always return same sample.
-
-    Integration Points:
-        - Deterministic __getitem__ behavior
-        - No state modification on access
-        - Caching or lazy-loading implications
-
-    Success Criteria:
-        - Multiple accesses to same index return consistent results
-        - No errors or exceptions
-    """
-    TestFixtures.set_seed()
-
-    var data_list = List[Float32]()
-    for i in range(10):
-        data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
-
-    var labels_list = List[Int]()
-    for i in range(10):
-        labels_list.append(i)
-    var labels = ExTensor(labels_list^)
-
-    var dataset = ExTensorDataset(data^, labels^)
-
-    # Access same sample multiple times
-    var s5_a = dataset.__getitem__(5)
-    var s5_b = dataset.__getitem__(5)
-    var s5_c = dataset.__getitem__(5)
-
-    # All should be identical
-    assert_equal(dataset.__len__(), 10)
-
-
-fn test_dataset_with_different_batch_sizes() raises:
-    """Test ExTensorDataset works with various batch sizes in loader.
-
-    Should integrate with loaders using different batch_size values.
-
-    Integration Points:
-        - Dataset + Loader with variable batch_size
-        - Batch count calculation
-        - Loader flexibility
-
-    Success Criteria:
-        - Dataset length correctly reported
-        - Batch count scales with batch_size
-    """
-    TestFixtures.set_seed()
-
-    var data_list = List[Float32]()
-    for i in range(100):
-        data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
-
-    var labels_list = List[Int]()
-    for i in range(100):
-        labels_list.append(i)
-    var labels = ExTensor(labels_list^)
-
-    var dataset = ExTensorDataset(data^, labels^)
-    var dataset_len = dataset.__len__()
-
-    # Verify dataset reports correct length
-    assert_equal(dataset_len, 100)
-
-    # Batch count is determined by ceil(dataset_len / batch_size)
-    # batch_size=1: ceil(100/1) = 100
-    # batch_size=16: ceil(100/16) = 7
-    # batch_size=32: ceil(100/32) = 4
-
-
-# ============================================================================
 # Main Test Runner
 # ============================================================================
 
 
 fn main() raises:
-    """Run all dataset integration tests."""
-    print("Running dataset integration tests...")
+    """Run dataset integration tests (Part 1)."""
+    print("Running dataset integration tests (Part 1)...")
 
     # Interface conformance tests
     test_dataset_length_consistency()
@@ -520,11 +350,4 @@ fn main() raises:
     # Type consistency tests
     test_dataset_interface_protocol()
 
-    # Edge case tests
-    test_dataset_small_size()
-    test_dataset_single_sample()
-    test_dataset_large_size()
-    test_dataset_repeated_access()
-    test_dataset_with_different_batch_sizes()
-
-    print("✓ All dataset integration tests passed!")
+    print("✓ All dataset integration tests (Part 1) passed!")

--- a/tests/shared/data/test_datasets_part2.mojo
+++ b/tests/shared/data/test_datasets_part2.mojo
@@ -1,0 +1,218 @@
+"""High-level integration tests for dataset abstractions (Part 2 of 2).
+
+Tests cover edge cases and advanced access patterns for ExTensorDataset.
+Individual unit tests exist in datasets/ subdirectory.
+
+ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+high test load. Split from test_datasets.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Integration Points:
+- Edge cases: empty datasets, bounds checking
+- Repeated access consistency
+- Batch size variability
+"""
+
+from tests.shared.conftest import (
+    assert_true,
+    assert_equal,
+    assert_not_equal,
+    assert_greater,
+    TestFixtures,
+)
+from shared.data.datasets import ExTensorDataset
+from shared.data.loaders import BatchLoader
+from shared.data.samplers import SequentialSampler
+from shared.core.extensor import ExTensor
+
+
+# ============================================================================
+# Dataset Edge Case Tests
+# ============================================================================
+
+
+fn test_dataset_small_size() raises:
+    """Test ExTensorDataset with very small number of samples.
+
+    Should handle minimal datasets (2-5 samples) correctly.
+
+    Integration Points:
+        - Small dataset initialization
+        - Indexing for minimal samples
+
+    Success Criteria:
+        - Can create 2-sample dataset
+        - Can access both samples
+        - Length reported correctly
+    """
+    TestFixtures.set_seed()
+
+    var data_list = List[Float32]()
+    data_list.append(1.0)
+    data_list.append(2.0)
+    var data = ExTensor(data_list^)
+
+    var labels_list = List[Int]()
+    labels_list.append(0)
+    labels_list.append(1)
+    var labels = ExTensor(labels_list^)
+
+    var dataset = ExTensorDataset(data^, labels^)
+    assert_equal(dataset.__len__(), 2)
+
+
+fn test_dataset_single_sample() raises:
+    """Test ExTensorDataset with single sample (minimal edge case).
+
+    Should handle 1-sample datasets correctly.
+
+    Integration Points:
+        - Minimal dataset size
+        - Single-sample access
+
+    Success Criteria:
+        - 1-sample dataset initializes
+        - Can access via index 0
+        - Can access via index -1
+        - Length is 1
+    """
+    TestFixtures.set_seed()
+
+    var data_list = List[Float32]()
+    data_list.append(42.0)
+    var data = ExTensor(data_list^)
+
+    var labels_list = List[Int]()
+    labels_list.append(99)
+    var labels = ExTensor(labels_list^)
+
+    var dataset = ExTensorDataset(data^, labels^)
+
+    assert_equal(dataset.__len__(), 1)
+    var s0 = dataset.__getitem__(0)
+    var s_neg = dataset.__getitem__(-1)
+
+
+fn test_dataset_large_size() raises:
+    """Test ExTensorDataset with larger number of samples.
+
+    Should scale to thousands of samples without issues.
+
+    Integration Points:
+        - Large dataset creation
+        - Memory efficiency
+        - Indexing performance
+
+    Success Criteria:
+        - Can create 1000-sample dataset
+        - Length reported correctly
+        - Access patterns still work
+    """
+    TestFixtures.set_seed()
+
+    var data_list = List[Float32]()
+    for i in range(1000):
+        data_list.append(Float32(i % 100) / 100.0)
+    var data = ExTensor(data_list^)
+
+    var labels_list = List[Int]()
+    for i in range(1000):
+        labels_list.append(i % 10)
+    var labels = ExTensor(labels_list^)
+
+    var dataset = ExTensorDataset(data^, labels^)
+    assert_equal(dataset.__len__(), 1000)
+
+
+fn test_dataset_repeated_access() raises:
+    """Test ExTensorDataset handles repeated access to same sample.
+
+    Accessing the same index multiple times should always return same sample.
+
+    Integration Points:
+        - Deterministic __getitem__ behavior
+        - No state modification on access
+        - Caching or lazy-loading implications
+
+    Success Criteria:
+        - Multiple accesses to same index return consistent results
+        - No errors or exceptions
+    """
+    TestFixtures.set_seed()
+
+    var data_list = List[Float32]()
+    for i in range(10):
+        data_list.append(Float32(i))
+    var data = ExTensor(data_list^)
+
+    var labels_list = List[Int]()
+    for i in range(10):
+        labels_list.append(i)
+    var labels = ExTensor(labels_list^)
+
+    var dataset = ExTensorDataset(data^, labels^)
+
+    # Access same sample multiple times
+    var s5_a = dataset.__getitem__(5)
+    var s5_b = dataset.__getitem__(5)
+    var s5_c = dataset.__getitem__(5)
+
+    # All should be identical
+    assert_equal(dataset.__len__(), 10)
+
+
+fn test_dataset_with_different_batch_sizes() raises:
+    """Test ExTensorDataset works with various batch sizes in loader.
+
+    Should integrate with loaders using different batch_size values.
+
+    Integration Points:
+        - Dataset + Loader with variable batch_size
+        - Batch count calculation
+        - Loader flexibility
+
+    Success Criteria:
+        - Dataset length correctly reported
+        - Batch count scales with batch_size
+    """
+    TestFixtures.set_seed()
+
+    var data_list = List[Float32]()
+    for i in range(100):
+        data_list.append(Float32(i))
+    var data = ExTensor(data_list^)
+
+    var labels_list = List[Int]()
+    for i in range(100):
+        labels_list.append(i)
+    var labels = ExTensor(labels_list^)
+
+    var dataset = ExTensorDataset(data^, labels^)
+    var dataset_len = dataset.__len__()
+
+    # Verify dataset reports correct length
+    assert_equal(dataset_len, 100)
+
+    # Batch count is determined by ceil(dataset_len / batch_size)
+    # batch_size=1: ceil(100/1) = 100
+    # batch_size=16: ceil(100/16) = 7
+    # batch_size=32: ceil(100/32) = 4
+
+
+# ============================================================================
+# Main Test Runner
+# ============================================================================
+
+
+fn main() raises:
+    """Run dataset integration tests (Part 2)."""
+    print("Running dataset integration tests (Part 2)...")
+
+    # Edge case tests
+    test_dataset_small_size()
+    test_dataset_single_sample()
+    test_dataset_large_size()
+    test_dataset_repeated_access()
+    test_dataset_with_different_batch_sizes()
+
+    print("✓ All dataset integration tests (Part 2) passed!")


### PR DESCRIPTION
## Summary

- Splits `tests/shared/data/test_datasets.mojo` (13 `fn test_` functions) into two files of ≤8 tests each, per ADR-009
- `test_datasets_part1.mojo` (8 tests): interface conformance + loader integration tests
- `test_datasets_part2.mojo` (5 tests): edge case tests
- Updates `tests/shared/README.md` to reference the new filenames
- All 13 original test cases are preserved — none deleted

## Problem

Mojo v0.26.1 intermittently triggers heap corruption (`libKGENCompilerRTShared.so` JIT fault)
when a single test file exceeds 10 `fn test_` functions. The original file had 13, causing
the `Data` CI group to fail non-deterministically (13/20 recent runs on `main`).

## Changes

- **Deleted**: `tests/shared/data/test_datasets.mojo` (13 tests — over limit)
- **Added**: `tests/shared/data/test_datasets_part1.mojo` (8 tests)
- **Added**: `tests/shared/data/test_datasets_part2.mojo` (5 tests)
- **Updated**: `tests/shared/README.md` — references new filenames

Both new files include the ADR-009 header comment. The CI `Data` group pattern
(`test_*.mojo`) already matches both new files automatically — no workflow changes needed.

## Test plan

- [x] All 13 original test functions preserved across the two new files
- [x] Each file has ≤8 `fn test_` functions (ADR-009 compliant)
- [x] Both files include the required ADR-009 header comment
- [x] Pre-commit hooks pass (mojo format, markdown lint, validate-test-coverage)
- [x] CI `Data` group pattern picks up new files automatically

Closes #3505

🤖 Generated with [Claude Code](https://claude.com/claude-code)