### PR TITLE
docs: batch documentation fixes for 22 open issues

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -632,6 +632,71 @@ All CI workflows use justfile recipes for consistent command execution between l
 
 **See**: `/justfile` for complete implementation and `CLAUDE.md` for developer documentation.
 
+### SHA-Pinned Action References
+
+**Policy**: All third-party GitHub Actions must be pinned to a full SHA commit hash, not a
+mutable tag (`@v4`, `@main`). This prevents supply-chain attacks where a tag is silently moved
+to a malicious commit.
+
+**Correct pattern** (SHA-pinned):
+
+```yaml
+- name: Checkout code
+  uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+- name: Set up Pixi
+  uses: prefix-dev/setup-pixi@ba3bb36eb2066252b2363392b7739741bb777659  # v0.9.3
+```
+
+**Incorrect pattern** (mutable tag — do not use):
+
+```yaml
+- name: Checkout code
+  uses: actions/checkout@v4  # ❌ tag can be moved
+
+- name: Set up Pixi
+  uses: prefix-dev/setup-pixi@v0.9.3  # ❌ tag can be moved
+```
+
+**Finding the correct SHA**: Use `gh release view` on the action's repository or check the
+workflow file after Dependabot pins it:
+
+```bash
+gh release view v4.2.2 --repo actions/checkout --json tagName,targetCommitish
+```
+
+### `path:` Field Does Not Support Glob Patterns
+
+**Constraint**: The `path:` field in `on.push` and `on.pull_request` trigger blocks does
+**not** support glob wildcards. Only the `paths:` array field supports patterns.
+
+**Incorrect** (silently ignored):
+
+```yaml
+on:
+  push:
+    path: "tests/**"   # ❌ 'path:' (singular) is not a valid key — treated as unknown field
+```
+
+**Correct**:
+
+```yaml
+on:
+  push:
+    paths:             # ✅ 'paths:' (plural) with array supports glob patterns
+      - "tests/**"
+      - "shared/**/*.mojo"
+```
+
+If you need to trigger on a single path without globs, still use the `paths:` array form:
+
+```yaml
+on:
+  push:
+    paths:
+      - "justfile"
+```
+
 ### Composite Action Checkout Invariant
 
 **Rule**: `actions/checkout` must appear as a step **before** any `uses: ./.github/actions/` reference

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
       - id: bandit
         name: Bandit Security Scan
         description: Scan Python files for security vulnerabilities using bandit
