### PR TITLE
feat(shared): expose AdaGrad and RMSprop as top-level shared imports

### DIFF
--- a/tests/shared/autograd/test_top_level_optimizer_imports.mojo
+++ b/tests/shared/autograd/test_top_level_optimizer_imports.mojo
@@ -1,0 +1,84 @@
+"""Tests for top-level optimizer imports from shared package.
+
+Verifies that AdaGrad, RMSprop, SGD, Adam, and AdamW are all importable
+directly from the top-level `shared` package (Issue #3745).
+
+Run with: mojo test tests/shared/autograd/test_top_level_optimizer_imports.mojo
+
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""
+
+from testing import assert_true
+from tests.shared.conftest import assert_almost_equal
+from shared import AdaGrad, RMSprop, SGD, Adam, AdamW
+
+
+# ============================================================================
+# Top-Level Import Tests (Issue #3745)
+# ============================================================================
+
+
+fn test_adagrad_top_level_import() raises:
+    """Test AdaGrad is importable from top-level shared package."""
+    var opt = AdaGrad(learning_rate=0.01)
+    assert_almost_equal(opt.get_lr(), 0.01, tolerance=1e-10)
+
+    opt.set_lr(0.005)
+    assert_almost_equal(opt.get_lr(), 0.005, tolerance=1e-10)
+
+    print("✓ AdaGrad top-level import test passed")
+
+
+fn test_rmsprop_top_level_import() raises:
+    """Test RMSprop is importable from top-level shared package."""
+    var opt = RMSprop(learning_rate=0.001)
+    assert_almost_equal(opt.get_lr(), 0.001, tolerance=1e-10)
+
+    opt.set_lr(0.01)
+    assert_almost_equal(opt.get_lr(), 0.01, tolerance=1e-10)
+
+    print("✓ RMSprop top-level import test passed")
+
+
+fn test_sgd_top_level_import() raises:
+    """Test SGD is importable from top-level shared package (regression)."""
+    var opt = SGD(learning_rate=0.01)
+    assert_almost_equal(opt.get_lr(), 0.01, tolerance=1e-10)
+
+    print("✓ SGD top-level import test passed")
+
+
+fn test_adam_top_level_import() raises:
+    """Test Adam is importable from top-level shared package (regression)."""
+    var opt = Adam(learning_rate=0.001)
+    assert_almost_equal(opt.get_lr(), 0.001, tolerance=1e-10)
+
+    print("✓ Adam top-level import test passed")
+
+
+fn test_adamw_top_level_import() raises:
+    """Test AdamW is importable from top-level shared package (regression)."""
+    var opt = AdamW(learning_rate=0.001)
+    assert_almost_equal(opt.get_lr(), 0.001, tolerance=1e-10)
+
+    print("✓ AdamW top-level import test passed")
+
+
+# ============================================================================
+# Test Main
+# ============================================================================
+
+
+fn main() raises:
+    """Run top-level optimizer import tests."""
+    print("Running top-level optimizer import tests (Issue #3745)...")
+
+    test_adagrad_top_level_import()
+    test_rmsprop_top_level_import()
+    test_sgd_top_level_import()
+    test_adam_top_level_import()
+    test_adamw_top_level_import()
+
+    print("\nAll top-level optimizer import tests passed! ✓")

--- a/tests/shared/test_imports.mojo
+++ b/tests/shared/test_imports.mojo
@@ -115,9 +115,11 @@ fn test_training_optimizers_imports() raises:
 
 
 fn test_shared_optimizer_imports() raises:
-    """Test that SGD, Adam, AdamW are importable directly from shared package.
+    """Test that SGD, Adam, AdamW, AdaGrad, RMSprop are importable from shared package.
+
+    Covers Issue #3745: AdaGrad and RMSprop exposed as top-level shared imports.
     """
-    from shared.autograd.optimizers import SGD, Adam, AdamW
+    from shared import SGD, Adam, AdamW, AdaGrad, RMSprop
 
     print("✓ Shared optimizer imports test passed")
 


### PR DESCRIPTION
## Summary

- Add `from shared.autograd.optimizers import SGD, Adam, AdamW, AdaGrad, RMSprop` to `shared/__init__.mojo` so `from shared import AdaGrad, RMSprop` works
- All five optimizers now available at the top-level `shared` package for consistency
- Update Public API table comment to document optimizer exports

## Changes Made

- `shared/__init__.mojo`: Add active optimizer re-export line (line 85); update API table comment
- `tests/shared/autograd/test_top_level_optimizer_imports.mojo`: New test verifying all 5 optimizers import and instantiate from `shared`
- `tests/shared/test_imports.mojo`: Update `test_shared_optimizer_imports` to import from `shared` directly

## Verification

All new tests call `get_lr()` on each instantiated optimizer to confirm functional import, not just parse-time success.

Closes #3745

🤖 Generated with [Claude Code](https://claude.com/claude-code)