### PR TITLE
docs: update scripts/README, CLAUDE.md with missing documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ gh pr merge --auto --rebase
 - [Git Commit Policy](/.claude/shared/git-commit-policy.md)
 - [Output Style Guidelines](/.claude/shared/output-style-guidelines.md)
 - [Tool Use Optimization](/.claude/shared/tool-use-optimization.md)
+- [ADR-009 Heap Corruption Workaround](docs/adr/ADR-009-heap-corruption-workaround.md)
 
 ### Agent System & Skills
 
@@ -401,6 +402,9 @@ This project uses Pixi for environment management:
 # Mojo is the primary language target for future implementations
 ```
 
+**GLIBC Constraint**: CI runners use Ubuntu with GLIBC 2.35. Any native binaries built
+locally must be compatible with this version to avoid CI failures.
+
 ## Common Commands
 
 ### Justfile Build System
@@ -583,6 +587,10 @@ SKIP=trailing-whitespace git commit -m "message"
 
 # Note: SKIP=mojo-format is not needed — use scripts/mojo-format-compat.sh or just shell on incompatible hosts
 ```
+
+**Mojo Format Compatibility**: `mojo format` requires the exact Mojo version pinned in
+`pixi.toml`. If your local Mojo version differs, the pre-commit hook may fail or produce
+unexpected formatting changes.
 
 ### Pre-Commit Hook Policy - STRICT ENFORCEMENT
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -490,6 +490,28 @@ python3 scripts/package_papers.py --output dist/
 
 ---
 
+#### `convert_image_to_idx.py`
+
+**Purpose**: Convert PNG/JPEG images to IDX format for LeNet-5 inference.
+
+**Features**
+
+- Converts images to 28x28 grayscale
+- Optional EMNIST transpose+flip transform
+- Requires Pillow (`pip install Pillow`)
+
+**Usage**
+
+```bash
+# Convert image to IDX format
+python3 scripts/convert_image_to_idx.py input.png output.idx
+
+# Without EMNIST transform
+python3 scripts/convert_image_to_idx.py input.jpg output.idx --no-emnist-transform
+```
+
+---
+
 ---
 
 ### Deprecated Scripts


### PR DESCRIPTION
## Summary
- Add `convert_image_to_idx.py` documentation to scripts/README
- Update scripts/README directory tree to match actual filesystem
- Fix 16 malformed code block closing tags (```` ```text ```` → ```` ``` ````) in scripts/README
- Add GLIBC constraint note to CLAUDE.md Environment Setup section
- Add `mojo format` compatibility note to CLAUDE.md Pre-commit Hooks section
- Add ADR-009 quick link to CLAUDE.md Core Guidelines section

Closes #3709, #3968, #4465, #3814, #3822, #3961

## Test plan
- [ ] Verify markdown linting passes
- [ ] Verify all links in CLAUDE.md resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)