### PR TITLE
test(core): add tests for __setitem__ on view/non-contiguous tensors

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -236,7 +236,7 @@ jobs:
           # and the constraints of the pattern field (no true glob support).
           - name: "Core Utilities"
             path: "tests/shared/core"
-            pattern: "test_utilities.mojo test_utility*.mojo test_utils*.mojo test_validation*.mojo test_integration*.mojo test_inplace_simd.mojo test_lazy_expression.mojo test_memory_pool_part*.mojo test_constants.mojo test_extensor_*.mojo test_memory_leaks*.mojo test_initializers_*.mojo test_layers*.mojo test_linear*.mojo test_conv*.mojo test_normalization*.mojo test_dropout_part*.mojo test_module.mojo test_composed_op*.mojo test_hash.mojo test_sequential.mojo"
+            pattern: "test_utilities.mojo test_utility*.mojo test_utils*.mojo test_validation*.mojo test_integration*.mojo test_inplace_simd.mojo test_lazy_expression.mojo test_memory_pool_part*.mojo test_constants.mojo test_extensor_*.mojo test_setitem_view.mojo test_memory_leaks*.mojo test_initializers_*.mojo test_layers*.mojo test_linear*.mojo test_conv*.mojo test_normalization*.mojo test_dropout_part*.mojo test_module.mojo test_composed_op*.mojo test_hash.mojo test_sequential.mojo"
           # ---- All data subsystems (formats/datasets/samplers/transforms/loaders) ----
           # NOTE: Some data tests (test_prefetch, test_random_transform_base) crash
           # on CI with heap corruption — non-blocking pending investigation

--- a/tests/shared/core/test_setitem_view.mojo
+++ b/tests/shared/core/test_setitem_view.mojo
@@ -39,7 +39,7 @@ fn test_setitem_view_1d_writes_correctly() raises:
     When we write to a sliced tensor, the write should affect the correct
     position in the original tensor (offset by slice start).
     """
-    var original = zeros(List[Int](10), DType.float32)
+    var original = zeros([10], DType.float32)
     var view = original[2:5]
 
     # Write to the view
@@ -60,7 +60,7 @@ fn test_setitem_view_multidim_writes_correctly() raises:
 
     Slice a 2D tensor and verify writes go to the correct parent positions.
     """
-    var original = zeros(List[Int](3, 4), DType.float32)
+    var original = zeros([3, 4], DType.float32)
     var view = original[1:3, 1:3]
 
     # Write to the view (it should be 2x2)
@@ -68,10 +68,10 @@ fn test_setitem_view_multidim_writes_correctly() raises:
         raise Error("View shape should be (2, 2)")
 
     # Set using List[Int] multi-index
-    var idx1 = List[Int](0, 0)
-    var idx2 = List[Int](0, 1)
-    var idx3 = List[Int](1, 0)
-    var idx4 = List[Int](1, 1)
+    var idx1 = [0, 0]
+    var idx2 = [0, 1]
+    var idx3 = [1, 0]
+    var idx4 = [1, 1]
 
     view.__setitem__(idx1, 11.0)
     view.__setitem__(idx2, 12.0)
@@ -81,10 +81,10 @@ fn test_setitem_view_multidim_writes_correctly() raises:
     # Verify positions in original tensor
     # view[0,0] = original[1,1], view[0,1] = original[1,2],
     # view[1,0] = original[2,1], view[1,1] = original[2,2]
-    var idx_11 = List[Int](1, 1)
-    var idx_12 = List[Int](1, 2)
-    var idx_21 = List[Int](2, 1)
-    var idx_22 = List[Int](2, 2)
+    var idx_11 = [1, 1]
+    var idx_12 = [1, 2]
+    var idx_21 = [2, 1]
+    var idx_22 = [2, 2]
 
     assert_value_at(original, 0, 0.0, "original[0,0] should be 0.0 (outside slice)")
     assert_value_at(original.__getitem__(idx_11), Float32(11.0), "original[1,1]")
@@ -99,7 +99,7 @@ fn test_setitem_view_does_not_corrupt_adjacent_elements() raises:
     Write to a sliced tensor and verify that elements outside the slice
     remain unchanged.
     """
-    var original = ones(List[Int](10), DType.float32)
+    var original = ones([10], DType.float32)
     var view = original[3:7]
 
     # Write to view


### PR DESCRIPTION
Add comprehensive tests for __setitem__ behavior on sliced tensors to verify
correct memory writes when target tensor is a view with non-identity strides.

Tests verify correct parent position writes, multi-dimensional slices, and
adjacent element integrity.

Closes #4076