### PR TITLE
tool: add stale script detection utility

### DIFF
--- a/scripts/detect_stale_scripts.py
+++ b/scripts/detect_stale_scripts.py
@@ -22,7 +22,7 @@ import argparse
 import re
 import sys
 from pathlib import Path
-from typing import List, Set
+from typing import Set
 
 
 # Known utility/library scripts that don't need to be referenced


### PR DESCRIPTION
Add detect_stale_scripts.py utility to automatically identify potentially
stale scripts in the scripts/ directory. Lightweight detection that checks
whether each script is referenced in justfile, workflows, or documentation.

Script detection looks for references in:
- justfile (task definitions)
- .github/workflows/*.yml (CI workflows)
- scripts/ modules (imports/function calls)
- docs/ (documentation references)

Provides exit codes suitable for CI use:
- 0: No stale scripts detected
- 1: Stale scripts found (warnings printed)

Usage:
    python3 scripts/detect_stale_scripts.py
    python3 scripts/detect_stale_scripts.py --verbose
    python3 scripts/detect_stale_scripts.py --exclude test_

Replaces manual audit rounds (#3148, #3337) with automated detection
for ongoing code hygiene.

Closes #3969