### PR TITLE
fix(ci): split test_gradient_ops.mojo into 2 files per ADR-009

### DIFF
--- a/tests/shared/training/test_gradient_ops_part1.mojo
+++ b/tests/shared/training/test_gradient_ops_part1.mojo
@@ -1,11 +1,14 @@
-"""Tests for gradient operation optimizations.
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_gradient_ops.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for gradient accumulation and scaling operations (Part 1 of 2).
 
-Verifies correctness and performance of in-place gradient operations.
+Verifies correctness and performance of in-place gradient accumulation
+and scaling operations.
 
 Test Coverage:
 - accumulate_gradient_inplace: Correctness across dtypes, shapes
 - scale_gradient_inplace: Correctness for scaling factors
-- zero_gradient_inplace: Complete zeroing
 
 All tests use small tensors for fast runtime.
 """
@@ -165,144 +168,42 @@ fn test_scale_gradient_large_tensor() raises:
         )
 
 
-fn test_zero_gradient_float32() raises:
-    """Test gradient zeroing with float32."""
-    # Create tensor with non-zero values
-    var grad = full([100], 42.0, DType.float32)
-
-    # Zero the gradient
-    zero_gradient_inplace(grad)
-
-    # Verify all zeros
-    for i in range(100):
-        var val = grad._get_float64(i)
-        assert_equal_float(
-            Float32(val), Float32(0.0), "Zeroed gradient should be exactly 0.0"
-        )
-
-
-fn test_zero_gradient_float16() raises:
-    """Test gradient zeroing with float16."""
-    # Create tensor with non-zero values
-    var grad = full([50], 3.14, DType.float16)
-
-    # Zero the gradient
-    zero_gradient_inplace(grad)
-
-    # Verify all zeros
-    for i in range(50):
-        var val = grad._get_float64(i)
-        assert_equal_float(
-            Float32(val), Float32(0.0), "Zeroed gradient should be exactly 0.0"
-        )
-
-
-fn test_zero_gradient_large_tensor() raises:
-    """Test gradient zeroing with larger tensor (vectorization test)."""
-    # Create large tensor with non-zero values
-    var grad = full([1000], 123.456, DType.float32)
-
-    # Zero the gradient
-    zero_gradient_inplace(grad)
-
-    # Verify all zeros
-    for i in range(1000):
-        var val = grad._get_float64(i)
-        assert_equal_float(
-            Float32(val), Float32(0.0), "Zeroed gradient should be exactly 0.0"
-        )
-
-
-fn test_gradient_ops_workflow() raises:
-    """Test complete gradient accumulation workflow."""
-    # Simulate gradient accumulation over 4 mini-batches
-    var batch_size = 4
-    var accumulated = zeros([200], DType.float32)
-
-    # Accumulate gradients from 4 mini-batches
-    for batch in range(batch_size):
-        var batch_grad = full([200], Float64(batch + 1), DType.float32)
-        accumulate_gradient_inplace(accumulated, batch_grad)
-
-    # accumulated now contains: 1 + 2 + 3 + 4 = 10.0
-
-    # Average over batch size
-    scale_gradient_inplace(accumulated, 1.0 / Float32(batch_size))
-
-    # Verify averaged gradient
-    for i in range(200):
-        var val = accumulated._get_float64(i)
-        assert_close_float(
-            val,
-            2.5,
-            atol=1e-5,
-            message="Averaged gradient should equal (1+2+3+4)/4 = 2.5",
-        )
-
-    # Zero for next iteration
-    zero_gradient_inplace(accumulated)
-
-    # Verify zeroed
-    for i in range(200):
-        var val = accumulated._get_float64(i)
-        assert_equal_float(
-            Float32(val), Float32(0.0), "Should be zero after zeroing"
-        )
-
-
 fn main() raises:
-    """Run all gradient operation tests."""
-    print("Testing Gradient Operations...")
+    """Run gradient accumulation and scaling tests (Part 1 of 2)."""
+    print("Testing Gradient Operations - Part 1 (Accumulate & Scale)...")
     print("=" * 70)
 
