### PR TITLE
feat(extensor): add split and split_with_indices method wrappers

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -3525,6 +3525,69 @@ struct ExTensor(
         return current^
 
 
+    fn split(self, num_splits: Int, axis: Int = 0) raises -> List[ExTensor]:
+        """Split tensor into equal-sized parts along an axis.
+
+        Method wrapper for the module-level `split()` function, providing
+        convenient object syntax: `tensor.split(3)` instead of
+        `split(tensor, 3)`.
+
+        Args:
+            num_splits: Number of equal parts to split into.
+            axis: Axis along which to split (default: 0).
+
+        Returns:
+            List of ExTensor objects, each with same shape except along
+            split axis.
+
+        Raises:
+            Error: If axis is invalid, num_splits <= 0, or tensor size not
+                divisible by num_splits.
+
+        Example:
+        ```mojo
+            var a = arange(0.0, 12.0, 1.0, DType.float32)
+            var parts = a.split(3)  # 3 parts of size 4 each
+        ```
+        """
+        from shared.core.shape import split as split_fn
+
+        return split_fn(self, num_splits, axis)
+
+    fn split_with_indices(
+        self, split_indices: List[Int], axis: Int = 0
+    ) raises -> List[ExTensor]:
+        """Split tensor at specified indices along an axis.
+
+        Method wrapper for the module-level `split_with_indices()` function,
+        providing convenient object syntax:
+        `tensor.split_with_indices([3, 7])` instead of
+        `split_with_indices(tensor, [3, 7])`.
+
+        Args:
+            split_indices: List of indices where to split (e.g., [3, 7]
+                creates 3 sections: [0-2], [3-6], [7-end]).
+            axis: Axis along which to split (default: 0).
+
+        Returns:
+            List of ExTensor objects resulting from splits.
+
+        Raises:
+            Error: If axis is invalid or indices are out of bounds/unordered.
+
+        Example:
+        ```mojo
+            var a = arange(0.0, 10.0, 1.0, DType.float32)
+            var parts = a.split_with_indices([3, 7])
+            # parts[0].shape() = (3,)  # indices 0-2
+            # parts[1].shape() = (4,)  # indices 3-6
+            # parts[2].shape() = (3,)  # indices 7-9
+        ```
+        """
+        from shared.core.shape import split_with_indices as split_with_indices_fn
+
+        return split_with_indices_fn(self, split_indices, axis)
+
 
 # ============================================================================
 # Creation Operations

--- a/tests/shared/core/test_extensor_method_api.mojo
+++ b/tests/shared/core/test_extensor_method_api.mojo
@@ -1,21 +1,180 @@
-"""Tests for ExTensor method-style API: tile, repeat, permute, split.
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for ExTensor method-style API: split and split_with_indices.
 
 Verifies that the thin wrapper methods on ExTensor produce identical results
-to the functional implementations in shared.core.shape. Follows #3243.
-
-NOTE: All tests are currently skipped because the ExTensor method wrappers
-(.tile(), .repeat(), .permute(), .split()) have not been implemented yet.
-The functional versions (tile(), repeat(), permute(), split()) work correctly.
-TODO: Re-enable tests once ExTensor method wrappers are implemented.
-  - ExTensor.tile(): https://github.com/HomericIntelligence/ProjectOdyssey/issues/TBD
-  - ExTensor.repeat(): https://github.com/HomericIntelligence/ProjectOdyssey/issues/TBD
-  - ExTensor.permute(): https://github.com/HomericIntelligence/ProjectOdyssey/issues/TBD
-  - ExTensor.split(): https://github.com/HomericIntelligence/ProjectOdyssey/issues/TBD
+to the functional implementations in shared.core.shape. Follows #3243 and #3804.
 """
+
+from shared.core import (
+    ExTensor,
+    zeros,
+    ones,
+    full,
+    arange,
+    split,
+    split_with_indices,
+)
+
+from tests.shared.conftest import (
+    assert_numel,
+    assert_dim,
+    assert_value_at,
+)
+
+
+fn test_split_method_equal() raises:
+    """Test split() method splits into equal parts matching free function."""
+    var a = arange(0.0, 12.0, 1.0, DType.float32)
+
+    var method_parts = a.split(3)
+    var free_parts = split(a, 3)
+
+    if len(method_parts) != 3:
+        raise Error("split method should return 3 parts")
+    if len(free_parts) != 3:
+        raise Error("split free function should return 3 parts")
+
+    for i in range(3):
+        assert_numel(
+            method_parts[i], 4, "Each part should have 4 elements"
+        )
+
+    # Verify method matches free function values
+    assert_value_at(
+        method_parts[0], 0, 0.0, message="Part 0, index 0 should be 0.0"
+    )
+    assert_value_at(
+        method_parts[0], 3, 3.0, message="Part 0, index 3 should be 3.0"
+    )
+    assert_value_at(
+        method_parts[1], 0, 4.0, message="Part 1, index 0 should be 4.0"
+    )
+    assert_value_at(
+        method_parts[1], 3, 7.0, message="Part 1, index 3 should be 7.0"
+    )
+    assert_value_at(
+        method_parts[2], 0, 8.0, message="Part 2, index 0 should be 8.0"
+    )
+    assert_value_at(
+        method_parts[2], 3, 11.0, message="Part 2, index 3 should be 11.0"
+    )
+
+
+fn test_split_method_axis() raises:
+    """Test split() method on 2D tensor along axis=1."""
+    var shape = List[Int]()
+    shape.append(4)
+    shape.append(6)
+    var a = arange(0.0, 24.0, 1.0, DType.float32).reshape(shape)
+
+    var parts = a.split(3, 1)  # Split 6 cols into 3 parts of 2
+
+    if len(parts) != 3:
+        raise Error("Should split into 3 parts along axis=1")
+
+    for i in range(3):
+        assert_dim(parts[i], 2, "Each part should be 2D")
+        assert_numel(parts[i], 8, "Each part should have 8 elements (4x2)")
+
+
+fn test_split_with_indices_method_basic() raises:
+    """Test split_with_indices() method on 1D tensor at [3, 7]."""
+    var a = arange(0.0, 10.0, 1.0, DType.float32)
+    var indices = List[Int]()
+    indices.append(3)
+    indices.append(7)
+
+    var parts = a.split_with_indices(indices)
+
+    if len(parts) != 3:
+        raise Error("Should split into 3 sections")
+
+    assert_numel(parts[0], 3, "First section: indices 0-2 (3 elements)")
+    assert_numel(parts[1], 4, "Second section: indices 3-6 (4 elements)")
+    assert_numel(parts[2], 3, "Third section: indices 7-9 (3 elements)")
+
+    # Verify values: [0,1,2], [3,4,5,6], [7,8,9]
+    assert_value_at(parts[0], 0, 0.0, message="Part 0, index 0 should be 0.0")
+    assert_value_at(parts[0], 2, 2.0, message="Part 0, index 2 should be 2.0")
+    assert_value_at(parts[1], 0, 3.0, message="Part 1, index 0 should be 3.0")
+    assert_value_at(parts[1], 3, 6.0, message="Part 1, index 3 should be 6.0")
+    assert_value_at(parts[2], 0, 7.0, message="Part 2, index 0 should be 7.0")
+    assert_value_at(parts[2], 2, 9.0, message="Part 2, index 2 should be 9.0")
+
+
+fn test_split_with_indices_method_2d() raises:
+    """Test split_with_indices() method on 2D tensor along axis=0."""
+    var shape = List[Int]()
+    shape.append(10)
+    shape.append(5)
+    var a = ones(shape, DType.float32)
+    var indices = List[Int]()
+    indices.append(3)
+    indices.append(7)
+
+    var parts = a.split_with_indices(indices, 0)
+
+    if len(parts) != 3:
+        raise Error("Should split into 3 sections along axis=0")
+
+    assert_numel(
+        parts[0], 15, "First section: 3 rows x 5 cols = 15 elements"
+    )
+    assert_numel(
+        parts[1], 20, "Second section: 4 rows x 5 cols = 20 elements"
+    )
+    assert_numel(
+        parts[2], 15, "Third section: 3 rows x 5 cols = 15 elements"
+    )
+
+
+fn test_split_with_indices_method_vs_free_fn() raises:
+    """Test that method result matches free function result (symmetry test)."""
+    var a = arange(0.0, 10.0, 1.0, DType.float32)
+    var indices = List[Int]()
+    indices.append(3)
+    indices.append(7)
+
+    var method_parts = a.split_with_indices(indices)
+    var free_parts = split_with_indices(a, indices)
+
+    if len(method_parts) != len(free_parts):
+        raise Error(
+            "Method and free function should return same number of parts"
+        )
+
+    for i in range(len(method_parts)):
+        if method_parts[i].numel() != free_parts[i].numel():
+            raise Error(
+                "Part sizes should match between method and free function"
+            )
+
+    # Spot-check values match
+    assert_value_at(method_parts[0], 0, 0.0, message="Method part 0[0] == 0.0")
+    assert_value_at(free_parts[0], 0, 0.0, message="Free fn part 0[0] == 0.0")
+    assert_value_at(method_parts[2], 2, 9.0, message="Method part 2[2] == 9.0")
+    assert_value_at(free_parts[2], 2, 9.0, message="Free fn part 2[2] == 9.0")
 
 
 fn main() raises:
-    print(
-        "SKIPPED: ExTensor method API tests (tile, repeat, permute, split) -"
-        " methods not yet implemented on ExTensor struct"
-    )
+    """Run ExTensor method API tests for split and split_with_indices."""
+    print("Testing ExTensor method API: split and split_with_indices...")
+
+    print("  Testing split() method (equal splits)...")
+    test_split_method_equal()
+
+    print("  Testing split() method (axis=1)...")
+    test_split_method_axis()
+
+    print("  Testing split_with_indices() method (basic 1D)...")
+    test_split_with_indices_method_basic()
+
+    print("  Testing split_with_indices() method (2D)...")
+    test_split_with_indices_method_2d()
+
+    print("  Testing split_with_indices() method vs free function...")
+    test_split_with_indices_method_vs_free_fn()
+
+    print("All ExTensor method API tests passed!")


### PR DESCRIPTION
## Summary

- Add `ExTensor.split(num_splits, axis)` method wrapper delegating to `shared.core.shape.split()`
- Add `ExTensor.split_with_indices(split_indices, axis)` method wrapper delegating to `shared.core.shape.split_with_indices()`
- Replace skip stub in `test_extensor_method_api.mojo` with 5 real tests

Both methods are thin wrappers (no logic duplication) following the same pattern used by `broadcast_to()`. `split_with_indices` was exported from `shared.core` alongside `split` in #3243 but only `split` got a method wrapper — this PR adds both to complete API symmetry.

## Test plan

- [x] `test_split_method_equal` — 1D tensor split into 3 equal parts, values verified
- [x] `test_split_method_axis` — 2D tensor split along axis=1
- [x] `test_split_with_indices_method_basic` — 1D split at [3,7], shapes and values verified
- [x] `test_split_with_indices_method_2d` — 2D tensor split along axis=0
- [x] `test_split_with_indices_method_vs_free_fn` — method output matches free function output
- [x] `test_shape.mojo` passes (no regressions)

Closes #3804

🤖 Generated with [Claude Code](https://claude.com/claude-code)