### PR TITLE
test(conv): add gradient checking for depthwise_conv2d_backward

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -227,7 +227,7 @@ jobs:
           # Non-blocking pending Mojo runtime fix.
           - name: "Core Gradient"
             path: "tests/shared/core"
-            pattern: "test_backward_linear.mojo test_backward_conv_pool.mojo test_backward_losses.mojo test_gradient_checking_basic.mojo test_gradient_checking_dtype.mojo test_gradient_validation_activations.mojo test_gradient_validation_layers.mojo test_gradient_validation_part1.mojo test_gradient_validation_part2.mojo test_variable_backward.mojo"
+            pattern: "test_backward_linear.mojo test_backward_conv_pool.mojo test_backward_losses.mojo test_gradient_checking_basic.mojo test_gradient_checking_dtype.mojo test_gradient_validation_activations.mojo test_gradient_validation_layers.mojo test_gradient_validation_part1.mojo test_gradient_validation_part2.mojo test_variable_backward.mojo test_depthwise_conv_grad_check_part1.mojo test_depthwise_conv_grad_check_part2.mojo"
             continue-on-error: true
           # ---- Core Utilities ----
           # NOTE: This pattern has 28+ explicit file patterns and is difficult to maintain.

--- a/tests/shared/core/test_depthwise_conv_grad_check_part1.mojo
+++ b/tests/shared/core/test_depthwise_conv_grad_check_part1.mojo
@@ -1,0 +1,254 @@
+# ADR-009: This file is intentionally limited to ≤8 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_depthwise_conv_grad_check.
+# See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Gradient checking tests for depthwise_conv2d_backward (part 1).
+
+Tests grad_input correctness via numerical gradient checking across
+stride/padding configurations and multi-channel cases.
+Follow-up from issue #3233.
+"""
+
+from tests.shared.conftest import (
+    assert_almost_equal,
+    assert_equal,
+)
+from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.conv import depthwise_conv2d, depthwise_conv2d_backward
+from shared.testing import check_gradient
+
+
+fn test_depthwise_conv2d_backward_shapes() raises:
+    """Test that depthwise_conv2d_backward returns correct gradient shapes."""
+    var channels = 2
+    var in_h = 6
+    var in_w = 6
+    var kh = 3
+    var kw = 3
+
+    var input_shape = List[Int]()
+    input_shape.append(1)
+    input_shape.append(channels)
+    input_shape.append(in_h)
+    input_shape.append(in_w)
+    var x = ones(input_shape, DType.float32)
+
+    var kernel_shape = List[Int]()
+    kernel_shape.append(channels)
+    kernel_shape.append(1)
+    kernel_shape.append(kh)
+    kernel_shape.append(kw)
+    var kernel = ones(kernel_shape, DType.float32)
+
+    var bias_shape = List[Int]()
+    bias_shape.append(channels)
+    var bias = zeros(bias_shape, DType.float32)
+
+    var output = depthwise_conv2d(x, kernel, bias, stride=1, padding=0)
+    var grad_output = ones_like(output)
+    var grads = depthwise_conv2d_backward(grad_output, x, kernel, stride=1, padding=0)
+
+    var gi_shape = grads.grad_input.shape()
+    assert_equal(gi_shape[0], 1)
+    assert_equal(gi_shape[1], channels)
+    assert_equal(gi_shape[2], in_h)
+    assert_equal(gi_shape[3], in_w)
+
+    var gk_shape = grads.grad_weights.shape()
+    assert_equal(gk_shape[0], channels)
+    assert_equal(gk_shape[1], 1)
+    assert_equal(gk_shape[2], kh)
+    assert_equal(gk_shape[3], kw)
+
+    var gb_shape = grads.grad_bias.shape()
+    assert_equal(gb_shape[0], channels)
+
+
+fn test_depthwise_conv2d_backward_stride1_padding0_grad_input() raises:
+    """Test grad_input via numerical gradient check: stride=1, padding=0.
+
+    Input (1,1,4,4), kernel (1,1,3,3). Uses non-uniform input and
+    non-uniform grad_output to avoid pathological cancellation.
+    """
+    var input_shape = List[Int]()
+    input_shape.append(1)
+    input_shape.append(1)
+    input_shape.append(4)
+    input_shape.append(4)
+    var x = zeros(input_shape, DType.float32)
+
+    for i in range(16):
+        x._data.bitcast[Float32]()[i] = Float32(i) * 0.1
+
+    var kernel_shape = List[Int]()
+    kernel_shape.append(1)
+    kernel_shape.append(1)
+    kernel_shape.append(3)
+    kernel_shape.append(3)
+    var kernel = zeros(kernel_shape, DType.float32)
+
+    for i in range(9):
+        kernel._data.bitcast[Float32]()[i] = Float32(i) * 0.05 + 0.1
+
+    var bias_shape = List[Int]()
+    bias_shape.append(1)
+    var bias = zeros(bias_shape, DType.float32)
+
+    fn forward_input(inp: ExTensor) raises -> ExTensor:
+        return depthwise_conv2d(inp, kernel, bias, stride=1, padding=0)
+
+    fn backward_input(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+        var grads = depthwise_conv2d_backward(grad_out, inp, kernel, stride=1, padding=0)
+        return grads.grad_input
+
+    var output = forward_input(x)
+    var grad_output = zeros_like(output)
+    for i in range(output.numel()):
+        grad_output._data.bitcast[Float32]()[i] = Float32(i % 4) * 0.25 - 0.3
+
+    check_gradient(forward_input, backward_input, x, grad_output, rtol=1e-2, atol=1e-2)
+
+
+fn test_depthwise_conv2d_backward_stride2_grad_input() raises:
+    """Test grad_input via numerical gradient check: stride=2, padding=0.
+
+    Input (1,1,8,8), kernel (1,1,3,3).
+    """
+    var input_shape = List[Int]()
+    input_shape.append(1)
+    input_shape.append(1)
+    input_shape.append(8)
+    input_shape.append(8)
+    var x = zeros(input_shape, DType.float32)
+
+    for i in range(64):
+        x._data.bitcast[Float32]()[i] = Float32(i) * 0.05
+
+    var kernel_shape = List[Int]()
+    kernel_shape.append(1)
+    kernel_shape.append(1)
+    kernel_shape.append(3)
+    kernel_shape.append(3)
+    var kernel = zeros(kernel_shape, DType.float32)
+
+    for i in range(9):
+        kernel._data.bitcast[Float32]()[i] = Float32(i) * 0.05 + 0.1
+
+    var bias_shape = List[Int]()
+    bias_shape.append(1)
+    var bias = zeros(bias_shape, DType.float32)
+
+    fn forward_input(inp: ExTensor) raises -> ExTensor:
+        return depthwise_conv2d(inp, kernel, bias, stride=2, padding=0)
+
+    fn backward_input(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+        var grads = depthwise_conv2d_backward(grad_out, inp, kernel, stride=2, padding=0)
+        return grads.grad_input
+
+    var output = forward_input(x)
+    var grad_output = zeros_like(output)
+    for i in range(output.numel()):
+        grad_output._data.bitcast[Float32]()[i] = Float32(i % 4) * 0.25 - 0.3
+
+    check_gradient(forward_input, backward_input, x, grad_output, rtol=1e-2, atol=1e-2)
+
+
+fn test_depthwise_conv2d_backward_padding1_grad_input() raises:
+    """Test grad_input via numerical gradient check: stride=1, padding=1.
+
+    Input (1,1,4,4), kernel (1,1,3,3).
+    """
+    var input_shape = List[Int]()
+    input_shape.append(1)
+    input_shape.append(1)
+    input_shape.append(4)
+    input_shape.append(4)
+    var x = zeros(input_shape, DType.float32)
+
+    for i in range(16):
+        x._data.bitcast[Float32]()[i] = Float32(i) * 0.1
+
+    var kernel_shape = List[Int]()
+    kernel_shape.append(1)
+    kernel_shape.append(1)
+    kernel_shape.append(3)
+    kernel_shape.append(3)
+    var kernel = zeros(kernel_shape, DType.float32)
+
+    for i in range(9):
+        kernel._data.bitcast[Float32]()[i] = Float32(i) * 0.05 + 0.1
+
+    var bias_shape = List[Int]()
+    bias_shape.append(1)
+    var bias = zeros(bias_shape, DType.float32)
+
+    fn forward_input(inp: ExTensor) raises -> ExTensor:
+        return depthwise_conv2d(inp, kernel, bias, stride=1, padding=1)
+
+    fn backward_input(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+        var grads = depthwise_conv2d_backward(grad_out, inp, kernel, stride=1, padding=1)
+        return grads.grad_input
+
+    var output = forward_input(x)
+    var grad_output = zeros_like(output)
+    for i in range(output.numel()):
+        grad_output._data.bitcast[Float32]()[i] = Float32(i % 4) * 0.25 - 0.3
+
+    check_gradient(forward_input, backward_input, x, grad_output, rtol=1e-2, atol=1e-2)
+
+
+fn test_depthwise_conv2d_backward_multichannel_grad_input() raises:
+    """Test grad_input via numerical gradient check: 3 channels.
+
+    Input (1,3,4,4), kernel (3,1,3,3). Each channel processed independently.
+    """
+    var channels = 3
+    var input_shape = List[Int]()
+    input_shape.append(1)
+    input_shape.append(channels)
+    input_shape.append(4)
+    input_shape.append(4)
+    var x = zeros(input_shape, DType.float32)
+
+    for i in range(channels * 16):
+        x._data.bitcast[Float32]()[i] = Float32(i) * 0.05
+
+    var kernel_shape = List[Int]()
+    kernel_shape.append(channels)
+    kernel_shape.append(1)
+    kernel_shape.append(3)
+    kernel_shape.append(3)
+    var kernel = zeros(kernel_shape, DType.float32)
+
+    for i in range(channels * 9):
+        kernel._data.bitcast[Float32]()[i] = Float32(i % 9) * 0.05 + 0.1
+
+    var bias_shape = List[Int]()
+    bias_shape.append(channels)
+    var bias = zeros(bias_shape, DType.float32)
+
+    fn forward_input(inp: ExTensor) raises -> ExTensor:
+        return depthwise_conv2d(inp, kernel, bias, stride=1, padding=0)
+
+    fn backward_input(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+        var grads = depthwise_conv2d_backward(grad_out, inp, kernel, stride=1, padding=0)
+        return grads.grad_input
+
+    var output = forward_input(x)
+    var grad_output = zeros_like(output)
+    for i in range(output.numel()):
+        grad_output._data.bitcast[Float32]()[i] = Float32(i % 4) * 0.25 - 0.3
+
+    check_gradient(forward_input, backward_input, x, grad_output, rtol=1e-2, atol=1e-2)
+
+
+fn run_all_tests() raises:
+    test_depthwise_conv2d_backward_shapes()
+    test_depthwise_conv2d_backward_stride1_padding0_grad_input()
+    test_depthwise_conv2d_backward_stride2_grad_input()
+    test_depthwise_conv2d_backward_padding1_grad_input()
+    test_depthwise_conv2d_backward_multichannel_grad_input()
+
+
+fn main() raises:
+    run_all_tests()

--- a/tests/shared/core/test_depthwise_conv_grad_check_part2.mojo
+++ b/tests/shared/core/test_depthwise_conv_grad_check_part2.mojo
@@ -1,0 +1,257 @@
+# ADR-009: This file is intentionally limited to ≤8 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_depthwise_conv_grad_check.
+# See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Gradient checking tests for depthwise_conv2d_backward (part 2).
+
+Tests grad_weights and grad_bias correctness via numerical gradient checking,
+plus a full pipeline test verifying all three gradient fields.
+Follow-up from issue #3233.
+"""
+
+from tests.shared.conftest import (
+    assert_almost_equal,
+    assert_equal,
+)
+from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.conv import depthwise_conv2d, depthwise_conv2d_backward
+from shared.testing import check_gradient
+
+
+fn test_depthwise_conv2d_backward_grad_weights_numerical() raises:
+    """Test grad_weights via numerical gradient check: stride=1, padding=0.
+
+    Perturbs kernel with x held fixed. Input (1,1,4,4), kernel (1,1,3,3).
+    """
+    var input_shape = List[Int]()
+    input_shape.append(1)
+    input_shape.append(1)
+    input_shape.append(4)
+    input_shape.append(4)
+    var x = zeros(input_shape, DType.float32)
+
+    for i in range(16):
+        x._data.bitcast[Float32]()[i] = Float32(i) * 0.1
+
+    var kernel_shape = List[Int]()
+    kernel_shape.append(1)
+    kernel_shape.append(1)
+    kernel_shape.append(3)
+    kernel_shape.append(3)
+    var kernel = zeros(kernel_shape, DType.float32)
+
+    for i in range(9):
+        kernel._data.bitcast[Float32]()[i] = Float32(i) * 0.05 + 0.1
+
+    var bias_shape = List[Int]()
+    bias_shape.append(1)
+    var bias = zeros(bias_shape, DType.float32)
+
+    # Perturb kernel, hold x fixed
+    fn forward_weights(k: ExTensor) raises -> ExTensor:
+        return depthwise_conv2d(x, k, bias, stride=1, padding=0)
+
+    fn backward_weights(grad_out: ExTensor, k: ExTensor) raises -> ExTensor:
+        var grads = depthwise_conv2d_backward(grad_out, x, k, stride=1, padding=0)
+        return grads.grad_weights
+
+    var output = forward_weights(kernel)
+    var grad_output = zeros_like(output)
+    for i in range(output.numel()):
+        grad_output._data.bitcast[Float32]()[i] = Float32(i % 4) * 0.25 - 0.3
+
+    check_gradient(forward_weights, backward_weights, kernel, grad_output, rtol=1e-2, atol=1e-2)
+
+
+fn test_depthwise_conv2d_backward_grad_bias_value() raises:
+    """Test grad_bias = sum(grad_output, dims=[batch, H, W]) per channel.
+
+    Uses a 1x2x2x2 case where the analytical value is easily verified.
+    Two channels, each with a 1x1 output so grad_bias = grad_output summed
+    over batch=1, out_H=1, out_W=1 → equals the single grad_output element.
+    """
+    var channels = 2
+
+    var input_shape = List[Int]()
+    input_shape.append(1)
+    input_shape.append(channels)
+    input_shape.append(3)
+    input_shape.append(3)
+    var x = zeros(input_shape, DType.float32)
+
+    for i in range(channels * 9):
+        x._data.bitcast[Float32]()[i] = Float32(i) * 0.1 + 0.1
+
+    var kernel_shape = List[Int]()
+    kernel_shape.append(channels)
+    kernel_shape.append(1)
+    kernel_shape.append(3)
+    kernel_shape.append(3)
+    var kernel = zeros(kernel_shape, DType.float32)
+
+    for i in range(channels * 9):
+        kernel._data.bitcast[Float32]()[i] = Float32(i % 9) * 0.05 + 0.1
+
+    var bias_shape = List[Int]()
+    bias_shape.append(channels)
+    var bias = zeros(bias_shape, DType.float32)
+
+    # stride=1, padding=0, kernel=3x3, input=3x3 → output is 1x1 per channel
+    var output = depthwise_conv2d(x, kernel, bias, stride=1, padding=0)
+
+    # grad_output: channel 0 gets 0.5, channel 1 gets -0.3
+    var grad_output = zeros_like(output)
+    grad_output._data.bitcast[Float32]()[0] = Float32(0.5)
+    grad_output._data.bitcast[Float32]()[1] = Float32(-0.3)
+
+    var grads = depthwise_conv2d_backward(grad_output, x, kernel, stride=1, padding=0)
+
+    # grad_bias[c] = sum of grad_output over batch and spatial dims for channel c
+    # Since output is 1x1 per channel: grad_bias[c] = grad_output[0, c, 0, 0]
+    assert_almost_equal(
+        grads.grad_bias._data.bitcast[Float32]()[0], Float32(0.5), tolerance=1e-5
+    )
+    assert_almost_equal(
+        grads.grad_bias._data.bitcast[Float32]()[1], Float32(-0.3), tolerance=1e-5
+    )
+
+
+fn test_depthwise_conv2d_backward_grad_weights_multichannel() raises:
+    """Test grad_weights via numerical gradient check: 2 channels, kernel 2x2.
+
+    Input (1,2,4,4), kernel (2,1,2,2). Verifies per-channel kernel gradients.
+    """
+    var channels = 2
+    var input_shape = List[Int]()
+    input_shape.append(1)
+    input_shape.append(channels)
+    input_shape.append(4)
+    input_shape.append(4)
+    var x = zeros(input_shape, DType.float32)
+
+    for i in range(channels * 16):
+        x._data.bitcast[Float32]()[i] = Float32(i) * 0.05
+
+    var kernel_shape = List[Int]()
+    kernel_shape.append(channels)
+    kernel_shape.append(1)
+    kernel_shape.append(2)
+    kernel_shape.append(2)
+    var kernel = zeros(kernel_shape, DType.float32)
+
+    for i in range(channels * 4):
+        kernel._data.bitcast[Float32]()[i] = Float32(i % 4) * 0.1 + 0.1
+
+    var bias_shape = List[Int]()
+    bias_shape.append(channels)
+    var bias = zeros(bias_shape, DType.float32)
+
+    fn forward_weights(k: ExTensor) raises -> ExTensor:
+        return depthwise_conv2d(x, k, bias, stride=1, padding=0)
+
+    fn backward_weights(grad_out: ExTensor, k: ExTensor) raises -> ExTensor:
+        var grads = depthwise_conv2d_backward(grad_out, x, k, stride=1, padding=0)
+        return grads.grad_weights
+
+    var output = forward_weights(kernel)
+    var grad_output = zeros_like(output)
+    for i in range(output.numel()):
+        grad_output._data.bitcast[Float32]()[i] = Float32(i % 4) * 0.25 - 0.3
+
+    check_gradient(forward_weights, backward_weights, kernel, grad_output, rtol=1e-2, atol=1e-2)
+
+
+fn test_depthwise_conv2d_backward_full_gradient_pipeline() raises:
+    """Test full forward + backward pipeline: all three gradient fields non-zero.
+
+    Runs depthwise_conv2d forward then depthwise_conv2d_backward and verifies
+    that grad_input, grad_weights, and grad_bias all have correct shapes and
+    contain non-zero values (non-trivial gradients).
+    """
+    var channels = 2
+    var in_h = 5
+    var in_w = 5
+    var kh = 3
+    var kw = 3
+
+    var input_shape = List[Int]()
+    input_shape.append(1)
+    input_shape.append(channels)
+    input_shape.append(in_h)
+    input_shape.append(in_w)
+    var x = zeros(input_shape, DType.float32)
+
+    for i in range(channels * in_h * in_w):
+        x._data.bitcast[Float32]()[i] = Float32(i) * 0.1 - 1.2
+
+    var kernel_shape = List[Int]()
+    kernel_shape.append(channels)
+    kernel_shape.append(1)
+    kernel_shape.append(kh)
+    kernel_shape.append(kw)
+    var kernel = zeros(kernel_shape, DType.float32)
+
+    for i in range(channels * kh * kw):
+        kernel._data.bitcast[Float32]()[i] = Float32(i % 9) * 0.05 + 0.1
+
+    var bias_shape = List[Int]()
+    bias_shape.append(channels)
+    var bias = zeros(bias_shape, DType.float32)
+    bias._data.bitcast[Float32]()[0] = Float32(0.1)
+    bias._data.bitcast[Float32]()[1] = Float32(-0.1)
+
+    var output = depthwise_conv2d(x, kernel, bias, stride=1, padding=0)
+    var grad_output = zeros_like(output)
+    for i in range(output.numel()):
+        grad_output._data.bitcast[Float32]()[i] = Float32(i % 4) * 0.25 - 0.3
+
+    var grads = depthwise_conv2d_backward(grad_output, x, kernel, stride=1, padding=0)
+
+    # Verify shapes
+    var gi_shape = grads.grad_input.shape()
+    assert_equal(gi_shape[0], 1)
+    assert_equal(gi_shape[1], channels)
+    assert_equal(gi_shape[2], in_h)
+    assert_equal(gi_shape[3], in_w)
+
+    var gk_shape = grads.grad_weights.shape()
+    assert_equal(gk_shape[0], channels)
+    assert_equal(gk_shape[1], 1)
+    assert_equal(gk_shape[2], kh)
+    assert_equal(gk_shape[3], kw)
+
+    var gb_shape = grads.grad_bias.shape()
+    assert_equal(gb_shape[0], channels)
+
+    # Verify all three gradient fields contain non-zero values
+    var gi_nonzero = False
+    for i in range(channels * in_h * in_w):
+        if grads.grad_input._data.bitcast[Float32]()[i] != Float32(0.0):
+            gi_nonzero = True
+            break
+    assert_equal(gi_nonzero, True)
+
+    var gk_nonzero = False
+    for i in range(channels * kh * kw):
+        if grads.grad_weights._data.bitcast[Float32]()[i] != Float32(0.0):
+            gk_nonzero = True
+            break
+    assert_equal(gk_nonzero, True)
+
+    var gb_nonzero = False
+    for i in range(channels):
+        if grads.grad_bias._data.bitcast[Float32]()[i] != Float32(0.0):
+            gb_nonzero = True
+            break
+    assert_equal(gb_nonzero, True)
+
+
+fn run_all_tests() raises:
+    test_depthwise_conv2d_backward_grad_weights_numerical()
+    test_depthwise_conv2d_backward_grad_bias_value()
+    test_depthwise_conv2d_backward_grad_weights_multichannel()
+    test_depthwise_conv2d_backward_full_gradient_pipeline()
+
+
+fn main() raises:
+    run_all_tests()


