### PR TITLE
feat(core): extend __getitem__(Slice) to support multi-dimensional tensors

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -933,24 +933,29 @@ struct ExTensor(
         self.__setitem__(flat_idx, value)
 
     fn __getitem__(self, slice: Slice) raises -> Self:
-        """Get slice of 1D tensor [start:end] or [start:end:step].
+        """Get slice along axis 0 using [start:end] or [start:end:step].
+
+        For 1D tensors this is equivalent to element-level slicing. For N-D
+        tensors this slices along axis 0, returning all inner dimensions
+        intact — consistent with NumPy semantics (e.g. ``t[1:3]`` on a 2D
+        tensor returns rows 1 and 2 as a copy).
 
         Args:
-            slice: Slice object specifying start, end, and optional step.
+            slice: Slice object specifying start, end, and optional step
+                   along axis 0.
 
         Returns:
             New tensor containing a **copy** of the sliced data. The result
-            does not share memory with the original tensor.
-
-        Raises:
-            Error: If tensor is not 1D or indices are invalid.
+            does not share memory with the original tensor. For memory-efficient
+            contiguous batch extraction along axis 0, use `slice()` instead,
+            which returns a true view (but does not support strided or reverse
+            slicing).
 
         Notes:
-            This method always returns a copy (`_is_view = False`), regardless
-            of the step value. This is by design: materializing a strided copy
-            keeps the implementation simple and avoids lifetime management
-            complexity. For memory-efficient batch extraction over the first
-            axis, use `slice()` instead, which returns a true view.
+            This method always returns a copy (``_is_view = False``),
+            regardless of step value or tensor rank. The result shape is
+            ``[result_size, shape[1], shape[2], ...]`` where ``result_size``
+            is the number of axis-0 indices selected by the slice.
 
         Example:
             ```mojo
@@ -958,11 +963,11 @@ struct ExTensor(
             var sliced = t[2:7]  # Copy of [2, 3, 4, 5, 6]
             var strided = t[0:10:2]  # Copy of [0, 2, 4, 6, 8]
             var reversed = t[::-1]  # Copy of [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+
+            var mat = zeros([4, 5], DType.float32)
+            var rows = mat[1:3]  # Copy with shape [2, 5] (rows 1 and 2)
         ```
         """
-        if len(self._shape) != 1:
-            raise Error("Single slice only supported for 1D tensors")
-
         # Handle slice parameters — extract step first so defaults depend on sign
         var size = self._shape[0]
         var step = slice.step.or_else(1)
@@ -983,63 +988,81 @@ struct ExTensor(
         if end < 0:
             end = size + end
 
-        # Handle negative step (reverse)
+        # Compute result_size (number of axis-0 indices selected)
         var result_size: Int
         if step < 0:
             var neg_step = -step
             # Clamp start to [0, size-1], end to [-1, size-1]
             start = max(0, min(start, size - 1))
             end = max(-1, min(end, size - 1))
-            # No swap: iterate src_idx = start - i * neg_step while src_idx > end
             result_size = max(0, ceildiv(start - end, neg_step))
-
-            # Create result tensor with shape
-            var shape = List[Int]()
-            shape.append(result_size)
-            var result = Self(shape, self._dtype)
-            result._is_view = False
-
-            # Copy in reverse
-            var dtype_size = self._get_dtype_size()
-            var src_ptr = self._data
-            var dst_ptr = result._data
-
-            for i in range(result_size):
-                var src_idx = start - i * neg_step
-                var src_offset = src_idx * dtype_size
-                var dst_offset = i * dtype_size
-                for b in range(dtype_size):
-                    dst_ptr[dst_offset + b] = src_ptr[src_offset + b]
-
-            return result^
         else:
             # Clamp forward slice to [0, size]
             start = max(0, min(start, size))
             end = max(0, min(end, size))
-            # Normal forward slice
             result_size = max(0, ceildiv(end - start, step))
 
-        # Create result tensor with shape
-        var shape = List[Int]()
-        shape.append(result_size)
-        var result = Self(shape, self._dtype)
-        result._is_view = False  # Strided slice creates copy, not view
-
-        # Copy strided data
         var dtype_size = self._get_dtype_size()
         var src_ptr = self._data
-        var dst_ptr = result._data
 
-        for i in range(result_size):
-            var src_idx = start + i * step
-            var src_offset = src_idx * dtype_size
-            var dst_offset = i * dtype_size
+        if len(self._shape) == 1:
+            # 1D path: copy individual elements
+            var shape = List[Int]()
+            shape.append(result_size)
+            var result = Self(shape, self._dtype)
+            result._is_view = False
+            var dst_ptr = result._data
 
-            # Copy element (byte-wise)
-            for b in range(dtype_size):
-                dst_ptr[dst_offset + b] = src_ptr[src_offset + b]
+            if step < 0:
+                var neg_step = -step
+                for i in range(result_size):
+                    var src_idx = start - i * neg_step
+                    var src_offset = src_idx * dtype_size
+                    var dst_offset = i * dtype_size
+                    for b in range(dtype_size):
+                        dst_ptr[dst_offset + b] = src_ptr[src_offset + b]
+            else:
+                for i in range(result_size):
+                    var src_idx = start + i * step
+                    var src_offset = src_idx * dtype_size
+                    var dst_offset = i * dtype_size
+                    for b in range(dtype_size):
+                        dst_ptr[dst_offset + b] = src_ptr[src_offset + b]
 
-        return result^
+            return result^
+        else:
+            # N-D path: slice along axis 0, copy entire inner slabs
+            # result shape: [result_size, shape[1], shape[2], ...]
+            var result_shape = List[Int]()
+            result_shape.append(result_size)
+            for d in range(1, len(self._shape)):
+                result_shape.append(self._shape[d])
+
+            var result = Self(result_shape, self._dtype)
+            result._is_view = False
+            var dst_ptr = result._data
+
+            # _strides[0] is the number of elements per axis-0 slab (row-major)
+            var inner_numel = self._strides[0]
+            var slab_bytes = inner_numel * dtype_size
+
+            if step < 0:
+                var neg_step = -step
+                for i in range(result_size):
+                    var src_axis0 = start - i * neg_step
+                    var src_offset = src_axis0 * slab_bytes
+                    var dst_offset = i * slab_bytes
+                    for b in range(slab_bytes):
+                        dst_ptr[dst_offset + b] = src_ptr[src_offset + b]
+            else:
+                for i in range(result_size):
+                    var src_axis0 = start + i * step
+                    var src_offset = src_axis0 * slab_bytes
+                    var dst_offset = i * slab_bytes
+                    for b in range(slab_bytes):
+                        dst_ptr[dst_offset + b] = src_ptr[src_offset + b]
+
+            return result^
 
     fn __getitem__(self, *slices: Slice) raises -> Self:
         """Get multi-dimensional slice (e.g., tensor[a:b, c:d, :]).

--- a/tests/shared/core/test_extensor_slicing_multidim.mojo
+++ b/tests/shared/core/test_extensor_slicing_multidim.mojo
@@ -1,0 +1,194 @@
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_extensor_slicing.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for ExTensor __getitem__(Slice) on multi-dimensional tensors.
+
+Covers axis-0 slicing of N-D tensors via t[start:end:step], extending the
+previously 1D-only implementation. NumPy-consistent semantics: a single Slice
+maps to axis 0 and all inner dimensions are preserved.
+"""
+
+from shared.core.extensor import ExTensor, zeros, ones, full, arange
+from tests.shared.conftest import assert_true, assert_almost_equal, assert_equal
+
+
+fn test_slice_2d_axis0_basic() raises:
+    """Test t[1:3] on a 2D tensor slices along axis 0."""
+    # 4x5 tensor with sequential values 0..19
+    var t = arange(0.0, 20.0, 1.0, DType.float32)
+    var t2d = t.reshape([4, 5])
+
+    var sliced = t2d[1:3]
+
+    var shape = sliced.shape()
+    assert_equal(len(shape), 2)
+    assert_equal(shape[0], 2)
+    assert_equal(shape[1], 5)
+
+    # sliced[0,:] = row 1 of original = [5,6,7,8,9]
+    # sliced[1,:] = row 2 of original = [10,11,12,13,14]
+    assert_almost_equal(Float64(sliced[0]), 5.0, tolerance=1e-6)
+    assert_almost_equal(Float64(sliced[4]), 9.0, tolerance=1e-6)
+    assert_almost_equal(Float64(sliced[5]), 10.0, tolerance=1e-6)
+    assert_almost_equal(Float64(sliced[9]), 14.0, tolerance=1e-6)
+
+
+fn test_slice_2d_axis0_full() raises:
+    """Test t[:] on a 2D tensor returns a full copy."""
+    var t = arange(0.0, 12.0, 1.0, DType.float32)
+    var t2d = t.reshape([3, 4])
+
+    var sliced = t2d[:]
+
+    var shape = sliced.shape()
+    assert_equal(shape[0], 3)
+    assert_equal(shape[1], 4)
+    assert_equal(sliced.numel(), 12)
+
+    # All values should match original
+    for i in range(12):
+        assert_almost_equal(Float64(sliced[i]), Float64(i), tolerance=1e-6)
+
+
+fn test_slice_2d_axis0_step2() raises:
+    """Test t[::2] on a 2D tensor selects every other row."""
+    # 6x3 tensor with sequential values 0..17
+    var t = arange(0.0, 18.0, 1.0, DType.float32)
+    var t2d = t.reshape([6, 3])
+
+    var sliced = t2d[::2]
+
+    var shape = sliced.shape()
+    assert_equal(shape[0], 3)
+    assert_equal(shape[1], 3)
+
+    # Row 0 of sliced = row 0 of original = [0,1,2]
+    assert_almost_equal(Float64(sliced[0]), 0.0, tolerance=1e-6)
+    assert_almost_equal(Float64(sliced[2]), 2.0, tolerance=1e-6)
+    # Row 1 of sliced = row 2 of original = [6,7,8]
+    assert_almost_equal(Float64(sliced[3]), 6.0, tolerance=1e-6)
+    assert_almost_equal(Float64(sliced[5]), 8.0, tolerance=1e-6)
+    # Row 2 of sliced = row 4 of original = [12,13,14]
+    assert_almost_equal(Float64(sliced[6]), 12.0, tolerance=1e-6)
+
+
+fn test_slice_2d_axis0_reverse() raises:
+    """Test t[::-1] on a 2D tensor reverses the row order."""
+    var t = arange(0.0, 12.0, 1.0, DType.float32)
+    var t2d = t.reshape([3, 4])
+
+    var sliced = t2d[::-1]
+
+    var shape = sliced.shape()
+    assert_equal(shape[0], 3)
+    assert_equal(shape[1], 4)
+
+    # Row 0 of sliced = row 2 of original = [8,9,10,11]
+    assert_almost_equal(Float64(sliced[0]), 8.0, tolerance=1e-6)
+    assert_almost_equal(Float64(sliced[3]), 11.0, tolerance=1e-6)
+    # Row 1 of sliced = row 1 of original = [4,5,6,7]
+    assert_almost_equal(Float64(sliced[4]), 4.0, tolerance=1e-6)
+    # Row 2 of sliced = row 0 of original = [0,1,2,3]
+    assert_almost_equal(Float64(sliced[8]), 0.0, tolerance=1e-6)
+    assert_almost_equal(Float64(sliced[11]), 3.0, tolerance=1e-6)
+
+
+fn test_slice_3d_axis0_basic() raises:
+    """Test t[1:3] on a 3D tensor slices along axis 0."""
+    # 4x3x2 tensor with sequential values 0..23
+    var t = arange(0.0, 24.0, 1.0, DType.float32)
+    var t3d = t.reshape([4, 3, 2])
+
+    var sliced = t3d[1:3]
+
+    var shape = sliced.shape()
+    assert_equal(len(shape), 3)
+    assert_equal(shape[0], 2)
+    assert_equal(shape[1], 3)
+    assert_equal(shape[2], 2)
+
+    # sliced[0,:,:] = original[1,:,:] = elements 6..11
+    assert_almost_equal(Float64(sliced[0]), 6.0, tolerance=1e-6)
+    assert_almost_equal(Float64(sliced[5]), 11.0, tolerance=1e-6)
+    # sliced[1,:,:] = original[2,:,:] = elements 12..17
+    assert_almost_equal(Float64(sliced[6]), 12.0, tolerance=1e-6)
+    assert_almost_equal(Float64(sliced[11]), 17.0, tolerance=1e-6)
+
+
+fn test_slice_2d_is_copy_not_view() raises:
+    """Test that sliced result is a copy — mutating it does not affect original."""
+    var t = arange(0.0, 20.0, 1.0, DType.float32)
+    var t2d = t.reshape([4, 5])
+
+    var sliced = t2d[1:3]
+
+    # Mutate sliced
+    sliced[0] = 999.0
+
+    # Original must be unchanged at the corresponding flat index (row 1, col 0 = index 5)
+    assert_almost_equal(Float64(t2d[5]), 5.0, tolerance=1e-6)
+
+
+fn test_slice_2d_negative_start() raises:
+    """Test t[-2:] on a 2D tensor selects the last two rows."""
+    var t = arange(0.0, 20.0, 1.0, DType.float32)
+    var t2d = t.reshape([4, 5])
+
+    var sliced = t2d[-2:]
+
+    var shape = sliced.shape()
+    assert_equal(shape[0], 2)
+    assert_equal(shape[1], 5)
+
+    # sliced[0,:] = row 2 of original = [10,11,12,13,14]
+    assert_almost_equal(Float64(sliced[0]), 10.0, tolerance=1e-6)
+    assert_almost_equal(Float64(sliced[4]), 14.0, tolerance=1e-6)
+    # sliced[1,:] = row 3 of original = [15,16,17,18,19]
+    assert_almost_equal(Float64(sliced[5]), 15.0, tolerance=1e-6)
+
+
+fn test_slice_2d_empty_result() raises:
+    """Test t[3:1] on a 2D tensor returns an empty tensor with shape (0, cols)."""
+    var t = arange(0.0, 20.0, 1.0, DType.float32)
+    var t2d = t.reshape([4, 5])
+
+    var sliced = t2d[3:1]
+
+    var shape = sliced.shape()
+    assert_equal(shape[0], 0)
+    assert_equal(shape[1], 5)
+    assert_equal(sliced.numel(), 0)
+
+
+fn test_slice_1d_regression() raises:
+    """Regression: __getitem__(Slice) on 1D tensors still works correctly."""
+    var t = arange(0.0, 10.0, 1.0, DType.float32)
+
+    var fwd = t[2:7]
+    assert_equal(fwd.numel(), 5)
+    assert_almost_equal(Float64(fwd[0]), 2.0, tolerance=1e-6)
+    assert_almost_equal(Float64(fwd[4]), 6.0, tolerance=1e-6)
+
+    var rev = t[::-1]
+    assert_equal(rev.numel(), 10)
+    assert_almost_equal(Float64(rev[0]), 9.0, tolerance=1e-6)
+    assert_almost_equal(Float64(rev[9]), 0.0, tolerance=1e-6)
+
+    var strided = t[0:10:2]
+    assert_equal(strided.numel(), 5)
+    assert_almost_equal(Float64(strided[0]), 0.0, tolerance=1e-6)
+    assert_almost_equal(Float64(strided[4]), 8.0, tolerance=1e-6)
+
+
+fn main() raises:
+    """Run all multi-dimensional single-slice tests."""
+    test_slice_2d_axis0_basic()
+    test_slice_2d_axis0_full()
+    test_slice_2d_axis0_step2()
+    test_slice_2d_axis0_reverse()
+    test_slice_3d_axis0_basic()
+    test_slice_2d_is_copy_not_view()
+    test_slice_2d_negative_start()
+    test_slice_2d_empty_result()
+    test_slice_1d_regression()
+    print("All multi-dimensional single-slice (__getitem__(Slice)) tests passed!")


### PR DESCRIPTION
## Summary

- Removes the `raise Error("Single slice only supported for 1D tensors")` guard from `__getitem__(Slice)` in `shared/core/extensor.mojo`
- A single `Slice` now slices along **axis 0** for tensors of any rank, preserving all inner dimensions (NumPy-consistent semantics)
- Full step support (forward, strided, reverse) is preserved via contiguous slab copies using row-major strides
- Copy semantics (`_is_view = False`) maintained for all ranks

## Test plan

- [x] New file `tests/shared/core/test_extensor_slicing_multidim.mojo` (9 functions, ≤10 per ADR-009)
  - 2D axis-0 basic, full, step-2, reverse
  - 3D axis-0 basic
  - Copy-not-view verification
  - Negative start index
  - Empty result
  - 1D regression
- [x] Existing tests still pass: `test_extensor_slicing_1d`, `test_extensor_slicing_2d`, `test_extensor_slicing_edge`

Closes #3696

🤖 Generated with [Claude Code](https://claude.com/claude-code)