### PR TITLE
ci(syntax-check): add CI step to block deprecated backward result alias names

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -61,6 +61,35 @@ jobs:
             echo "✅ PASSED: No deprecated List constructor patterns found"
           fi
 
+      - name: Check for deprecated backward result alias names
+        run: |
+          echo "============================================================"
+          echo "Checking for deprecated backward result alias names..."
+          echo "============================================================"
+
+          # The 8 deprecated type aliases removed in #3059/#3267.
+          # They must not reappear in shared/ or tests/.
+          PATTERN='LinearBackwardResult\|LinearNoBiasBackwardResult\|Conv2dBackwardResult\|Conv2dNoBiasBackwardResult\|DepthwiseConv2dBackwardResult\|DepthwiseConv2dNoBiasBackwardResult\|DepthwiseSeparableConv2dBackwardResult\|DepthwiseSeparableConv2dNoBiasBackwardResult'
+
+          # Two-phase grep: broad scan, then exclude comment-only lines and docstrings.
+          if grep -rn "$PATTERN" shared/ tests/ --include='*.mojo' 2>/dev/null \
+               | grep -v '^\s*#' \
+               | grep -v '^\s*"""' \
+               | grep -q .; then
+            echo ""
+            echo "::error::Deprecated alias names detected in shared/ or tests/"
+            grep -rn "$PATTERN" shared/ tests/ --include='*.mojo' 2>/dev/null \
+              | grep -v '^\s*#' \
+              | grep -v '^\s*"""'
+            echo ""
+            echo "FAILED: The above deprecated type aliases were removed in #3059."
+            echo "Use the replacement struct names directly (e.g., LinearGradients)."
+            exit 1
+          else
+            echo ""
+            echo "PASSED: No deprecated backward result alias names found"
+          fi
+
   # ============================================================================
   # Mojo Package Compilation Check - Verify shared package compiles
   # This runs BEFORE tests to catch compilation errors early


### PR DESCRIPTION
## Summary

- Adds a new step to the `mojo-syntax-check` job in `comprehensive-tests.yml`
- Hard-fails if any of the 8 deprecated backward-result type aliases reappear in `shared/` or `tests/`
- Uses two-phase grep to filter out comment-only and docstring lines (avoids false positives)

## Changes Made

**`.github/workflows/comprehensive-tests.yml`** — added step after the existing `Check for deprecated List[Type](args) pattern` step:
- Scans `shared/` and `tests/` for 8 deprecated alias names (`LinearBackwardResult`, `LinearNoBiasBackwardResult`, `Conv2dBackwardResult`, `Conv2dNoBiasBackwardResult`, `DepthwiseConv2dBackwardResult`, `DepthwiseConv2dNoBiasBackwardResult`, `DepthwiseSeparableConv2dBackwardResult`, `DepthwiseSeparableConv2dNoBiasBackwardResult`)
- Excludes `# comment` lines and `"""` docstring lines from match
- Emits `::error::` annotation and exits 1 on any match

## Verification

- Pre-checked codebase: zero current matches (grep returns empty — no false positives on day one)
- Step placed in `mojo-syntax-check` which `mojo-compilation` depends on, so regressions are caught before compilation runs

Closes #3834