-    print("\n[1/13] Testing gradient accumulation (float32)...")
+    print("\n[1/8] Testing gradient accumulation (float32)...")
     test_accumulate_gradient_float32()
     print("✓ PASSED")
 
-    print("[2/13] Testing gradient accumulation (float16)...")
+    print("[2/8] Testing gradient accumulation (float16)...")
     test_accumulate_gradient_float16()
     print("✓ PASSED")
 
-    print("[3/13] Testing gradient accumulation (large tensor)...")
+    print("[3/8] Testing gradient accumulation (large tensor)...")
     test_accumulate_gradient_large_tensor()
     print("✓ PASSED")
 
-    print("[4/13] Testing accumulation with mismatched shapes (error case)...")
+    print("[4/8] Testing accumulation with mismatched shapes (error case)...")
     test_accumulate_gradient_mismatched_shapes_fails()
     print("✓ PASSED")
 
-    print("[5/13] Testing accumulation with mismatched dtypes (error case)...")
+    print("[5/8] Testing accumulation with mismatched dtypes (error case)...")
     test_accumulate_gradient_mismatched_dtypes_fails()
     print("✓ PASSED")
 
-    print("[6/13] Testing gradient scaling (float32)...")
+    print("[6/8] Testing gradient scaling (float32)...")
     test_scale_gradient_float32()
     print("✓ PASSED")
 
-    print("[7/13] Testing gradient scaling (averaging)...")
+    print("[7/8] Testing gradient scaling (averaging)...")
     test_scale_gradient_averaging()
     print("✓ PASSED")
 
-    print("[8/13] Testing gradient scaling (large tensor)...")
+    print("[8/8] Testing gradient scaling (large tensor)...")
     test_scale_gradient_large_tensor()
     print("✓ PASSED")
 
-    print("[9/13] Testing gradient zeroing (float32)...")
-    test_zero_gradient_float32()
-    print("✓ PASSED")
-
-    print("[10/13] Testing gradient zeroing (float16)...")
-    test_zero_gradient_float16()
-    print("✓ PASSED")
-
-    print("[11/13] Testing gradient zeroing (large tensor)...")
-    test_zero_gradient_large_tensor()
-    print("✓ PASSED")
-
-    print("[12/13] Testing complete gradient workflow...")
-    test_gradient_ops_workflow()
-    print("✓ PASSED")
-
     print("\n" + "=" * 70)
-    print("All 12 gradient operation tests PASSED! ✓")
-    print("Optimized gradient operations are working correctly.")
+    print("All 8 gradient accumulate/scale tests PASSED! ✓")

