### PR TITLE
fix(ci): split test_data_integrity.mojo (11 tests) — Mojo heap corruption (ADR-009)

### DIFF
--- a/docs/dev/phases.md
+++ b/docs/dev/phases.md
@@ -34,7 +34,8 @@ Links to detailed fixes in [fixes.md](fixes.md), learnings in [learnings.md](../
 
 **Impact**: Correct dequant size restore; no corruption in conversions.
 
-**Tests**: `test_data_integrity.mojo` (12 funcs, unaligned/edge cases).
+**Tests**: `test_data_integrity_part1.mojo` (8 funcs) + `test_data_integrity_part2.mojo` (3 funcs),
+split per ADR-009 (≤10 fn test_ per file, unaligned/edge cases).
 
 ## Phase 4: Testing & Docs
 

--- a/tests/test_data_integrity_part1.mojo
+++ b/tests/test_data_integrity_part1.mojo
@@ -1,13 +1,16 @@
-"""Data Integrity Tests for ExTensor Quantization Functions.
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_data_integrity.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Data Integrity Tests for ExTensor Quantization Functions (Part 1).
 
 Tests for Phase 3 data integrity fixes:
 - #1909 (DATA-001): Padding data loss in quantization
 - #1910 (DATA-002): Missing size tracking in dequantization
 - #1911 (DATA-003): Unvalidated DType in conversions
-- #1912 (DATA-004): Unsafe bitcasts without bounds checks
 - #1913 (DATA-005): FP16→FP32 conversion documentation
 
-Run with: `mojo test_data_integrity.mojo`
+Split from test_data_integrity.mojo per ADR-009 (≤10 fn test_ per file).
+Run with: `mojo test_data_integrity_part1.mojo`
 """
 
 from collections import List
@@ -215,89 +218,10 @@ fn test_fp16_conversion_behavior() raises:
     print("  ✓ FP16 conversion: FP16 → FP32 (internal) → MXFP4 → Float32")
 
 
-fn test_int_conversion_bounds() raises:
-    """Test integer conversion with bounds checking."""
-    print("Test: Integer conversion bounds checking...")
-
-    var shape = List[Int]()
-    shape.append(10)
-    var t = zeros(shape, DType.float32)
-    for i in range(10):
-        t._data.bitcast[Float32]()[i] = Float32(i)
-
-    # Test to_int8
-    var i8_t = t.to_int8()
-    assert_true(i8_t.numel() == 10, "Int8 tensor should have 10 elements")
-
-    # Test to_int16
-    var i16_t = t.to_int16()
-    assert_true(i16_t.numel() == 10, "Int16 tensor should have 10 elements")
-
-    # Test to_int32
-    var i32_t = t.to_int32()
-    assert_true(i32_t.numel() == 10, "Int32 tensor should have 10 elements")
-
-    # Test to_uint8
-    var u8_t = t.to_uint8()
-    assert_true(u8_t.numel() == 10, "UInt8 tensor should have 10 elements")
-
-    print("  ✓ Integer conversion bounds checking works")
-
-
-fn test_metadata_preservation() raises:
-    """Test that quantization metadata is properly set and used."""
-    print("Test: Quantization metadata preservation...")
-
-    var shape = List[Int]()
-    shape.append(123)
-    var t = zeros(shape, DType.float32)
-    for i in range(123):
-        t._data.bitcast[Float32]()[i] = Float32(i)
-
-    # Encode to MXFP4
-    var encoded = t.to_mxfp4()
-
-    # Metadata should be set
-    assert_true(
-        encoded._original_numel_quantized == 123,
-        "Original size should be stored in metadata",
-    )
-
-    # Decode using metadata
-    var decoded = encoded.from_mxfp4()
-
-    # Should restore exact size
-    assert_true(
-        decoded.numel() == 123,
-        "Decoded should restore original size from metadata",
-    )
-    print("  ✓ Quantization metadata preserved and used correctly")
-
-
-fn test_backwards_compatibility() raises:
-    """Test backwards compatibility for non-quantized tensors."""
-    print("Test: Backwards compatibility...")
-
-    var shape = List[Int]()
-    shape.append(10)
-    var t = zeros(shape, DType.float32)
-
-    # Non-quantized tensors should have _original_numel_quantized = -1
-    assert_true(
-        t._original_numel_quantized == -1,
-        "Non-quantized tensor should have -1 flag",
-    )
-
-    # Regular operations should not be affected
-    var t2 = t.copy()
-    assert_true(t2.numel() == 10, "Copy should work normally")
-    print("  ✓ Backwards compatibility maintained")
-
-
 fn main() raises:
-    """Run all data integrity tests."""
+    """Run data integrity tests part 1."""
     print("=" * 60)
-    print("DATA INTEGRITY TESTS FOR EXTENSOR QUANTIZATION")
+    print("DATA INTEGRITY TESTS PART 1 (ADR-009 split)")
     print("=" * 60)
     print()
 
@@ -310,7 +234,6 @@ fn main() raises:
 
     # DATA-004: Bounds checking
     test_fp8_bounds_checking()
-    test_int_conversion_bounds()
     print()
 
     # DATA-003: Dtype validation
@@ -322,11 +245,6 @@ fn main() raises:
     test_fp16_conversion_behavior()
     print()
 
-    # Metadata and backwards compatibility
-    test_metadata_preservation()
-    test_backwards_compatibility()
-    print()
-
     print("=" * 60)
-    print("ALL DATA INTEGRITY TESTS PASSED!")
+    print("DATA INTEGRITY TESTS PART 1 PASSED!")
     print("=" * 60)

--- a/tests/test_data_integrity_part2.mojo
+++ b/tests/test_data_integrity_part2.mojo
@@ -1,0 +1,118 @@
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_data_integrity.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Data Integrity Tests for ExTensor Quantization Functions (Part 2).
+
+Tests for Phase 3 data integrity fixes:
+- #1912 (DATA-004): Unsafe bitcasts without bounds checks
+- Quantization metadata preservation
+- Backwards compatibility
+
+Split from test_data_integrity.mojo per ADR-009 (≤10 fn test_ per file).
+Run with: `mojo test_data_integrity_part2.mojo`
+"""
+
+from collections import List
+from memory import UnsafePointer
+from shared.core.extensor import ExTensor, zeros, ones
+from tests.shared.conftest import assert_equal_int, assert_true
+
+
+fn test_int_conversion_bounds() raises:
+    """Test integer conversion with bounds checking."""
+    print("Test: Integer conversion bounds checking...")
+
+    var shape = List[Int]()
+    shape.append(10)
+    var t = zeros(shape, DType.float32)
+    for i in range(10):
+        t._data.bitcast[Float32]()[i] = Float32(i)
+
+    # Test to_int8
+    var i8_t = t.to_int8()
+    assert_true(i8_t.numel() == 10, "Int8 tensor should have 10 elements")
+
+    # Test to_int16
+    var i16_t = t.to_int16()
+    assert_true(i16_t.numel() == 10, "Int16 tensor should have 10 elements")
+
+    # Test to_int32
+    var i32_t = t.to_int32()
+    assert_true(i32_t.numel() == 10, "Int32 tensor should have 10 elements")
+
+    # Test to_uint8
+    var u8_t = t.to_uint8()
+    assert_true(u8_t.numel() == 10, "UInt8 tensor should have 10 elements")
+
+    print("  ✓ Integer conversion bounds checking works")
+
+
+fn test_metadata_preservation() raises:
+    """Test that quantization metadata is properly set and used."""
+    print("Test: Quantization metadata preservation...")
+
+    var shape = List[Int]()
+    shape.append(123)
+    var t = zeros(shape, DType.float32)
+    for i in range(123):
+        t._data.bitcast[Float32]()[i] = Float32(i)
+
+    # Encode to MXFP4
+    var encoded = t.to_mxfp4()
+
+    # Metadata should be set
+    assert_true(
+        encoded._original_numel_quantized == 123,
+        "Original size should be stored in metadata",
+    )
+
+    # Decode using metadata
+    var decoded = encoded.from_mxfp4()
+
+    # Should restore exact size
+    assert_true(
+        decoded.numel() == 123,
+        "Decoded should restore original size from metadata",
+    )
+    print("  ✓ Quantization metadata preserved and used correctly")
+
+
+fn test_backwards_compatibility() raises:
+    """Test backwards compatibility for non-quantized tensors."""
+    print("Test: Backwards compatibility...")
+
+    var shape = List[Int]()
+    shape.append(10)
+    var t = zeros(shape, DType.float32)
+
+    # Non-quantized tensors should have _original_numel_quantized = -1
+    assert_true(
+        t._original_numel_quantized == -1,
+        "Non-quantized tensor should have -1 flag",
+    )
+
+    # Regular operations should not be affected
+    var t2 = t.copy()
+    assert_true(t2.numel() == 10, "Copy should work normally")
+    print("  ✓ Backwards compatibility maintained")
+
+
+fn main() raises:
+    """Run data integrity tests part 2."""
+    print("=" * 60)
+    print("DATA INTEGRITY TESTS PART 2 (ADR-009 split)")
+    print("=" * 60)
+    print()
+
+    # DATA-004: Bounds checking
+    test_int_conversion_bounds()
+    print()
+
+    # Metadata and backwards compatibility
+    test_metadata_preservation()
+    test_backwards_compatibility()
+    print()
+
+    print("=" * 60)
+    print("DATA INTEGRITY TESTS PART 2 PASSED!")
+    print("=" * 60)


### PR DESCRIPTION
## Summary

- Split `tests/test_data_integrity.mojo` (11 `fn test_` functions) into two files to comply with ADR-009 (≤10 per file)
- `tests/test_data_integrity_part1.mojo`: 8 tests (DATA-001/002/003/004/005 + FP16 behavior)
- `tests/test_data_integrity_part2.mojo`: 3 tests (integer bounds, metadata preservation, backwards compat)
- All 11 original test cases preserved — no tests deleted
- Each new file includes the required ADR-009 header comment
- New files are automatically covered by the existing "Misc Tests" CI group (`tests/` + `test_*.mojo` pattern)

## Test plan

- [x] Pre-commit hooks pass (mojo format, validate-test-coverage, markdown lint)
- [x] All 11 original tests preserved across the two files
- [x] Part 1: 8 `fn test_` functions (≤10 ✓)
- [x] Part 2: 3 `fn test_` functions (≤10 ✓)
- [x] Both files include ADR-009 header comment
- [x] `validate_test_coverage.py` passes (new files covered by existing glob pattern)
- [x] `docs/dev/phases.md` updated to reference new filenames

Closes #3631

🤖 Generated with [Claude Code](https://claude.com/claude-code)