### PR TITLE
fix(core): add as_contiguous guard to all flat-buffer kernels

### DIFF
--- a/shared/core/arithmetic.mojo
+++ b/shared/core/arithmetic.mojo
@@ -7,6 +7,7 @@ from collections import List
 from math import nan
 from shared.core.extensor import ExTensor, full
 from shared.core.broadcasting import broadcast_shapes, compute_broadcast_strides
+from shared.core.shape import as_contiguous
 from shared.core.gradient_types import GradientPair
 from shared.core.dtype_ordinal import (
     dtype_to_ordinal,
@@ -56,13 +57,19 @@ fn _broadcast_binary[
     Returns:
         Result tensor with operation applied element-wise with broadcasting.
     """
+    # Ensure inputs are contiguous before flat-buffer kernel access.
+    # Non-contiguous views (e.g. from transpose) have non-unit strides that
+    # are not reflected in flat index arithmetic, causing silent wrong results.
+    var a_cont = a if a.is_contiguous() else as_contiguous(a)
+    var b_cont = b if b.is_contiguous() else as_contiguous(b)
+
     # Compute broadcast shape
-    var result_shape = broadcast_shapes(a.shape(), b.shape())
+    var result_shape = broadcast_shapes(a_cont.shape(), b_cont.shape())
     var result = ExTensor(result_shape, dtype)
 
     # Compute broadcast strides
-    var strides_a = compute_broadcast_strides(a.shape(), result_shape)
-    var strides_b = compute_broadcast_strides(b.shape(), result_shape)
+    var strides_a = compute_broadcast_strides(a_cont.shape(), result_shape)
+    var strides_b = compute_broadcast_strides(b_cont.shape(), result_shape)
 
     # Calculate total elements in result
     var total_elems = 1
@@ -82,8 +89,8 @@ fn _broadcast_binary[
         result_strides_final.append(result_strides[i])
 
     # Get typed pointers for zero-overhead access
-    var a_ptr = a._data.bitcast[Scalar[dtype]]()
-    var b_ptr = b._data.bitcast[Scalar[dtype]]()
+    var a_ptr = a_cont._data.bitcast[Scalar[dtype]]()
+    var b_ptr = b_cont._data.bitcast[Scalar[dtype]]()
     var result_ptr = result._data.bitcast[Scalar[dtype]]()
 
     # Iterate over all result elements
@@ -338,77 +345,80 @@ fn multiply_scalar(tensor: ExTensor, scalar: Float32) raises -> ExTensor:
         var negated = multiply_scalar(b, -1.0)  # Shape (2, 3), all -3.0
         ```
     """
-    var result = ExTensor(tensor.shape(), tensor.dtype())
+    # Ensure input is contiguous before flat-buffer kernel access.
+    var t = tensor if tensor.is_contiguous() else as_contiguous(tensor)
+
+    var result = ExTensor(t.shape(), t.dtype())
     var numel = 1
-    for dim in tensor.shape():
+    for dim in t.shape():
         numel *= dim
 
     # Get ordinal for dispatch (compiler can optimize to efficient lookup)
-    var ordinal = dtype_to_ordinal(tensor.dtype())
+    var ordinal = dtype_to_ordinal(t.dtype())
 
     # Dispatch based on ordinal - compiler generates jump table for consecutive integers
     if ordinal == DTYPE_FLOAT16:
-        var input_ptr = tensor._data.bitcast[Scalar[DType.float16]]()
+        var input_ptr = t._data.bitcast[Scalar[DType.float16]]()
         var result_ptr = result._data.bitcast[Scalar[DType.float16]]()
         var scalar_cast = Scalar[DType.float16](scalar)
         for i in range(numel):
             result_ptr[i] = input_ptr[i] * scalar_cast
     elif ordinal == DTYPE_FLOAT32:
-        var input_ptr = tensor._data.bitcast[Scalar[DType.float32]]()
+        var input_ptr = t._data.bitcast[Scalar[DType.float32]]()
         var result_ptr = result._data.bitcast[Scalar[DType.float32]]()
         var scalar_cast = Scalar[DType.float32](scalar)
         for i in range(numel):
             result_ptr[i] = input_ptr[i] * scalar_cast
     elif ordinal == DTYPE_FLOAT64:
-        var input_ptr = tensor._data.bitcast[Scalar[DType.float64]]()
+        var input_ptr = t._data.bitcast[Scalar[DType.float64]]()
         var result_ptr = result._data.bitcast[Scalar[DType.float64]]()
         var scalar_cast = Scalar[DType.float64](scalar)
         for i in range(numel):
             result_ptr[i] = input_ptr[i] * scalar_cast
     elif ordinal == DTYPE_INT8:
-        var input_ptr = tensor._data.bitcast[Scalar[DType.int8]]()
+        var input_ptr = t._data.bitcast[Scalar[DType.int8]]()
         var result_ptr = result._data.bitcast[Scalar[DType.int8]]()
         var scalar_cast = Scalar[DType.int8](scalar)
         for i in range(numel):
             result_ptr[i] = input_ptr[i] * scalar_cast
     elif ordinal == DTYPE_INT16:
-        var input_ptr = tensor._data.bitcast[Scalar[DType.int16]]()
+        var input_ptr = t._data.bitcast[Scalar[DType.int16]]()
         var result_ptr = result._data.bitcast[Scalar[DType.int16]]()
         var scalar_cast = Scalar[DType.int16](scalar)
         for i in range(numel):
             result_ptr[i] = input_ptr[i] * scalar_cast
     elif ordinal == DTYPE_INT32:
-        var input_ptr = tensor._data.bitcast[Scalar[DType.int32]]()
+        var input_ptr = t._data.bitcast[Scalar[DType.int32]]()
         var result_ptr = result._data.bitcast[Scalar[DType.int32]]()
         var scalar_cast = Scalar[DType.int32](scalar)
         for i in range(numel):
             result_ptr[i] = input_ptr[i] * scalar_cast
     elif ordinal == DTYPE_INT64:
-        var input_ptr = tensor._data.bitcast[Scalar[DType.int64]]()
+        var input_ptr = t._data.bitcast[Scalar[DType.int64]]()
         var result_ptr = result._data.bitcast[Scalar[DType.int64]]()
         var scalar_cast = Scalar[DType.int64](scalar)
         for i in range(numel):
             result_ptr[i] = input_ptr[i] * scalar_cast
     elif ordinal == DTYPE_UINT8:
-        var input_ptr = tensor._data.bitcast[Scalar[DType.uint8]]()
+        var input_ptr = t._data.bitcast[Scalar[DType.uint8]]()
         var result_ptr = result._data.bitcast[Scalar[DType.uint8]]()
         var scalar_cast = Scalar[DType.uint8](scalar)
         for i in range(numel):
             result_ptr[i] = input_ptr[i] * scalar_cast
     elif ordinal == DTYPE_UINT16:
-        var input_ptr = tensor._data.bitcast[Scalar[DType.uint16]]()
+        var input_ptr = t._data.bitcast[Scalar[DType.uint16]]()
         var result_ptr = result._data.bitcast[Scalar[DType.uint16]]()
         var scalar_cast = Scalar[DType.uint16](scalar)
         for i in range(numel):
             result_ptr[i] = input_ptr[i] * scalar_cast
     elif ordinal == DTYPE_UINT32:
-        var input_ptr = tensor._data.bitcast[Scalar[DType.uint32]]()
+        var input_ptr = t._data.bitcast[Scalar[DType.uint32]]()
         var result_ptr = result._data.bitcast[Scalar[DType.uint32]]()
         var scalar_cast = Scalar[DType.uint32](scalar)
         for i in range(numel):
             result_ptr[i] = input_ptr[i] * scalar_cast
     elif ordinal == DTYPE_UINT64:
-        var input_ptr = tensor._data.bitcast[Scalar[DType.uint64]]()
+        var input_ptr = t._data.bitcast[Scalar[DType.uint64]]()
         var result_ptr = result._data.bitcast[Scalar[DType.uint64]]()
         var scalar_cast = Scalar[DType.uint64](scalar)
         for i in range(numel):

--- a/shared/core/conv.mojo
+++ b/shared/core/conv.mojo
@@ -11,7 +11,7 @@ from collections import List
 from shared.core.extensor import ExTensor, zeros
 from shared.core.arithmetic import add
 from shared.core.reduction import sum as reduce_sum
-from shared.core.shape import conv2d_output_shape
+from shared.core.shape import conv2d_output_shape, as_contiguous
 from shared.core.gradient_types import (
     GradientPair,
     GradientTriple,
@@ -419,13 +419,18 @@ fn conv2d(
     var out_height = out_h
     var out_width = out_w
 
+    # Ensure inputs are contiguous before flat-buffer kernel access.
+    var x_cont = x if x.is_contiguous() else as_contiguous(x)
+    var kernel_cont = kernel if kernel.is_contiguous() else as_contiguous(kernel)
+    var bias_cont = bias if bias.is_contiguous() else as_contiguous(bias)
+
     # Dispatch to dtype-generic kernel based on input dtype
-    var input_dtype = x.dtype()
+    var input_dtype = x_cont.dtype()
     if input_dtype == DType.float16:
         return _conv2d_kernel[DType.float16](
-            x,
-            kernel,
-            bias,
+            x_cont,
+            kernel_cont,
+            bias_cont,
             stride,
             padding,
             batch,
@@ -440,9 +445,9 @@ fn conv2d(
         )
     elif input_dtype == DType.float32:
         return _conv2d_kernel[DType.float32](
-            x,
-            kernel,
-            bias,
+            x_cont,
+            kernel_cont,
+            bias_cont,
             stride,
             padding,
             batch,
@@ -457,9 +462,9 @@ fn conv2d(
         )
     elif input_dtype == DType.float64:
         return _conv2d_kernel[DType.float64](
-            x,
-            kernel,
-            bias,
+            x_cont,
+            kernel_cont,
+            bias_cont,
             stride,
             padding,
             batch,
@@ -770,13 +775,20 @@ fn conv2d_backward(
     var out_height = grad_out_shape[2]
     var out_width = grad_out_shape[3]
 
+    # Ensure inputs are contiguous before flat-buffer kernel access.
+    var grad_output_cont = (
+        grad_output if grad_output.is_contiguous() else as_contiguous(grad_output)
+    )
+    var x_cont = x if x.is_contiguous() else as_contiguous(x)
+    var kernel_cont = kernel if kernel.is_contiguous() else as_contiguous(kernel)
+
     # Dispatch to dtype-generic kernel based on input dtype
-    var input_dtype = x.dtype()
+    var input_dtype = x_cont.dtype()
     if input_dtype == DType.float16:
         return _conv2d_backward_kernel[DType.float16](
-            grad_output,
-            x,
-            kernel,
+            grad_output_cont,
+            x_cont,
+            kernel_cont,
             stride,
             padding,
             batch,
@@ -791,9 +803,9 @@ fn conv2d_backward(
         )
     elif input_dtype == DType.float32:
         return _conv2d_backward_kernel[DType.float32](
-            grad_output,
-            x,
-            kernel,
+            grad_output_cont,
+            x_cont,
+            kernel_cont,
             stride,
             padding,
             batch,
@@ -808,9 +820,9 @@ fn conv2d_backward(
         )
     elif input_dtype == DType.float64:
         return _conv2d_backward_kernel[DType.float64](
-            grad_output,
-            x,
-            kernel,
+            grad_output_cont,
+            x_cont,
+            kernel_cont,
             stride,
             padding,
             batch,
@@ -940,13 +952,18 @@ fn depthwise_conv2d(
     var out_height = out_h
     var out_width = out_w
 
+    # Ensure inputs are contiguous before flat-buffer kernel access.
+    var x_cont = x if x.is_contiguous() else as_contiguous(x)
+    var kernel_cont = kernel if kernel.is_contiguous() else as_contiguous(kernel)
+    var bias_cont = bias if bias.is_contiguous() else as_contiguous(bias)
+
     # Create output tensor
     var out_shape = List[Int]()
     out_shape.append(batch)
     out_shape.append(channels)
     out_shape.append(out_height)
     out_shape.append(out_width)
-    var output = zeros(out_shape, x.dtype())
+    var output = zeros(out_shape, x_cont.dtype())
 
     # Depthwise convolution: each channel convolved independently
     for b in range(batch):
@@ -982,15 +999,15 @@ fn depthwise_conv2d(
                                 # Get kernel value (kernel shape is [channels, 1, kH, kW])
                                 var k_idx = c * (1 * kH * kW) + kh * kW + kw
 
-                                var in_val = x._data.bitcast[Float32]()[in_idx]
-                                var k_val = kernel._data.bitcast[Float32]()[
+                                var in_val = x_cont._data.bitcast[Float32]()[in_idx]
+                                var k_val = kernel_cont._data.bitcast[Float32]()[
                                     k_idx
                                 ]
 
                                 sum_val += in_val * k_val
 
                     # Add bias
-                    var b_val = bias._data.bitcast[Float32]()[c]
+                    var b_val = bias_cont._data.bitcast[Float32]()[c]
                     sum_val += b_val
 
                     # Write to output
@@ -1092,9 +1109,16 @@ fn depthwise_conv2d_backward(
     var out_height = grad_out_shape[2]
     var out_width = grad_out_shape[3]
 
+    # Ensure inputs are contiguous before flat-buffer kernel access.
+    var grad_output_cont = (
+        grad_output if grad_output.is_contiguous() else as_contiguous(grad_output)
+    )
+    var x_cont = x if x.is_contiguous() else as_contiguous(x)
+    var kernel_cont = kernel if kernel.is_contiguous() else as_contiguous(kernel)
+
     # Initialize gradients
-    var grad_input = zeros(x_shape, x.dtype())
-    var grad_kernel = zeros(k_shape, kernel.dtype())
+    var grad_input = zeros(x_shape, x_cont.dtype())
+    var grad_kernel = zeros(k_shape, kernel_cont.dtype())
 
     # Compute grad_input
     # For depthwise conv, each channel's gradient only depends on its own kernel
@@ -1119,13 +1143,13 @@ fn depthwise_conv2d_backward(
                                     + oh * out_width
                                     + ow
                                 )
-                                var grad_out_val = grad_output._data.bitcast[
+                                var grad_out_val = grad_output_cont._data.bitcast[
                                     Float32
                                 ]()[grad_out_idx]
 
                                 # Get kernel value (shape: [channels, 1, kH, kW])
                                 var k_idx = c * (1 * kH * kW) + kh * kW + kw
-                                var k_val = kernel._data.bitcast[Float32]()[
+                                var k_val = kernel_cont._data.bitcast[Float32]()[
                                     k_idx
                                 ]
 
@@ -1167,7 +1191,7 @@ fn depthwise_conv2d_backward(
                                     + in_h * in_width
                                     + in_w
                                 )
-                                var in_val = x._data.bitcast[Float32]()[in_idx]
+                                var in_val = x_cont._data.bitcast[Float32]()[in_idx]
 
                                 # Get grad_output value
                                 var grad_out_idx = (
@@ -1176,7 +1200,7 @@ fn depthwise_conv2d_backward(
                                     + oh * out_width
                                     + ow
                                 )
-                                var grad_out_val = grad_output._data.bitcast[
+                                var grad_out_val = grad_output_cont._data.bitcast[
                                     Float32
                                 ]()[grad_out_idx]
 
@@ -1189,7 +1213,7 @@ fn depthwise_conv2d_backward(
     # Compute grad_bias: sum over batch, height, width
     var grad_bias_shape = List[Int]()
     grad_bias_shape.append(channels)
-    var grad_bias = zeros(grad_bias_shape, grad_output.dtype())
+    var grad_bias = zeros(grad_bias_shape, grad_output_cont.dtype())
 
     for c in range(channels):
         var bias_grad_sum = Float32(0.0)
@@ -1203,7 +1227,7 @@ fn depthwise_conv2d_backward(
                         + oh * out_width
                         + ow
                     )
-                    var grad_out_val = grad_output._data.bitcast[Float32]()[
+                    var grad_out_val = grad_output_cont._data.bitcast[Float32]()[
                         grad_out_idx
                     ]
                     bias_grad_sum += grad_out_val

--- a/shared/core/reduction.mojo
+++ b/shared/core/reduction.mojo
@@ -5,6 +5,7 @@ Implements operations that reduce tensors along specified axes
 
 from collections import List
 from shared.core.extensor import ExTensor
+from shared.core.shape import as_contiguous
 from shared.core.reduction_utils import (
     compute_strides,
     linear_to_coords,
@@ -54,17 +55,19 @@ fn _dispatch_reduce_all[
     Op: ReduceOp
 ](result: ExTensor, tensor: ExTensor, numel: Int) raises:
     """Generic runtime dispatch for reduction over all elements."""
-    var dt = tensor.dtype()
+    # Ensure input is contiguous before flat-buffer kernel access.
+    var t = tensor if tensor.is_contiguous() else as_contiguous(tensor)
+    var dt = t.dtype()
     if dt == DType.float16:
-        _reduce_all_impl[DType.float16, Op](result, tensor, numel)
+        _reduce_all_impl[DType.float16, Op](result, t, numel)
     elif dt == DType.float32:
-        _reduce_all_impl[DType.float32, Op](result, tensor, numel)
+        _reduce_all_impl[DType.float32, Op](result, t, numel)
     elif dt == DType.float64:
-        _reduce_all_impl[DType.float64, Op](result, tensor, numel)
+        _reduce_all_impl[DType.float64, Op](result, t, numel)
     elif dt == DType.int32:
-        _reduce_all_impl[DType.int32, Op](result, tensor, numel)
+        _reduce_all_impl[DType.int32, Op](result, t, numel)
     elif dt == DType.int64:
-        _reduce_all_impl[DType.int64, Op](result, tensor, numel)
+        _reduce_all_impl[DType.int64, Op](result, t, numel)
     else:
         raise Error("reduce_all: unsupported dtype")
 
@@ -109,26 +112,28 @@ fn _dispatch_reduce_axis[
     inner_size: Int,
 ) raises:
     """Generic runtime dispatch for reduction along axis."""
-    var dt = tensor.dtype()
+    # Ensure input is contiguous before flat-buffer kernel access.
+    var t = tensor if tensor.is_contiguous() else as_contiguous(tensor)
+    var dt = t.dtype()
     if dt == DType.float16:
         _reduce_axis_impl[DType.float16, Op](
-            result, tensor, outer_size, axis_size, inner_size
+            result, t, outer_size, axis_size, inner_size
         )
     elif dt == DType.float32:
         _reduce_axis_impl[DType.float32, Op](
-            result, tensor, outer_size, axis_size, inner_size
+            result, t, outer_size, axis_size, inner_size
         )
     elif dt == DType.float64:
         _reduce_axis_impl[DType.float64, Op](
-            result, tensor, outer_size, axis_size, inner_size
+            result, t, outer_size, axis_size, inner_size
         )
     elif dt == DType.int32:
         _reduce_axis_impl[DType.int32, Op](
-            result, tensor, outer_size, axis_size, inner_size
+            result, t, outer_size, axis_size, inner_size
         )
     elif dt == DType.int64:
         _reduce_axis_impl[DType.int64, Op](
-            result, tensor, outer_size, axis_size, inner_size
+            result, t, outer_size, axis_size, inner_size
         )
     else:
         raise Error("reduce_axis: unsupported dtype")

--- a/tests/shared/core/test_arithmetic_noncontiguous_part1.mojo
+++ b/tests/shared/core/test_arithmetic_noncontiguous_part1.mojo
@@ -1,0 +1,221 @@
+"""Tests for arithmetic operations on non-contiguous tensors - Part 1.
+
+Verifies that add, subtract, multiply, divide produce correct results
+when given non-contiguous inputs (e.g., from transpose_view). Without
+the as_contiguous() guard these operations silently returned wrong values.
+
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Follow-up from #3236.
+"""
+
+from tests.shared.conftest import (
+    assert_almost_equal,
+    assert_equal_int,
+    assert_false,
+    assert_true,
+)
+from shared.core.extensor import ExTensor, zeros, ones, full, arange
+from shared.core.arithmetic import add, subtract, multiply, divide
+from shared.core import transpose_view, as_contiguous
+
+
+fn _make_noncontiguous_2x3() raises -> ExTensor:
+    """Create a non-contiguous 3×2 tensor by transposing a 2×3.
+
+    The logical values (row-major for 3×2) are:
+        row 0: [0.0, 3.0]
+        row 1: [1.0, 4.0]
+        row 2: [2.0, 5.0]
+    """
+    # Allocate a 2×3 contiguous tensor with sequential values
+    var base = arange(0.0, 6.0, 1.0, DType.float32)
+    var shaped = base.reshape([2, 3])
+    # transpose_view swaps axes → shape (3, 2), non-contiguous strides
+    var nc = transpose_view(shaped)
+    assert_false(nc.is_contiguous(), "fixture must be non-contiguous")
+    return nc^
+
+
+fn test_add_noncontiguous_lhs() raises:
+    """Non-contiguous lhs + contiguous rhs should produce correct values."""
+    var nc = _make_noncontiguous_2x3()       # shape (3, 2), non-contiguous
+    var rhs = full([3, 2], 10.0, DType.float32)  # contiguous
+
+    var result = add(nc, rhs)
+
+    # nc logical layout (row-major for 3x2): 0,3,1,4,2,5 → after +10: 10,13,11,14,12,15
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(10.0), tolerance=1e-5)
+    assert_almost_equal(ptr[1], Float32(13.0), tolerance=1e-5)
+    assert_almost_equal(ptr[2], Float32(11.0), tolerance=1e-5)
+    assert_almost_equal(ptr[3], Float32(14.0), tolerance=1e-5)
+    assert_almost_equal(ptr[4], Float32(12.0), tolerance=1e-5)
+    assert_almost_equal(ptr[5], Float32(15.0), tolerance=1e-5)
+
+
+fn test_add_noncontiguous_rhs() raises:
+    """Contiguous lhs + non-contiguous rhs should produce correct values."""
+    var lhs = full([3, 2], 10.0, DType.float32)
+    var nc = _make_noncontiguous_2x3()
+
+    var result = add(lhs, nc)
+
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(10.0), tolerance=1e-5)
+    assert_almost_equal(ptr[1], Float32(13.0), tolerance=1e-5)
+    assert_almost_equal(ptr[2], Float32(11.0), tolerance=1e-5)
+    assert_almost_equal(ptr[3], Float32(14.0), tolerance=1e-5)
+    assert_almost_equal(ptr[4], Float32(12.0), tolerance=1e-5)
+    assert_almost_equal(ptr[5], Float32(15.0), tolerance=1e-5)
+
+
+fn test_add_both_noncontiguous() raises:
+    """Both inputs non-contiguous should produce correct values."""
+    var nc_a = _make_noncontiguous_2x3()  # logical values: 0,3,1,4,2,5
+    var nc_b = _make_noncontiguous_2x3()  # same
+
+    var result = add(nc_a, nc_b)
+
+    # Expected: each logical element doubled
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(0.0), tolerance=1e-5)
+    assert_almost_equal(ptr[1], Float32(6.0), tolerance=1e-5)
+    assert_almost_equal(ptr[2], Float32(2.0), tolerance=1e-5)
+    assert_almost_equal(ptr[3], Float32(8.0), tolerance=1e-5)
+    assert_almost_equal(ptr[4], Float32(4.0), tolerance=1e-5)
+    assert_almost_equal(ptr[5], Float32(10.0), tolerance=1e-5)
+
+
+fn test_subtract_noncontiguous_lhs() raises:
+    """Non-contiguous lhs - contiguous rhs should produce correct values."""
+    var nc = _make_noncontiguous_2x3()
+    var rhs = ones([3, 2], DType.float32)
+
+    var result = subtract(nc, rhs)
+
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(-1.0), tolerance=1e-5)
+    assert_almost_equal(ptr[1], Float32(2.0), tolerance=1e-5)
+    assert_almost_equal(ptr[2], Float32(0.0), tolerance=1e-5)
+    assert_almost_equal(ptr[3], Float32(3.0), tolerance=1e-5)
+    assert_almost_equal(ptr[4], Float32(1.0), tolerance=1e-5)
+    assert_almost_equal(ptr[5], Float32(4.0), tolerance=1e-5)
+
+
+fn test_subtract_noncontiguous_rhs() raises:
+    """Contiguous lhs - non-contiguous rhs should produce correct values."""
+    var lhs = ones([3, 2], DType.float32)
+    var nc = _make_noncontiguous_2x3()
+
+    var result = subtract(lhs, nc)
+
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(1.0), tolerance=1e-5)
+    assert_almost_equal(ptr[1], Float32(-2.0), tolerance=1e-5)
+    assert_almost_equal(ptr[2], Float32(0.0), tolerance=1e-5)
+    assert_almost_equal(ptr[3], Float32(-3.0), tolerance=1e-5)
+    assert_almost_equal(ptr[4], Float32(-1.0), tolerance=1e-5)
+    assert_almost_equal(ptr[5], Float32(-4.0), tolerance=1e-5)
+
+
+fn test_multiply_noncontiguous_lhs() raises:
+    """Non-contiguous lhs * contiguous rhs should produce correct values."""
+    var nc = _make_noncontiguous_2x3()
+    var rhs = full([3, 2], 2.0, DType.float32)
+
+    var result = multiply(nc, rhs)
+
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(0.0), tolerance=1e-5)
+    assert_almost_equal(ptr[1], Float32(6.0), tolerance=1e-5)
+    assert_almost_equal(ptr[2], Float32(2.0), tolerance=1e-5)
+    assert_almost_equal(ptr[3], Float32(8.0), tolerance=1e-5)
+    assert_almost_equal(ptr[4], Float32(4.0), tolerance=1e-5)
+    assert_almost_equal(ptr[5], Float32(10.0), tolerance=1e-5)
+
+
+fn test_multiply_noncontiguous_rhs() raises:
+    """Contiguous lhs * non-contiguous rhs should produce correct values."""
+    var lhs = full([3, 2], 2.0, DType.float32)
+    var nc = _make_noncontiguous_2x3()
+
+    var result = multiply(lhs, nc)
+
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(0.0), tolerance=1e-5)
+    assert_almost_equal(ptr[1], Float32(6.0), tolerance=1e-5)
+    assert_almost_equal(ptr[2], Float32(2.0), tolerance=1e-5)
+    assert_almost_equal(ptr[3], Float32(8.0), tolerance=1e-5)
+    assert_almost_equal(ptr[4], Float32(4.0), tolerance=1e-5)
+    assert_almost_equal(ptr[5], Float32(10.0), tolerance=1e-5)
+
+
+fn test_divide_noncontiguous_lhs() raises:
+    """Non-contiguous lhs / contiguous rhs should produce correct values."""
+    var nc = _make_noncontiguous_2x3()  # logical values: 0,3,1,4,2,5
+    # Use values starting from 1 to avoid division by zero
+    var base = arange(1.0, 7.0, 1.0, DType.float32)
+    var rhs_cont = full([3, 2], 2.0, DType.float32)
+
+    var result = divide(nc, rhs_cont)
+
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(0.0), tolerance=1e-5)
+    assert_almost_equal(ptr[1], Float32(1.5), tolerance=1e-5)
+    assert_almost_equal(ptr[2], Float32(0.5), tolerance=1e-5)
+    assert_almost_equal(ptr[3], Float32(2.0), tolerance=1e-5)
+    assert_almost_equal(ptr[4], Float32(1.0), tolerance=1e-5)
+    assert_almost_equal(ptr[5], Float32(2.5), tolerance=1e-5)
+
+
+fn test_divide_noncontiguous_rhs() raises:
+    """Contiguous lhs / non-contiguous rhs should produce correct values."""
+    # Avoid division by zero: use lhs values aligned with nc logical layout
+    # nc logical flat: 0,3,1,4,2,5  - index 0 would be div-by-zero
+    # Use a non-contiguous from 1..6 instead
+    var base2 = arange(1.0, 7.0, 1.0, DType.float32)
+    var shaped2 = base2.reshape([2, 3])
+    var nc = transpose_view(shaped2)  # logical values: 1,4,2,5,3,6
+    assert_false(nc.is_contiguous(), "fixture must be non-contiguous")
+
+    var lhs = full([3, 2], 12.0, DType.float32)
+    var result = divide(lhs, nc)
+
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(12.0), tolerance=1e-4)  # 12/1
+    assert_almost_equal(ptr[1], Float32(3.0), tolerance=1e-4)   # 12/4
+    assert_almost_equal(ptr[2], Float32(6.0), tolerance=1e-4)   # 12/2
+    assert_almost_equal(ptr[3], Float32(2.4), tolerance=1e-4)   # 12/5
+    assert_almost_equal(ptr[4], Float32(4.0), tolerance=1e-4)   # 12/3
+    assert_almost_equal(ptr[5], Float32(2.0), tolerance=1e-4)   # 12/6
+
+
+fn test_result_is_contiguous() raises:
+    """Result of ops on non-contiguous inputs should be contiguous."""
+    var nc = _make_noncontiguous_2x3()
+    var rhs = ones([3, 2], DType.float32)
+
+    var result = add(nc, rhs)
+
+    assert_true(result.is_contiguous(), "result should always be contiguous")
+
+
+fn main() raises:
+    """Run all non-contiguous arithmetic tests (part 1)."""
+    print("Running arithmetic non-contiguous tests (part 1)...")
+
+    test_add_noncontiguous_lhs()
+    test_add_noncontiguous_rhs()
+    test_add_both_noncontiguous()
+    test_subtract_noncontiguous_lhs()
+    test_subtract_noncontiguous_rhs()
+    test_multiply_noncontiguous_lhs()
+    test_multiply_noncontiguous_rhs()
+    test_divide_noncontiguous_lhs()
+    test_divide_noncontiguous_rhs()
+    test_result_is_contiguous()
+
+    print("All arithmetic non-contiguous tests (part 1) passed!")

--- a/tests/shared/core/test_arithmetic_noncontiguous_part2.mojo
+++ b/tests/shared/core/test_arithmetic_noncontiguous_part2.mojo
@@ -1,0 +1,196 @@
+"""Tests for arithmetic operations on non-contiguous tensors - Part 2.
+
+Verifies broadcasting with non-contiguous inputs. Broadcasting already
+computed strides from the logical shape, but the flat-buffer read was
+using the wrong (gap-filled) memory layout. These tests confirm the
+as_contiguous() guard fixes broadcast cases too.
+
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Follow-up from #3236.
+"""
+
+from tests.shared.conftest import (
+    assert_almost_equal,
+    assert_equal_int,
+    assert_false,
+    assert_true,
+)
+from shared.core.extensor import ExTensor, zeros, ones, full, arange
+from shared.core.arithmetic import add, subtract, multiply
+from shared.core import transpose_view, as_contiguous
+
+
+fn _make_nc_2x3() raises -> ExTensor:
+    """Non-contiguous 3×2 tensor (logical values: 0,3,1,4,2,5)."""
+    var base = arange(0.0, 6.0, 1.0, DType.float32)
+    var shaped = base.reshape([2, 3])
+    var nc = transpose_view(shaped)
+    assert_false(nc.is_contiguous(), "fixture must be non-contiguous")
+    return nc^
+
+
+fn test_add_noncontiguous_shape_match() raises:
+    """Non-contiguous tensors with matching shapes should add correctly."""
+    var nc_a = _make_nc_2x3()
+    var nc_b = _make_nc_2x3()
+
+    var result = add(nc_a, nc_b)
+
+    # Each element doubled
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(0.0), tolerance=1e-5)
+    assert_almost_equal(ptr[1], Float32(6.0), tolerance=1e-5)
+    assert_almost_equal(ptr[2], Float32(2.0), tolerance=1e-5)
+    assert_almost_equal(ptr[3], Float32(8.0), tolerance=1e-5)
+    assert_almost_equal(ptr[4], Float32(4.0), tolerance=1e-5)
+    assert_almost_equal(ptr[5], Float32(10.0), tolerance=1e-5)
+
+
+fn test_subtract_noncontiguous_shape_match() raises:
+    """Non-contiguous tensors with matching shapes should subtract correctly."""
+    var nc_a = _make_nc_2x3()
+    var nc_b = _make_nc_2x3()
+
+    var result = subtract(nc_a, nc_b)
+
+    # a - a = 0 for all elements
+    var ptr = result._data.bitcast[Float32]()
+    for i in range(6):
+        assert_almost_equal(ptr[i], Float32(0.0), tolerance=1e-5)
+
+
+fn test_multiply_noncontiguous_shape_match() raises:
+    """Non-contiguous tensors with matching shapes should multiply correctly."""
+    var nc_a = _make_nc_2x3()
+    var nc_b = _make_nc_2x3()
+
+    var result = multiply(nc_a, nc_b)
+
+    # Each element squared: 0*0, 3*3, 1*1, 4*4, 2*2, 5*5
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(0.0), tolerance=1e-5)
+    assert_almost_equal(ptr[1], Float32(9.0), tolerance=1e-5)
+    assert_almost_equal(ptr[2], Float32(1.0), tolerance=1e-5)
+    assert_almost_equal(ptr[3], Float32(16.0), tolerance=1e-5)
+    assert_almost_equal(ptr[4], Float32(4.0), tolerance=1e-5)
+    assert_almost_equal(ptr[5], Float32(25.0), tolerance=1e-5)
+
+
+fn test_add_broadcast_noncontiguous_1d() raises:
+    """Non-contiguous 2D + contiguous 1D broadcast should work correctly."""
+    # nc shape: (3, 2), contiguous 1D shape: (2,) → broadcasts to (3, 2)
+    var nc = _make_nc_2x3()  # logical flat: 0,3,1,4,2,5
+    var b = full([2], 1.0, DType.float32)  # add 1 to each row
+
+    var result = add(nc, b)
+
+    # Expected: nc[i,j] + b[j] = nc[i,j] + 1
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(1.0), tolerance=1e-5)   # 0+1
+    assert_almost_equal(ptr[1], Float32(4.0), tolerance=1e-5)   # 3+1
+    assert_almost_equal(ptr[2], Float32(2.0), tolerance=1e-5)   # 1+1
+    assert_almost_equal(ptr[3], Float32(5.0), tolerance=1e-5)   # 4+1
+    assert_almost_equal(ptr[4], Float32(3.0), tolerance=1e-5)   # 2+1
+    assert_almost_equal(ptr[5], Float32(6.0), tolerance=1e-5)   # 5+1
+
+
+fn test_add_broadcast_contiguous_to_noncontiguous() raises:
+    """Contiguous 1D + non-contiguous 2D broadcast should work correctly."""
+    var b = full([2], 1.0, DType.float32)
+    var nc = _make_nc_2x3()
+
+    var result = add(b, nc)
+
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(1.0), tolerance=1e-5)
+    assert_almost_equal(ptr[1], Float32(4.0), tolerance=1e-5)
+    assert_almost_equal(ptr[2], Float32(2.0), tolerance=1e-5)
+    assert_almost_equal(ptr[3], Float32(5.0), tolerance=1e-5)
+    assert_almost_equal(ptr[4], Float32(3.0), tolerance=1e-5)
+    assert_almost_equal(ptr[5], Float32(6.0), tolerance=1e-5)
+
+
+fn test_result_shape_preserved() raises:
+    """Result of non-contiguous op should have correct shape."""
+    var nc = _make_nc_2x3()  # shape (3, 2)
+    var rhs = ones([3, 2], DType.float32)
+
+    var result = add(nc, rhs)
+
+    assert_equal_int(result.shape()[0], 3)
+    assert_equal_int(result.shape()[1], 2)
+
+
+fn test_noncontiguous_add_matches_contiguous_baseline() raises:
+    """Non-contiguous result must match contiguous baseline computation."""
+    # Build contiguous equivalent of the logical 3x2 transposed tensor
+    var logical = zeros([3, 2], DType.float32)
+    var lp = logical._data.bitcast[Float32]()
+    lp[0] = 0.0; lp[1] = 3.0
+    lp[2] = 1.0; lp[3] = 4.0
+    lp[4] = 2.0; lp[5] = 5.0
+
+    var rhs = full([3, 2], 10.0, DType.float32)
+
+    # Contiguous baseline
+    var baseline = add(logical, rhs)
+
+    # Non-contiguous path
+    var nc = _make_nc_2x3()
+    var result = add(nc, rhs)
+
+    # Compare element by element
+    var bp = baseline._data.bitcast[Float32]()
+    var rp = result._data.bitcast[Float32]()
+    for i in range(6):
+        assert_almost_equal(rp[i], bp[i], tolerance=1e-5)
+
+
+fn test_multiply_broadcast_noncontiguous_lhs() raises:
+    """Non-contiguous 2D * contiguous 1D broadcast should work."""
+    var nc = _make_nc_2x3()  # logical flat: 0,3,1,4,2,5
+    var b = full([2], 2.0, DType.float32)
+
+    var result = multiply(nc, b)
+
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(0.0), tolerance=1e-5)    # 0*2
+    assert_almost_equal(ptr[1], Float32(6.0), tolerance=1e-5)    # 3*2
+    assert_almost_equal(ptr[2], Float32(2.0), tolerance=1e-5)    # 1*2
+    assert_almost_equal(ptr[3], Float32(8.0), tolerance=1e-5)    # 4*2
+    assert_almost_equal(ptr[4], Float32(4.0), tolerance=1e-5)    # 2*2
+    assert_almost_equal(ptr[5], Float32(10.0), tolerance=1e-5)   # 5*2
+
+
+fn test_noncontiguous_result_is_always_contiguous() raises:
+    """Results of all binary ops on non-contiguous inputs should be contiguous."""
+    var nc = _make_nc_2x3()
+    var rhs = ones([3, 2], DType.float32)
+
+    var r_add = add(nc, rhs)
+    var r_sub = subtract(nc, rhs)
+    var r_mul = multiply(nc, rhs)
+
+    assert_true(r_add.is_contiguous(), "add result should be contiguous")
+    assert_true(r_sub.is_contiguous(), "subtract result should be contiguous")
+    assert_true(r_mul.is_contiguous(), "multiply result should be contiguous")
+
+
+fn main() raises:
+    """Run all non-contiguous arithmetic tests (part 2)."""
+    print("Running arithmetic non-contiguous tests (part 2)...")
+
+    test_add_noncontiguous_shape_match()
+    test_subtract_noncontiguous_shape_match()
+    test_multiply_noncontiguous_shape_match()
+    test_add_broadcast_noncontiguous_1d()
+    test_add_broadcast_contiguous_to_noncontiguous()
+    test_result_shape_preserved()
+    test_noncontiguous_add_matches_contiguous_baseline()
+    test_multiply_broadcast_noncontiguous_lhs()
+    test_noncontiguous_result_is_always_contiguous()
+
+    print("All arithmetic non-contiguous tests (part 2) passed!")

--- a/tests/shared/core/test_conv_noncontiguous_part1.mojo
+++ b/tests/shared/core/test_conv_noncontiguous_part1.mojo
@@ -1,0 +1,218 @@
+"""Tests for conv2d operations on non-contiguous inputs - Part 1.
+
+Verifies that conv2d() produces correct results when given non-contiguous
+inputs. Without the as_contiguous() guard, flat-index arithmetic reads from
+wrong memory positions, silently producing wrong values.
+
+Strategy: compute conv2d on a contiguous tensor and on a non-contiguous
+tensor with the same logical values; results must match.
+
+Non-contiguous tensors are created by transposing H and W dims on
+non-square tensors (e.g. 4×6 → 6×4 via transpose(2,3)), which produces
+non-unit strides that violate C-order.
+
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Follow-up from #3236.
+"""
+
+from tests.shared.conftest import (
+    assert_almost_equal,
+    assert_equal_int,
+    assert_false,
+    assert_true,
+)
+from shared.core.extensor import ExTensor, zeros, ones, full, arange
+from shared.core.conv import conv2d, conv2d_no_bias
+from shared.core import as_contiguous
+
+
+fn _make_nc_nchw_symmetric() raises -> ExTensor:
+    """Create a non-contiguous (1,1,6,4) tensor by transposing (1,1,4,6).
+
+    The input (1,1,4,6) has all ones. Transposing H (dim2) and W (dim3)
+    gives shape (1,1,6,4) with strides [24, 24, 1, 6] — non-contiguous.
+    Since values are all ones, the logical content is identical to a
+    contiguous (1,1,6,4) tensor of all ones.
+    """
+    var x = ones([1, 1, 4, 6], DType.float32)
+    var nc = x.transpose(2, 3)  # shape (1,1,6,4), strides non-C-order
+    assert_false(nc.is_contiguous(), "fixture must be non-contiguous")
+    return nc^
+
+
+fn test_conv2d_noncontiguous_input_ones() raises:
+    """Conv2d with non-contiguous all-ones input matches contiguous baseline."""
+    # Both contiguous (1,1,6,4) and non-contiguous (1,1,6,4) have all-ones
+    var x_cont = ones([1, 1, 6, 4], DType.float32)
+    var nc_x = _make_nc_nchw_symmetric()  # logical (1,1,6,4) all-ones, non-contiguous
+
+    var kernel = ones([1, 1, 3, 3], DType.float32)
+    var bias = zeros([1], DType.float32)
+
+    var baseline = conv2d(x_cont, kernel, bias, stride=1, padding=0)
+    var result = conv2d(nc_x, kernel, bias, stride=1, padding=0)
+
+    var bp = baseline._data.bitcast[Float32]()
+    var rp = result._data.bitcast[Float32]()
+    for i in range(baseline.numel()):
+        assert_almost_equal(rp[i], bp[i], tolerance=1e-4)
+
+
+fn test_conv2d_noncontiguous_kernel() raises:
+    """Conv2d with non-contiguous kernel matches contiguous baseline."""
+    # Kernel (1,1,3,4) transposed to (1,1,4,3) — non-contiguous, all ones
+    var kernel_cont = ones([1, 1, 3, 4], DType.float32)
+    var nc_kernel = kernel_cont.transpose(2, 3)  # (1,1,4,3) non-contiguous
+    assert_false(nc_kernel.is_contiguous(), "kernel must be non-contiguous")
+
+    var x = ones([1, 1, 6, 5], DType.float32)
+    var bias = zeros([1], DType.float32)
+    # Both compute with all-ones values, so results must match
+    var kernel_ref = ones([1, 1, 4, 3], DType.float32)
+
+    var baseline = conv2d(x, kernel_ref, bias, stride=1, padding=0)
+    var result = conv2d(x, nc_kernel, bias, stride=1, padding=0)
+
+    var bp = baseline._data.bitcast[Float32]()
+    var rp = result._data.bitcast[Float32]()
+    for i in range(baseline.numel()):
+        assert_almost_equal(rp[i], bp[i], tolerance=1e-4)
+
+
+fn test_conv2d_result_shape_correct() raises:
+    """Conv2d on non-contiguous input should return the correct output shape."""
+    var nc_x = _make_nc_nchw_symmetric()  # logical (1,1,6,4)
+    var kernel = ones([1, 1, 3, 3], DType.float32)
+    var bias = zeros([1], DType.float32)
+    var x_cont = ones([1, 1, 6, 4], DType.float32)
+
+    var baseline = conv2d(x_cont, kernel, bias, stride=1, padding=0)
+    var result = conv2d(nc_x, kernel, bias, stride=1, padding=0)
+
+    assert_equal_int(result.shape()[0], baseline.shape()[0])
+    assert_equal_int(result.shape()[1], baseline.shape()[1])
+    assert_equal_int(result.shape()[2], baseline.shape()[2])
+    assert_equal_int(result.shape()[3], baseline.shape()[3])
+
+
+fn test_conv2d_result_is_contiguous() raises:
+    """Conv2d output should always be contiguous regardless of input."""
+    var nc_x = _make_nc_nchw_symmetric()
+    var kernel = ones([1, 1, 3, 3], DType.float32)
+    var bias = zeros([1], DType.float32)
+
+    var result = conv2d(nc_x, kernel, bias, stride=1, padding=0)
+
+    assert_true(result.is_contiguous(), "conv2d output should be contiguous")
+
+
+fn test_conv2d_noncontiguous_both_input_and_kernel() raises:
+    """Conv2d with both non-contiguous input and kernel matches contiguous baseline."""
+    var nc_x = _make_nc_nchw_symmetric()  # logical (1,1,6,4) all-ones
+
+    var kernel_cont = ones([1, 1, 3, 4], DType.float32)
+    var nc_kernel = kernel_cont.transpose(2, 3)  # logical (1,1,4,3) all-ones
+    assert_false(nc_kernel.is_contiguous(), "kernel must be non-contiguous")
+
+    var bias = zeros([1], DType.float32)
+    var x_ref = ones([1, 1, 6, 4], DType.float32)
+    var kernel_ref = ones([1, 1, 4, 3], DType.float32)
+
+    var baseline = conv2d(x_ref, kernel_ref, bias, stride=1, padding=0)
+    var result = conv2d(nc_x, nc_kernel, bias, stride=1, padding=0)
+
+    var bp = baseline._data.bitcast[Float32]()
+    var rp = result._data.bitcast[Float32]()
+    for i in range(baseline.numel()):
+        assert_almost_equal(rp[i], bp[i], tolerance=1e-4)
+
+
+fn test_conv2d_no_bias_noncontiguous_input() raises:
+    """Conv2d_no_bias with non-contiguous input matches contiguous baseline."""
+    var nc_x = _make_nc_nchw_symmetric()  # logical (1,1,6,4) all-ones
+    var x_cont = ones([1, 1, 6, 4], DType.float32)
+    var kernel = ones([1, 1, 3, 3], DType.float32)
+
+    var baseline = conv2d_no_bias(x_cont, kernel, stride=1, padding=0)
+    var result = conv2d_no_bias(nc_x, kernel, stride=1, padding=0)
+
+    var bp = baseline._data.bitcast[Float32]()
+    var rp = result._data.bitcast[Float32]()
+    for i in range(baseline.numel()):
+        assert_almost_equal(rp[i], bp[i], tolerance=1e-4)
+
+
+fn test_conv2d_noncontiguous_with_stride() raises:
+    """Conv2d with non-contiguous input and stride > 1 matches contiguous baseline."""
+    # Use (1,1,8,6) → transpose(2,3) → logical (1,1,6,8), stride=2
+    var x_cont_base = ones([1, 1, 8, 6], DType.float32)
+    var nc_x = x_cont_base.transpose(2, 3)  # logical (1,1,6,8) all-ones
+    assert_false(nc_x.is_contiguous(), "input must be non-contiguous")
+
+    var x_ref = ones([1, 1, 6, 8], DType.float32)
+    var kernel = ones([1, 1, 3, 3], DType.float32)
+    var bias = zeros([1], DType.float32)
+
+    var baseline = conv2d(x_ref, kernel, bias, stride=2, padding=0)
+    var result = conv2d(nc_x, kernel, bias, stride=2, padding=0)
+
+    var bp = baseline._data.bitcast[Float32]()
+    var rp = result._data.bitcast[Float32]()
+    for i in range(baseline.numel()):
+        assert_almost_equal(rp[i], bp[i], tolerance=1e-4)
+
+
+fn test_conv2d_noncontiguous_with_padding() raises:
+    """Conv2d with non-contiguous input and padding matches contiguous baseline."""
+    var nc_x = _make_nc_nchw_symmetric()  # logical (1,1,6,4)
+    var x_ref = ones([1, 1, 6, 4], DType.float32)
+    var kernel = ones([1, 1, 3, 3], DType.float32)
+    var bias = zeros([1], DType.float32)
+
+    var baseline = conv2d(x_ref, kernel, bias, stride=1, padding=1)
+    var result = conv2d(nc_x, kernel, bias, stride=1, padding=1)
+
+    var bp = baseline._data.bitcast[Float32]()
+    var rp = result._data.bitcast[Float32]()
+    for i in range(baseline.numel()):
+        assert_almost_equal(rp[i], bp[i], tolerance=1e-4)
+
+
+fn test_conv2d_nc_output_shape_with_multichannel() raises:
+    """Conv2d on non-contiguous input with multiple channels has correct output shape."""
+    # (2,3,8,6) → transpose(2,3) → logical (2,3,6,8) non-contiguous
+    var x_cont_base = ones([2, 3, 8, 6], DType.float32)
+    var nc_x = x_cont_base.transpose(2, 3)
+    assert_false(nc_x.is_contiguous(), "input must be non-contiguous")
+
+    var kernel = ones([4, 3, 3, 3], DType.float32)
+    var bias = zeros([4], DType.float32)
+    var x_ref = ones([2, 3, 6, 8], DType.float32)
+
+    var baseline = conv2d(x_ref, kernel, bias, stride=1, padding=0)
+    var result = conv2d(nc_x, kernel, bias, stride=1, padding=0)
+
+    assert_equal_int(result.shape()[0], baseline.shape()[0])
+    assert_equal_int(result.shape()[1], baseline.shape()[1])
+    assert_equal_int(result.shape()[2], baseline.shape()[2])
+    assert_equal_int(result.shape()[3], baseline.shape()[3])
+
+
+fn main() raises:
+    """Run all non-contiguous conv2d tests (part 1)."""
+    print("Running conv2d non-contiguous tests (part 1)...")
+
+    test_conv2d_noncontiguous_input_ones()
+    test_conv2d_noncontiguous_kernel()
+    test_conv2d_result_shape_correct()
+    test_conv2d_result_is_contiguous()
+    test_conv2d_noncontiguous_both_input_and_kernel()
+    test_conv2d_no_bias_noncontiguous_input()
+    test_conv2d_noncontiguous_with_stride()
+    test_conv2d_noncontiguous_with_padding()
+    test_conv2d_nc_output_shape_with_multichannel()
+
+    print("All conv2d non-contiguous tests (part 1) passed!")

--- a/tests/shared/core/test_conv_noncontiguous_part2.mojo
+++ b/tests/shared/core/test_conv_noncontiguous_part2.mojo
@@ -1,0 +1,242 @@
+"""Tests for conv2d_backward on non-contiguous inputs - Part 2.
+
+Verifies that conv2d_backward() produces correct gradients when given
+non-contiguous inputs. Without the as_contiguous() guard, flat-index
+arithmetic reads from wrong memory positions.
+
+Non-contiguous tensors are created by transposing H and W spatial dims on
+non-square tensors. For example, (1,1,2,4) transposed to (1,1,4,2) gives
+strides [8,8,1,4] instead of C-order [8,8,2,1] — genuinely non-contiguous.
+
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Follow-up from #3236.
+"""
+
+from tests.shared.conftest import (
+    assert_almost_equal,
+    assert_equal_int,
+    assert_false,
+    assert_true,
+)
+from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.conv import conv2d_backward, conv2d_no_bias_backward
+
+
+fn _make_nc_grad_output() raises -> ExTensor:
+    """Non-contiguous grad_output of logical shape (1,1,4,2).
+
+    Base (1,1,2,4) all-ones transposed to (1,1,4,2): strides [8,8,1,4]
+    vs C-order [8,8,2,1] — genuinely non-contiguous.
+    Logical values are all ones, matching a contiguous (1,1,4,2) ones tensor.
+    """
+    var g = ones([1, 1, 2, 4], DType.float32)
+    var nc = g.transpose(2, 3)  # shape (1,1,4,2), strides non-C-order
+    assert_false(nc.is_contiguous(), "grad_output must be non-contiguous")
+    return nc^
+
+
+fn _make_nc_input() raises -> ExTensor:
+    """Non-contiguous input of logical shape (1,1,6,4) with all ones.
+
+    Base (1,1,4,6) transposed to (1,1,6,4): strides [24,24,1,6]
+    vs C-order [24,24,4,1].
+    """
+    var x = ones([1, 1, 4, 6], DType.float32)
+    var nc = x.transpose(2, 3)  # shape (1,1,6,4), non-contiguous
+    assert_false(nc.is_contiguous(), "input must be non-contiguous")
+    return nc^
+
+
+fn test_conv2d_backward_noncontiguous_grad_output() raises:
+    """Conv2d_backward with non-contiguous grad_output matches contiguous baseline.
+
+    Input (1,1,6,4), kernel (1,1,3,3) → output shape (1,1,4,2).
+    Non-contiguous grad: (1,1,2,4) transposed to logical (1,1,4,2), all ones.
+    """
+    var x = ones([1, 1, 6, 4], DType.float32)
+    var kernel = ones([1, 1, 3, 3], DType.float32)
+    var grad_cont = ones([1, 1, 4, 2], DType.float32)
+
+    var baseline = conv2d_backward(grad_cont, x, kernel, stride=1, padding=0)
+
+    var nc_grad = _make_nc_grad_output()  # logical (1,1,4,2) all-ones
+
+    var result = conv2d_backward(nc_grad, x, kernel, stride=1, padding=0)
+
+    var bi = baseline.grad_input
+    var ri = result.grad_input
+    assert_equal_int(bi.shape()[0], ri.shape()[0])
+    assert_equal_int(bi.shape()[1], ri.shape()[1])
+    assert_equal_int(bi.shape()[2], ri.shape()[2])
+    assert_equal_int(bi.shape()[3], ri.shape()[3])
+
+    var bip = bi._data.bitcast[Float32]()
+    var rip = ri._data.bitcast[Float32]()
+    for i in range(bi.numel()):
+        assert_almost_equal(rip[i], bip[i], tolerance=1e-4)
+
+
+fn test_conv2d_backward_noncontiguous_input() raises:
+    """Conv2d_backward with non-contiguous x matches contiguous baseline."""
+    var x_cont = ones([1, 1, 6, 4], DType.float32)
+    var kernel = ones([1, 1, 3, 3], DType.float32)
+    var grad = ones([1, 1, 4, 2], DType.float32)
+
+    var baseline = conv2d_backward(grad, x_cont, kernel, stride=1, padding=0)
+
+    var nc_x = _make_nc_input()  # logical (1,1,6,4) all-ones
+    var result = conv2d_backward(grad, nc_x, kernel, stride=1, padding=0)
+
+    var bk = baseline.grad_weights
+    var rk = result.grad_weights
+    var bkp = bk._data.bitcast[Float32]()
+    var rkp = rk._data.bitcast[Float32]()
+    for i in range(bk.numel()):
+        assert_almost_equal(rkp[i], bkp[i], tolerance=1e-4)
+
+
+fn test_conv2d_backward_noncontiguous_kernel() raises:
+    """Conv2d_backward with non-contiguous kernel matches contiguous baseline."""
+    var x = ones([1, 1, 6, 4], DType.float32)
+    var kernel_cont = ones([1, 1, 3, 4], DType.float32)
+    var grad = ones([1, 1, 4, 1], DType.float32)
+
+    var baseline = conv2d_backward(grad, x, kernel_cont, stride=1, padding=0)
+
+    # Transpose (1,1,3,4) → (1,1,4,3): strides non-C-order, all-ones logical
+    var nc_kernel = kernel_cont.transpose(2, 3)
+    assert_false(nc_kernel.is_contiguous(), "kernel must be non-contiguous")
+
+    var kernel_ref = ones([1, 1, 4, 3], DType.float32)
+    # Use same grad shape for nc_kernel (1,1,4,3) → output is (1,1,3,2)
+    var grad_nc = ones([1, 1, 3, 2], DType.float32)
+    var result = conv2d_backward(grad_nc, x, nc_kernel, stride=1, padding=0)
+
+    var bi = baseline.grad_input
+    var ri = result.grad_input
+    # Shape check only — different kernel sizes produce different grad shapes
+    assert_equal_int(bi.shape()[0], ri.shape()[0])
+    assert_equal_int(bi.shape()[1], ri.shape()[1])
+    assert_equal_int(bi.shape()[2], ri.shape()[2])
+
+
+fn test_conv2d_backward_grad_input_is_contiguous() raises:
+    """Conv2d_backward grad_input output should be contiguous."""
+    var x = ones([1, 1, 6, 4], DType.float32)
+    var kernel = ones([1, 1, 3, 3], DType.float32)
+
+    var nc_grad = _make_nc_grad_output()  # logical (1,1,4,2)
+    var result = conv2d_backward(nc_grad, x, kernel, stride=1, padding=0)
+
+    assert_true(
+        result.grad_input.is_contiguous(),
+        "grad_input should be contiguous",
+    )
+    assert_true(
+        result.grad_weights.is_contiguous(),
+        "grad_kernel should be contiguous",
+    )
+    assert_true(
+        result.grad_bias.is_contiguous(),
+        "grad_bias should be contiguous",
+    )
+
+
+fn test_conv2d_backward_grad_bias_noncontiguous() raises:
+    """Conv2d_backward grad_bias sum correct with non-contiguous grad_output.
+
+    All-ones grad_output (1,1,4,2) → grad_bias[0] = 4*2 = 8.
+    """
+    var x = ones([1, 1, 6, 4], DType.float32)
+    var kernel = ones([1, 1, 3, 3], DType.float32)
+    var grad_cont = ones([1, 1, 4, 2], DType.float32)
+
+    var baseline = conv2d_backward(grad_cont, x, kernel, stride=1, padding=0)
+    var nc_grad = _make_nc_grad_output()
+    var result = conv2d_backward(nc_grad, x, kernel, stride=1, padding=0)
+
+    var bb = baseline.grad_bias
+    var rb = result.grad_bias
+    var bbp = bb._data.bitcast[Float32]()
+    var rbp = rb._data.bitcast[Float32]()
+    for i in range(bb.numel()):
+        assert_almost_equal(rbp[i], bbp[i], tolerance=1e-4)
+
+
+fn test_conv2d_no_bias_backward_noncontiguous() raises:
+    """Conv2d_no_bias_backward with non-contiguous grad_output matches baseline."""
+    var x = ones([1, 1, 6, 4], DType.float32)
+    var kernel = ones([1, 1, 3, 3], DType.float32)
+    var grad_cont = ones([1, 1, 4, 2], DType.float32)
+
+    var baseline = conv2d_no_bias_backward(
+        grad_cont, x, kernel, stride=1, padding=0
+    )
+
+    var nc_grad = _make_nc_grad_output()
+    assert_false(nc_grad.is_contiguous(), "grad_output must be non-contiguous")
+
+    var result = conv2d_no_bias_backward(nc_grad, x, kernel, stride=1, padding=0)
+
+    var bi = baseline.grad_input
+    var ri = result.grad_input
+    var bip = bi._data.bitcast[Float32]()
+    var rip = ri._data.bitcast[Float32]()
+    for i in range(bi.numel()):
+        assert_almost_equal(rip[i], bip[i], tolerance=1e-4)
+
+
+fn test_conv2d_backward_all_noncontiguous() raises:
+    """Conv2d_backward with all non-contiguous inputs matches contiguous baseline."""
+    var x_cont = ones([1, 1, 6, 4], DType.float32)
+    var kernel_cont = ones([1, 1, 3, 3], DType.float32)
+    var grad_cont = ones([1, 1, 4, 2], DType.float32)
+
+    var baseline = conv2d_backward(grad_cont, x_cont, kernel_cont, stride=1, padding=0)
+
+    var nc_grad = _make_nc_grad_output()
+    var nc_x = _make_nc_input()
+
+    var result = conv2d_backward(nc_grad, nc_x, kernel_cont, stride=1, padding=0)
+
+    var bi = baseline.grad_input
+    var ri = result.grad_input
+    var bip = bi._data.bitcast[Float32]()
+    var rip = ri._data.bitcast[Float32]()
+    for i in range(bi.numel()):
+        assert_almost_equal(rip[i], bip[i], tolerance=1e-4)
+
+
+fn test_conv2d_backward_grad_weights_shape() raises:
+    """Conv2d_backward grad_weights has the correct shape with non-contiguous inputs."""
+    var x = ones([1, 1, 6, 4], DType.float32)
+    var kernel = ones([1, 1, 3, 3], DType.float32)
+
+    var nc_grad = _make_nc_grad_output()
+    assert_false(nc_grad.is_contiguous(), "grad_output must be non-contiguous")
+
+    var result = conv2d_backward(nc_grad, x, kernel, stride=1, padding=0)
+
+    assert_equal_int(result.grad_weights.shape()[0], 1)  # out_channels
+    assert_equal_int(result.grad_weights.shape()[1], 1)  # in_channels
+    assert_equal_int(result.grad_weights.shape()[2], 3)  # kH
+    assert_equal_int(result.grad_weights.shape()[3], 3)  # kW
+
+
+fn main() raises:
+    """Run all non-contiguous conv2d_backward tests (part 2)."""
+    print("Running conv2d_backward non-contiguous tests (part 2)...")
+
+    test_conv2d_backward_noncontiguous_grad_output()
+    test_conv2d_backward_noncontiguous_input()
+    test_conv2d_backward_noncontiguous_kernel()
+    test_conv2d_backward_grad_input_is_contiguous()
+    test_conv2d_backward_grad_bias_noncontiguous()
+    test_conv2d_no_bias_backward_noncontiguous()
+    test_conv2d_backward_all_noncontiguous()
+    test_conv2d_backward_grad_weights_shape()
+
+    print("All conv2d_backward non-contiguous tests (part 2) passed!")

--- a/tests/shared/core/test_reduction_noncontiguous_part1.mojo
+++ b/tests/shared/core/test_reduction_noncontiguous_part1.mojo
@@ -1,0 +1,178 @@
+"""Tests for reduction operations on non-contiguous tensors - Part 1.
+
+Verifies that sum() and mean() produce correct results when given
+non-contiguous inputs. Without the as_contiguous() guard these operations
+read from wrong memory positions, silently producing wrong values.
+
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Follow-up from #3236.
+"""
+
+from tests.shared.conftest import (
+    assert_almost_equal,
+    assert_equal_int,
+    assert_false,
+    assert_true,
+)
+from shared.core.extensor import ExTensor, zeros, ones, full, arange
+from shared.core.reduction import sum, mean
+from shared.core import transpose_view
+
+
+fn _make_nc_2x3() raises -> ExTensor:
+    """Non-contiguous 3×2 tensor (transpose of 2×3 sequential).
+
+    Logical layout (3×2 row-major): 0,3,1,4,2,5
+    Sum of all logical elements = 0+3+1+4+2+5 = 15
+    Mean = 15/6 = 2.5
+    """
+    var base = arange(0.0, 6.0, 1.0, DType.float32)
+    var shaped = base.reshape([2, 3])
+    var nc = transpose_view(shaped)
+    assert_false(nc.is_contiguous(), "fixture must be non-contiguous")
+    return nc^
+
+
+fn test_sum_all_noncontiguous() raises:
+    """Reduction sum() over all elements of a non-contiguous tensor should be correct."""
+    var nc = _make_nc_2x3()  # logical values: 0,3,1,4,2,5; sum=15
+
+    var result = sum(nc)
+
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(15.0), tolerance=1e-4)
+
+
+fn test_sum_axis0_noncontiguous() raises:
+    """Reduction sum(axis=0) on non-contiguous 3×2 should sum along rows correctly."""
+    # nc shape (3,2), logical rows: [0,3], [1,4], [2,5]
+    # sum axis 0: [0+1+2, 3+4+5] = [3, 12]
+    var nc = _make_nc_2x3()
+
+    var result = sum(nc, axis=0)
+
+    assert_equal_int(result.shape()[0], 2)
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(3.0), tolerance=1e-4)
+    assert_almost_equal(ptr[1], Float32(12.0), tolerance=1e-4)
+
+
+fn test_sum_axis1_noncontiguous() raises:
+    """Reduction sum(axis=1) on non-contiguous 3×2 should sum along columns correctly."""
+    # nc shape (3,2), logical rows: [0,3], [1,4], [2,5]
+    # sum axis 1: [0+3, 1+4, 2+5] = [3, 5, 7]
+    var nc = _make_nc_2x3()
+
+    var result = sum(nc, axis=1)
+
+    assert_equal_int(result.shape()[0], 3)
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(3.0), tolerance=1e-4)
+    assert_almost_equal(ptr[1], Float32(5.0), tolerance=1e-4)
+    assert_almost_equal(ptr[2], Float32(7.0), tolerance=1e-4)
+
+
+fn test_mean_all_noncontiguous() raises:
+    """Reduction mean() over all elements of a non-contiguous tensor should be correct."""
+    var nc = _make_nc_2x3()  # logical values: 0,3,1,4,2,5; mean=2.5
+
+    var result = mean(nc)
+
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(2.5), tolerance=1e-4)
+
+
+fn test_mean_axis0_noncontiguous() raises:
+    """Reduction mean(axis=0) on non-contiguous 3×2 should average along rows correctly."""
+    # nc shape (3,2), logical rows: [0,3], [1,4], [2,5]
+    # mean axis 0: [0+1+2/3, 3+4+5/3] = [1.0, 4.0]
+    var nc = _make_nc_2x3()
+
+    var result = mean(nc, axis=0)
+
+    assert_equal_int(result.shape()[0], 2)
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(1.0), tolerance=1e-4)
+    assert_almost_equal(ptr[1], Float32(4.0), tolerance=1e-4)
+
+
+fn test_mean_axis1_noncontiguous() raises:
+    """Reduction mean(axis=1) on non-contiguous 3×2 should average along columns correctly."""
+    # nc shape (3,2), logical rows: [0,3], [1,4], [2,5]
+    # mean axis 1: [0+3/2, 1+4/2, 2+5/2] = [1.5, 2.5, 3.5]
+    var nc = _make_nc_2x3()
+
+    var result = mean(nc, axis=1)
+
+    assert_equal_int(result.shape()[0], 3)
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(1.5), tolerance=1e-4)
+    assert_almost_equal(ptr[1], Float32(2.5), tolerance=1e-4)
+    assert_almost_equal(ptr[2], Float32(3.5), tolerance=1e-4)
+
+
+fn test_sum_noncontiguous_matches_contiguous_baseline() raises:
+    """Non-contiguous sum must match contiguous baseline."""
+    # Build contiguous tensor with same logical values as nc
+    var logical = zeros([3, 2], DType.float32)
+    var lp = logical._data.bitcast[Float32]()
+    lp[0] = 0.0; lp[1] = 3.0
+    lp[2] = 1.0; lp[3] = 4.0
+    lp[4] = 2.0; lp[5] = 5.0
+
+    var baseline = sum(logical, axis=0)
+    var nc = _make_nc_2x3()
+    var result = sum(nc, axis=0)
+
+    var bp = baseline._data.bitcast[Float32]()
+    var rp = result._data.bitcast[Float32]()
+    for i in range(2):
+        assert_almost_equal(rp[i], bp[i], tolerance=1e-4)
+
+
+fn test_mean_noncontiguous_matches_contiguous_baseline() raises:
+    """Non-contiguous mean must match contiguous baseline."""
+    var logical = zeros([3, 2], DType.float32)
+    var lp = logical._data.bitcast[Float32]()
+    lp[0] = 0.0; lp[1] = 3.0
+    lp[2] = 1.0; lp[3] = 4.0
+    lp[4] = 2.0; lp[5] = 5.0
+
+    var baseline = mean(logical)
+    var nc = _make_nc_2x3()
+    var result = mean(nc)
+
+    var bp = baseline._data.bitcast[Float32]()
+    var rp = result._data.bitcast[Float32]()
+    assert_almost_equal(rp[0], bp[0], tolerance=1e-4)
+
+
+fn test_sum_keepdims_noncontiguous() raises:
+    """Reduction sum(keepdims=True) on non-contiguous tensor should work correctly."""
+    var nc = _make_nc_2x3()  # shape (3,2), sum=15
+
+    var result = sum(nc, axis=-1, keepdims=True)
+
+    # keepdims=True with axis=-1 should give shape [1, 1] scalar-like
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(15.0), tolerance=1e-4)
+
+
+fn main() raises:
+    """Run all non-contiguous reduction tests (part 1)."""
+    print("Running reduction non-contiguous tests (part 1)...")
+
+    test_sum_all_noncontiguous()
+    test_sum_axis0_noncontiguous()
+    test_sum_axis1_noncontiguous()
+    test_mean_all_noncontiguous()
+    test_mean_axis0_noncontiguous()
+    test_mean_axis1_noncontiguous()
+    test_sum_noncontiguous_matches_contiguous_baseline()
+    test_mean_noncontiguous_matches_contiguous_baseline()
+    test_sum_keepdims_noncontiguous()
+
+    print("All reduction non-contiguous tests (part 1) passed!")

--- a/tests/shared/core/test_reduction_noncontiguous_part2.mojo
+++ b/tests/shared/core/test_reduction_noncontiguous_part2.mojo
@@ -1,0 +1,193 @@
+"""Tests for reduction operations on non-contiguous tensors - Part 2.
+
+Verifies that max_reduce() and min_reduce() produce correct results when
+given non-contiguous inputs. Without the as_contiguous() guard these
+operations would read from wrong buffer positions.
+
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Follow-up from #3236.
+"""
+
+from tests.shared.conftest import (
+    assert_almost_equal,
+    assert_equal_int,
+    assert_false,
+)
+from shared.core.extensor import ExTensor, zeros, arange
+from shared.core.reduction import max_reduce, min_reduce
+from shared.core import transpose_view
+
+
+fn _make_nc_2x3() raises -> ExTensor:
+    """Non-contiguous 3×2 tensor (transpose of 2×3 sequential).
+
+    Logical layout (3×2 row-major): 0,3,1,4,2,5
+    Max = 5, Min = 0
+    """
+    var base = arange(0.0, 6.0, 1.0, DType.float32)
+    var shaped = base.reshape([2, 3])
+    var nc = transpose_view(shaped)
+    assert_false(nc.is_contiguous(), "fixture must be non-contiguous")
+    return nc^
+
+
+fn test_max_all_noncontiguous() raises:
+    """Max_reduce() over all elements of a non-contiguous tensor should be correct."""
+    var nc = _make_nc_2x3()  # logical values: 0,3,1,4,2,5; max=5
+
+    var result = max_reduce(nc)
+
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(5.0), tolerance=1e-5)
+
+
+fn test_max_axis0_noncontiguous() raises:
+    """Max_reduce(axis=0) on non-contiguous 3×2 should find column maxima."""
+    # nc shape (3,2), logical rows: [0,3], [1,4], [2,5]
+    # max axis 0: [max(0,1,2), max(3,4,5)] = [2, 5]
+    var nc = _make_nc_2x3()
+
+    var result = max_reduce(nc, axis=0)
+
+    assert_equal_int(result.shape()[0], 2)
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(2.0), tolerance=1e-5)
+    assert_almost_equal(ptr[1], Float32(5.0), tolerance=1e-5)
+
+
+fn test_max_axis1_noncontiguous() raises:
+    """Max_reduce(axis=1) on non-contiguous 3×2 should find row maxima."""
+    # nc shape (3,2), logical rows: [0,3], [1,4], [2,5]
+    # max axis 1: [max(0,3), max(1,4), max(2,5)] = [3, 4, 5]
+    var nc = _make_nc_2x3()
+
+    var result = max_reduce(nc, axis=1)
+
+    assert_equal_int(result.shape()[0], 3)
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(3.0), tolerance=1e-5)
+    assert_almost_equal(ptr[1], Float32(4.0), tolerance=1e-5)
+    assert_almost_equal(ptr[2], Float32(5.0), tolerance=1e-5)
+
+
+fn test_min_all_noncontiguous() raises:
+    """Min_reduce() over all elements of a non-contiguous tensor should be correct."""
+    var nc = _make_nc_2x3()  # logical values: 0,3,1,4,2,5; min=0
+
+    var result = min_reduce(nc)
+
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(0.0), tolerance=1e-5)
+
+
+fn test_min_axis0_noncontiguous() raises:
+    """Min_reduce(axis=0) on non-contiguous 3×2 should find column minima."""
+    # nc shape (3,2), logical rows: [0,3], [1,4], [2,5]
+    # min axis 0: [min(0,1,2), min(3,4,5)] = [0, 3]
+    var nc = _make_nc_2x3()
+
+    var result = min_reduce(nc, axis=0)
+
+    assert_equal_int(result.shape()[0], 2)
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(0.0), tolerance=1e-5)
+    assert_almost_equal(ptr[1], Float32(3.0), tolerance=1e-5)
+
+
+fn test_min_axis1_noncontiguous() raises:
+    """Min_reduce(axis=1) on non-contiguous 3×2 should find row minima."""
+    # nc shape (3,2), logical rows: [0,3], [1,4], [2,5]
+    # min axis 1: [min(0,3), min(1,4), min(2,5)] = [0, 1, 2]
+    var nc = _make_nc_2x3()
+
+    var result = min_reduce(nc, axis=1)
+
+    assert_equal_int(result.shape()[0], 3)
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(0.0), tolerance=1e-5)
+    assert_almost_equal(ptr[1], Float32(1.0), tolerance=1e-5)
+    assert_almost_equal(ptr[2], Float32(2.0), tolerance=1e-5)
+
+
+fn test_max_noncontiguous_matches_contiguous_baseline() raises:
+    """Non-contiguous max_reduce must match contiguous baseline."""
+    var logical = zeros([3, 2], DType.float32)
+    var lp = logical._data.bitcast[Float32]()
+    lp[0] = 0.0; lp[1] = 3.0
+    lp[2] = 1.0; lp[3] = 4.0
+    lp[4] = 2.0; lp[5] = 5.0
+
+    var baseline = max_reduce(logical, axis=1)
+    var nc = _make_nc_2x3()
+    var result = max_reduce(nc, axis=1)
+
+    var bp = baseline._data.bitcast[Float32]()
+    var rp = result._data.bitcast[Float32]()
+    for i in range(3):
+        assert_almost_equal(rp[i], bp[i], tolerance=1e-5)
+
+
+fn test_min_noncontiguous_matches_contiguous_baseline() raises:
+    """Non-contiguous min_reduce must match contiguous baseline."""
+    var logical = zeros([3, 2], DType.float32)
+    var lp = logical._data.bitcast[Float32]()
+    lp[0] = 0.0; lp[1] = 3.0
+    lp[2] = 1.0; lp[3] = 4.0
+    lp[4] = 2.0; lp[5] = 5.0
+
+    var baseline = min_reduce(logical, axis=0)
+    var nc = _make_nc_2x3()
+    var result = min_reduce(nc, axis=0)
+
+    var bp = baseline._data.bitcast[Float32]()
+    var rp = result._data.bitcast[Float32]()
+    for i in range(2):
+        assert_almost_equal(rp[i], bp[i], tolerance=1e-5)
+
+
+fn test_max_larger_noncontiguous() raises:
+    """Max_reduce on a larger non-contiguous tensor should be correct."""
+    # Create a 3×4 contiguous tensor and transpose to (4,3) non-contiguous
+    var base = arange(0.0, 12.0, 1.0, DType.float32)
+    var shaped = base.reshape([3, 4])
+    var nc = transpose_view(shaped)   # shape (4,3), non-contiguous
+    assert_false(nc.is_contiguous(), "fixture must be non-contiguous")
+
+    var result = max_reduce(nc)
+
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(11.0), tolerance=1e-5)
+
+
+fn test_min_larger_noncontiguous() raises:
+    """Min_reduce on a larger non-contiguous tensor should be correct."""
+    var base = arange(1.0, 13.0, 1.0, DType.float32)
+    var shaped = base.reshape([3, 4])
+    var nc = transpose_view(shaped)   # shape (4,3), non-contiguous
+    assert_false(nc.is_contiguous(), "fixture must be non-contiguous")
+
+    var result = min_reduce(nc)
+
+    var ptr = result._data.bitcast[Float32]()
+    assert_almost_equal(ptr[0], Float32(1.0), tolerance=1e-5)
+
+
+fn main() raises:
+    """Run all non-contiguous reduction tests (part 2)."""
+    print("Running reduction non-contiguous tests (part 2)...")
+
+    test_max_all_noncontiguous()
+    test_max_axis0_noncontiguous()
+    test_max_axis1_noncontiguous()
+    test_min_all_noncontiguous()
+    test_min_axis0_noncontiguous()
+    test_min_axis1_noncontiguous()
+    test_max_noncontiguous_matches_contiguous_baseline()
+    test_min_noncontiguous_matches_contiguous_baseline()
+    test_max_larger_noncontiguous()
+    test_min_larger_noncontiguous()
+
+    print("All reduction non-contiguous tests (part 2) passed!")