### PR DESCRIPTION
## Summary

- Add numerical gradient checking tests for `depthwise_conv2d_backward` (closes #3775)
- Split across two files per ADR-009 (≤8 `fn test_` per file) to avoid Mojo v0.26.1 heap corruption

## Changes Made

**New files:**

- `tests/shared/core/test_depthwise_conv_grad_check_part1.mojo` (5 tests)
  - Shape verification for all three gradient fields (`grad_input`, `grad_weights`, `grad_bias`)
  - `grad_input` numerical gradient checks: stride=1/padding=0, stride=2, padding=1, 3-channel

- `tests/shared/core/test_depthwise_conv_grad_check_part2.mojo` (4 tests)
  - `grad_weights` numerical gradient check (kernel perturbed, x held fixed)
  - `grad_bias` analytical value check (sum over batch/H/W per channel)
  - `grad_weights` multichannel (2 channels, 2x2 kernel)
  - Full pipeline: forward + backward verifying all three fields non-zero with correct shapes

**Modified files:**

- `.github/workflows/comprehensive-tests.yml` — Added both new files to the `"Core Gradient"` matrix entry pattern

## Verification

- Both files have ≤8 `fn test_` functions (ADR-009 compliant): part1=5, part2=4
- Uses `check_gradient()` from `shared/testing/gradient_checker.mojo` with `rtol=1e-2, atol=1e-2`
- Non-uniform `grad_output` (`Float32(i % 4) * 0.25 - 0.3`) to avoid pathological cancellation
- Follows identical patterns to `test_backward_conv_pool.mojo` (the `conv2d_backward` tests)

Closes #3775