### PR TITLE
feat(extensor): add view_with_strides and _nd_index_to_flat_offset to ExTensor

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -575,6 +575,60 @@ struct ExTensor(
             expected_stride *= self._shape[i]
         return True
 
+    fn _nd_index_to_flat_offset(self, linear_idx: Int) -> Int:
+        """Convert a C-order flat index to a byte offset using per-dimension strides.
+
+        For contiguous tensors this equals `linear_idx * dtype_size`. For
+        non-contiguous views (e.g., after transpose) it correctly traverses
+        arbitrary strides.
+
+        Args:
+            linear_idx: Flat 0-based index in C-order iteration.
+
+        Returns:
+            Byte offset into `_data`.
+        """
+        var dtype_size = self._get_dtype_size()
+        var ndim = len(self._shape)
+        var remaining = linear_idx
+        var element_offset = 0
+        for i in range(ndim - 1, -1, -1):
+            var coord = remaining % self._shape[i]
+            remaining //= self._shape[i]
+            element_offset += coord * self._strides[i]
+        return element_offset * dtype_size
+
+    fn view_with_strides(
+        self, new_shape: List[Int], new_strides: List[Int]
+    ) -> ExTensor:
+        """Create a zero-copy view with the given shape and strides.
+
+        Increments the reference count via __copyinit__. The returned tensor
+        shares underlying data with `self`. Both shape and strides are replaced;
+        the data pointer is NOT moved — callers that need a different base offset
+        (e.g., `slice()`) must adjust `_data` after calling this method.
+
+        Args:
+            new_shape: Shape for the view.
+            new_strides: Element-level strides for the view.
+
+        Returns:
+            A new ExTensor view sharing `_data` with `self`.
+        """
+        var result = self.copy()
+        result._is_view = True
+        result._shape = List[Int]()
+        for i in range(len(new_shape)):
+            result._shape.append(new_shape[i])
+        result._strides = List[Int]()
+        for i in range(len(new_strides)):
+            result._strides.append(new_strides[i])
+        var n = 1
+        for i in range(len(new_shape)):
+            n *= new_shape[i]
+        result._numel = n
+        return result^
+
     fn reshape(self, new_shape: List[Int]) raises -> ExTensor:
         """Reshape tensor to new shape (must have same total elements).
 
@@ -701,27 +755,16 @@ struct ExTensor(
                 + "]"
             )
 
-        # Calculate offset to start of slice
-        var offset_elements = start * self._strides[axis]
-        var dtype_size = self._get_dtype_size()
-        var offset_bytes = offset_elements * dtype_size
+        # Build new shape (same as self except axis shrinks)
+        var new_shape = self._shape.copy()
+        new_shape[axis] = end - start
 
-        # Create view by copying (increments refcount)
-        var result = self.copy()
-        result._is_view = True
+        # Strides are unchanged — create view with same strides, new shape
+        var result = self.view_with_strides(new_shape, self._strides)
 
-        # Update the sliced dimension in place
-        result._shape[axis] = end - start
-
-        # Update data pointer to point to sliced data
+        # Adjust base pointer to start of slice
+        var offset_bytes = start * self._strides[axis] * self._get_dtype_size()
         result._data = self._data + offset_bytes
-
-        # Strides remain the same (already copied by __copyinit__)
-
-        # Recalculate numel after shape change
-        result._numel = 1
-        for i in range(len(result._shape)):
-            result._numel *= result._shape[i]
 
         return result^
 
@@ -1143,8 +1186,11 @@ struct ExTensor(
         Returns:
             The value at the index as Float64.
         """
-        var dtype_size = self._get_dtype_size()
-        var offset = index * dtype_size
+        var offset: Int
+        if self.is_contiguous():
+            offset = index * self._get_dtype_size()
+        else:
+            offset = self._nd_index_to_flat_offset(index)
 
         if self._dtype == DType.float16:
             var ptr = (self._data + offset).bitcast[Float16]()
@@ -1169,8 +1215,11 @@ struct ExTensor(
             index: The element index to set.
             value: The value to set (as Float64).
         """
-        var dtype_size = self._get_dtype_size()
-        var offset = index * dtype_size
+        var offset: Int
+        if self.is_contiguous():
+            offset = index * self._get_dtype_size()
+        else:
+            offset = self._nd_index_to_flat_offset(index)
 
         if self._dtype == DType.float16:
             var ptr = (self._data + offset).bitcast[Float16]()
@@ -1198,8 +1247,11 @@ struct ExTensor(
             For Float64 and integer types, value is cast to Float32.
             For Float16, value is upcast to Float32.
         """
-        var dtype_size = self._get_dtype_size()
-        var offset = index * dtype_size
+        var offset: Int
+        if self.is_contiguous():
+            offset = index * self._get_dtype_size()
+        else:
+            offset = self._nd_index_to_flat_offset(index)
 
         if self._dtype == DType.float16:
             var ptr = (self._data + offset).bitcast[Float16]()
@@ -1229,8 +1281,11 @@ struct ExTensor(
             For Float64, value is upcast to Float64.
             For integer types, value is truncated to integer.
         """
-        var dtype_size = self._get_dtype_size()
-        var offset = index * dtype_size
+        var offset: Int
+        if self.is_contiguous():
+            offset = index * self._get_dtype_size()
+        else:
+            offset = self._nd_index_to_flat_offset(index)
 
         if self._dtype == DType.float16:
             var ptr = (self._data + offset).bitcast[Float16]()
@@ -1254,8 +1309,11 @@ struct ExTensor(
         Returns:
             The value at the index as Int64.
         """
-        var dtype_size = self._get_dtype_size()
-        var offset = index * dtype_size
+        var offset: Int
+        if self.is_contiguous():
+            offset = index * self._get_dtype_size()
+        else:
+            offset = self._nd_index_to_flat_offset(index)
 
         if self._dtype == DType.int8:
             var ptr = (self._data + offset).bitcast[Int8]()
@@ -1294,8 +1352,11 @@ struct ExTensor(
             index: The element index to set.
             value: The value to set (as Int64).
         """
-        var dtype_size = self._get_dtype_size()
-        var offset = index * dtype_size
+        var offset: Int
+        if self.is_contiguous():
+            offset = index * self._get_dtype_size()
+        else:
+            offset = self._nd_index_to_flat_offset(index)
 
         if self._dtype == DType.int8:
             var ptr = (self._data + offset).bitcast[Int8]()

--- a/tests/shared/core/test_extensor_slicing_view.mojo
+++ b/tests/shared/core/test_extensor_slicing_view.mojo
@@ -1,0 +1,131 @@
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split per ADR-009. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for ExTensor slice() view semantics (#3799).
+
+Verifies that slice() returns a zero-copy view using view_with_strides,
+element access on sliced views returns correct values, writes through
+views affect the original, and slice + transpose composition works.
+"""
+
+from shared.core.extensor import ExTensor, zeros, ones, arange
+from tests.shared.conftest import assert_true, assert_false, assert_almost_equal, assert_equal
+
+
+# ============================================================================
+# slice() view semantics tests
+# ============================================================================
+
+
+fn test_slice_returns_view() raises:
+    """The slice() method returns a tensor with _is_view == True."""
+    var t = arange(0.0, 10.0, 1.0, DType.float32)
+    var s = t.slice(0, 5)
+    assert_true(s._is_view)
+
+
+fn test_slice_view_correct_values() raises:
+    """A slice() view has correct element values."""
+    var t = arange(0.0, 10.0, 1.0, DType.float32)
+    var s = t.slice(3, 7)
+
+    assert_equal(s.numel(), 4)
+    assert_almost_equal(Float64(s[0]), 3.0, tolerance=1e-5)
+    assert_almost_equal(Float64(s[1]), 4.0, tolerance=1e-5)
+    assert_almost_equal(Float64(s[2]), 5.0, tolerance=1e-5)
+    assert_almost_equal(Float64(s[3]), 6.0, tolerance=1e-5)
+
+
+fn test_slice_view_mutates_original() raises:
+    """Writing to a slice view affects the original tensor."""
+    var t = zeros([6], DType.float32)
+    var s = t.slice(2, 5)
+
+    s[0] = 99.0
+    s[1] = 88.0
+    s[2] = 77.0
+
+    # The original tensor's elements 2, 3, 4 should reflect the writes
+    assert_almost_equal(Float64(t[2]), 99.0, tolerance=1e-5)
+    assert_almost_equal(Float64(t[3]), 88.0, tolerance=1e-5)
+    assert_almost_equal(Float64(t[4]), 77.0, tolerance=1e-5)
+
+
+fn test_slice_view_axis1() raises:
+    """The slice() method along axis=1 on a 2D tensor returns correct shape and values."""
+    # 4x6 tensor with sequential values [0..23]
+    var t = arange(0.0, 24.0, 1.0, DType.float32)
+    var t2d = t.reshape([4, 6])
+
+    var s = t2d.slice(1, 4, axis=1)
+
+    var shape = s.shape()
+    assert_equal(shape[0], 4)
+    assert_equal(shape[1], 3)
+
+    # s[0] (flat index 0) -> row 0, col 1 of original (value 1)
+    assert_almost_equal(Float64(s[0]), 1.0, tolerance=1e-5)
+    # s[1] (flat index 1) -> row 0, col 2 of original (value 2)
+    assert_almost_equal(Float64(s[1]), 2.0, tolerance=1e-5)
+
+
+fn test_slice_view_axis_bounds_error() raises:
+    """The slice() method raises on invalid axis."""
+    var t = arange(0.0, 6.0, 1.0, DType.float32)
+    var t2d = t.reshape([2, 3])
+    var raised = False
+    try:
+        var _ = t2d.slice(0, 1, axis=5)
+    except:
+        raised = True
+    assert_true(raised)
+
+
+fn test_slice_view_index_bounds_error() raises:
+    """The slice() method raises when end index exceeds dimension size."""
+    var t = arange(0.0, 6.0, 1.0, DType.float32)
+    var raised = False
+    try:
+        var _ = t.slice(0, 10)
+    except:
+        raised = True
+    assert_true(raised)
+
+
+fn test_slice_on_transposed_view() raises:
+    """Applying slice() on a transposed view returns correct values via _nd_index_to_flat_offset."""
+    # 3x4 tensor: values 0..11
+    var t = arange(0.0, 12.0, 1.0, DType.float32)
+    var t2d = t.reshape([3, 4])
+    # Transpose to shape (4, 3)
+    var tx = t2d.transpose(0, 1)
+    # slice(1, 3) along axis=0 gives rows 1 and 2 of the (4,3) transposed view
+    # i.e., original columns 1 and 2
+    var s = tx.slice(1, 3, axis=0)
+
+    var shape = s.shape()
+    assert_equal(shape[0], 2)
+    assert_equal(shape[1], 3)
+
+    # s[0] (flat index 0) -> coord (0,0) in shape (2,3), which in tx is row 1, col 0
+    # tx strides are [1, 4] (transposed from original [4,1])
+    # tx[1,0] -> element at byte offset 1*1 + 0*4 = 1 -> original element 1 = value 1
+    assert_almost_equal(Float64(s[0]), 1.0, tolerance=1e-5)
+    # s[1] -> coord (0,1) in (2,3) -> tx[1,1] -> 1*1 + 1*4 = 5 -> value 5
+    assert_almost_equal(Float64(s[1]), 5.0, tolerance=1e-5)
+    # s[2] -> coord (0,2) in (2,3) -> tx[1,2] -> 1*1 + 2*4 = 9 -> value 9
+    assert_almost_equal(Float64(s[2]), 9.0, tolerance=1e-5)
+    # s[3] -> coord (1,0) in (2,3) -> tx[2,0] -> 2*1 + 0*4 = 2 -> value 2
+    assert_almost_equal(Float64(s[3]), 2.0, tolerance=1e-5)
+
+
+fn main() raises:
+    """Run all slice() view semantics tests."""
+    test_slice_returns_view()
+    test_slice_view_correct_values()
+    test_slice_view_mutates_original()
+    test_slice_view_axis1()
+    test_slice_view_axis_bounds_error()
+    test_slice_view_index_bounds_error()
+    test_slice_on_transposed_view()
+    print("All slice() view semantics tests passed!")

--- a/tests/shared/core/test_extensor_slicing_view_strides.mojo
+++ b/tests/shared/core/test_extensor_slicing_view_strides.mojo
@@ -1,0 +1,142 @@
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split per ADR-009. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for ExTensor view_with_strides primitive and _nd_index_to_flat_offset (#3799)."""
+
+from shared.core.extensor import ExTensor, zeros, ones, arange
+from tests.shared.conftest import assert_true, assert_false, assert_almost_equal, assert_equal
+
+
+# ============================================================================
+# view_with_strides Tests
+# ============================================================================
+
+
+fn test_view_with_strides_is_view() raises:
+    """The view_with_strides method returns a tensor marked as a view."""
+    var t = arange(0.0, 12.0, 1.0, DType.float32)
+    var t2d = t.reshape([3, 4])
+
+    var new_shape = t2d.shape()
+    var new_strides = List[Int]()
+    new_strides.append(4)
+    new_strides.append(1)
+    var v = t2d.view_with_strides(new_shape, new_strides)
+
+    assert_true(v._is_view)
+
+
+fn test_view_with_strides_shape_strides() raises:
+    """The view_with_strides method sets shape and strides from arguments."""
+    var t = arange(0.0, 12.0, 1.0, DType.float32)
+    var t2d = t.reshape([3, 4])
+
+    var new_shape = List[Int]()
+    new_shape.append(4)
+    new_shape.append(3)
+    var new_strides = List[Int]()
+    new_strides.append(1)
+    new_strides.append(4)
+    var v = t2d.view_with_strides(new_shape, new_strides)
+
+    var shape = v.shape()
+    assert_equal(shape[0], 4)
+    assert_equal(shape[1], 3)
+    assert_equal(v._strides[0], 1)
+    assert_equal(v._strides[1], 4)
+
+
+fn test_view_with_strides_numel() raises:
+    """The view_with_strides method computes numel from new shape."""
+    var t = arange(0.0, 24.0, 1.0, DType.float32)
+
+    var new_shape = List[Int]()
+    new_shape.append(2)
+    new_shape.append(3)
+    new_shape.append(4)
+    var new_strides = List[Int]()
+    new_strides.append(12)
+    new_strides.append(4)
+    new_strides.append(1)
+    var v = t.view_with_strides(new_shape, new_strides)
+
+    assert_equal(v.numel(), 24)
+
+
+fn test_view_with_strides_shares_data() raises:
+    """The view_with_strides method shares underlying data with original."""
+    var t = arange(0.0, 6.0, 1.0, DType.float32)
+
+    var new_shape = List[Int]()
+    new_shape.append(2)
+    new_shape.append(3)
+    var new_strides = List[Int]()
+    new_strides.append(3)
+    new_strides.append(1)
+    var v = t.view_with_strides(new_shape, new_strides)
+
+    # Both point to same data — raw pointer equality
+    assert_equal(Int(v._data), Int(t._data))
+
+
+# ============================================================================
+# _nd_index_to_flat_offset Tests
+# ============================================================================
+
+
+fn test_nd_index_to_flat_offset_contiguous() raises:
+    """For a contiguous tensor, offset equals index * dtype_size."""
+    var t = arange(0.0, 12.0, 1.0, DType.float32)
+    var t2d = t.reshape([3, 4])
+
+    var dtype_size = t2d._get_dtype_size()
+    for i in range(t2d.numel()):
+        assert_equal(t2d._nd_index_to_flat_offset(i), i * dtype_size)
+
+
+fn test_nd_index_to_flat_offset_transposed() raises:
+    """For a transposed 2D tensor, offset uses permuted strides."""
+    # 2x3 tensor: row 0 = [0,1,2], row 1 = [3,4,5]
+    var t = arange(0.0, 6.0, 1.0, DType.float32)
+    var t2d = t.reshape([2, 3])
+    var tx = t2d.transpose(0, 1)  # shape (3,2), strides [1, 3]
+
+    # tx[0,0] -> element 0 of original (value 0)
+    # tx[0,1] -> element 3 of original (value 3)
+    # tx[1,0] -> element 1 of original (value 1)
+    # C-order flat index 0 in tx shape (3,2): coord (0,0) -> offset = 0*1 + 0*3 = 0
+    # flat index 1 in tx: coord (0,1) -> offset = 0*1 + 1*3 = 3
+    var dtype_size = tx._get_dtype_size()
+    assert_equal(tx._nd_index_to_flat_offset(0), 0 * dtype_size)
+    assert_equal(tx._nd_index_to_flat_offset(1), 3 * dtype_size)
+    assert_equal(tx._nd_index_to_flat_offset(2), 1 * dtype_size)
+    assert_equal(tx._nd_index_to_flat_offset(3), 4 * dtype_size)
+
+
+fn test_view_with_strides_element_read_transposed() raises:
+    """Element read via __getitem__ on transposed view returns correct values."""
+    # 2x3 tensor filled with [0..5]
+    var t = arange(0.0, 6.0, 1.0, DType.float32)
+    var t2d = t.reshape([2, 3])
+    var tx = t2d.transpose(0, 1)  # shape (3, 2)
+
+    # tx flat index 0 -> coord (0,0) in (3,2) -> original [0,0] = 0
+    assert_almost_equal(Float64(tx[0]), 0.0, tolerance=1e-5)
+    # tx flat index 1 -> coord (0,1) in (3,2) -> original [1,0] = 3
+    assert_almost_equal(Float64(tx[1]), 3.0, tolerance=1e-5)
+    # tx flat index 2 -> coord (1,0) in (3,2) -> original [0,1] = 1
+    assert_almost_equal(Float64(tx[2]), 1.0, tolerance=1e-5)
+    # tx flat index 5 -> coord (2,1) in (3,2) -> original [1,2] = 5
+    assert_almost_equal(Float64(tx[5]), 5.0, tolerance=1e-5)
+
+
+fn main() raises:
+    """Run all view_with_strides and _nd_index_to_flat_offset tests."""
+    test_view_with_strides_is_view()
+    test_view_with_strides_shape_strides()
+    test_view_with_strides_numel()
+    test_view_with_strides_shares_data()
+    test_nd_index_to_flat_offset_contiguous()
+    test_nd_index_to_flat_offset_transposed()
+    test_view_with_strides_element_read_transposed()
+    print("All view_with_strides and _nd_index_to_flat_offset tests passed!")


### PR DESCRIPTION
## Summary

- Adds `_nd_index_to_flat_offset(linear_idx)` to `ExTensor`: converts a C-order flat index to a byte offset using per-dimension strides, correctly handling non-contiguous views (e.g., post-transpose)
- Adds `view_with_strides(new_shape, new_strides)` to `ExTensor`: creates a zero-copy view with arbitrary shape/strides sharing underlying data via refcount
- Fixes `_get_float32`, `_set_float32`, `_get_float64`, `_set_float64`, `_get_int64`, `_set_int64` to dispatch through `_nd_index_to_flat_offset` for non-contiguous tensors (pre-existing bug: transposed/strided views returned wrong values)
- Refactors `slice()` to delegate to `view_with_strides`, keeping identical semantics while using the new primitive

## Test plan

- [x] `test_extensor_slicing_view_strides.mojo`: 7 tests covering `view_with_strides` (is_view flag, shape/strides assignment, numel, shared data pointer) and `_nd_index_to_flat_offset` (contiguous and transposed layouts, element read via `__getitem__` on strided view)
- [x] `test_extensor_slicing_view.mojo`: 7 tests covering `slice()` view semantics (returns view, correct values, mutation propagates to original, axis=1 slicing, bounds errors, slice on transposed view)
- [x] All existing `test_extensor_slicing_*.mojo` tests pass (pre-existing failures in `test_extensor_slicing_part3.mojo` and `test_slicing_part2.mojo` confirmed as pre-existing and unrelated)

Closes #3799

🤖 Generated with [Claude Code](https://claude.com/claude-code)