### PR TITLE
fix(ci): split test_merging.mojo (12 tests) into 2 files per ADR-009

### DIFF
--- a/tests/configs/test_merging_part1.mojo
+++ b/tests/configs/test_merging_part1.mojo
@@ -1,11 +1,17 @@
 """
-Configuration Merging Tests
+Configuration Merging Tests - Part 1
 
 Tests for merging configurations across the 3-tier hierarchy:
 defaults → paper-specific → experiment-specific
 
-Run with: mojo test tests/configs/test_merging.mojo
+Split from test_merging.mojo per ADR-009 (≤10 fn test_ per file).
+
+Run with: mojo test tests/configs/test_merging_part1.mojo
 """
+
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_merging.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 
 from testing import assert_true, assert_false, assert_equal
 from shared.utils.config import Config, load_config, merge_configs
@@ -243,136 +249,15 @@ fn test_merge_nested_structures() raises:
     print("✓ test_merge_nested_structures passed")
 
 
-fn test_merge_with_dotted_keys() raises:
-    """Test merging configs using dotted key notation.
-
-    Verifies that dot-notation keys are handled correctly.
-    """
-    var base = Config()
-    base.set("optimizer.name", "sgd")
-    base.set("optimizer.lr", 0.01)
-
-    var override = Config()
-    override.set("optimizer.lr", 0.001)
-
-    var merged = merge_configs(base, override)
-
-    var opt = merged.get_string("optimizer.name")
-    assert_equal(opt, "sgd", "Should preserve base dotted key")
-
-    var lr = merged.get_float("optimizer.lr")
-    assert_equal(lr, 0.001, "Should override dotted key value")
-
-    print("✓ test_merge_with_dotted_keys passed")
-
-
-# ============================================================================
-# Merge Conflict Tests
-# ============================================================================
-
-
-fn test_merge_type_conflicts() raises:
-    """Test merging when same key has different types.
-
-    Verifies that override type takes precedence.
-    """
-    var base = Config()
-    base.set("value", 42)  # Int
-
-    var override = Config()
-    override.set("value", "forty-two")  # String
-
-    var merged = merge_configs(base, override)
-
-    # Override should win, changing type
-    var val = merged.get_string("value")
-    assert_equal(val, "forty-two", "Override type should take precedence")
-
-    print("✓ test_merge_type_conflicts passed")
-
-
-fn test_merge_multiple_times() raises:
-    """Test merging same config multiple times.
-
-    Verifies that repeated merges produce consistent results.
-    """
-    var base = Config()
-    base.set("a", 1)
-    base.set("b", 2)
-
-    var override = Config()
-    override.set("b", 20)
-    override.set("c", 30)
-
-    var merged1 = merge_configs(base, override)
-    var merged2 = merge_configs(base, override)
-
-    # Should produce identical results
-    assert_equal(
-        merged1.get_int("a"),
-        merged2.get_int("a"),
-        "Multiple merges should be consistent",
-    )
-    assert_equal(
-        merged1.get_int("b"),
-        merged2.get_int("b"),
-        "Multiple merges should be consistent",
-    )
-    assert_equal(
-        merged1.get_int("c"),
-        merged2.get_int("c"),
-        "Multiple merges should be consistent",
-    )
-
-    print("✓ test_merge_multiple_times passed")
-
-
-# ============================================================================
-# Property-Based Tests
-# ============================================================================
-
-
-fn test_merge_associativity() raises:
-    """Test that merge operation is associative.
-
-    Verifies: (A merge B) merge C == A merge (B merge C)
-    Note: This is only true when using right-precedence merging.
-    """
-    var a = Config()
-    a.set("x", 1)
-    a.set("y", 2)
-
-    var b = Config()
-    b.set("y", 20)
-    b.set("z", 30)
-
-    var c = Config()
-    c.set("z", 300)
-    c.set("w", 400)
-
-    # Left-associative: (A merge B) merge C
-    var left = merge_configs(a, b)
-    left = merge_configs(left, c)
-
-    # With right-precedence merging, order matters
-    # This test verifies expected behavior
-    assert_equal(left.get_int("x"), 1, "Should have value from A")
-    assert_equal(left.get_int("y"), 20, "Should have value from B")
-    assert_equal(left.get_int("z"), 300, "Should have value from C")
-    assert_equal(left.get_int("w"), 400, "Should have value from C")
-
-    print("✓ test_merge_associativity passed")
-
-
 # ============================================================================
 # Main Test Runner
 # ============================================================================
 
 
 fn main() raises:
