### PR TITLE
fix(serialization): normalize trailing slash in dirpath for load/save_named_tensors

### DIFF
--- a/shared/utils/serialization.mojo
+++ b/shared/utils/serialization.mojo
@@ -262,6 +262,7 @@ fn save_named_tensors(tensors: List[NamedTensor], dirpath: String) raises:
     Args:
             tensors: List of NamedTensor objects.
             dirpath: Output directory path (created if doesn't exist).
+                Trailing slashes are accepted and normalized automatically.
 
     Raises:
             Error: If directory creation or file write fails.
@@ -274,14 +275,16 @@ fn save_named_tensors(tensors: List[NamedTensor], dirpath: String) raises:
             save_named_tensors(tensors, "checkpoint/epoch_10/")
             ```
     """
+    var normalized = String(dirpath.rstrip("/"))
+
     # Create directory if needed
-    if not create_directory(dirpath):
-        raise Error("Failed to create directory: " + dirpath)
+    if not create_directory(normalized):
+        raise Error("Failed to create directory: " + normalized)
 
     # Save each tensor
     for i in range(len(tensors)):
         var filename = tensors[i].name + ".weights"
-        var filepath = dirpath + "/" + filename
+        var filepath = normalized + "/" + filename
 
         save_tensor(tensors[i].tensor, filepath, tensors[i].name)
 
@@ -294,6 +297,7 @@ fn load_named_tensors(dirpath: String) raises -> List[NamedTensor]:
 
     Args:
             dirpath: Directory containing .weights files.
+                Trailing slashes are accepted and normalized automatically.
 
     Returns:
             List of NamedTensor objects.
@@ -309,10 +313,11 @@ fn load_named_tensors(dirpath: String) raises -> List[NamedTensor]:
             ```
     """
     var result: List[NamedTensor] = []
+    var normalized = String(dirpath.rstrip("/"))
 
     try:
         # List directory contents using Mojo native os.listdir
-        var entries = os.listdir(dirpath)
+        var entries = os.listdir(normalized)
 
         # Collect .weights files and sort for deterministic ordering
         var weight_files: List[String] = []
@@ -332,7 +337,7 @@ fn load_named_tensors(dirpath: String) raises -> List[NamedTensor]:
 
         # Load each weights file
         for i in range(len(weight_files)):
-            var filepath = dirpath + "/" + weight_files[i]
+            var filepath = normalized + "/" + weight_files[i]
             var (name, tensor) = load_tensor_with_name(filepath)
             result.append(NamedTensor(name, tensor))
 

--- a/tests/shared/utils/test_serialization.mojo
+++ b/tests/shared/utils/test_serialization.mojo
@@ -389,6 +389,91 @@ fn test_checkpoint_with_many_tensors() raises:
         _ = cleanup_test_dir(test_dir)
 
 
+# ============================================================================
+# Trailing Slash Normalization Tests
+# ============================================================================
+
+
+fn test_save_named_tensors_trailing_slash() raises:
+    """Test that save_named_tensors handles trailing slash in dirpath."""
+    var test_dir = create_test_dir("/tmp")
+
+    try:
+        var shape = List[Int]()
+        shape.append(2)
+        shape.append(3)
+        var tensor = ones(shape, DType.float32)
+
+        var tensors: List[NamedTensor] = []
+        tensors.append(NamedTensor("weights", tensor))
+
+        # Save with trailing slash
+        save_named_tensors(tensors, test_dir + "/")
+
+        # Load without trailing slash - should work correctly
+        var loaded = load_named_tensors(test_dir)
+
+        assert_equal(len(loaded), 1, "Should load 1 tensor")
+        assert_equal(loaded[0].name, "weights", "Tensor name should match")
+        assert_equal(loaded[0].tensor.shape()[0], 2, "Shape dim 0 should match")
+        assert_equal(loaded[0].tensor.shape()[1], 3, "Shape dim 1 should match")
+
+    finally:
+        _ = cleanup_test_dir(test_dir)
+
+
+fn test_load_named_tensors_trailing_slash() raises:
+    """Test that load_named_tensors handles trailing slash in dirpath."""
+    var test_dir = create_test_dir("/tmp")
+
+    try:
+        var shape = List[Int]()
+        shape.append(4)
+        var tensor = ones(shape, DType.float32)
+
+        var tensors: List[NamedTensor] = []
+        tensors.append(NamedTensor("bias", tensor))
+
+        # Save without trailing slash
+        save_named_tensors(tensors, test_dir)
+
+        # Load with trailing slash - should work correctly
+        var loaded = load_named_tensors(test_dir + "/")
+
+        assert_equal(len(loaded), 1, "Should load 1 tensor")
+        assert_equal(loaded[0].name, "bias", "Tensor name should match")
+        assert_equal(loaded[0].tensor.shape()[0], 4, "Shape dim 0 should match")
+
+    finally:
+        _ = cleanup_test_dir(test_dir)
+
+
+fn test_save_load_trailing_slash_round_trip() raises:
+    """Test save with trailing slash and load with trailing slash both work."""
+    var test_dir = create_test_dir("/tmp")
+
+    try:
+        var shape = List[Int]()
+        shape.append(3)
+        shape.append(3)
+        var tensor = ones(shape, DType.float32)
+
+        var tensors: List[NamedTensor] = []
+        tensors.append(NamedTensor("kernel", tensor))
+
+        # Save and load both with trailing slash
+        save_named_tensors(tensors, test_dir + "/")
+        var loaded = load_named_tensors(test_dir + "/")
+
+        assert_equal(len(loaded), 1, "Should load 1 tensor")
+        assert_equal(loaded[0].name, "kernel", "Tensor name should match")
+        assert_equal(loaded[0].tensor.shape()[0], 3, "Shape dim 0 should match")
+        assert_equal(loaded[0].tensor.shape()[1], 3, "Shape dim 1 should match")
+
+    finally:
+        _ = cleanup_test_dir(test_dir)
+
+
 fn main() raises:
     """Run all serialization tests."""
     print("Running serialization tests...")
@@ -431,6 +516,18 @@ fn main() raises:
 
     print("  test_checkpoint_with_many_tensors...")
     test_checkpoint_with_many_tensors()
+    print("  ✓ passed")
+
+    print("  test_save_named_tensors_trailing_slash...")
+    test_save_named_tensors_trailing_slash()
+    print("  ✓ passed")
+
+    print("  test_load_named_tensors_trailing_slash...")
+    test_load_named_tensors_trailing_slash()
+    print("  ✓ passed")
+
+    print("  test_save_load_trailing_slash_round_trip...")
+    test_save_load_trailing_slash_round_trip()
     print("  ✓ passed")
 
     print("\nAll serialization tests passed!")


### PR DESCRIPTION
## Summary

- Normalize `dirpath` with `String(dirpath.rstrip("/"))` at function entry in both `save_named_tensors` and `load_named_tensors`
- Paths like `"checkpoint/"` no longer produce double-slash paths (`"checkpoint//weights.weights"`)
- Both `os.listdir(dirpath)` and filepath concatenation now use the normalized path
- Updated `dirpath` docstrings to document trailing-slash tolerance

## Changes Made

- `shared/utils/serialization.mojo`: add `var normalized = String(dirpath.rstrip("/"))` at the top of both functions; replace all `dirpath` references with `normalized`; update docstrings
- `tests/shared/utils/test_serialization.mojo`: add three regression tests covering save-with-slash, load-with-slash, and full round-trip-with-slash scenarios

## Verification

All 13 tests pass (10 existing + 3 new):

```text
✅ PASSED: tests/shared/utils/test_serialization.mojo
Total: 1 tests | Passed: 1 tests | Failed: 0 tests
```

Closes #3791