### PR TITLE
refactor(extensor): extract _normalize_slice_indices to unify slice normalization

### DIFF
--- a/tests/shared/core/test_normalize_slice_indices.mojo
+++ b/tests/shared/core/test_normalize_slice_indices.mojo
@@ -1,0 +1,149 @@
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Unit tests for ExTensor._normalize_slice_indices helper."""
+
+from shared.core.extensor import ExTensor, zeros
+from tests.shared.conftest import assert_equal
+
+
+fn _make_1d(size: Int) raises -> ExTensor:
+    """Create a 1D tensor of the given size."""
+    var shape = List[Int]()
+    shape.append(size)
+    return ExTensor(shape, DType.float32)
+
+
+fn test_normalize_forward_full() raises:
+    """[::] on size=5 → start=0, end=5, step=1, result_size=5."""
+    var t = _make_1d(5)
+    var norm = t._normalize_slice_indices(
+        Optional[Int](None), Optional[Int](None), Optional[Int](None), 5
+    )
+    assert_equal(norm[0], 0)
+    assert_equal(norm[1], 5)
+    assert_equal(norm[2], 1)
+    assert_equal(norm[3], 5)
+
+
+fn test_normalize_forward_basic() raises:
+    """[2:7:1] on size=10 → start=2, end=7, step=1, result_size=5."""
+    var t = _make_1d(10)
+    var norm = t._normalize_slice_indices(
+        Optional[Int](2), Optional[Int](7), Optional[Int](1), 10
+    )
+    assert_equal(norm[0], 2)
+    assert_equal(norm[1], 7)
+    assert_equal(norm[2], 1)
+    assert_equal(norm[3], 5)
+
+
+fn test_normalize_empty_slice() raises:
+    """[3:3:1] on size=5 → result_size=0."""
+    var t = _make_1d(5)
+    var norm = t._normalize_slice_indices(
+        Optional[Int](3), Optional[Int](3), Optional[Int](1), 5
+    )
+    assert_equal(norm[0], 3)
+    assert_equal(norm[1], 3)
+    assert_equal(norm[2], 1)
+    assert_equal(norm[3], 0)
+
+
+fn test_normalize_negative_start() raises:
+    """[-3::1] on size=10 → start=7, end=10, result_size=3."""
+    var t = _make_1d(10)
+    var norm = t._normalize_slice_indices(
+        Optional[Int](-3), Optional[Int](None), Optional[Int](1), 10
+    )
+    assert_equal(norm[0], 7)
+    assert_equal(norm[1], 10)
+    assert_equal(norm[2], 1)
+    assert_equal(norm[3], 3)
+
+
+fn test_normalize_negative_end() raises:
+    """[0:-2:1] on size=10 → start=0, end=8, result_size=8."""
+    var t = _make_1d(10)
+    var norm = t._normalize_slice_indices(
+        Optional[Int](0), Optional[Int](-2), Optional[Int](1), 10
+    )
+    assert_equal(norm[0], 0)
+    assert_equal(norm[1], 8)
+    assert_equal(norm[2], 1)
+    assert_equal(norm[3], 8)
+
+
+fn test_normalize_strided_step2() raises:
+    """[0:10:2] on size=10 → result_size=5."""
+    var t = _make_1d(10)
+    var norm = t._normalize_slice_indices(
+        Optional[Int](0), Optional[Int](10), Optional[Int](2), 10
+    )
+    assert_equal(norm[0], 0)
+    assert_equal(norm[1], 10)
+    assert_equal(norm[2], 2)
+    assert_equal(norm[3], 5)
+
+
+fn test_normalize_reverse_full() raises:
+    """[::-1] on size=5 → start=4, end=-1, result_size=5."""
+    var t = _make_1d(5)
+    var norm = t._normalize_slice_indices(
+        Optional[Int](None), Optional[Int](None), Optional[Int](-1), 5
+    )
+    assert_equal(norm[0], 4)
+    assert_equal(norm[1], -1)
+    assert_equal(norm[2], -1)
+    assert_equal(norm[3], 5)
+
+
+fn test_normalize_reverse_partial() raises:
+    """[3:1:-1] on size=5 → start=3, end=1, result_size=2."""
+    var t = _make_1d(5)
+    var norm = t._normalize_slice_indices(
+        Optional[Int](3), Optional[Int](1), Optional[Int](-1), 5
+    )
+    assert_equal(norm[0], 3)
+    assert_equal(norm[1], 1)
+    assert_equal(norm[2], -1)
+    assert_equal(norm[3], 2)
+
+
+fn test_normalize_oob_clamp_forward() raises:
+    """[8:20:1] on size=10 → end clamped to 10, result_size=2."""
+    var t = _make_1d(10)
+    var norm = t._normalize_slice_indices(
+        Optional[Int](8), Optional[Int](20), Optional[Int](1), 10
+    )
+    assert_equal(norm[0], 8)
+    assert_equal(norm[1], 10)
+    assert_equal(norm[2], 1)
+    assert_equal(norm[3], 2)
+
+
+fn test_normalize_oob_clamp_reverse() raises:
+    """[20::-1] on size=10 → start clamped to 9, result_size=10."""
+    var t = _make_1d(10)
+    var norm = t._normalize_slice_indices(
+        Optional[Int](20), Optional[Int](None), Optional[Int](-1), 10
+    )
+    assert_equal(norm[0], 9)
+    assert_equal(norm[1], -1)
+    assert_equal(norm[2], -1)
+    assert_equal(norm[3], 10)
+
+
+fn main() raises:
+    """Run all _normalize_slice_indices tests."""
+    test_normalize_forward_full()
+    test_normalize_forward_basic()
+    test_normalize_empty_slice()
+    test_normalize_negative_start()
+    test_normalize_negative_end()
+    test_normalize_strided_step2()
+    test_normalize_reverse_full()
+    test_normalize_reverse_partial()
+    test_normalize_oob_clamp_forward()
+    test_normalize_oob_clamp_reverse()
+    print("All _normalize_slice_indices tests passed!")


### PR DESCRIPTION
## Summary

- Extract duplicated slice index normalization from `__getitem__(Slice)` and `__getitem__(*slices)` into a shared `_normalize_slice_indices(start, end, step, size)` helper method
- Helper resolves defaults (step-sign-aware), normalizes negative indices, clamps to valid bounds, and returns `(normalized_start, normalized_end, step_val, result_size)`
- Both call sites now delegate to the helper, eliminating ~25 lines of duplication

## Changes Made

- `shared/core/extensor.mojo`: Added `_normalize_slice_indices` before `__getitem__(Slice)`; refactored both `__getitem__` overloads to use it
- `tests/shared/core/test_normalize_slice_indices.mojo`: 10 unit tests covering full forward, basic forward, empty slice, negative start/end, strided step=2, full reverse, partial reverse, out-of-bounds clamping (forward and reverse)

## Verification

- New unit tests: all 10 pass
- Existing slicing regression tests (`test_extensor_slicing_1d`, `2d`, `edge`, `part1`, `part2`): all pass
- `test_extensor_slicing_part3` was already failing before this PR (pre-existing issue with `test_slice_2d_value_correctness` calling single `Slice` on a 2D tensor)

Closes #3700

🤖 Generated with [Claude Code](https://claude.com/claude-code)