### PR TITLE
fix: clarify glibc 2.32+ minimum version requirement in docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,8 @@
 # See https://pre-commit.com for more information
 
 repos:
-  # mojo-format: Requires Mojo binary (glibc >= 2.32, i.e., Ubuntu 22.04+, Debian 11+).
-  # On older hosts (Debian 10/Buster, glibc 2.28) the wrapper script detects the
+  # mojo-format: Requires Mojo binary (glibc >= 2.32, i.e., Ubuntu 22.04+, Debian 12+).
+  # On older hosts (Debian 10-11, glibc < 2.32) the wrapper script detects the
   # incompatibility and exits 0 with a warning instead of failing the commit.
   # CI runs on Ubuntu 24.04 (glibc 2.39) and always formats.
   # See docs/dev/mojo-glibc-compatibility.md for details. Tracked: #3170 (closed), #3253, #3365

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -327,7 +327,7 @@ If a hook itself is broken (not your code):
 
 #### Known Hook Incompatibility: mojo-format on Debian Buster / glibc < 2.32
 
-The `mojo-format` hook requires **glibc 2.32+** (Debian 12 / Ubuntu 22.04 or newer).
+The `mojo-format` hook requires **glibc 2.32+** (Debian 12+ or Ubuntu 22.04+).
 On Debian 10 (Buster) or other hosts with glibc < 2.32, the hook automatically detects
 the incompatibility and **skips with a warning** instead of failing your commit.
 


### PR DESCRIPTION
Closes #3823