### PR TITLE
feat(testing): integrate Sequential3 into SimpleMLP2 fixture

### DIFF
--- a/shared/core/layers/linear.mojo
+++ b/shared/core/layers/linear.mojo
@@ -10,9 +10,10 @@ Key components:
 """
 
 from shared.core.extensor import ExTensor, zeros, randn, zeros_like
+from shared.core.module import Module
 
 
-struct Linear(Copyable, Movable):
+struct Linear(Copyable, Module, Movable):
     """Linear layer: y = xW + b.
 
     A fully connected neural network layer that transforms inputs
@@ -57,7 +58,7 @@ struct Linear(Copyable, Movable):
         # Initialize bias to zeros
         self.bias = zeros([out_features], DType.float32)
 
-    fn forward(self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: ExTensor) raises -> ExTensor:
         """Forward pass: y = xW + b.
 
         Computes the linear transformation: output = input @ weight + bias.
@@ -121,3 +122,11 @@ struct Linear(Copyable, Movable):
         params.append(weight_copy^)
         params.append(bias_copy^)
         return params^
+
+    fn train(mut self):
+        """Switch to training mode (no-op for Linear layer)."""
+        pass
+
+    fn eval(mut self):
+        """Switch to inference mode (no-op for Linear layer)."""
+        pass

--- a/shared/core/layers/relu.mojo
+++ b/shared/core/layers/relu.mojo
@@ -11,9 +11,10 @@ Key components:
 
 from shared.core.extensor import ExTensor, zeros_like
 from shared.core.activation import relu, relu_backward
+from shared.core.module import Module
 
 
-struct ReLULayer(Copyable, Movable):
+struct ReLULayer(Copyable, Module, Movable):
     """ReLU activation layer: y = max(0, x).
 
     A simple activation layer that applies the Rectified Linear Unit (ReLU)
@@ -47,7 +48,7 @@ struct ReLULayer(Copyable, Movable):
         """
         pass
 
-    fn forward(self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: ExTensor) raises -> ExTensor:
         """Forward pass: y = max(0, x).
 
         Applies ReLU activation element-wise to the input tensor.
@@ -71,7 +72,7 @@ struct ReLULayer(Copyable, Movable):
         return relu(input)
 
     fn backward(
-        self, grad_output: ExTensor, input: ExTensor
+        mut self, grad_output: ExTensor, input: ExTensor
     ) raises -> ExTensor:
         """Backward pass: compute gradient w.r.t. input.
 
@@ -120,3 +121,11 @@ struct ReLULayer(Copyable, Movable):
         """
         var params: List[ExTensor] = []
         return params^
+
+    fn train(mut self):
+        """Switch to training mode (no-op for ReLULayer)."""
+        pass
+
+    fn eval(mut self):
+        """Switch to inference mode (no-op for ReLULayer)."""
+        pass

