### PR TITLE
fix(ci): replace cache: true with explicit actions/cache in setup-pixi composite action

### DIFF
--- a/.github/actions/setup-pixi/action.yml
+++ b/.github/actions/setup-pixi/action.yml
@@ -6,10 +6,6 @@ inputs:
     description: Pixi version to install
     required: false
     default: latest
-  cache:
-    description: Whether to enable Pixi built-in caching
-    required: false
-    default: 'true'
 
 runs:
   using: composite
@@ -18,4 +14,13 @@ runs:
       uses: prefix-dev/setup-pixi@v0.9.4
       with:
         pixi-version: ${{ inputs.pixi-version }}
-        cache: ${{ inputs.cache }}
+
+    - name: Cache Pixi environments
+      uses: actions/cache@v5
+      with:
+        path: |
+          .pixi
+          ~/.cache/rattler/cache
+        key: pixi-${{ runner.os }}-${{ hashFiles('pixi.lock') }}
+        restore-keys: |
+          pixi-${{ runner.os }}-

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -496,17 +496,16 @@ All CI workflows use justfile recipes for consistent command execution between l
 
 ### Pixi-Based Environment Setup
 
-All workflows use the modern Pixi setup:
+All workflows use the shared composite action for Pixi setup:
 
 ```yaml
 - name: Set up Pixi
-  uses: prefix-dev/setup-pixi@v0.9.3
-  with:
-    pixi-version: latest
-    cache: true
-```text
+  uses: ./.github/actions/setup-pixi
+```
 
-This replaces the older `modular` CLI approach with Pixi's conda-compatible package management.
+This composite action installs Pixi and caches both `.pixi` and `~/.cache/rattler/cache` using
+an explicit `actions/cache@v5` step keyed on `pixi.lock`. This replaces the older inline setup
+pattern with `cache: true` (which was unreliable) and the `modular` CLI approach.
 
 ### Matrix Strategies for Parallelization
 


### PR DESCRIPTION
## Summary

- Updates `.github/actions/setup-pixi/action.yml` to use explicit `actions/cache@v5` instead of the broken `cache: true` built-in option
- Caches both `.pixi` and `~/.cache/rattler/cache` using `pixi.lock` as the cache key for precision
- Updates workflow README documentation to show the composite action pattern

## Changes Made

All 19 workflow references across 15+ files already use `./.github/actions/setup-pixi`, so this single change makes Pixi caching DRY and correct across all CI — reducing from 14+ independent implementations to 1 shared implementation.

**Before**: `prefix-dev/setup-pixi@v0.9.4` with `cache: true` (unreliable — logs show "Saved cache with ID -1")

**After**: Explicit `actions/cache@v5` caching both `.pixi` and `~/.cache/rattler/cache`, keyed on `pixi.lock`

## Verification

- No inline `prefix-dev/setup-pixi` calls remain in any workflow files
- All 19 workflow uses point to `./.github/actions/setup-pixi`
- YAML syntax validated by pre-commit `check-yaml` hook (passed)

Closes #3155