### PR TITLE
fix(shared): add bfloat16 support, fix bare except patterns, add div-zero guard

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -811,6 +811,7 @@ struct ExTensor(
             self._dtype == DType.float16
             or self._dtype == DType.float32
             or self._dtype == DType.float64
+            or self._dtype == DType.bfloat16
         ):
             self._set_float64(index, value)
         else:
@@ -1162,6 +1163,9 @@ struct ExTensor(
         elif self._dtype == DType.float64:
             var ptr = (self._data + offset).bitcast[Float64]()
             return ptr[].cast[DType.float32]()
+        elif self._dtype == DType.bfloat16:
+            var ptr = (self._data + offset).bitcast[BFloat16]()
+            return ptr[].cast[DType.float32]()
         else:
             # For integer types, cast to float32
             return Float32(self._get_int64(index))
@@ -1190,6 +1194,9 @@ struct ExTensor(
         elif self._dtype == DType.float64:
             var ptr = (self._data + offset).bitcast[Float64]()
             ptr[] = value.cast[DType.float64]()
+        elif self._dtype == DType.bfloat16:
+            var ptr = (self._data + offset).bitcast[BFloat16]()
+            ptr[] = value.cast[DType.bfloat16]()
 
     fn _get_int64(self, index: Int) -> Int64:
         """Internal: Get value at index as Int64 (assumes integer-compatible dtype).
@@ -1571,6 +1578,7 @@ struct ExTensor(
             self._dtype == DType.float16
             or self._dtype == DType.float32
             or self._dtype == DType.float64
+            or self._dtype == DType.bfloat16
         ):
             raise Error("to_fp8() requires a floating-point tensor")
 
@@ -2126,6 +2134,7 @@ struct ExTensor(
             self._dtype == DType.float16
             or self._dtype == DType.float32
             or self._dtype == DType.float64
+            or self._dtype == DType.bfloat16
         ):
             raise Error("to_bf8() requires a floating-point tensor")
 
@@ -2268,6 +2277,7 @@ struct ExTensor(
             self._dtype == DType.float16
             or self._dtype == DType.float32
             or self._dtype == DType.float64
+            or self._dtype == DType.bfloat16
         ):
             raise Error("to_mxfp4() requires a floating-point tensor")
 
@@ -2483,6 +2493,7 @@ struct ExTensor(
             self._dtype == DType.float16
             or self._dtype == DType.float32
             or self._dtype == DType.float64
+            or self._dtype == DType.bfloat16
         ):
             raise Error("to_nvfp4() requires a floating-point tensor")
 
@@ -3269,6 +3280,7 @@ fn ones(shape: List[Int], dtype: DType) raises -> ExTensor:
         dtype == DType.float16
         or dtype == DType.float32
         or dtype == DType.float64
+        or dtype == DType.bfloat16
     ):
         tensor._fill_value_float(1.0)
     else:
@@ -3303,6 +3315,7 @@ fn full(shape: List[Int], fill_value: Float64, dtype: DType) raises -> ExTensor:
         dtype == DType.float16
         or dtype == DType.float32
         or dtype == DType.float64
+        or dtype == DType.bfloat16
     ):
         tensor._fill_value_float(fill_value)
     else:
@@ -3379,6 +3392,7 @@ fn arange(
             dtype == DType.float16
             or dtype == DType.float32
             or dtype == DType.float64
+            or dtype == DType.bfloat16
         ):
             tensor._set_float64(i, value)
         else:
@@ -3428,6 +3442,7 @@ fn eye(n: Int, m: Int, k: Int, dtype: DType) raises -> ExTensor:
                 dtype == DType.float16
                 or dtype == DType.float32
                 or dtype == DType.float64
+                or dtype == DType.bfloat16
             ):
                 tensor._set_float64(index, 1.0)
             else:
@@ -3472,6 +3487,7 @@ fn linspace(
             dtype == DType.float16
             or dtype == DType.float32
             or dtype == DType.float64
+            or dtype == DType.bfloat16
         ):
             tensor._set_float64(0, start)
         else:
@@ -3487,6 +3503,7 @@ fn linspace(
                 dtype == DType.float16
                 or dtype == DType.float32
                 or dtype == DType.float64
+                or dtype == DType.bfloat16
             ):
                 tensor._set_float64(i, value)
             else:
@@ -3713,6 +3730,7 @@ fn randn(shape: List[Int], dtype: DType, seed: Int = 0) raises -> ExTensor:
         dtype == DType.float16
         or dtype == DType.float32
         or dtype == DType.float64
+        or dtype == DType.bfloat16
     ):
         print(
             "Warning: randn() is designed for floating-point types, got",
@@ -3750,6 +3768,7 @@ fn randn(shape: List[Int], dtype: DType, seed: Int = 0) raises -> ExTensor:
             dtype == DType.float16
             or dtype == DType.float32
             or dtype == DType.float64
+            or dtype == DType.bfloat16
         ):
             tensor._set_float64(i, z0)
         else:
@@ -3763,6 +3782,7 @@ fn randn(shape: List[Int], dtype: DType, seed: Int = 0) raises -> ExTensor:
                 dtype == DType.float16
                 or dtype == DType.float32
                 or dtype == DType.float64
+                or dtype == DType.bfloat16
             ):
                 tensor._set_float64(i, z1)
             else:

--- a/shared/training/checkpoint.mojo
+++ b/shared/training/checkpoint.mojo
@@ -294,7 +294,7 @@ struct CheckpointManager:
                     return atol(epoch_str)
 
             return -1
-        except:
+        except e:
             return -1
 
     fn _cleanup_old_checkpoints(self) raises:

--- a/shared/training/loops/validation_loop.mojo
+++ b/shared/training/loops/validation_loop.mojo
@@ -276,7 +276,11 @@ struct ValidationLoop:
             total_loss += batch_loss
             num_batches += 1
 
-        var avg_loss = total_loss / Float64(num_batches)
+        var avg_loss = Float64(0.0)
+        if num_batches > 0:
+            avg_loss = total_loss / Float64(num_batches)
+        else:
+            print("Warning: No validation batches available")
 
         print("  Subset Validation Loss: " + String(avg_loss))
 

--- a/shared/utils/arg_parser.mojo
+++ b/shared/utils/arg_parser.mojo
@@ -121,7 +121,7 @@ struct ParsedArgs(Copyable, Movable):
         var value = self.values[name]
         try:
             return Int(value)
-        except:
+        except e:
             raise Error(
                 "Cannot parse '"
                 + value
@@ -148,7 +148,7 @@ struct ParsedArgs(Copyable, Movable):
         var value = self.values[name]
         try:
             return Float64(value)
-        except:
+        except e:
             raise Error(
                 "Cannot parse '"
                 + value

--- a/shared/utils/config.mojo
+++ b/shared/utils/config.mojo
@@ -442,7 +442,7 @@ struct Config(Copyable, ImplicitlyCopyable, Movable):
             return default
         try:
             return self.get_int(key, default)
-        except:
+        except e:
             return default
 
     fn get_float_with_default(self, key: String, default: Float64) -> Float64:
@@ -459,7 +459,7 @@ struct Config(Copyable, ImplicitlyCopyable, Movable):
             return default
         try:
             return self.get_float(key, default)
-        except:
+        except e:
             return default
 
     fn get_string_with_default(self, key: String, default: String) -> String:
@@ -476,7 +476,7 @@ struct Config(Copyable, ImplicitlyCopyable, Movable):
             return default
         try:
             return self.get_string(key, default)
-        except:
+        except e:
             return default
 
     fn get_bool_with_default(self, key: String, default: Bool) -> Bool:
@@ -493,7 +493,7 @@ struct Config(Copyable, ImplicitlyCopyable, Movable):
             return default
         try:
             return self.get_bool(key, default)
-        except:
+        except e:
             return default
 
     fn merge(self, other: Config) -> Config:
@@ -803,13 +803,13 @@ struct Config(Copyable, ImplicitlyCopyable, Movable):
                                 try:
                                     var float_val = Float64(atof(value_str))
                                     config.set(key, float_val)
-                                except:
+                                except e:
                                     config.set(key, value_str)
                             else:
                                 try:
                                     var int_val = atol(value_str)
                                     config.set(key, int_val)
-                                except:
+                                except e:
                                     config.set(key, value_str)
         except e:
             raise Error("Failed to load JSON file: " + String(e))
@@ -963,7 +963,7 @@ struct Config(Copyable, ImplicitlyCopyable, Movable):
                 var python = Python.import_module("os")
                 var py_value = python.getenv(var_name, default_value)
                 env_value = String(py_value)
-            except:
+            except e:
                 # If Python interop fails, use default value
                 pass
 

--- a/shared/utils/config_loader.mojo
+++ b/shared/utils/config_loader.mojo
@@ -66,7 +66,7 @@ fn load_paper_config(
     var defaults = Config()
     try:
         defaults = load_default_config(config_type)
-    except:
+    except e:
         # If no defaults exist, start with empty config
         pass
 
@@ -127,7 +127,7 @@ fn load_experiment_config(
         try:
             var default_config = load_default_config(config_type)
             config = merge_configs(config, default_config)
-        except:
+        except e:
             # Skip if default doesn't exist
             pass
 
@@ -140,7 +140,7 @@ fn load_experiment_config(
             )
             var paper_config = load_config(paper_filepath)
             config = merge_configs(config, paper_config)
-        except:
+        except e:
             # Skip if paper config doesn't exist
             pass
 

--- a/shared/utils/file_io.mojo
+++ b/shared/utils/file_io.mojo
@@ -312,7 +312,7 @@ fn save_tensor_to_checkpoint(
             f.write(hex_data + "\n")
 
         return True
-    except:
+    except e:
         return False
 
 
@@ -595,14 +595,14 @@ fn safe_write_file(filepath: String, content: String) -> Bool:
         try:
             var python = Python.import_module("os")
             python.rename(temp_filepath, filepath)
-        except:
+        except e:
             # If Python interop fails, fall back to non-atomic write
             # This is not ideal but better than failing completely
             with open(filepath, "w") as f:
                 f.write(content)
 
         return True
-    except:
+    except e:
         return False
 
 
@@ -621,7 +621,7 @@ fn safe_read_file(filepath: String) raises -> String:
     try:
         with open(filepath, "r") as f:
             return f.read()
-    except:
+    except e:
         raise Error("File not found: " + filepath)
 
 
@@ -655,7 +655,7 @@ fn create_backup(filepath: String) -> Bool:
 
         # Write backup
         return safe_write_file(backup_path, content)
-    except:
+    except e:
         return False
 
 
@@ -675,7 +675,7 @@ fn remove_safely(filepath: String) -> Bool:
         var python = Python.import_module("os")
         python.remove(filepath)
         return True
-    except:
+    except e:
         return False
 
 
@@ -796,7 +796,7 @@ fn expand_path(filepath: String) -> String:
         var python = Python.import_module("os.path")
         var expanded = python.expanduser(filepath)
         return String(expanded)
-    except:
+    except e:
         # Fall back to returning original path if Python interop fails
         return filepath
 
@@ -820,7 +820,7 @@ fn file_exists(filepath: String) -> Bool:
         with open(filepath, "r") as f:
             _ = f.read()  # Attempt to read (confirms it's a file)
         return True
-    except:
+    except e:
         return False
 
 
@@ -838,7 +838,7 @@ fn directory_exists(dirpath: String) -> Bool:
         var python = Python.import_module("os.path")
         var result = python.isdir(dirpath)
         return Bool(result)
-    except:
+    except e:
         # Fall back to False if Python interop fails
         return False
 
@@ -859,7 +859,7 @@ fn create_directory(dirpath: String) -> Bool:
         var python = Python.import_module("os")
         python.makedirs(dirpath, exist_ok=PythonObject(True))
         return True
-    except:
+    except e:
         # Return False if directory creation fails
         return False
 
@@ -880,7 +880,7 @@ fn get_file_size(filepath: String) -> Int:
         # Read file and count bytes
         var content = safe_read_file(filepath)
         return len(content)
-    except:
+    except e:
         return -1
 
 

--- a/shared/utils/logging.mojo
+++ b/shared/utils/logging.mojo
@@ -297,7 +297,7 @@ struct FileHandler(Copyable, Handler, ImplicitlyCopyable, Movable):
             # Open file in append mode
             with open(self.filepath, "a") as file:
                 _ = file.write(message + "\n")
-        except:
+        except e:
             # Fallback to print if file write fails
             print("[LOG ERROR] Failed to write to " + self.filepath)
             print(message)

--- a/shared/utils/serialization.mojo
+++ b/shared/utils/serialization.mojo
@@ -336,7 +336,7 @@ fn load_named_tensors(dirpath: String) raises -> List[NamedTensor]:
             var (name, tensor) = load_tensor_with_name(filepath)
             result.append(NamedTensor(name, tensor))
 
-    except:
+    except e:
         raise Error("Failed to load tensors from: " + dirpath)
 
     return result^
@@ -429,7 +429,7 @@ fn load_named_checkpoint(
         with open(meta_path, "r") as f:
             meta_content = f.read()
         metadata = _deserialize_metadata(meta_content)
-    except:
+    except e:
         # Metadata file not found, return empty metadata
         pass
 


### PR DESCRIPTION
## Summary
- Add `bfloat16` to all dtype guard conditions in `extensor.mojo` (16 locations) including `__setitem__`, `_get_float32`, `_set_float32`, `arange`, `eye`, `linspace`, `randn`
- Add `bfloat16` branches to `_get_float32()` and `_set_float32()` for proper type casting
- Replace 27 bare `except:` with `except e:` across 7 files for better error capture
- Add division-by-zero guard in `ValidationLoop.run_subset()` when no batches are processed

Closes #3905, #3906, #3910, #4072, #3690

## Test plan
- [ ] Verify package compilation (pre-existing error unrelated)
- [ ] Run bfloat16 test suite to verify new dtype handling
- [ ] Verify validation loop handles empty data gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)