### PR TITLE
docs(skill): add fix-conflicting-prs-and-ci skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -68,6 +68,20 @@
       }
     },
     {
+      "name": "fix-conflicting-prs-and-ci",
+      "category": "ci-cd",
+      "description": "Batch rebase conflicting PR branches, resolve merge conflicts, and fix CI failures (compilation, formatting, test coverage) on main",
+      "tags": ["git", "rebase", "ci-fix", "mojo", "formatting", "conflict-resolution", "workflow"],
+      "skillPath": "skills/fix-conflicting-prs-and-ci/SKILL.md",
+      "referencesPath": "skills/fix-conflicting-prs-and-ci/references/notes.md",
+      "metrics": {
+        "branches_rebased": 7,
+        "ci_failures_fixed": 5,
+        "formatting_files_patched": 34,
+        "test_files_covered": 140
+      }
+    },
+    {
       "name": "fix-mojo-nightly-compat",
       "category": "debugging",
       "description": "Fix CI failures from Mojo stable vs nightly version mismatch: String[byte=] removal, alias->comptime, owned->var, mojo format crashes",

--- a/.claude-plugin/skills/fix-conflicting-prs-and-ci/SKILL.md
+++ b/.claude-plugin/skills/fix-conflicting-prs-and-ci/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: fix-conflicting-prs-and-ci
+description: Batch rebase conflicting PR branches and fix CI failures on main
+category: ci-cd
+user-invocable: false
+date: 2026-03-11
+objective: Resolve merge conflicts on 7 PR branches and fix 3 CI failures on main
+outcome: All branches rebased and mergeable; CI fix PR created
+---
+
+# fix-conflicting-prs-and-ci
+
+## When to Use
+
+- Multiple PR branches have merge conflicts with main
+- CI is failing on main and needs fixing before PRs can merge
+- Test files were split (ADR-009) but CI workflow wasn't updated
+- Mojo nightly breaks `py=` keyword args or deprecates `alias`
+
+## Verified Workflow
+
+### 1. Batch Rebase Conflicting Branches
+
+```bash
+git fetch origin
+for branch in branch1 branch2 branch3; do
+  git checkout $branch
+  git rebase origin/main
+  # Resolve conflicts
+  git rebase --continue
+done
+git push --force-with-lease origin branch1 branch2 branch3
+```
+
+### 2. Resolve Common Conflict Patterns
+
+- **Add/add conflicts**: Keep the richer version (more tests, better docstrings)
+- **Modify/delete**: If main deleted the file, accept deletion (`git rm`)
+- **New method additions (HEAD empty)**: Keep the PR's addition
+- **Import ordering**: Merge both, remove duplicates
+
+### 3. Fix Mojo Nightly Compilation Errors
+
+```mojo
+# BROKEN (py= keyword removed in nightly)
+var int_val = Int(py=val_obj)
+var float_val = Float64(py=val_obj)
+
+# FIXED (portable workaround)
+var int_val = atol(String(val_obj))
+var float_val = Float64(atof(String(val_obj)))
+```
+
+### 4. Fix `alias` Deprecation
+
+```mojo
+# BROKEN (deprecated in nightly)
+alias THRESHOLD = 1000
+
+# FIXED
+comptime THRESHOLD = 1000
+```
+
+### 5. Apply Formatting from CI When Local Formatter Crashes
+
+Local `mojo format` may crash with `'_python_symbols' object has no attribute
+'comptime_assert_stmt'`. Extract the diff from CI logs instead:
+
+```bash
+# Get failed run ID
+gh run list --branch <branch> --status completed --json name,conclusion,databaseId \
+  --jq '.[] | select(.conclusion == "failure") | {name, id: .databaseId}'
+
+# Extract clean patch from CI logs
+gh run view <run-id> --log-failed 2>&1 \
+  | grep "Run pre-commit hooks" \
+  | sed 's/^.*Run pre-commit hooks\t[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}T[0-9:\.]*Z //' \
+  > /tmp/ci_clean.txt
+
+sed -n '/^diff --git/,/^##\[error\]/p' /tmp/ci_clean.txt \
+  | grep -v '^\(##\[error\]\)' > /tmp/format.patch
+
+git apply /tmp/format.patch
+```
+
+### 6. Update CI Workflow for Split Test Files
+
+When test files are split (`test_foo.mojo` -> `test_foo_part1.mojo`, etc.),
+update `comprehensive-tests.yml` to use wildcards:
+
+```yaml
+# BEFORE (breaks when files are split)
+pattern: "test_tensors.mojo test_broadcasting.mojo test_creation.mojo"
+
+# AFTER (auto-discovers split files)
+pattern: "test_tensors*.mojo test_broadcasting*.mojo test_creation*.mojo"
+```
+
+### 7. Verify
+
+```bash
+# Check all PRs are mergeable
+for pr in 1234 5678; do
+  echo -n "PR #$pr: "
+  gh pr view $pr --json mergeable --jq .mergeable
+done
+```
+
+## Failed Attempts
+
+| Attempt | Why Failed | Lesson Learned |
+|---------|-----------|----------------|
+| First CI fix only addressed `py=` keyword | Missed `view_with_strides` error, 34 formatting files, test coverage gaps | Always get ALL failure logs from ALL failed jobs before fixing |
+| Ran local `mojo format` on files | Crashes with `comptime_assert_stmt` error on nightly-formatted files | Extract formatting patch from CI logs instead of running locally |
+| Listed specific test files in CI workflow | Breaks every time files are split per ADR-009 | Use wildcard patterns like `test_foo*.mojo` |
+
+## Results & Parameters
+
+- **Branches rebased**: 7 (across 2 sessions)
+- **Conflict types**: add/add, modify/delete, content merge
+- **CI failures fixed**: compilation (py= keyword, view_with_strides), formatting (34 files), test coverage validation
+- **Key files**: `shared/utils/toml_loader.mojo`, `shared/core/extensor.mojo`, `shared/core/matrix.mojo`, `.github/workflows/comprehensive-tests.yml`
+- **Safe push**: Always use `git push --force-with-lease` (never `--force`)

--- a/.claude-plugin/skills/fix-conflicting-prs-and-ci/references/notes.md
+++ b/.claude-plugin/skills/fix-conflicting-prs-and-ci/references/notes.md
@@ -1,0 +1,94 @@
+# Fix Conflicting PRs and CI - Raw Notes
+
+## Session Date: 2026-03-11
+
+## Branches Fixed
+
+### Session 1 (3 branches)
+
+| PR | Branch | Conflict Type | Resolution |
+|----|--------|---------------|------------|
+| #4317 | 3476-auto-impl | add/add in test_extensor_abs_ops.mojo, rename/delete in test_extensor_slicing.mojo.DEPRECATED | Kept incoming tests (more comprehensive), accepted main's deletion |
+| #3933 | 3311-auto-impl | content in test_migrate_odyssey_skills.py | Merged import ordering, kept new test classes from PR |
+| #3885 | 3285-auto-impl | modify/delete in test_alexnet_layers.mojo | Accepted main's deletion (file was split) |
+
+### Session 2 (4 branches)
+
+| PR | Branch | Conflict Type | Resolution |
+|----|--------|---------------|------------|
+| #3836 | 3275-auto-impl | 3 conflicts in extensor.mojo | Kept PR's new __setitem__ method, kept HEAD's richer __str__ with truncation |
+| #4053 | 3379-auto-impl | 2 conflicts in test_utility.mojo | Kept PR's new test function + call |
+| #4054 | 3380-auto-impl | 2 conflicts in test_utility.mojo | Kept PR's new test function + call |
+| #4059 | 3383-auto-impl | 2 conflicts in test_utility.mojo | Kept PR's new test function + call |
+
+## CI Failures on Main
+
+### 1. Compilation Error - `py=` keyword removed
+
+```
+shared/utils/toml_loader.mojo:104:36: error: no matching function in initialization
+    var float_val = Float64(py=val_obj)
+```
+
+**Root cause**: Mojo nightly removed `py=` keyword argument from `Float64()` and `Int()`.
+
+**Fix**: `atol(String(val_obj))` for Int, `Float64(atof(String(val_obj)))` for Float64.
+
+### 2. Compilation Error - missing `view_with_strides`
+
+```
+shared/core/matrix.mojo:824:18: error: 'ExTensor' value has no attribute 'view_with_strides'
+    return tensor.view_with_strides(result_shape, result_strides)
+```
+
+**Root cause**: `transpose()` called a method that was never implemented on ExTensor.
+
+**Fix**: Replaced with element-by-element data copy using multi-index decomposition and permuted indices.
+
+### 3. Pre-commit Formatting - 34+ files
+
+**Root cause**: CI uses nightly `mojo format` which has stricter line-length enforcement.
+Local `mojo format` (stable) crashes on these files with `comptime_assert_stmt` error.
+
+**Fix**: Extracted diff from CI logs as a patch and applied with `git apply`.
+
+### 4. Test Coverage Validation
+
+**Root cause**: Test files split per ADR-009 (e.g., `test_tensors.mojo` -> `test_tensors_part1.mojo` + `test_tensors_part2.mojo` + `test_tensors_part3.mojo`) but `comprehensive-tests.yml` still listed old names.
+
+**Fix**: Changed explicit file lists to wildcard patterns (`test_tensors*.mojo`).
+
+### 5. Test Count Badge Stale
+
+**Root cause**: Badge showed 379+ tests but actual count was 498 after splits.
+
+**Fix**: `python3 scripts/check_test_count_badge.py --fix`
+
+## Key Commands
+
+```bash
+# Batch push multiple rebased branches
+git push --force-with-lease origin branch1 branch2 branch3
+
+# Check mergeability of multiple PRs
+for pr in 1234 5678; do
+  gh pr view $pr --json mergeable --jq .mergeable
+done
+
+# Extract formatting patch from CI
+gh run view <id> --log-failed 2>&1 | grep "Run pre-commit hooks" | ...
+
+# Fix test count badge
+python3 scripts/check_test_count_badge.py --fix
+```
+
+## Worktree Management
+
+```bash
+# Remove worktree after PR work is done
+git worktree remove .worktrees/pr-XXXX
+git worktree prune
+
+# Verify only main worktree remains
+git worktree list
+```


### PR DESCRIPTION
## Summary

- Add new skill plugin capturing workflow for batch rebasing conflicting PR branches and fixing CI failures
- Covers: Mojo nightly compat (`py=` removal, `alias`->`comptime`), extracting formatting patches from CI logs, updating test coverage workflow patterns
- Includes failed attempts documentation (incomplete first fix, local formatter crashes, explicit file lists breaking on splits)

## Test plan

- [ ] Skill YAML frontmatter validates
- [ ] plugin.json is valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)