--- a/tests/shared/training/test_gradient_ops_part2.mojo
+++ b/tests/shared/training/test_gradient_ops_part2.mojo
@@ -1,0 +1,136 @@
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_gradient_ops.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for gradient zeroing operations and workflow (Part 2 of 2).
+
+Verifies correctness and performance of in-place gradient zeroing
+and the complete gradient accumulation workflow.
+
+Test Coverage:
+- zero_gradient_inplace: Complete zeroing across dtypes
+- gradient_ops_workflow: End-to-end accumulation, scaling, and zeroing
+
+All tests use small tensors for fast runtime.
+"""
+
+from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.training.gradient_ops import (
+    accumulate_gradient_inplace,
+    scale_gradient_inplace,
+    zero_gradient_inplace,
+)
+from shared.testing.assertions import (
+    assert_true,
+    assert_close_float,
+    assert_equal_float,
+)
+
+
+fn test_zero_gradient_float32() raises:
+    """Test gradient zeroing with float32."""
+    # Create tensor with non-zero values
+    var grad = full([100], 42.0, DType.float32)
+
+    # Zero the gradient
+    zero_gradient_inplace(grad)
+
+    # Verify all zeros
+    for i in range(100):
+        var val = grad._get_float64(i)
+        assert_equal_float(
+            Float32(val), Float32(0.0), "Zeroed gradient should be exactly 0.0"
+        )
+
+
+fn test_zero_gradient_float16() raises:
+    """Test gradient zeroing with float16."""
+    # Create tensor with non-zero values
+    var grad = full([50], 3.14, DType.float16)
+
+    # Zero the gradient
+    zero_gradient_inplace(grad)
+
+    # Verify all zeros
+    for i in range(50):
+        var val = grad._get_float64(i)
+        assert_equal_float(
+            Float32(val), Float32(0.0), "Zeroed gradient should be exactly 0.0"
+        )
+
+
+fn test_zero_gradient_large_tensor() raises:
+    """Test gradient zeroing with larger tensor (vectorization test)."""
+    # Create large tensor with non-zero values
+    var grad = full([1000], 123.456, DType.float32)
+
+    # Zero the gradient
+    zero_gradient_inplace(grad)
+
+    # Verify all zeros
+    for i in range(1000):
+        var val = grad._get_float64(i)
+        assert_equal_float(
+            Float32(val), Float32(0.0), "Zeroed gradient should be exactly 0.0"
+        )
+
+
+fn test_gradient_ops_workflow() raises:
+    """Test complete gradient accumulation workflow."""
+    # Simulate gradient accumulation over 4 mini-batches
+    var batch_size = 4
+    var accumulated = zeros([200], DType.float32)
+
+    # Accumulate gradients from 4 mini-batches
+    for batch in range(batch_size):
+        var batch_grad = full([200], Float64(batch + 1), DType.float32)
+        accumulate_gradient_inplace(accumulated, batch_grad)
+
+    # accumulated now contains: 1 + 2 + 3 + 4 = 10.0
+
+    # Average over batch size
+    scale_gradient_inplace(accumulated, 1.0 / Float32(batch_size))
+
+    # Verify averaged gradient
+    for i in range(200):
+        var val = accumulated._get_float64(i)
+        assert_close_float(
+            val,
+            2.5,
+            atol=1e-5,
+            message="Averaged gradient should equal (1+2+3+4)/4 = 2.5",
+        )
+
+    # Zero for next iteration
+    zero_gradient_inplace(accumulated)
+
+    # Verify zeroed
+    for i in range(200):
+        var val = accumulated._get_float64(i)
+        assert_equal_float(
+            Float32(val), Float32(0.0), "Should be zero after zeroing"
+        )
+
+
+fn main() raises:
+    """Run gradient zeroing and workflow tests (Part 2 of 2)."""
+    print("Testing Gradient Operations - Part 2 (Zero & Workflow)...")
+    print("=" * 70)
+
+    print("\n[1/4] Testing gradient zeroing (float32)...")
+    test_zero_gradient_float32()
+    print("✓ PASSED")
+
+    print("[2/4] Testing gradient zeroing (float16)...")
+    test_zero_gradient_float16()
+    print("✓ PASSED")
+
+    print("[3/4] Testing gradient zeroing (large tensor)...")
+    test_zero_gradient_large_tensor()
+    print("✓ PASSED")
+
+    print("[4/4] Testing complete gradient workflow...")
+    test_gradient_ops_workflow()
+    print("✓ PASSED")
+
+    print("\n" + "=" * 70)
+    print("All 4 gradient zero/workflow tests PASSED! ✓")


### PR DESCRIPTION
## Summary

- Split `tests/shared/training/test_gradient_ops.mojo` (12 `fn test_` functions) into two files of ≤8 tests each, complying with ADR-009's ≤10 limit per file
- Eliminates intermittent heap corruption crashes (`libKGENCompilerRTShared.so`) in the `Shared Infra & Testing` CI group

## Changes Made

- **Deleted**: `tests/shared/training/test_gradient_ops.mojo` (12 tests)
- **Created**: `tests/shared/training/test_gradient_ops_part1.mojo` (8 tests: accumulate + scale operations)
- **Created**: `tests/shared/training/test_gradient_ops_part2.mojo` (4 tests: zero operations + workflow)
- Each file includes the ADR-009 tracking comment header
- No CI workflow changes needed — existing `training/test_*.mojo` wildcard covers both new files

## Verification

- All 12 original tests preserved across both files
- All pre-commit hooks passed (Mojo format, validate test coverage, etc.)
- `validate_test_coverage.py` confirms coverage via wildcard pattern

Closes #3623

🤖 Generated with [Claude Code](https://claude.com/claude-code)