### PR TITLE
docs: fix malformed code blocks in first_model.md

### DIFF
--- a/docs/getting-started/first_model.md
+++ b/docs/getting-started/first_model.md
@@ -95,9 +95,6 @@ See `examples/getting-started/first_model_train.mojo`
 Key training steps:
 
 ```mojo
-
-```mojo
-
 # Configure training
 var optimizer = SGD(learning_rate=0.01, momentum=0.9)
 var loss_fn = CrossEntropyLoss()
@@ -109,8 +106,7 @@ trainer.add_callback(ModelCheckpoint(filepath="best_model.mojo", save_best_only=
 
 # Train
 trainer.train(train_loader, val_loader, epochs=10, verbose=True)
-
-```text
+```
 
 Full example: `examples/getting-started/first_model_train.mojo`
 
@@ -119,15 +115,10 @@ Full example: `examples/getting-started/first_model_train.mojo`
 Execute your training script:
 
 ```bash
-```bash
-
 pixi run mojo run train.mojo
-
-```text
+```
 
 You should see output like:
-
-```text
 
 ```text
 
@@ -160,16 +151,13 @@ Validation: loss=0.189, accuracy=0.951
 Model checkpoint saved: best_model.mojo
 
 Training complete!
-
-```text
+```
 
 ## Step 6: Evaluate the Model
 
 Create `evaluate.mojo` to test your trained model:
 
 ```mojo
-```mojo
-
 from shared.training import evaluate_model
 from shared.utils import load_model, plot_confusion_matrix
 from prepare_data import prepare_mnist
@@ -203,24 +191,17 @@ fn main() raises:
     )
 
     print("\nConfusion matrix saved to confusion_matrix.png")
-
-```text
+```
 
 Run evaluation:
 
 ```bash
-
-```bash
-
 pixi run mojo run evaluate.mojo
-
-```text
+```
 
 Expected output:
 
 ```text
-```text
-
 Evaluating model...
 
 Test Results:
@@ -230,17 +211,13 @@ Test Results:
   F1 Score:  95.10
 
 Confusion matrix saved to confusion_matrix.png
-
-```text
+```
 
 ## Step 7: Make Predictions
 
 Create `predict.mojo` to classify individual images:
 
 ```mojo
-
-```mojo
-
 from shared.utils import load_model, load_image, plot_image
 from model import DigitClassifier
 
@@ -268,8 +245,7 @@ fn predict_digit(image_path: String) raises:
 
 fn main() raises:
     predict_digit("my_digit.png")
-
-```text
+```
 
 ## Understanding the Code
 
@@ -282,8 +258,6 @@ fn main() raises:
 ### Model Architecture
 
 ```text
-```text
-
 Input (784)
     ↓
 Linear Layer (784 → 128)
@@ -297,8 +271,7 @@ ReLU Activation
 Linear Layer (64 → 10)
     ↓
 Softmax (Output Probabilities)
-
-```text
+```
 
 ### Training Process
 
@@ -321,9 +294,6 @@ Softmax (Output Probabilities)
 **Solutions**:
 
 ```mojo
-
-```mojo
-
 # Try adjusting learning rate
 var optimizer = SGD(learning_rate=0.001)  # Lower LR
 
@@ -333,60 +303,43 @@ trainer.train(train_loader, val_loader, epochs=20)
 # Verify data normalization
 print("Data range: ", train_images.min(), " to ", train_images.max())
 # Should be [0.0, 1.0]
-
-```text
+```
 
 ### Training Too Slow
 
 ### Solutions
 
 ```mojo
-```mojo
-
 # Increase batch size
-
 var train_loader = BatchLoader(train_data, batch_size=128)
 
 # Use release build for better performance
-
-```text
-
-```bash
+```
 
 ```bash
-
 pixi run mojo build --release train.mojo
 ./train
-
-```text
+```
 
 ### Out of Memory
 
 ### Solutions
 
 ```mojo
-```mojo
-
 # Reduce batch size
-
 var train_loader = BatchLoader(train_data, batch_size=16)
 
 # Use smaller model
-
 self.model = Sequential([
     Layer("linear", input_size=784, output_size=64),  # Smaller
     ReLU(),
     Layer("linear", input_size=64, output_size=10),
 ])
-
-```python
+```
 
 ### Import Errors
 
 ```bash
-
-```bash
-
 # Ensure you're in the right directory
 cd ProjectOdyssey/examples/first_model
 
@@ -396,16 +349,13 @@ ls ../../shared/
 # Run from repository root
 cd ../..
 pixi run mojo run examples/first_model/train.mojo
-
-```text
+```
 
 ## Improving Your Model
 
 ### 1. Deeper Network
 
 ```mojo
-```mojo
-
 self.model = Sequential([
     Layer("linear", input_size=784, output_size=256),
     ReLU(),
@@ -416,39 +366,28 @@ self.model = Sequential([
     Layer("linear", input_size=64, output_size=10),
     Softmax(),
 ])
-
-```text
+```
 
 ### 2. Different Optimizer
 
 ```mojo
-
-```mojo
-
 from shared.training import Adam
 
 var optimizer = Adam(learning_rate=0.001, beta1=0.9, beta2=0.999)
-
-```text
+```
 
 ### 3. Learning Rate Scheduling
 
 ```mojo
-```mojo
-
 from shared.training.schedulers import StepLR
 
 var scheduler = StepLR(initial_lr=0.01, step_size=5, gamma=0.5)
 trainer.add_scheduler(scheduler)
-
-```text
+```
 
 ### 4. Data Augmentation
 
 ```mojo
-
-```mojo
-
 from shared.data.transforms import RandomRotation, RandomShift
 
 var train_loader = BatchLoader(
@@ -459,8 +398,7 @@ var train_loader = BatchLoader(
         RandomShift(max_shift=2),
     ]
 )
-
-```text
+```
 
 ## Next Steps
 


### PR DESCRIPTION
Closes #3919

Fixes duplicate and malformed code block tags in the getting-started guide.