### PR TITLE
fix(packaging): export Normalize and Compose from shared

### DIFF
--- a/shared/__init__.mojo
+++ b/shared/__init__.mojo
@@ -90,7 +90,7 @@ comptime Accuracy = AccuracyMetric
 # Data components (most commonly used)
 # from .data.datasets import TensorDataset, ImageDataset
 # from .data.loaders import DataLoader
-# from .data.transforms import Normalize, ToTensor, Compose
+from .data.transforms import Normalize, Compose
 
 # Utils (most commonly used)
 # from .utils.logging import Logger


### PR DESCRIPTION
Fix import errors in test_packaging.mojo by exporting Normalize and Compose from the shared root package.

All 26 packaging integration tests now pass.

Closes #3761