### PR TITLE
test(normalization): add numerical gradient test for layer_norm_backward on 4D inputs

### DIFF
--- a/tests/shared/core/test_normalization_part3.mojo
+++ b/tests/shared/core/test_normalization_part3.mojo
@@ -256,6 +256,119 @@ fn test_layer_norm_backward_gradient_input() raises:
     print("✓ Layer norm backward gradient (input) validated numerically")
 
 
+fn test_layer_norm_backward_gradient_input_4d() raises:
+    """Test layer_norm_backward gradient w.r.t. input on 4D inputs using numerical validation.
+
+    CRITICAL TEST: Validates mathematical correctness of layer norm backpropagation for
+    4D inputs (batch, channels, H, W), where normalization is applied over the last 3
+    dimensions. Indexing and reduction logic differs from 2D inputs, so independent
+    numerical validation is required.
+
+    Shape: [2, 2, 2, 4] — 2 samples, normalized over [2, 2, 4] = 16 elements each.
+    Gamma shape: [16] (flattened last 3 dims), matching 4D implementation convention.
+
+    Uses non-uniform grad_output to prevent algebraic cancellation:
+    When grad_output=ones, sum(grad_output * x_hat) = sum(x_hat) = 0 by normalization,
+    making the last term in the backward formula vanish. Non-uniform grad_output
+    ensures sum(grad_output * x_hat) != 0, exercising the full backward formula.
+    """
+    # 4D tensor: (batch=2, channels=2, H=2, W=4)
+    var shape = List[Int]()
+    shape.append(2)
+    shape.append(2)
+    shape.append(2)
+    shape.append(4)
+
+    # Input with varying values across all 32 elements (not uniform, not zero)
+    var x = zeros(shape, DType.float32)
+    for i in range(32):
+        x._data.bitcast[Float32]()[i] = Float32(i) * 0.1 + 0.05
+
+    # Parameters: gamma shape [16] (flattened last 3 dims), non-trivial values
+    var param_shape = List[Int]()
+    param_shape.append(16)
+    var gamma = ones(param_shape, DType.float32)
+    # Non-uniform gamma values cycling through [1.5, 0.8, 1.2, 2.0]
+    for i in range(16):
+        var cycling_values = List[Float32]()
+        cycling_values.append(1.5)
+        cycling_values.append(0.8)
+        cycling_values.append(1.2)
+        cycling_values.append(2.0)
+        gamma._data.bitcast[Float32]()[i] = cycling_values[i % 4]
+    var beta = zeros(param_shape, DType.float32)
+
+    # Non-uniform grad_output: critical to avoid algebraic cancellation
+    # Shape [2, 2, 2, 4] = 32 elements; alternating mixed signs, small magnitudes
+    var grad_output = zeros(shape, DType.float32)
+    var go_vals = List[Float32]()
+    go_vals.append(0.03)
+    go_vals.append(-0.07)
+    go_vals.append(0.05)
+    go_vals.append(-0.02)
+    go_vals.append(0.06)
+    go_vals.append(-0.04)
+    go_vals.append(0.08)
+    go_vals.append(-0.01)
+    go_vals.append(-0.05)
+    go_vals.append(0.09)
+    go_vals.append(-0.03)
+    go_vals.append(0.07)
+    go_vals.append(-0.06)
+    go_vals.append(0.02)
+    go_vals.append(-0.08)
+    go_vals.append(0.04)
+    go_vals.append(0.05)
+    go_vals.append(-0.09)
+    go_vals.append(0.01)
+    go_vals.append(-0.06)
+    go_vals.append(0.07)
+    go_vals.append(-0.03)
+    go_vals.append(0.04)
+    go_vals.append(-0.08)
+    go_vals.append(0.02)
+    go_vals.append(-0.05)
+    go_vals.append(0.09)
+    go_vals.append(-0.01)
+    go_vals.append(0.06)
+    go_vals.append(-0.07)
+    go_vals.append(0.03)
+    go_vals.append(-0.04)
+    for i in range(32):
+        grad_output._data.bitcast[Float32]()[i] = go_vals[i]
+
+    # Analytical backward pass
+    var result = layer_norm_backward(grad_output, x, gamma, epsilon=1e-5)
+    var grad_input = result[0]
+
+    # Numerical gradient via finite differences.
+    # The scalar loss is sum(layer_norm(x) * grad_output), so the numerical
+    # gradient matches what layer_norm_backward(grad_output, x, gamma) computes.
+    fn forward_for_grad_4d(inp: ExTensor) raises -> ExTensor:
+        var out = layer_norm(inp, gamma, beta, epsilon=1e-5)
+        # Weighted sum: sum(out * grad_output) matches backward with non-uniform grad_output
+        var weighted = multiply(out, grad_output)
+        var result_inner = weighted
+        while result_inner.dim() > 0:
+            result_inner = reduce_sum(result_inner, axis=0, keepdims=False)
+        return result_inner
+
+    var numerical_grad = compute_numerical_gradient(
+        forward_for_grad_4d, x, epsilon=1e-4
+    )
+
+    # Validate analytical gradient matches numerical gradient
+    assert_gradients_close(
+        grad_input,
+        numerical_grad,
+        rtol=1e-2,
+        atol=1e-5,
+        message="Layer norm 4D gradient w.r.t. input",
+    )
+
+    print("✓ Layer norm backward 4D gradient (input) validated numerically")
+
+
 # ============================================================================
 # Main Test Runner
 # ============================================================================
@@ -363,6 +476,9 @@ fn main() raises:
 
     test_layer_norm_backward_gradient_input()
     print("✓ test_layer_norm_backward_gradient_input")
+
+    test_layer_norm_backward_gradient_input_4d()
+    print("✓ test_layer_norm_backward_gradient_input_4d")
 
     # Batch norm backward tests
     test_batch_norm2d_backward_gamma_beta_nonzero()


### PR DESCRIPTION
## Summary

- Adds `test_layer_norm_backward_gradient_input_4d()` to `tests/shared/core/test_normalization_part3.mojo`
- Validates `layer_norm_backward` on 4D input shape `[2, 2, 2, 4]` via central finite differences (h=1e-4)
- Uses non-uniform `grad_output` (alternating mixed signs) to prevent algebraic cancellation that masks bugs when `grad_output=ones`
- Gamma shape `[16]` (flattened last 3 dims) matches the 4D implementation convention
- Tolerances: `rtol=1e-2`, `atol=1e-5`

## Test plan

- [x] New test added to existing file (no new files created)
- [x] 8 total test functions — within ADR-009 ≤10 limit
- [x] Follows pattern of existing `test_layer_norm_backward_gradient_input` (2D version)
- [x] Non-uniform `grad_output` prevents false passes from cancellation

Closes #3813

🤖 Generated with [Claude Code](https://claude.com/claude-code)