### PR TITLE
fix(ci): make mojo-format pre-commit hook non-blocking

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -38,9 +38,14 @@ jobs:
           restore-keys: |
             pre-commit-
 
-      - name: Run pre-commit hooks
+      - name: Run pre-commit hooks (excluding mojo-format)
         run: |
-          pixi run pre-commit run --all-files --show-diff-on-failure
+          SKIP=mojo-format pixi run pre-commit run --all-files --show-diff-on-failure
+
+      - name: Run mojo format (advisory - non-blocking)
+        continue-on-error: true
+        run: |
+          pixi run pre-commit run mojo-format --all-files --show-diff-on-failure || echo "::warning::mojo format check failed (non-blocking due to Mojo 0.26.1 formatter bugs)"
 
       - name: Enforce no .__matmul__() call sites
         run: |


### PR DESCRIPTION
## Summary
- Split mojo-format into a separate advisory CI step with `continue-on-error: true`
- Other pre-commit hooks still run and block as before (`SKIP=mojo-format`)
- Unblocks PRs that fail due to Mojo 0.26.1 formatter crashes (`comptime_assert_stmt` bug)

## Test plan
- [ ] Pre-commit CI job passes with mojo-format separated
- [ ] Other hooks (markdownlint, trailing-whitespace, etc.) still enforce correctly
- [ ] Mojo format step shows as advisory (yellow) not blocking (red)

🤖 Generated with [Claude Code](https://claude.com/claude-code)