### PR TITLE
feat: add SimpleMLP2 variant for Sequential container integration

### DIFF
--- a/shared/testing/models.mojo
+++ b/shared/testing/models.mojo
@@ -1108,3 +1108,22 @@ struct SimpleMLP2(Copyable, Model, Movable):
         var output = zeros(output_shape, input._dtype)
 
         return output^
+
+    fn parameters(self) raises -> List[ExTensor]:
+        """Get all trainable parameters.
+
+        Returns:
+            Empty list (placeholder has no trainable parameters).
+
+        Raises:
+            Error: If parameter collection fails.
+        """
+        return List[ExTensor]()
+
+    fn zero_grad(mut self) raises:
+        """Placeholder for gradient reset (no gradient state in this fixture).
+
+        Raises:
+            Error: If operation fails.
+        """
+        pass


### PR DESCRIPTION
Add SimpleMLP2 struct as real-world usage example of Sequential2 container,
demonstrating container-based composition pattern for multi-layer networks.
Includes documentation reference from SimpleMLP.

Closes #3742

Co-Authored-By: Claude <noreply@anthropic.com>