--- a/shared/testing/__init__.mojo
+++ b/shared/testing/__init__.mojo
@@ -95,6 +95,7 @@ from shared.testing.models import (
     SimpleCNN,
     LinearModel,
     SimpleMLP,
+    SimpleMLP2,
     MockLayer,
     SimpleLinearModel,
     Parameter,

--- a/shared/testing/models.mojo
+++ b/shared/testing/models.mojo
@@ -8,6 +8,7 @@ Test Models:
     - SimpleCNN: Minimal CNN for testing image processing
     - LinearModel: Single fully-connected layer for basic testing
     - SimpleMLP: Multi-layer perceptron (2-3 layers) for composition testing
+    - SimpleMLP2: MLP using Sequential3[Linear, ReLULayer, Linear] containers
     - SimpleLinearModel: Linear model with weights and bias
     - MockLayer: Minimal layer with identity/scaled transformation
 
@@ -39,6 +40,8 @@ Example:
 
 from shared.core import ExTensor, zeros, ones, zeros_like
 from shared.core.traits import Model
+from shared.core.sequential import Sequential3
+from shared.core.layers import Linear, ReLULayer
 
 
 # ============================================================================
@@ -1010,3 +1013,136 @@ struct SimpleMLP(Copyable, Model, Movable):
         """
         # Placeholder for weight loading
         pass
+
+
+# ============================================================================
+# SimpleMLP2 - Sequential-based MLP (integration example)
+# ============================================================================
+
+
+struct SimpleMLP2(Model, Movable):
+    """Simple MLP using Sequential3 as a real-world integration example.
+
+    Implements a one-hidden-layer MLP as:
+        Linear(input_dim -> hidden_dim) -> ReLU -> Linear(hidden_dim -> output_dim)
+
+    Uses Sequential3[Linear, ReLULayer, Linear] internally to demonstrate
+    and integration-test the Sequential containers with real layers.
+
+    Attributes:
+        input_dim: Input feature dimension.
+        hidden_dim: Hidden layer dimension.
+        output_dim: Output feature dimension.
+        net: Sequential3 container holding the three layers.
+
+    Example:
+        ```mojo
+        var mlp = SimpleMLP2(10, 20, 5)
+        var input = zeros([10], DType.float32)
+        var output = mlp.forward(input)  # shape: [5]
+        ```
+    """
+
+    var input_dim: Int
+    """Input feature dimension."""
+    var hidden_dim: Int
+    """Hidden layer dimension."""
+    var output_dim: Int
+    """Output feature dimension."""
+    var net: Sequential3[Linear, ReLULayer, Linear]
+    """Sequential container: Linear -> ReLU -> Linear."""
+
+    fn __init__(
+        out self, input_dim: Int, hidden_dim: Int, output_dim: Int
+    ) raises:
+        """Initialize SimpleMLP2 with random weights.
+
+        Args:
+            input_dim: Number of input features.
+            hidden_dim: Number of hidden units.
+            output_dim: Number of output features.
+
+        Raises:
+            Error: If layer initialization fails.
+
+        Example:
+            ```mojo
+            var mlp = SimpleMLP2(784, 256, 10)
+            ```
+        """
+        self.input_dim = input_dim
+        self.hidden_dim = hidden_dim
+        self.output_dim = output_dim
+        self.net = Sequential3[Linear, ReLULayer, Linear](
+            Linear(input_dim, hidden_dim),
+            ReLULayer(),
+            Linear(hidden_dim, output_dim),
+        )
+
+    fn __moveinit__(out self, deinit other: Self):
+        """Move constructor.
+
+        Args:
+            other: Source SimpleMLP2 to move from.
+        """
+        self.input_dim = other.input_dim
+        self.hidden_dim = other.hidden_dim
+        self.output_dim = other.output_dim
+        self.net = other.net^
+
+    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+        """Forward pass through Linear -> ReLU -> Linear.
+
+        Args:
+            input: Input tensor of shape (input_dim,) or (batch_size, input_dim).
+
+        Returns:
+            Output tensor of shape (output_dim,) or (batch_size, output_dim).
+
+        Raises:
+            Error: If tensor operations fail.
+
+        Example:
+            ```mojo
+            var mlp = SimpleMLP2(10, 20, 5)
+            var input = ones([10], DType.float32)
+            var output = mlp.forward(input)  # shape: [5]
+            ```
+        """
+        return self.net.forward(input)
+
+    fn parameters(self) raises -> List[ExTensor]:
+        """Get all trainable parameters from the sequential container.
+
+        Returns:
+            List of ExTensor: [W1, b1, W2, b2] where W1 has shape
+            (input_dim, hidden_dim), b1 has shape (hidden_dim,),
+            W2 has shape (hidden_dim, output_dim), b2 has shape (output_dim,).
+
+        Raises:
+            Error: If parameter collection fails.
+
+        Example:
+            ```mojo
+            var mlp = SimpleMLP2(10, 20, 5)
+            var params = mlp.parameters()
+            # len(params) == 4
+            ```
+        """
+        return self.net.parameters()
+
+    fn zero_grad(mut self) raises:
+        """Placeholder for gradient reset (no gradient state in this fixture).
+
+        Raises:
+            Error: If operation fails.
+        """
+        pass
+
+    fn train(mut self):
+        """Switch to training mode, propagated through Sequential3."""
+        self.net.train()
+
+    fn set_inference_mode(mut self):
+        """Switch to inference mode, propagated through Sequential3."""
+        self.net.eval()

--- a/tests/shared/testing/test_test_models_simple_mlp2.mojo
+++ b/tests/shared/testing/test_test_models_simple_mlp2.mojo
@@ -1,0 +1,165 @@
+"""Tests for SimpleMLP2 - Sequential3-based MLP fixture.
+
+Coverage:
+    - SimpleMLP2 initialization (dimensions stored correctly)
+    - SimpleMLP2 forward pass output shape
+    - SimpleMLP2 parameters count and structure
+    - SimpleMLP2 train/inference mode propagation via Sequential3
+"""
+
+# ADR-009: This file is intentionally limited to <=10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+from shared.testing import (
+    SimpleMLP2,
+    assert_true,
+    assert_equal,
+)
+from shared.core import (
+    ExTensor,
+    zeros,
+    ones,
+)
+
+
+# ============================================================================
+# SimpleMLP2 Initialization Tests
+# ============================================================================
+
+
+fn test_simple_mlp2_initialization() raises:
+    """Test SimpleMLP2 stores dimension fields correctly after init."""
+    var mlp = SimpleMLP2(10, 20, 5)
+    assert_equal(mlp.input_dim, 10)
+    assert_equal(mlp.hidden_dim, 20)
+    assert_equal(mlp.output_dim, 5)
+
+
+# ============================================================================
+# SimpleMLP2 Forward Pass Tests
+# ============================================================================
+
+
+fn test_simple_mlp2_forward_shape_zeros() raises:
+    """Test SimpleMLP2 forward produces correct output shape with zero input."""
+    var mlp = SimpleMLP2(10, 20, 5)
+    var input_shape = [10]
+    var input = zeros(input_shape, DType.float32)
+
+    var output = mlp.forward(input)
+
+    assert_equal(len(output._shape), 1)
+    assert_equal(output._shape[0], 5)
+
+
+fn test_simple_mlp2_forward_shape_ones() raises:
+    """Test SimpleMLP2 forward produces correct output shape with ones input."""
+    var mlp = SimpleMLP2(10, 20, 5)
+    var input_shape = [10]
+    var input = ones(input_shape, DType.float32)
+
+    var output = mlp.forward(input)
+
+    assert_equal(len(output._shape), 1)
+    assert_equal(output._shape[0], 5)
+
+
+fn test_simple_mlp2_forward_dtype_preserved() raises:
+    """Test SimpleMLP2 forward preserves float32 dtype."""
+    var mlp = SimpleMLP2(4, 8, 2)
+    var input_shape = [4]
+    var input = zeros(input_shape, DType.float32)
+
+    var output = mlp.forward(input)
+
+    assert_true(
+        output._dtype == DType.float32, "Output dtype should be float32"
+    )
+
+
+fn test_simple_mlp2_forward_small_model() raises:
+    """Test SimpleMLP2 forward with minimal dimensions."""
+    var mlp = SimpleMLP2(2, 4, 1)
+    var input_shape = [2]
+    var input = ones(input_shape, DType.float32)
+
+    var output = mlp.forward(input)
+
+    assert_equal(output._shape[0], 1)
+
+
+# ============================================================================
+# SimpleMLP2 Parameter Tests
+# ============================================================================
+
+
+fn test_simple_mlp2_parameters_count() raises:
+    """Test SimpleMLP2 parameters() returns exactly 4 tensors: W1,b1,W2,b2."""
+    var mlp = SimpleMLP2(10, 20, 5)
+    var params = mlp.parameters()
+
+    # Sequential3[Linear, ReLULayer, Linear]:
+    # Linear(10,20): weight[10,20] + bias[20] = 2 params
+    # ReLULayer: 0 params
+    # Linear(20,5): weight[20,5] + bias[5] = 2 params
+    # Total: 4 tensors
+    assert_equal(len(params), 4)
+
+
+fn test_simple_mlp2_parameters_shapes() raises:
+    """Test SimpleMLP2 parameter tensors have correct element counts."""
+    var mlp = SimpleMLP2(10, 20, 5)
+    var params = mlp.parameters()
+
+    # W1: shape (10, 20) = 200 elements
+    assert_equal(params[0].numel(), 10 * 20)
+    # b1: shape (20,) = 20 elements
+    assert_equal(params[1].numel(), 20)
+    # W2: shape (20, 5) = 100 elements
+    assert_equal(params[2].numel(), 20 * 5)
+    # b2: shape (5,) = 5 elements
+    assert_equal(params[3].numel(), 5)
+
+
+# ============================================================================
+# SimpleMLP2 Mode Switching Tests
+# ============================================================================
+
+
+fn test_simple_mlp2_mode_switching() raises:
+    """Test SimpleMLP2 train/inference mode switching, forward still works."""
+    var mlp = SimpleMLP2(4, 8, 2)
+    var input_shape = [4]
+    var input = zeros(input_shape, DType.float32)
+
+    # Switch to training mode and verify forward works
+    mlp.train()
+    var out_train = mlp.forward(input)
+    assert_equal(out_train._shape[0], 2)
+
+    # Switch to inference mode and verify forward works
+    mlp.set_inference_mode()
+    var out_infer = mlp.forward(input)
+    assert_equal(out_infer._shape[0], 2)
+
+
+fn main() raises:
+    """Run all SimpleMLP2 tests."""
+    print("Testing SimpleMLP2 initialization...")
+    test_simple_mlp2_initialization()
+
+    print("Testing SimpleMLP2 forward pass...")
+    test_simple_mlp2_forward_shape_zeros()
+    test_simple_mlp2_forward_shape_ones()
+    test_simple_mlp2_forward_dtype_preserved()
+    test_simple_mlp2_forward_small_model()
+
+    print("Testing SimpleMLP2 parameters...")
+    test_simple_mlp2_parameters_count()
+    test_simple_mlp2_parameters_shapes()
+
+    print("Testing SimpleMLP2 mode switching...")
+    test_simple_mlp2_mode_switching()
+
+    print("All SimpleMLP2 tests passed!")


### PR DESCRIPTION
## Summary

- Add `SimpleMLP2` to `shared/testing/models.mojo` using `Sequential3[Linear, ReLULayer, Linear]` as a real-world integration example of the Sequential containers
- Add `Module` trait conformance to `Linear` and `ReLULayer` (required for Sequential3 generic constraint `T: Module & Movable`)
- Export `SimpleMLP2` from `shared/testing/__init__.mojo`
- Add tests in `tests/shared/testing/test_test_models_simple_mlp2.mojo` (8 test functions, ADR-009 compliant)

## Changes Made

- `shared/core/layers/linear.mojo`: Add `Module` import + trait, change `forward(self, ...)` to `forward(mut self, ...)`, add `train()`/`eval()` no-ops
- `shared/core/layers/relu.mojo`: Same as above
- `shared/testing/models.mojo`: Add imports for `Sequential3`, `Linear`, `ReLULayer`; add `SimpleMLP2` struct with `forward`, `parameters`, `zero_grad`, `train`, `set_inference_mode`
- `shared/testing/__init__.mojo`: Export `SimpleMLP2`
- `tests/shared/testing/test_test_models_simple_mlp2.mojo`: 8 test functions covering init, forward shape, dtype, parameter count/shapes, mode switching

## Verification

- `test_test_models_simple_mlp2.mojo`: All 8 tests pass
- `test_test_models_part2.mojo`: All existing SimpleMLP tests pass
- `tests/shared/core/layers/test_relu.mojo`: All 10 ReLULayer tests pass
- `tests/shared/core/test_sequential.mojo`: All sequential tests pass

Closes #3742