### PR TITLE
ci: create build-validation.yml workflow for package compilation checks

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Set up Pixi
         uses: ./.github/actions/setup-pixi
 
+      - name: Install Just
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b
+
       - name: Build shared package (debug mode)
         run: |
           echo "Building shared Mojo package in debug mode..."


### PR DESCRIPTION
Add the missing build-validation.yml workflow referenced in the README and consolidation plan. This workflow validates that the shared Mojo package compiles successfully by running:

- `just build` (debug mode)
- `just package` (validation-only compilation)

Triggers on:
- PRs affecting shared/**/*.mojo, pixi.toml, or justfile
- Pushes to main with same paths
- Manual dispatch

Prevents merging changes that would break the shared package compilation.

Closes #3980