-        entry: pixi run bandit -ll --skip B310,B202,B301
+        entry: pixi run bandit -ll --skip B310,B202,B301  # B301 skipped: bandit check for unsafe deserialization; excluded as test/dev scripts don't use untrusted data (B310/B202 rationale in .bandit config)
         language: system
         files: ^(scripts|tests|tools|examples)/.*\.py$
         types: [python]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,11 +263,35 @@ All documentation files follow markdown standards and must pass `markdownlint-cl
 
 See [CLAUDE.md](CLAUDE.md#markdown-standards) for complete markdown standards.
 
+### Security Scanning
+
+Python files in `scripts/`, `tests/`, and `tools/` are scanned for security issues using
+[Bandit](https://bandit.readthedocs.io/), an AST-based static analysis tool.
+
+**Configuration**: `.bandit` in the project root controls suppressions. Currently suppressed checks:
+
+- `B310` - URL schemes (safe for internal tooling)
+- `B202` - `tarfile.extractall` (extraction paths are controlled)
+- `B301` - Skipped for test/dev scripts that do not process untrusted data
+
+**Running Bandit manually**:
+
+```bash
+# Scan all Python scripts (same flags as pre-commit)
+pixi run bandit -ll --skip B310,B202,B301 scripts/ tests/ tools/
+
+# Check a single file
+pixi run bandit -ll scripts/my_script.py
+```
+
+Bandit runs automatically on every commit via the `bandit` pre-commit hook.
+
 ### Pre-commit Hooks
 
 Pre-commit hooks automatically check code quality before commits. They run:
 
 - `mojo format` - Auto-format Mojo code
+- `bandit` - Security scan for Python files (see [Security Scanning](#security-scanning) above)
 - `markdownlint-cli2` - Lint markdown files
 - `trailing-whitespace` - Remove trailing whitespace
 - `end-of-file-fixer` - Ensure files end with newline

--- a/docs/dev/extensor-view-contract.md
+++ b/docs/dev/extensor-view-contract.md
@@ -1,0 +1,113 @@
+# ExTensor View Contract
+
+**Status**: Active | **Tracked**: #3802 | **Last Updated**: 2026-03-14
+
+This document describes the copy-vs-view semantics for `ExTensor` operations.
+Understanding when an operation returns a view (shared data pointer) vs a copy
+(independent data buffer) is essential for correct gradient computation and
+memory management.
+
+## Background
+
+`ExTensor` uses reference-counted storage: each tensor holds an `UnsafePointer`
+to a flat data buffer plus a reference count. When a tensor is "copied" in Mojo's
+value-semantic sense, the `__copyinit__` method increments the reference count
+rather than duplicating the buffer — this is what makes views possible.
+
+A tensor is a **view** when:
+
+- `is_view() == True` (the `_is_view` flag is set)
+- It shares the same underlying data pointer as another tensor
+- Modifying elements through the view modifies the original
+
+A tensor is an **independent copy** when:
+
+- `is_view() == False`
+- It has its own data buffer
+- Modifying elements does not affect the original
+
+## Operations That Return Views
+
+These operations return a view — no data duplication occurs:
+
+| Operation | Location | View? | Notes |
+|-----------|----------|-------|-------|
+| `reshape(new_shape)` | `extensor.mojo` | Yes | Zero-copy; shape metadata changes only |
+| `transpose(dim0, dim1)` | `extensor.mojo` | Yes | Strides permuted; pointer shared |
+| `slice(...)` | `extensor.mojo` | Yes | Offset pointer into same buffer |
+| `squeeze(dim)` | `shape.mojo` | Yes | Removes size-1 dimensions |
+| `unsqueeze(dim)` | `shape.mojo` | Yes | Inserts size-1 dimensions |
+| `broadcast_to(shape)` | `shape.mojo` | Yes | Stride-based broadcast; no copy |
+
+All view operations set `_is_view = True` on the result. The refcount on the
+underlying buffer is incremented by the `__copyinit__` in the view constructor.
+
+## Operations That Return Copies
+
+These operations allocate a new data buffer:
+
+| Operation | Location | Notes |
+|-----------|----------|-------|
+| `as_contiguous()` | `extensor.mojo` | Forces C-order layout into new buffer |
+| `copy()` | `extensor.mojo` | Explicit deep copy |
+| Element-wise ops (`__add__`, `__mul__`, etc.) | `extensor.mojo` | Output is always new tensor |
+| Reduction ops (`sum()`, `mean()`, etc.) | `reduction.mojo` | Output is always new tensor |
+| `concatenate(tensors, axis)` | `shape.mojo` | Allocates output; copies all inputs |
+
+## The `transpose_view()` Special Case
+
+`transpose_view()` in `shared/core/matrix.mojo` is **not** a canonical view in the
+sense above. It copies the raw bytes and then sets permuted strides — the data pointer
+is independent. This makes it useful for testing `is_contiguous()` and `as_contiguous()`
+in isolation but it is **not** the recommended API for transposing tensors in production
+code. Prefer `transpose()` on `ExTensor`.
+
+## Detecting Views at Runtime
+
+```mojo
+var t = zeros([3, 4], DType.float32)
+var v = t.reshape([12])
+
+if v.is_view():
+    print("v shares data with t")  # This will print
+
+# Force an independent copy:
+var c = v.as_contiguous()
+if not c.is_view():
+    print("c is independent")  # This will print
+```
+
+## Implications for Gradient Computation
+
+When implementing backward passes:
+
+1. **Views propagate gradients to the original tensor** — if a forward pass creates a
+   view and the backward receives `grad_output`, the gradient must be accumulated into
+   the original tensor's gradient, not just the view's metadata.
+
+2. **`reshape` backward**: Return `grad_output.reshape(original_shape)` — this is
+   another zero-copy view of the incoming gradient.
+
+3. **`transpose` backward**: Return `grad_output.transpose(dim0, dim1)` — swapping
+   the same dimensions undoes the forward permutation.
+
+4. **`broadcast_to` backward**: Must sum over the broadcast dimensions. The gradient
+   of a broadcast is a reduction (sum) over the dimensions that were expanded.
+
+## Contiguity and Performance
+
+Non-contiguous views (e.g. after `transpose`) are valid tensors but may be slower for
+element-wise operations that assume C-order layout. Use `as_contiguous()` to materialize
+a contiguous copy before passing to performance-critical kernels (e.g. SIMD matmul).
+
+Check contiguity with `is_contiguous()`. A view is contiguous if and only if its strides
+match the standard C-order strides for its shape.
+
+## See Also
+
+- `shared/core/extensor.mojo` — `reshape()`, `transpose()`, `slice()`
+- `shared/core/shape.mojo` — `broadcast_to()`, `squeeze()`, `unsqueeze()`
+- `shared/core/matrix.mojo` — `transpose_view()` (test utility)
+- Issue #4082 — `transpose()` vs `transpose_view()` cross-reference
+- Issue #4462 — `reshape()` zero-copy view semantics
+- Issue #3862 — `broadcast_to()` dimension-reduction error documentation

--- a/docs/dev/mojo-migration-errors.md
+++ b/docs/dev/mojo-migration-errors.md
@@ -632,7 +632,51 @@ struct Container[T: Transform]:  # Compile-time generic
 
 ---
 
-### 8. Test-Specific Errors (7 errors)
+### 8. Compile-Time Import Limitation (#3731)
+
+#### 8.0 Mojo Cannot Resolve Imports at Compile Time from Dynamic Paths
+
+**Pattern**: Mojo v0.26.1 does not support importing symbols whose paths are
+determined at runtime or through multi-hop re-exports across `__init__.mojo` files.
+
+**Symptom**:
+
+```text
+error: cannot find 'LinearLayer' in module 'shared'
+```
+
+Even when `shared/__init__.mojo` imports from `shared.core` which imports from
+`shared.core.layers`, a consumer doing `from shared import LinearLayer` may fail
+because Mojo's compiler resolves imports at compile time and does not follow
+re-export chains through multiple `__init__.mojo` levels.
+
+**Root cause**: Mojo's import resolution is single-hop at compile time. A module
+can import a symbol for internal use, but that symbol is not automatically re-exported
+to the parent package's namespace in a way that downstream modules can discover.
+
+**Fix**: Import directly from the defining module:
+
+```mojo
+# WRONG (may fail due to re-export chain):
+from shared import LinearLayer
+
+# CORRECT (import from the defining module):
+from shared.core.layers import LinearLayer
+```
+
+**Workaround in `__init__.mojo`**: Keep commented import stubs with a note explaining
+when they will be enabled (once the compiler limitation is resolved):
+
+```mojo
+# from .core.layers import Linear  # Blocked: re-export chain (#3754, #3731)
+```
+
+**Agent Guidance**: Always import from the most specific module path. Do not assume
+that importing a symbol into `__init__.mojo` makes it available at the package level.
+
+---
+
+### 9. Test-Specific Errors (7 errors)
 
 #### 8.1 Function Renames (6 errors)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,10 @@ skip_covered = false
 line-length = 120
 target-version = "py311"
 
+# mypy configuration note: pyproject.toml [tool.mypy] and mypy.ini are both present.
+# mypy.ini takes precedence over pyproject.toml when both exist (mypy resolution order:
+# mypy.ini > .mypy.ini > setup.cfg > pyproject.toml). Settings here are intentionally
+# kept as a fallback reference; mypy.ini is the authoritative config. See #4034.
 [tool.mypy]
 python_version = "3.11"
 warn_return_any = true

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -43,25 +43,54 @@ scripts/
 ├── README.md                           # This file
 ├── common.py                           # Shared utilities and constants
 ├── validation.py                       # Shared validation framework
-├── create_issues.py                    # Main GitHub issue creation
-├── regenerate_github_issues.py         # Dynamic issue file generation
-├── validate_links.py                   # Markdown link validation
-├── validate_structure.py               # Repository structure validation
+├── analyze_issues.py                   # GitHub issue complexity analysis
+├── analyze_warnings.py                 # Compiler warning analysis
+├── audit_shared_links.py               # Audit .claude/shared/ link-backs in CLAUDE.md
+├── bench_precommit.py                  # Pre-commit hook performance benchmarking
+├── build_pr_comment.py                 # Build PR comment bodies from test results
+├── check_coverage.py                   # Test coverage reporting
+├── check_note_format.py                # Validate # NOTE comment format consistency
 ├── check_readmes.py                    # README completeness validation
-├── lint_configs.py                     # YAML configuration linting
+├── check_test_count_badge.py           # Validate README test count badge accuracy
+├── check_zero_warnings.sh              # Shell wrapper: fail on compiler warnings
+├── convert_image_to_idx.py             # Convert image files to IDX dataset format
+├── create_issues.py                    # GitHub issue creation (deprecated - see note above)
+├── download_cifar10.py                 # Download CIFAR-10 dataset
+├── download_cifar100.py                # Download CIFAR-100 dataset
+├── download_datasets.py                # Download all configured datasets
+├── download_emnist.py                  # Download EMNIST dataset
+├── download_fashion_mnist.py           # Download Fashion-MNIST dataset
+├── download_mnist.py                   # Download MNIST dataset
+├── generate_changelog.py               # Generate CHANGELOG.md from git log
+├── generate_test_metrics.py            # Generate test metrics report
+├── get_stats.py                        # Repository statistics collector
 ├── get_system_info.py                  # System information collector
+├── implement_issues.py                 # Automated issue implementation helper
+├── lint_configs.py                     # YAML configuration linting
 ├── merge_prs.py                        # PR merge automation
+├── migrate_odyssey_skills.py           # Skill migration tool (Odyssey2 → ProjectMnemosyne)
+├── mojo-format-compat.sh               # GLIBC-compatible mojo format wrapper
 ├── package_papers.py                   # Papers directory packaging
-└── agents/                             # Agent system utilities
-    ├── README.md                       # Agent scripts documentation
-    ├── agent_health_check.sh           # System health checks
-    ├── agent_stats.py                  # Statistics and metrics
-    ├── check_frontmatter.py            # YAML validation
-    ├── list_agents.py                  # Agent discovery
-    ├── setup_agents.sh                 # Setup automation
-    ├── test_agent_loading.py           # Loading tests
-    ├── validate_agents.py              # Configuration validation
-    └── tests/                          # Agent test suite
+├── plan_issues.py                      # Issue planning helper
+├── plot_training.py                    # Training curve visualization
+├── regenerate_github_issues.py         # Dynamic issue file generation (deprecated)
+├── update_version.py                   # Version bump helper
+├── validate_adr009_headers.py          # Validate ADR-009 split-file docstring headers
+├── validate_links.py                   # Markdown link validation
+├── validate_mojo_syntax_in_docs.py     # Validate Mojo code blocks in documentation
+├── validate_readme_commands.py         # Validate commands referenced in README.md
+├── validate_structure.py               # Repository structure validation
+├── validate_test_coverage.py           # CI test matrix coverage validation
+├── validate_test_file_sizes.py         # Enforce test file size limits
+├── validate_workflow_checkout_order.py # Validate actions/checkout precedes local actions
+├── build_configs_distribution.sh       # Build configs distribution archive
+├── build_data_package.sh               # Build data package
+├── build_training_package.sh           # Build training package
+├── build_utils_package.sh              # Build utils package
+├── bump_version.sh                     # Version bump shell helper
+├── install_verify_data.sh              # Install and verify data package
+├── install_verify_training.sh          # Install and verify training package
+└── install_verify_utils.sh             # Install and verify utils package
 ```
 
 ## Scripts

