### PR TITLE
fix(utils): add missing dtype_to_string import in file_io.mojo

### DIFF
--- a/shared/utils/file_io.mojo
+++ b/shared/utils/file_io.mojo
@@ -26,6 +26,7 @@
 from python import Python, PythonObject
 from memory import UnsafePointer
 from shared.core.extensor import ExTensor
+from shared.utils.serialization import dtype_to_string
 
 
 # ============================================================================


### PR DESCRIPTION
Audit and fix missing imports in file_io.mojo.

The save_tensor_to_checkpoint() function calls dtype_to_string() without
importing it. Added import from shared.utils.serialization.

This audit confirms file_io.mojo already uses Python interop correctly for
most Mojo v0.26.1 stdlib gaps:
- safe_write_file: os.rename() for atomic writes
- create_directory: os.makedirs()  
- directory_exists: os.path.isdir()
- remove_safely: os.remove()
- expand_path: os.path.expanduser()

The _hex_to_bytes function has a documented UnsafePointer limitation that
cannot be resolved in the current Mojo version.

Closes #3877