### PR TITLE
fix(ci): split test_cache.mojo (11 tests) into part1/part2 per ADR-009

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -224,8 +224,10 @@ jobs:
             path: "tests/shared/core"
             pattern: "test_utilities.mojo test_utility.mojo test_utils.mojo test_validation.mojo test_validation_extended.mojo test_integration.mojo test_inplace_simd.mojo test_lazy_expression.mojo test_memory_pool_part1.mojo test_memory_pool_part2.mojo test_constants.mojo test_extensor_getset_float32.mojo test_extensor_inplace_ops.mojo test_extensor_randn.mojo test_extensor_reflected_ops.mojo test_extensor_serialization.mojo test_extensor_slicing.mojo test_extensor_unary_ops.mojo test_memory_leaks.mojo test_initializers_part1.mojo test_initializers_part2.mojo test_initializers_part3.mojo test_initializers_part4.mojo test_initializers_part5.mojo test_initializers_part6.mojo test_initializers_validation.mojo test_layers.mojo test_linear.mojo test_conv.mojo test_normalization.mojo test_dropout_part1.mojo test_dropout_part2.mojo test_module.mojo test_composed_op.mojo"
           # ---- All data subsystems (formats/datasets/samplers/transforms/loaders) ----
-          # NOTE: Some data tests (test_cache, test_prefetch, test_random_transform_base) crash
+          # NOTE: Some data tests (test_prefetch, test_random_transform_base) crash
           # on CI with heap corruption — non-blocking pending investigation
+          # test_cache.mojo was split into test_cache_part1.mojo + test_cache_part2.mojo
+          # per ADR-009 (≤10 fn test_ per file) to fix heap corruption in the Data CI group.
           - name: "Data"
             path: "tests/shared/data"
             pattern: "test_*.mojo datasets/test_*.mojo samplers/test_*.mojo transforms/test_*.mojo loaders/test_*.mojo formats/test_*.mojo"

--- a/tests/shared/data/test_cache_part1.mojo
+++ b/tests/shared/data/test_cache_part1.mojo
@@ -1,4 +1,7 @@
-"""Tests for CachedDataset wrapper.
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_cache.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for CachedDataset wrapper (part 1 of 2).
 
 Tests that CachedDataset correctly caches samples and respects limits.
 """
@@ -186,84 +189,9 @@ fn test_cached_dataset_clear_cache() raises:
     assert_equal(cached.cache.__len__(), 0)
 
 
-fn test_cached_dataset_enable_disable() raises:
-    """Test enabling and disabling cache.
-
-    Should be able to toggle caching on/off.
-    """
-    var data_shape: List[Int] = [5, 1, 8, 8]
-    var label_shape: List[Int] = [5, 10]
-
-    var data = ones(data_shape, DType.float32)
-    var labels = zeros(label_shape, DType.float32)
-
-    var base_dataset = ExTensorDataset(data^, labels^)
-    var cached = CachedDataset(base_dataset^, max_cache_size=-1)
-
-    # Cache is enabled by default
-    assert_true(cached.cache_enabled)
-
-    # Disable
-    cached.disable_cache()
-    assert_true(not cached.cache_enabled)
-
-    # Enable again
-    cached.enable_cache()
-    assert_true(cached.cache_enabled)
-
-
-fn test_cached_dataset_hit_rate() raises:
-    """Test cache hit rate calculation.
-
-    Hit rate should be hits / (hits + misses).
-    """
-    var data_shape: List[Int] = [5, 1, 8, 8]
-    var label_shape: List[Int] = [5, 10]
-
-    var data = ones(data_shape, DType.float32)
-    var labels = zeros(label_shape, DType.float32)
-
-    var base_dataset = ExTensorDataset(data^, labels^)
-    var cached = CachedDataset(base_dataset^, max_cache_size=-1)
-
-    # No accesses yet - should return 0.0
-    assert_equal(cached.get_hit_rate(), Float32(0.0))
-
-    # 2 accesses to same sample - 1 hit, 1 miss
-    var _d1, _l1 = cached._get_and_cache(0)
-    var _d2, _l2 = cached._get_and_cache(0)
-
-    var hit_rate = cached.get_hit_rate()
-    assert_almost_equal(hit_rate, Float32(0.5), Float32(0.01))
-
-
-fn test_cached_dataset_get_stats() raises:
-    """Test cache statistics.
-
-    get_cache_stats should return (cache_size, hits, misses).
-    """
-    var data_shape: List[Int] = [5, 1, 8, 8]
-    var label_shape: List[Int] = [5, 10]
-
-    var data = ones(data_shape, DType.float32)
-    var labels = zeros(label_shape, DType.float32)
-
-    var base_dataset = ExTensorDataset(data^, labels^)
-    var cached = CachedDataset(base_dataset^, max_cache_size=-1)
-
-    var _d1, _l1 = cached._get_and_cache(0)
-    var _d2, _l2 = cached._get_and_cache(0)
-
-    var cache_size, hits, misses = cached.get_cache_stats()
-
-    assert_equal(cache_size, 1)
-    assert_equal(hits, 1)
-    assert_equal(misses, 1)
-
-
 fn main() raises:
     """Run all tests."""
-    print("Testing CachedDataset...")
+    print("Testing CachedDataset (part 1)...")
     print("  test_cached_dataset_creation...")
     test_cached_dataset_creation()
     print("  test_cached_dataset_length...")
