### PR TITLE
fix(ci): split test_confusion_matrix.mojo (11 tests) per ADR-009

### DIFF
--- a/tests/training/test_confusion_matrix_part1.mojo
+++ b/tests/training/test_confusion_matrix_part1.mojo
@@ -1,16 +1,18 @@
-"""Tests for confusion matrix metrics.
+"""Tests for confusion matrix metrics (Part 1 of 2).
 
-Comprehensive test suite for ConfusionMatrix with normalization modes
-and derived metrics (precision, recall, F1-score).
+Basic functionality, normalization, and derived metrics tests for ConfusionMatrix.
 
 Test coverage:
-- #289: Confusion matrix tests
+- #289: Confusion matrix tests (part 1)
 
 Testing strategy:
 - Correctness: Verify matrix values and derived metrics
 - Normalization: Test all modes (row, column, total, none)
-- Edge cases: Empty matrix, single class, perfect/worst predictions
 - Multi-class: Test with various class distributions
+
+ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+high test load. Split from test_confusion_matrix.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
 from testing import assert_true, assert_false, assert_equal, assert_almost_equal
@@ -434,142 +436,16 @@ fn test_confusion_matrix_f1_score() raises:
     print("  ✓ F1-score test passed")
 
 
-fn test_confusion_matrix_with_logits() raises:
-    """Test confusion matrix with logits (not class indices)."""
-    print("Testing ConfusionMatrix with logits...")
-
-    var cm = ConfusionMatrix(num_classes=3)
-
-    # Create logits [batch_size=4, num_classes=3]
-    var logits_shape = List[Int]()
-    logits_shape.append(4)
-    logits_shape.append(3)
-    var logits = ExTensor(logits_shape, DType.float32)
-    var labels_shape = List[Int]()
-    labels_shape.append(4)  # 4 samples
-    var labels = ExTensor(labels_shape, DType.int32)
-
-    # Sample 0: true=0, logits=[10, 0, 0] -> pred=0 ✓
-    logits._data.bitcast[Float32]()[0] = 10.0
-    logits._data.bitcast[Float32]()[1] = 0.0
-    logits._data.bitcast[Float32]()[2] = 0.0
-    labels._data.bitcast[Int32]()[0] = 0
-
-    # Sample 1: true=1, logits=[0, 10, 0] -> pred=1 ✓
-    logits._data.bitcast[Float32]()[3] = 0.0
-    logits._data.bitcast[Float32]()[4] = 10.0
-    logits._data.bitcast[Float32]()[5] = 0.0
-    labels._data.bitcast[Int32]()[1] = 1
-
-    # Sample 2: true=2, logits=[0, 0, 10] -> pred=2 ✓
-    logits._data.bitcast[Float32]()[6] = 0.0
-    logits._data.bitcast[Float32]()[7] = 0.0
-    logits._data.bitcast[Float32]()[8] = 10.0
-    labels._data.bitcast[Int32]()[2] = 2
-
-    # Sample 3: true=0, logits=[0, 10, 0] -> pred=1 ✗
-    logits._data.bitcast[Float32]()[9] = 0.0
-    logits._data.bitcast[Float32]()[10] = 10.0
-    logits._data.bitcast[Float32]()[11] = 0.0
-    labels._data.bitcast[Int32]()[3] = 0
-
-    cm.update(logits, labels)
-
-    # Expected matrix: [1,1,0; 0,1,0; 0,0,1]
-    var raw = cm.normalize(mode="none")
-
-    assert_equal(
-        Int(raw._data.bitcast[Float64]()[0]), 1, "Matrix[0,0] should be 1"
-    )
-    assert_equal(
-        Int(raw._data.bitcast[Float64]()[1]), 1, "Matrix[0,1] should be 1"
-    )
-    assert_equal(
-        Int(raw._data.bitcast[Float64]()[4]), 1, "Matrix[1,1] should be 1"
-    )
-    assert_equal(
-        Int(raw._data.bitcast[Float64]()[8]), 1, "Matrix[2,2] should be 1"
-    )
-
-    print("  ✓ Logits test passed")
-
-
-fn test_confusion_matrix_reset() raises:
-    """Test resetting confusion matrix."""
-    print("Testing ConfusionMatrix reset...")
-
-    var cm = ConfusionMatrix(num_classes=2)
-
-    # Add some data
-    var preds_shape = List[Int]()
-    preds_shape.append(2)  # 2 samples
-    var preds = ExTensor(preds_shape, DType.int32)
-    var labels_shape = List[Int]()
-    labels_shape.append(2)  # 2 samples
-    var labels = ExTensor(labels_shape, DType.int32)
-    preds._data.bitcast[Int32]()[0] = 0
-    preds._data.bitcast[Int32]()[1] = 1
-    labels._data.bitcast[Int32]()[0] = 0
-    labels._data.bitcast[Int32]()[1] = 1
-
-    cm.update(preds, labels)
-
-    # Reset
-    cm.reset()
-
-    # All values should be 0
-    var raw = cm.normalize(mode="none")
-    for i in range(4):
-        assert_equal(
-            Int(raw._data.bitcast[Float64]()[i]),
-            0,
-            "All values should be 0 after reset",
-        )
-
-    print("  ✓ Reset test passed")
-
-
-fn test_confusion_matrix_empty() raises:
-    """Test confusion matrix with no data."""
-    print("Testing ConfusionMatrix empty...")
-
-    var cm = ConfusionMatrix(num_classes=3)
-
-    # Get metrics without adding data
-    var precision = cm.get_precision()
-    var recall = cm.get_recall()
-    var f1 = cm.get_f1_score()
-
-    # All should be 0.0
-    for i in range(3):
-        assert_equal(
-            precision._data.bitcast[Float64]()[i],
-            0.0,
-            "Empty precision should be 0.0",
-        )
-        assert_equal(
-            recall._data.bitcast[Float64]()[i],
-            0.0,
-            "Empty recall should be 0.0",
-        )
-        assert_equal(
-            f1._data.bitcast[Float64]()[i], 0.0, "Empty F1 should be 0.0"
-        )
-
-    print("  ✓ Empty matrix test passed")
-
-
 fn main() raises:
-    """Run all confusion matrix tests."""
+    """Run confusion matrix tests (Part 1): basic, normalization, and derived metrics."""
     print("\n" + "=" * 70)
-    print("CONFUSION MATRIX TEST SUITE")
+    print("CONFUSION MATRIX TEST SUITE - PART 1")
     print("=" * 70 + "\n")
 
     print("Basic Functionality Tests (#289)")
     print("-" * 70)
     test_confusion_matrix_basic()
     test_confusion_matrix_perfect()
-    test_confusion_matrix_with_logits()
 
     print("\nNormalization Tests (#289)")
     print("-" * 70)
@@ -583,11 +459,6 @@ fn main() raises:
     test_confusion_matrix_recall()
     test_confusion_matrix_f1_score()
 
-    print("\nEdge Cases (#289)")
-    print("-" * 70)
-    test_confusion_matrix_reset()
-    test_confusion_matrix_empty()
-
     print("\n" + "=" * 70)
-    print("ALL CONFUSION MATRIX TESTS PASSED ✓")
+    print("ALL CONFUSION MATRIX PART 1 TESTS PASSED ✓")
     print("=" * 70 + "\n")

--- a/tests/training/test_confusion_matrix_part2.mojo
+++ b/tests/training/test_confusion_matrix_part2.mojo
@@ -1,0 +1,164 @@
+"""Tests for confusion matrix metrics (Part 2 of 2).
+
+Edge case and logits tests for ConfusionMatrix.
+
+Test coverage:
+- #289: Confusion matrix tests (part 2)
+
+Testing strategy:
+- Logits: Test with 2D logit inputs (argmax-based prediction)
+- Edge cases: Empty matrix, reset functionality
+
+ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+high test load. Split from test_confusion_matrix.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""
+
+from testing import assert_true, assert_false, assert_equal, assert_almost_equal
+from shared.core import ExTensor
+from shared.training.metrics import ConfusionMatrix
+
+
+fn test_confusion_matrix_with_logits() raises:
+    """Test confusion matrix with logits (not class indices)."""
+    print("Testing ConfusionMatrix with logits...")
+
+    var cm = ConfusionMatrix(num_classes=3)
+
+    # Create logits [batch_size=4, num_classes=3]
+    var logits_shape = List[Int]()
+    logits_shape.append(4)
+    logits_shape.append(3)
+    var logits = ExTensor(logits_shape, DType.float32)
+    var labels_shape = List[Int]()
+    labels_shape.append(4)  # 4 samples
+    var labels = ExTensor(labels_shape, DType.int32)
+
+    # Sample 0: true=0, logits=[10, 0, 0] -> pred=0 ✓
+    logits._data.bitcast[Float32]()[0] = 10.0
+    logits._data.bitcast[Float32]()[1] = 0.0
+    logits._data.bitcast[Float32]()[2] = 0.0
+    labels._data.bitcast[Int32]()[0] = 0
+
+    # Sample 1: true=1, logits=[0, 10, 0] -> pred=1 ✓
+    logits._data.bitcast[Float32]()[3] = 0.0
+    logits._data.bitcast[Float32]()[4] = 10.0
+    logits._data.bitcast[Float32]()[5] = 0.0
+    labels._data.bitcast[Int32]()[1] = 1
+
+    # Sample 2: true=2, logits=[0, 0, 10] -> pred=2 ✓
+    logits._data.bitcast[Float32]()[6] = 0.0
+    logits._data.bitcast[Float32]()[7] = 0.0
+    logits._data.bitcast[Float32]()[8] = 10.0
+    labels._data.bitcast[Int32]()[2] = 2
+
+    # Sample 3: true=0, logits=[0, 10, 0] -> pred=1 ✗
+    logits._data.bitcast[Float32]()[9] = 0.0
+    logits._data.bitcast[Float32]()[10] = 10.0
+    logits._data.bitcast[Float32]()[11] = 0.0
+    labels._data.bitcast[Int32]()[3] = 0
+
+    cm.update(logits, labels)
+
+    # Expected matrix: [1,1,0; 0,1,0; 0,0,1]
+    var raw = cm.normalize(mode="none")
+
+    assert_equal(
+        Int(raw._data.bitcast[Float64]()[0]), 1, "Matrix[0,0] should be 1"
+    )
+    assert_equal(
+        Int(raw._data.bitcast[Float64]()[1]), 1, "Matrix[0,1] should be 1"
+    )
+    assert_equal(
+        Int(raw._data.bitcast[Float64]()[4]), 1, "Matrix[1,1] should be 1"
+    )
+    assert_equal(
+        Int(raw._data.bitcast[Float64]()[8]), 1, "Matrix[2,2] should be 1"
+    )
+
+    print("  ✓ Logits test passed")
+
+
+fn test_confusion_matrix_reset() raises:
+    """Test resetting confusion matrix."""
+    print("Testing ConfusionMatrix reset...")
+
+    var cm = ConfusionMatrix(num_classes=2)
+
+    # Add some data
+    var preds_shape = List[Int]()
+    preds_shape.append(2)  # 2 samples
+    var preds = ExTensor(preds_shape, DType.int32)
+    var labels_shape = List[Int]()
+    labels_shape.append(2)  # 2 samples
+    var labels = ExTensor(labels_shape, DType.int32)
+    preds._data.bitcast[Int32]()[0] = 0
+    preds._data.bitcast[Int32]()[1] = 1
+    labels._data.bitcast[Int32]()[0] = 0
+    labels._data.bitcast[Int32]()[1] = 1
+
+    cm.update(preds, labels)
+
+    # Reset
+    cm.reset()
+
+    # All values should be 0
+    var raw = cm.normalize(mode="none")
+    for i in range(4):
+        assert_equal(
+            Int(raw._data.bitcast[Float64]()[i]),
+            0,
+            "All values should be 0 after reset",
+        )
+
+    print("  ✓ Reset test passed")
+
+
+fn test_confusion_matrix_empty() raises:
+    """Test confusion matrix with no data."""
+    print("Testing ConfusionMatrix empty...")
+
+    var cm = ConfusionMatrix(num_classes=3)
+
+    # Get metrics without adding data
+    var precision = cm.get_precision()
+    var recall = cm.get_recall()
+    var f1 = cm.get_f1_score()
+
+    # All should be 0.0
+    for i in range(3):
+        assert_equal(
+            precision._data.bitcast[Float64]()[i],
+            0.0,
+            "Empty precision should be 0.0",
+        )
+        assert_equal(
+            recall._data.bitcast[Float64]()[i],
+            0.0,
+            "Empty recall should be 0.0",
+        )
+        assert_equal(
+            f1._data.bitcast[Float64]()[i], 0.0, "Empty F1 should be 0.0"
+        )
+
+    print("  ✓ Empty matrix test passed")
+
+
+fn main() raises:
+    """Run confusion matrix tests (Part 2): logits and edge cases."""
+    print("\n" + "=" * 70)
+    print("CONFUSION MATRIX TEST SUITE - PART 2")
+    print("=" * 70 + "\n")
+
+    print("Logits Input Tests (#289)")
+    print("-" * 70)
+    test_confusion_matrix_with_logits()
+
+    print("\nEdge Cases (#289)")
+    print("-" * 70)
+    test_confusion_matrix_reset()
+    test_confusion_matrix_empty()
+
+    print("\n" + "=" * 70)
+    print("ALL CONFUSION MATRIX PART 2 TESTS PASSED ✓")
+    print("=" * 70 + "\n")


### PR DESCRIPTION
## Summary

- Splits `tests/training/test_confusion_matrix.mojo` (11 tests) into two files of ≤8 tests each, per ADR-009 heap corruption workaround
- All 11 original test cases preserved — no tests deleted or modified
- Each new file includes the ADR-009 tracking comment in its header

## Changes Made

- **Deleted**: `tests/training/test_confusion_matrix.mojo` (11 `fn test_` functions — exceeded ADR-009 limit)
- **Created**: `tests/training/test_confusion_matrix_part1.mojo` (8 tests: basic, perfect, normalize_row, normalize_column, normalize_total, precision, recall, f1_score)
- **Created**: `tests/training/test_confusion_matrix_part2.mojo` (3 tests: with_logits, reset, empty)

## CI Impact

The CI "Misc Tests" group uses `pattern: "training/test_*.mojo"` which automatically discovers both new files. No workflow changes required.

## Verification

- Pre-commit hooks passed (Mojo format, validate test coverage, trailing whitespace, end-of-file)
- Test count per file: part1=8, part2=3 (both ≤ ADR-009 limit of 10)
- ADR-009 header comment present in both files

Closes #3630