### PR TITLE
feat(scripts): add split file group tracking to validate_test_coverage.py

### DIFF
--- a/shared/testing/models.mojo
+++ b/shared/testing/models.mojo
@@ -1108,3 +1108,22 @@ struct SimpleMLP2(Copyable, Model, Movable):
         var output = zeros(output_shape, input._dtype)
 
         return output^
+
+    fn parameters(self) raises -> List[ExTensor]:
+        """Get all trainable parameters.
+
+        Returns:
+            Empty list (placeholder - no trainable parameters in this fixture).
+
+        Raises:
+            Error: If parameter collection fails.
+        """
+        return List[ExTensor]()
+
+    fn zero_grad(mut self) raises:
+        """Placeholder for gradient reset (no gradient state in this fixture).
+
+        Raises:
+            Error: If operation fails.
+        """
+        pass


### PR DESCRIPTION
Add group_split_files() function to track test_*_partN.mojo files as
logical groups in coverage reports. When monolithic test files are split,
they now appear grouped in the report instead of as separate entries.

Closes #4109