### PR TITLE
fix: add step validation for N-D __getitem__(*slices)

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -1086,6 +1086,19 @@ struct ExTensor(
         for dim in range(num_dims):
             var s = slices[dim]
             var size = self._shape[dim]
+            var step = s.step.or_else(1)
+
+            # Check for unsupported stride (step != 1)
+            if step != 1:
+                raise Error(
+                    "Strided slicing (step != 1) is not yet supported in "
+                    + "multi-dimensional __getitem__(*slices). "
+                    + "Dimension "
+                    + String(dim)
+                    + " has step="
+                    + String(step)
+                    + ". Use 1D __getitem__(Slice) for strided slicing."
+                )
 
             var start = s.start.or_else(0)
             var end = s.end.or_else(size)


### PR DESCRIPTION
Add explicit error when step != 1 passed to multi-dimensional slicing to
prevent silent wrong results. Documents supported strided slicing via 1D
__getitem__(Slice).

Closes #3695

Co-Authored-By: Claude <noreply@anthropic.com>