### PR TITLE
fix(autograd): split test_no_grad_context.mojo per ADR-009 (≤10 tests/file)

### DIFF
--- a/tests/shared/autograd/test_no_grad_context_part1.mojo
+++ b/tests/shared/autograd/test_no_grad_context_part1.mojo
@@ -1,17 +1,16 @@
-"""Tests for NoGradContext and gradient tracking control.
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_no_grad_context.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for NoGradContext enter/exit and disable/restore gradient tracking.
 
 Tests the gradient tracking control functionality including:
 - NoGradContext enter/exit methods
 - disable_gradient_tracking and restore_gradient_tracking functions
-- State preservation across nested contexts
-- Operations not being recorded when tracking is disabled
 
-This verifies that gradient tracking can be properly controlled
-for inference or non-differentiable operations.
+Split from test_no_grad_context.mojo per ADR-009 (≤10 fn test_ per file).
 """
 
-from testing import assert_true, assert_equal
-from shared.core.extensor import ExTensor, ones
+from testing import assert_true
 from shared.autograd import (
     GradientTape,
     NoGradContext,
@@ -140,99 +139,8 @@ fn test_restore_gradient_tracking_keeps_disabled() raises:
     )
 
 
-fn test_disable_restore_roundtrip() raises:
-    """Test that disable/restore roundtrip works correctly."""
-    var tape = GradientTape()
-    tape.enable()
-    assert_true(tape.enabled, "Tape should be enabled initially")
-
-    # Disable and store state
-    var was_enabled = disable_gradient_tracking(tape)
-    assert_true(not tape.enabled, "Tape should be disabled")
-    assert_true(was_enabled, "Should have returned True")
-
-    # Restore state
-    restore_gradient_tracking(tape, was_enabled)
-    assert_true(tape.enabled, "Tape should be re-enabled after restore")
-
-
-fn test_disable_restore_roundtrip_from_disabled() raises:
-    """Test disable/restore roundtrip when starting from disabled state."""
-    var tape = GradientTape()
-    tape.disable()
-    assert_true(not tape.enabled, "Tape should be disabled initially")
-
-    # Disable and store state
-    var was_enabled = disable_gradient_tracking(tape)
-    assert_true(not tape.enabled, "Tape should remain disabled")
-    assert_true(not was_enabled, "Should have returned False")
-
-    # Restore state
-    restore_gradient_tracking(tape, was_enabled)
-    assert_true(not tape.enabled, "Tape should remain disabled after restore")
-
-
-# ============================================================================
-# Tape Node Recording Tests
-# ============================================================================
-
-
-fn test_operations_not_recorded_when_disabled() raises:
-    """Test that operations are not recorded when tape is disabled.
-
-    This is an integration test that verifies the tape doesn't record
-    nodes when it's disabled via disable_gradient_tracking().
-    """
-    var tape = GradientTape()
-
-    # Start with tape disabled
-    tape.disable()
-    var initial_node_count = len(tape.nodes)
-
-    # Operations should not be recorded (manually verify via tape state)
-    assert_true(not tape.enabled, "Tape should be disabled")
-    assert_equal(
-        len(tape.nodes), initial_node_count, "No nodes should be recorded"
-    )
-
-
-fn test_operations_recorded_when_enabled() raises:
-    """Test that tape is in correct state to record when enabled.
-
-    This verifies the tape is ready to record by checking the enabled flag.
-    """
-    var tape = GradientTape()
-    tape.enable()
-
-    assert_true(tape.enabled, "Tape should be enabled and ready to record")
-
-
-fn test_clear_tape_between_operations() raises:
-    """Test clearing tape between different no-grad contexts."""
-    var tape = GradientTape()
-    tape.enable()
-
-    # First operation block
-    var ctx1 = NoGradContext()
-    ctx1.enter(tape)
-    assert_true(not tape.enabled, "Tape should be disabled in first context")
-    ctx1.exit(tape)
-    assert_true(tape.enabled, "Tape should be re-enabled after first context")
-
-    # Clear tape
-    tape.clear()
-    assert_equal(len(tape.nodes), 0, "Tape should be empty after clear()")
-
-    # Second operation block
-    var ctx2 = NoGradContext()
-    ctx2.enter(tape)
-    assert_true(not tape.enabled, "Tape should be disabled in second context")
-    ctx2.exit(tape)
-    assert_true(tape.enabled, "Tape should be re-enabled after second context")
-
-
 fn main() raises:
-    """Run all NoGradContext tests."""
+    """Run NoGradContext enter/exit and disable/restore tests."""
     print("Running NoGradContext enter/exit tests...")
     test_no_grad_context_enter_disables_tracking()
     test_no_grad_context_exit_restores_enabled()
@@ -244,12 +152,5 @@ fn main() raises:
     test_disable_gradient_tracking_returns_previous_state_disabled()
     test_restore_gradient_tracking_enables()
     test_restore_gradient_tracking_keeps_disabled()
-    test_disable_restore_roundtrip()
-    test_disable_restore_roundtrip_from_disabled()
 
-    print("Running tape node recording tests...")
-    test_operations_not_recorded_when_disabled()
-    test_operations_recorded_when_enabled()
-    test_clear_tape_between_operations()
-
-    print("\nAll NoGradContext tests passed! ✓")
+    print("\nAll NoGradContext part1 tests passed! ✓")