--- a/scripts/migrate_odyssey_skills.py
+++ b/scripts/migrate_odyssey_skills.py
@@ -16,6 +16,22 @@ Source structure (Odyssey2):
 Target structure (ProjectMnemosyne):
     skills/<category>/<skill-name>/.claude-plugin/plugin.json
     skills/<category>/<skill-name>/skills/<skill-name>/SKILL.md
+
+Subdir Routing:
+    Each skill is placed under a category subdirectory determined by CATEGORY_MAP.
+    The skill's YAML frontmatter `category:` field (e.g. "github", "mojo") is looked
+    up in CATEGORY_MAP and mapped to a Mnemosyne-valid category name (e.g. "tooling",
+    "architecture"). If the category is absent or unmapped, the skill falls back to
+    the "general" category.
+
+    Example routing:
+        category: github   → skills/tooling/<skill-name>/
+        category: mojo     → skills/architecture/<skill-name>/
+        category: doc      → skills/documentation/<skill-name>/
+        (unknown)          → skills/general/<skill-name>/
+
+    CATEGORY_MAP is defined as a module-level constant and can be extended as
+    new Mnemosyne categories are introduced.
 """
 
 import argparse

--- a/shared/__init__.mojo
+++ b/shared/__init__.mojo
@@ -125,19 +125,38 @@ comptime Accuracy = AccuracyMetric
 # This allows users to do: from shared import core, training, data, utils
 # Then access via: shared.core.layers.Linear, shared.training.optimizers.SGD
 #
-# NOTE (Mojo v0.26.1): Mojo v0.26.1+ does not support __all__ module-level assignments.
+# NOTE(#3751, Mojo v0.26.1): Mojo v0.26.1+ does not support __all__ module-level assignments.
 # In Mojo, all public symbols (those not prefixed with _) are automatically
 # exported when the module is imported. The public API documentation below
 # describes what should be exposed at this package level:
 #
-# Public API (modules and symbols exposed at package level):
-# - VERSION, AUTHOR, LICENSE - Package metadata
-# - core - Core neural network components
-# - training - Training infrastructure and optimizers
-# - data - Data loading and transformation utilities
-# - utils - Helper utilities
-# - autograd - Automatic differentiation (when available)
-# - testing - Test utilities and fixtures
+# Re-export Chain Limitation (Mojo v0.26.1, #3754):
+# Mojo v0.26.1 does not support re-export chains where an intermediate __init__.mojo
+# re-exports a symbol and a consumer imports it from the top-level package.
+# Example: `from shared import Linear` fails even if shared/core/__init__.mojo
+# re-exports Linear from shared/core/layers.mojo.
+# Workaround: Import directly from the submodule that defines the symbol:
+#   from shared.core.layers import Linear   # ✓ works
+#   from shared import Linear               # ✗ fails in v0.26.1
+# This limitation is tracked upstream. Once resolved, top-level convenience
+# imports will be enabled by un-commenting the import lines above.
+#
+# Public API Table (top-level exports at package level):
+# ┌─────────────────────────────────┬────────────────────────────────────────┐
+# │ Symbol                          │ Source                                 │
+# ├─────────────────────────────────┼────────────────────────────────────────┤
+# │ VERSION, AUTHOR, LICENSE        │ shared.version                         │
+# │ LossTracker, AccuracyMetric     │ shared.training.metrics                │
+# │ Accuracy                        │ comptime alias for AccuracyMetric      │
+# │ core                            │ shared.core (subpackage)               │
+# │ training                        │ shared.training (subpackage)           │
+# │ data                            │ shared.data (subpackage)               │
+# │ utils                           │ shared.utils (subpackage)              │
+# │ autograd                        │ shared.autograd (subpackage)           │
+# │ testing                         │ shared.testing (subpackage)            │
+# └─────────────────────────────────┴────────────────────────────────────────┘
+# Note: Component-level imports (Linear, Conv2D, etc.) are pending full
+# layer implementation. See tests/shared/integration/test_packaging.mojo.
 #
 # Once implementations are available, users will be able to import:
 #   from shared import core, training, data, utils

--- a/shared/autograd/__init__.mojo
+++ b/shared/autograd/__init__.mojo
@@ -178,5 +178,5 @@ from shared.core.dropout import (
     dropout2d_backward,
 )
 
-# NOTE (Mojo v0.26.1): In Mojo, all imported symbols are automatically available
+# Note: (Mojo v0.26.1): In Mojo, all imported symbols are automatically available
 # to package consumers. No __all__ equivalent is needed.

--- a/shared/core/__init__.mojo
+++ b/shared/core/__init__.mojo
@@ -670,5 +670,5 @@ from shared.core.lazy_eval import (
     evaluate,
 )
 
-# NOTE (Mojo v0.26.1): Mojo does not support Python's __all__ mechanism.
+# NOTE(#3751, Mojo v0.26.1): Mojo does not support Python's __all__ mechanism.
 # All imported symbols are automatically available to package consumers.

--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -577,15 +577,19 @@ struct ExTensor(
     fn reshape(self, new_shape: List[Int]) raises -> ExTensor:
         """Reshape tensor to new shape (must have same total elements).
 