-    """Run all configuration merging tests."""
+    """Run Part 1 configuration merging tests."""
     print("\n" + "=" * 70)
-    print("Running Configuration Merging Tests")
+    print("Running Configuration Merging Tests - Part 1")
     print("=" * 70 + "\n")
 
     # Basic merging tests
@@ -394,19 +279,9 @@ fn main() raises:
     # Deep merging tests
     print("\nTesting Deep Merging...")
     test_merge_nested_structures()
-    test_merge_with_dotted_keys()
-
-    # Conflict handling tests
-    print("\nTesting Merge Conflicts...")
-    test_merge_type_conflicts()
-    test_merge_multiple_times()
-
-    # Property-based tests
-    print("\nTesting Merge Properties...")
-    test_merge_associativity()
 
     # Summary
     print("\n" + "=" * 70)
-    print("✅ All Configuration Merging Tests Passed!")
+    print("✅ All Configuration Merging Tests (Part 1) Passed!")
     print("=" * 70)
     print("\nNote: Some tests will fail until Issue #74 creates config files")

--- a/tests/configs/test_merging_part2.mojo
+++ b/tests/configs/test_merging_part2.mojo
@@ -1,0 +1,172 @@
+"""
+Configuration Merging Tests - Part 2
+
+Tests for merge conflict handling and merge properties.
+
+Split from test_merging.mojo per ADR-009 (≤10 fn test_ per file).
+
+Run with: mojo test tests/configs/test_merging_part2.mojo
+"""
+
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_merging.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+from testing import assert_true, assert_false, assert_equal
+from shared.utils.config import Config, load_config, merge_configs
+
+
+# ============================================================================
+# Deep Merging Tests (continued)
+# ============================================================================
+
+
+fn test_merge_with_dotted_keys() raises:
+    """Test merging configs using dotted key notation.
+
+    Verifies that dot-notation keys are handled correctly.
+    """
+    var base = Config()
+    base.set("optimizer.name", "sgd")
+    base.set("optimizer.lr", 0.01)
+
+    var override = Config()
+    override.set("optimizer.lr", 0.001)
+
+    var merged = merge_configs(base, override)
+
+    var opt = merged.get_string("optimizer.name")
+    assert_equal(opt, "sgd", "Should preserve base dotted key")
+
+    var lr = merged.get_float("optimizer.lr")
+    assert_equal(lr, 0.001, "Should override dotted key value")
+
+    print("✓ test_merge_with_dotted_keys passed")
+
+
+# ============================================================================
+# Merge Conflict Tests
+# ============================================================================
+
+
+fn test_merge_type_conflicts() raises:
+    """Test merging when same key has different types.
+
+    Verifies that override type takes precedence.
+    """
+    var base = Config()
+    base.set("value", 42)  # Int
+
+    var override = Config()
+    override.set("value", "forty-two")  # String
+
+    var merged = merge_configs(base, override)
+
+    # Override should win, changing type
+    var val = merged.get_string("value")
+    assert_equal(val, "forty-two", "Override type should take precedence")
+
+    print("✓ test_merge_type_conflicts passed")
+
+
+fn test_merge_multiple_times() raises:
+    """Test merging same config multiple times.
+
+    Verifies that repeated merges produce consistent results.
+    """
+    var base = Config()
+    base.set("a", 1)
+    base.set("b", 2)
+
+    var override = Config()
+    override.set("b", 20)
+    override.set("c", 30)
+
+    var merged1 = merge_configs(base, override)
+    var merged2 = merge_configs(base, override)
+
+    # Should produce identical results
+    assert_equal(
+        merged1.get_int("a"),
+        merged2.get_int("a"),
+        "Multiple merges should be consistent",
+    )
+    assert_equal(
+        merged1.get_int("b"),
+        merged2.get_int("b"),
+        "Multiple merges should be consistent",
+    )
+    assert_equal(
+        merged1.get_int("c"),
+        merged2.get_int("c"),
+        "Multiple merges should be consistent",
+    )
+
+    print("✓ test_merge_multiple_times passed")
+
+
+# ============================================================================
+# Property-Based Tests
+# ============================================================================
+
+
+fn test_merge_associativity() raises:
+    """Test that merge operation is associative.
+
+    Verifies: (A merge B) merge C == A merge (B merge C)
+    Note: This is only true when using right-precedence merging.
+    """
+    var a = Config()
+    a.set("x", 1)
+    a.set("y", 2)
+
+    var b = Config()
+    b.set("y", 20)
+    b.set("z", 30)
+
+    var c = Config()
+    c.set("z", 300)
+    c.set("w", 400)
+
+    # Left-associative: (A merge B) merge C
+    var left = merge_configs(a, b)
+    left = merge_configs(left, c)
+
+    # With right-precedence merging, order matters
+    # This test verifies expected behavior
+    assert_equal(left.get_int("x"), 1, "Should have value from A")
+    assert_equal(left.get_int("y"), 20, "Should have value from B")
+    assert_equal(left.get_int("z"), 300, "Should have value from C")
+    assert_equal(left.get_int("w"), 400, "Should have value from C")
+
+    print("✓ test_merge_associativity passed")
+
+
+# ============================================================================
+# Main Test Runner
+# ============================================================================
+
+
+fn main() raises:
+    """Run Part 2 configuration merging tests."""
+    print("\n" + "=" * 70)
+    print("Running Configuration Merging Tests - Part 2")
+    print("=" * 70 + "\n")
+
+    # Deep merging tests (continued)
+    print("Testing Deep Merging (continued)...")
+    test_merge_with_dotted_keys()
+
+    # Conflict handling tests
+    print("\nTesting Merge Conflicts...")
+    test_merge_type_conflicts()
+    test_merge_multiple_times()
+
+    # Property-based tests
+    print("\nTesting Merge Properties...")
+    test_merge_associativity()
+
+    # Summary
+    print("\n" + "=" * 70)
+    print("✅ All Configuration Merging Tests (Part 2) Passed!")
+    print("=" * 70)