@@ -280,10 +208,4 @@ fn main() raises:
     test_cached_dataset_preload_cache()
     print("  test_cached_dataset_clear_cache...")
     test_cached_dataset_clear_cache()
-    print("  test_cached_dataset_enable_disable...")
-    test_cached_dataset_enable_disable()
-    print("  test_cached_dataset_hit_rate...")
-    test_cached_dataset_hit_rate()
-    print("  test_cached_dataset_get_stats...")
-    test_cached_dataset_get_stats()
-    print("All CachedDataset tests passed!")
+    print("All CachedDataset part 1 tests passed!")

--- a/tests/shared/data/test_cache_part2.mojo
+++ b/tests/shared/data/test_cache_part2.mojo
@@ -1,0 +1,108 @@
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_cache.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for CachedDataset wrapper (part 2 of 2).
+
+Tests cache enable/disable, hit rate, and statistics.
+"""
+
+from tests.shared.conftest import (
+    assert_true,
+    assert_equal,
+    assert_almost_equal,
+)
+from shared.data import ExTensorDataset, CachedDataset
+from shared.core.extensor import ExTensor, ones, zeros
+from collections import List
+
+
+# ============================================================================
+# CachedDataset Enable/Disable and Statistics Tests
+# ============================================================================
+
+
+fn test_cached_dataset_enable_disable() raises:
+    """Test enabling and disabling cache.
+
+    Should be able to toggle caching on/off.
+    """
+    var data_shape: List[Int] = [5, 1, 8, 8]
+    var label_shape: List[Int] = [5, 10]
+
+    var data = ones(data_shape, DType.float32)
+    var labels = zeros(label_shape, DType.float32)
+
+    var base_dataset = ExTensorDataset(data^, labels^)
+    var cached = CachedDataset(base_dataset^, max_cache_size=-1)
+
+    # Cache is enabled by default
+    assert_true(cached.cache_enabled)
+
+    # Disable
+    cached.disable_cache()
+    assert_true(not cached.cache_enabled)
+
+    # Enable again
+    cached.enable_cache()
+    assert_true(cached.cache_enabled)
+
+
+fn test_cached_dataset_hit_rate() raises:
+    """Test cache hit rate calculation.
+
+    Hit rate should be hits / (hits + misses).
+    """
+    var data_shape: List[Int] = [5, 1, 8, 8]
+    var label_shape: List[Int] = [5, 10]
+
+    var data = ones(data_shape, DType.float32)
+    var labels = zeros(label_shape, DType.float32)
+
+    var base_dataset = ExTensorDataset(data^, labels^)
+    var cached = CachedDataset(base_dataset^, max_cache_size=-1)
+
+    # No accesses yet - should return 0.0
+    assert_equal(cached.get_hit_rate(), Float32(0.0))
+
+    # 2 accesses to same sample - 1 hit, 1 miss
+    var _d1, _l1 = cached._get_and_cache(0)
+    var _d2, _l2 = cached._get_and_cache(0)
+
+    var hit_rate = cached.get_hit_rate()
+    assert_almost_equal(hit_rate, Float32(0.5), Float32(0.01))
+
+
+fn test_cached_dataset_get_stats() raises:
+    """Test cache statistics.
+
+    get_cache_stats should return (cache_size, hits, misses).
+    """
+    var data_shape: List[Int] = [5, 1, 8, 8]
+    var label_shape: List[Int] = [5, 10]
+
+    var data = ones(data_shape, DType.float32)
+    var labels = zeros(label_shape, DType.float32)
+
+    var base_dataset = ExTensorDataset(data^, labels^)
+    var cached = CachedDataset(base_dataset^, max_cache_size=-1)
+
+    var _d1, _l1 = cached._get_and_cache(0)
+    var _d2, _l2 = cached._get_and_cache(0)
+
+    var cache_size, hits, misses = cached.get_cache_stats()
+
+    assert_equal(cache_size, 1)
+    assert_equal(hits, 1)
+    assert_equal(misses, 1)
+
+
+fn main() raises:
+    """Run all tests."""
+    print("Testing CachedDataset (part 2)...")
+    print("  test_cached_dataset_enable_disable...")
+    test_cached_dataset_enable_disable()
+    print("  test_cached_dataset_hit_rate...")
+    test_cached_dataset_hit_rate()
+    print("  test_cached_dataset_get_stats...")
+    test_cached_dataset_get_stats()
+    print("All CachedDataset part 2 tests passed!")


### PR DESCRIPTION
## Summary

- Split `tests/shared/data/test_cache.mojo` (11 tests, exceeds ADR-009 limit of 10) into two files
- `test_cache_part1.mojo` — 8 tests (creation, length, stores_samples, cache_hit, max_cache_size, disabled_cache, preload_cache, clear_cache)
- `test_cache_part2.mojo` — 3 tests (enable_disable, hit_rate, get_stats)
- Each file includes the ADR-009 header comment
- Updated CI workflow comment to reflect the fix
- The existing `test_*.mojo` glob pattern auto-discovers both new files — no pattern change needed

## Test plan

- [ ] All 11 original test cases preserved across the two split files
- [ ] Both new files have the ADR-009 header comment (≤10 fn test_ per file)
- [ ] CI `Data` group picks up both files via existing `test_*.mojo` glob
- [ ] Pre-commit hooks pass (mojo format, YAML check, trailing whitespace)
- [ ] `Data` CI group passes reliably without heap corruption crashes

Closes #3636

🤖 Generated with [Claude Code](https://claude.com/claude-code)