### PR DESCRIPTION
## Summary

- Adds `as_contiguous()` guards to `arithmetic.mojo`, `reduction.mojo`, and `conv.mojo` so that non-contiguous tensor views (e.g. from `transpose()`) no longer silently produce wrong results in flat-buffer kernels.
- Follows the guard pattern established in `matrix.mojo` for `matmul()` (PR #3236).
- 6 new test files (split per ADR-009 ≤10-fn limit) covering arithmetic, reduction, and conv2d forward/backward.

## Changes Made

**`shared/core/arithmetic.mojo`**: guard in `_broadcast_binary` and `multiply_scalar`

**`shared/core/reduction.mojo`**: guard in `_dispatch_reduce_all` and `_dispatch_reduce_axis`

**`shared/core/conv.mojo`**: guard in `conv2d`, `conv2d_backward`, `depthwise_conv2d`, `depthwise_conv2d_backward`

**Tests** (non-square spatial dims + `transpose(H,W)` for reliable non-contiguous fixtures):

- `test_arithmetic_noncontiguous_part1.mojo` — element-wise add/sub/mul/div
- `test_arithmetic_noncontiguous_part2.mojo` — broadcasting with non-contiguous inputs
- `test_reduction_noncontiguous_part1.mojo` — sum/mean all/axis0/axis1
- `test_reduction_noncontiguous_part2.mojo` — max_reduce/min_reduce all/axis0/axis1
- `test_conv_noncontiguous_part1.mojo` — conv2d forward
- `test_conv_noncontiguous_part2.mojo` — conv2d_backward

## Test Plan

- [x] All 6 new test files pass locally
- [x] Fixtures verified non-contiguous via `assert_false(nc.is_contiguous(), ...)`
- [x] Results verified against contiguous baselines element-by-element

Closes #3800

🤖 Generated with [Claude Code](https://claude.com/claude-code)