### PR DESCRIPTION
## Summary

- Splits `tests/configs/test_merging.mojo` (12 `fn test_` functions) into two files of ≤8 tests each to fix intermittent heap corruption crashes (Mojo v0.26.1 `libKGENCompilerRTShared.so` JIT fault) in the **Configs** CI group
- `test_merging_part1.mojo`: 8 tests (basic merging, 2-level, 3-level, nested structures)
- `test_merging_part2.mojo`: 4 tests (dotted keys, type conflicts, idempotency, associativity)

## Changes

- Deleted `tests/configs/test_merging.mojo` (replaced)
- Created `tests/configs/test_merging_part1.mojo` (8 `fn test_` functions) with ADR-009 header
- Created `tests/configs/test_merging_part2.mojo` (4 `fn test_` functions) with ADR-009 header
- No CI workflow changes needed — Configs group uses `test_*.mojo` glob

## Test plan

- [x] All 12 original test cases preserved (no tests deleted)
- [x] Each new file has the ADR-009 tracking comment header
- [x] `test_merging_part1.mojo`: 8 tests (≤8 target met)
- [x] `test_merging_part2.mojo`: 4 tests (≤8 target met)
- [x] Pre-commit hooks pass (Mojo format, validate test coverage)
- [x] CI Configs group will discover both files via `test_*.mojo` glob

Closes #3629

🤖 Generated with [Claude Code](https://claude.com/claude-code)