--- a/tests/shared/autograd/test_no_grad_context_part2.mojo
+++ b/tests/shared/autograd/test_no_grad_context_part2.mojo
@@ -1,0 +1,130 @@
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_no_grad_context.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for disable/restore roundtrip and tape node recording.
+
+Tests the gradient tracking control functionality including:
+- disable/restore roundtrip correctness
+- Operations not recorded when tracking is disabled
+- Tape clearing between no-grad contexts
+
+Split from test_no_grad_context.mojo per ADR-009 (≤10 fn test_ per file).
+"""
+
+from testing import assert_true, assert_equal
+from shared.autograd import (
+    GradientTape,
+    NoGradContext,
+    disable_gradient_tracking,
+    restore_gradient_tracking,
+)
+
+
+# ============================================================================
+# Disable/Restore Roundtrip Tests
+# ============================================================================
+
+
+fn test_disable_restore_roundtrip() raises:
+    """Test that disable/restore roundtrip works correctly."""
+    var tape = GradientTape()
+    tape.enable()
+    assert_true(tape.enabled, "Tape should be enabled initially")
+
+    # Disable and store state
+    var was_enabled = disable_gradient_tracking(tape)
+    assert_true(not tape.enabled, "Tape should be disabled")
+    assert_true(was_enabled, "Should have returned True")
+
+    # Restore state
+    restore_gradient_tracking(tape, was_enabled)
+    assert_true(tape.enabled, "Tape should be re-enabled after restore")
+
+
+fn test_disable_restore_roundtrip_from_disabled() raises:
+    """Test disable/restore roundtrip when starting from disabled state."""
+    var tape = GradientTape()
+    tape.disable()
+    assert_true(not tape.enabled, "Tape should be disabled initially")
+
+    # Disable and store state
+    var was_enabled = disable_gradient_tracking(tape)
+    assert_true(not tape.enabled, "Tape should remain disabled")
+    assert_true(not was_enabled, "Should have returned False")
+
+    # Restore state
+    restore_gradient_tracking(tape, was_enabled)
+    assert_true(not tape.enabled, "Tape should remain disabled after restore")
+
+
+# ============================================================================
+# Tape Node Recording Tests
+# ============================================================================
+
+
+fn test_operations_not_recorded_when_disabled() raises:
+    """Test that operations are not recorded when tape is disabled.
+
+    This is an integration test that verifies the tape doesn't record
+    nodes when it's disabled via disable_gradient_tracking().
+    """
+    var tape = GradientTape()
+
+    # Start with tape disabled
+    tape.disable()
+    var initial_node_count = len(tape.nodes)
+
+    # Operations should not be recorded (manually verify via tape state)
+    assert_true(not tape.enabled, "Tape should be disabled")
+    assert_equal(
+        len(tape.nodes), initial_node_count, "No nodes should be recorded"
+    )
+
+
+fn test_operations_recorded_when_enabled() raises:
+    """Test that tape is in correct state to record when enabled.
+
+    This verifies the tape is ready to record by checking the enabled flag.
+    """
+    var tape = GradientTape()
+    tape.enable()
+
+    assert_true(tape.enabled, "Tape should be enabled and ready to record")
+
+
+fn test_clear_tape_between_operations() raises:
+    """Test clearing tape between different no-grad contexts."""
+    var tape = GradientTape()
+    tape.enable()
+
+    # First operation block
+    var ctx1 = NoGradContext()
+    ctx1.enter(tape)
+    assert_true(not tape.enabled, "Tape should be disabled in first context")
+    ctx1.exit(tape)
+    assert_true(tape.enabled, "Tape should be re-enabled after first context")
+
+    # Clear tape
+    tape.clear()
+    assert_equal(len(tape.nodes), 0, "Tape should be empty after clear()")
+
+    # Second operation block
+    var ctx2 = NoGradContext()
+    ctx2.enter(tape)
+    assert_true(not tape.enabled, "Tape should be disabled in second context")
+    ctx2.exit(tape)
+    assert_true(tape.enabled, "Tape should be re-enabled after second context")
+
+
+fn main() raises:
+    """Run disable/restore roundtrip and tape node recording tests."""
+    print("Running disable/restore roundtrip tests...")
+    test_disable_restore_roundtrip()
+    test_disable_restore_roundtrip_from_disabled()
+
+    print("Running tape node recording tests...")
+    test_operations_not_recorded_when_disabled()
+    test_operations_recorded_when_enabled()
+    test_clear_tape_between_operations()
+
+    print("\nAll NoGradContext part2 tests passed! ✓")


### PR DESCRIPTION
## Summary

- Split `tests/shared/autograd/test_no_grad_context.mojo` (13 tests) into 2 files to comply with ADR-009 (≤10 `fn test_` per file)
- `test_no_grad_context_part1.mojo`: 8 tests (enter/exit + disable/restore)
- `test_no_grad_context_part2.mojo`: 5 tests (roundtrip + recording)
- All 13 original tests preserved, no tests deleted
- Both files include the required ADR-009 header comment
- CI workflow pattern `autograd/test_*.mojo` picks up new files automatically — no workflow changes needed

## Test plan

- [x] Part 1 has exactly 8 `fn test_` functions (≤8 target)
- [x] Part 2 has exactly 5 `fn test_` functions (≤8 target)
- [x] All 13 original test cases preserved
- [x] ADR-009 header comment present in both files
- [x] Pre-commit hooks pass (Mojo format, validate test coverage, etc.)
- [x] CI workflow `autograd/test_*.mojo` pattern matches new filenames

Closes #3517

🤖 Generated with [Claude Code](https://claude.com/claude-code)