-        Creates a view sharing data with the original tensor.
-        Uses reference counting to ensure data remains valid.
+        Returns a zero-copy view (shallow pointer copy) sharing data with the
+        original tensor. The result has `is_view() == True` and `is_contiguous() == True`
+        (because reshape only changes the shape/stride metadata, not the flat layout).
+        Uses reference counting to ensure data remains valid while any view is alive.
 
+        Note: This mirrors the view semantics of `slice()` — no data is copied.
+        Compare with operations that return independent copies (e.g. `as_contiguous()`).
 
         Args:
             new_shape: The new shape for the tensor.
 
         Returns:
-            A new tensor with the requested shape, sharing the same data.
+            A zero-copy view with the requested shape, sharing the same flat data buffer.
 
         Raises:
             Error: If the total number of elements doesn't match.
@@ -593,7 +597,7 @@ struct ExTensor(
         Example:
         ```mojo
             var t = zeros([2, 3], DType.float32)
-            var reshaped = t.reshape([6])  # (2, 3) -> (6,)
+            var reshaped = t.reshape([6])  # (2, 3) -> (6,), zero-copy view
         ```
         """
         # Verify total elements match
@@ -722,6 +726,12 @@ struct ExTensor(
         Creates a stride-based view sharing the same underlying data — no
         copying occurs. For any non-trivial swap (dim0 != dim1) the result
         satisfies is_contiguous() == False.
+
+        Note: `transpose()` is the primary API for dimension swapping and returns a
+        true stride-based view (shape and strides permuted, data pointer shared).
+        Compare with `transpose_view()` in `shared/core/matrix.mojo`, which copies
+        raw bytes and sets permuted strides — useful for testing `is_contiguous()` and
+        `as_contiguous()` but not recommended for production use. See also #4082.
 
         Args:
             dim0: First dimension to swap.
@@ -1449,6 +1459,11 @@ struct ExTensor(
 
     fn __eq__(self, other: ExTensor) raises -> ExTensor:
         """Element-wise equality: a == b.
+
+        Note: NaN comparison follows IEEE 754 semantics — NaN is never equal to
+        anything, including itself. That is, `NaN == NaN` returns 0.0 (False) for
+        every element position where either operand is NaN. Use `isnan()` to detect
+        NaN values explicitly rather than relying on equality comparison.
 
         Args:
             other: The tensor to compare.

--- a/shared/core/gradient_types.mojo
+++ b/shared/core/gradient_types.mojo
@@ -4,10 +4,34 @@ Provides type-safe containers for multiple gradient returns, replacing tuple
 return types which are not fully supported in the current Mojo version.
 
 This module defines:
+
 - GradientPair: For binary operations returning 2 gradients.
 - GradientTriple: For ternary operations returning 3 gradients.
+- GradientQuad: For quaternary operations returning 4 gradients.
 - Conv2dNoBiasGradient: For conv2d_no_bias_backward with semantic field names.
 - DepthwiseConv2dNoBiasGradient: For depthwise_conv2d_no_bias_backward.
+
+When to Use Each Type:
+    Choose the container that matches the number of inputs your backward function
+    differentiates with respect to:
+
+    - **GradientPair** — binary ops: two-input functions such as add, subtract,
+      multiply, divide, matmul. Fields: `grad_a`, `grad_b`.
+
+    - **GradientTriple** — ternary ops: three-input functions such as linear
+      (input, weights, bias) and conv2d (input, kernel, bias). Fields:
+      `grad_input`, `grad_weights`, `grad_bias`.
+
+    - **GradientQuad** — quaternary ops: four-input functions such as batch
+      normalization (input, gamma, beta, running_mean). Fields: `grad_input`,
+      `grad_weights`, `grad_bias`, `grad_extra`.
+
+    - **Conv2dNoBiasGradient / DepthwiseConv2dNoBiasGradient** — specialized
+      containers for bias-free convolution backward passes. Use these instead of
+      GradientPair to retain semantic field names (`grad_input`, `grad_kernel`).
+
+    If a new op requires more than 4 gradients, define a dedicated named struct
+    rather than extending GradientQuad, so field names remain meaningful.
 """
 
 from shared.core.extensor import ExTensor

--- a/shared/core/module.mojo
+++ b/shared/core/module.mojo
@@ -37,6 +37,22 @@ Example:
     layer.eval()
     ```
 
+Sequential Usage Example:
+    ```mojo
+    from shared.core.module import Module
+    from shared.core.layers import Linear, ReLU
+    from shared.core.extensor import ExTensor, zeros
+
+    # Compose layers into a sequential stack manually (until Sequential is implemented)
+    var fc1 = Linear(784, 256)
+    var act1 = ReLU()
+    var fc2 = Linear(256, 10)
+
+    var input = zeros([32, 784], DType.float32)
+    var hidden = act1.forward(fc1.forward(input))
+    var output = fc2.forward(hidden)  # shape: [32, 10]
+    ```
+
 See Also:
     - shared.core.layers.linear: Linear layer implementation example
 """

--- a/shared/core/shape.mojo
+++ b/shared/core/shape.mojo
@@ -1254,6 +1254,9 @@ fn broadcast_to(tensor: ExTensor, target_shape: List[Int]) raises -> ExTensor:
 
     Raises:
             Error: If shapes are not broadcast-compatible.
+            Error: If `target_shape` has fewer dimensions than the input tensor
+                (broadcasting cannot reduce the number of dimensions; it can only
+                expand dimensions of size 1 or prepend new dimensions of any size).
 
     Examples:
     ```

--- a/shared/data/__init__.mojo
+++ b/shared/data/__init__.mojo
@@ -96,7 +96,7 @@ from shared.data._datasets_core import (
 # Public API
 # ============================================================================
 
-# NOTE (Mojo v0.26.1): Mojo does not support __all__ for controlling exports.
+# NOTE(#3751, Mojo v0.26.1): Mojo does not support __all__ for controlling exports.
 # All imported symbols are automatically available to package consumers.
 #
 # High-level usage:

--- a/shared/training/__init__.mojo
+++ b/shared/training/__init__.mojo
@@ -103,7 +103,7 @@ from shared.training.schedulers import (
 )
 
 # Export callback implementations
-# NOTE (Mojo v0.26.1): Callbacks must be imported directly from submodules due to
+# NOTE(#3754, Mojo v0.26.1): Callbacks must be imported directly from submodules due to
 # Mojo re-export limitations. Use:
 #   from shared.training.callbacks import EarlyStopping
 # NOT from shared.training import EarlyStopping

--- a/tests/shared/core/test_unsigned.mojo
+++ b/tests/shared/core/test_unsigned.mojo
@@ -3,6 +3,16 @@
 These tests verify the behavior of Mojo's native unsigned integer builtins,
 including arithmetic, bitwise operations, comparisons, boundary values,
 and conversions.
+
+Wrapping Semantics:
+    Unsigned integers use modular (wrap-around) arithmetic on overflow and underflow:
+
+    - Overflow: max_value + 1 wraps to 0. For example UInt8(255) + 1 == UInt8(0).
+    - Underflow: 0 - 1 wraps to max_value. For example UInt8(0) - 1 == UInt8(255).
+
+    This matches C/C++ unsigned integer behavior and is defined (not undefined behavior).
+    Test functions `test_*_overflow` and `test_*_underflow` validate this contract for
+    each unsigned type. See also: `test_uint8_boundary_values` for edge-case coverage.
 """
 
 

--- a/tests/shared/training/test_bf16_apple_silicon_guard.mojo
+++ b/tests/shared/training/test_bf16_apple_silicon_guard.mojo
@@ -1,10 +1,23 @@
 """Tests for the Apple Silicon guard in PrecisionConfig.bf16().
 
 These tests verify that:
+
 - The guard helper raises an error when Apple Silicon is simulated.
 - The guard helper does not raise on non-Apple Silicon (e.g., Linux CI).
 - PrecisionConfig.bf16() succeeds on non-Apple Silicon.
 - The error message matches the expected string.
+
+BF16 Support Status (as of Mojo v0.26.1):
+    BF16 (bfloat16) is NOT supported on Apple Silicon (M1/M2/M3) due to missing
+    hardware support in the Mojo runtime for that architecture. Attempting to use
+    `PrecisionConfig.bf16()` on Apple Silicon raises a descriptive error at runtime.
+
+    BF16 IS supported on Linux/x86 (the CI environment), allowing CI tests to
+    validate the full training pipeline with BF16 precision. The guard function
+    `_check_bf16_platform_support()` performs the platform detection.
+
+    If Apple Silicon BF16 support is added in a future Mojo release, these tests
+    should be updated and the guard removed. Track hardware support status upstream.
 """
 
 from shared.training.precision_config import (


### PR DESCRIPTION
## Summary

Batch implementation of 22 pure documentation issues classified as LOW complexity.
All changes are docstring additions, comment improvements, and new developer reference docs.
No logic or functionality was modified.

## Issues Closed

Closes #4022, #4034, #3976, #4082, #3802, #4110, #3754, #3751, #3731, #3741, #3862, #3677, #4061, #3968, #4014, #4462, #3788, #3728, #3771, #3674, #3883, #3904

## Changes Made

### Config/Meta Files
- **#4014** `.pre-commit-config.yaml`: add B301 skip rationale inline comment
- **#4022** `CONTRIBUTING.md`: add Security Scanning section documenting `.bandit` and `pixi run bandit`
- **#4034** `pyproject.toml`: add comment documenting mypy.ini takes precedence over pyproject.toml
- **#3976** `.github/workflows/README.md`: add SHA-pinned action reference policy section
- **#4110** `.github/workflows/README.md`: add note on `path:` vs `paths:` glob constraint
- **#3968** `scripts/README.md`: update directory tree to match actual scripts/ contents

### Module Docstrings
- **#3728** `shared/autograd/__init__.mojo`: fix `# Note:` format consistency (was `# NOTE`)
- **#3674, #3677** `tests/shared/core/test_unsigned.mojo`: add wrapping semantics section
- **#3741** `shared/core/module.mojo`: add Sequential usage example to module docstring
- **#3788** `shared/core/gradient_types.mojo`: add gradient type selection guide (GradientPair vs Triple vs Quad)
- **#3754, #3751** `shared/__init__.mojo`: add re-export chain limitation comment and public API table
- **#3771** `scripts/migrate_odyssey_skills.py`: add Subdir Routing section to module docstring

### ExTensor Docstrings
- **#4462** `shared/core/extensor.mojo` `reshape()`: clarify "zero-copy view (shallow pointer copy)" semantics
- **#4082** `shared/core/extensor.mojo` `transpose()`: add cross-reference to `transpose_view()` distinction
- **#4061** `shared/core/extensor.mojo` `__eq__()`: add NaN IEEE 754 behavior note
- **#3862** `shared/core/shape.mojo` `broadcast_to()`: add dimension-reduction error condition

### NOTE Comment Audit
- **#3883** Add issue tracker refs (`#3751`, `#3754`) to bare `# NOTE (Mojo v0.26.1):` comments in
  `shared/__init__.mojo`, `shared/core/__init__.mojo`, `shared/data/__init__.mojo`, `shared/training/__init__.mojo`

### New Developer Docs
- **#3802** `docs/dev/extensor-view-contract.md` (NEW): copy-vs-view semantics reference document
- **#3731** `docs/dev/mojo-migration-errors.md`: add section on Mojo compile-time import limitation

### Test File Docstring
- **#3904** `tests/shared/training/test_bf16_apple_silicon_guard.mojo`: update docstring to reflect BF16 support status

## Verification

- [x] All pre-commit hooks pass (`just pre-commit-all`)
- [x] No logic changes — documentation only
- [x] Markdownlint passes on all modified markdown files
- [x] YAML validation passes
- [x] Mojo format passes on all modified Mojo files

🤖 Generated with [Claude Code](https://claude.com/claude-code)