### PR TITLE
test(utility): add value-correctness assertions to test_contiguous_on_noncontiguous

### DIFF
--- a/tests/shared/core/test_utility.mojo
+++ b/tests/shared/core/test_utility.mojo
@@ -193,6 +193,26 @@ fn test_contiguous_on_noncontiguous() raises:
     assert_equal_int(c._strides[0], 3, "Stride for dim 0 should be 3 (rows)")
     assert_equal_int(c._strides[1], 1, "Stride for dim 1 should be 1")
 
+    # Verify element values are correctly reordered per transpose stride mapping.
+    # Original (3,4) row-major: a[i,j] = i*4 + j (values 0..11)
+    # After transpose to (4,3), reading row-major: t[j,i] = a[i,j]
+    # Row 0 of transpose = col 0 of original: 0, 4, 8
+    assert_almost_equal(c._get_float64(0), 0.0, 1e-6, "c[0,0] should be 0")
+    assert_almost_equal(c._get_float64(1), 4.0, 1e-6, "c[0,1] should be 4")
+    assert_almost_equal(c._get_float64(2), 8.0, 1e-6, "c[0,2] should be 8")
+    # Row 1 of transpose = col 1 of original: 1, 5, 9
+    assert_almost_equal(c._get_float64(3), 1.0, 1e-6, "c[1,0] should be 1")
+    assert_almost_equal(c._get_float64(4), 5.0, 1e-6, "c[1,1] should be 5")
+    assert_almost_equal(c._get_float64(5), 9.0, 1e-6, "c[1,2] should be 9")
+    # Row 2 of transpose = col 2 of original: 2, 6, 10
+    assert_almost_equal(c._get_float64(6), 2.0, 1e-6, "c[2,0] should be 2")
+    assert_almost_equal(c._get_float64(7), 6.0, 1e-6, "c[2,1] should be 6")
+    assert_almost_equal(c._get_float64(8), 10.0, 1e-6, "c[2,2] should be 10")
+    # Row 3 of transpose = col 3 of original: 3, 7, 11
+    assert_almost_equal(c._get_float64(9), 3.0, 1e-6, "c[3,0] should be 3")
+    assert_almost_equal(c._get_float64(10), 7.0, 1e-6, "c[3,1] should be 7")
+    assert_almost_equal(c._get_float64(11), 11.0, 1e-6, "c[3,2] should be 11")
+
 
 fn test_as_contiguous_values_correct() raises:
     """Test that as_contiguous() copies correct element values from non-contiguous views.


### PR DESCRIPTION
## Summary

Extends `test_contiguous_on_noncontiguous()` in `tests/shared/core/test_utility.mojo` to verify that `as_contiguous()` produces correctly reordered element values after a transpose — not just correct structural properties.

- Adds 12 `assert_almost_equal` checks for all elements of the (4,3) output
- Values follow the transpose stride mapping: column `j` of original (3,4) becomes row `j` of output (4,3)
- Uses `_get_float64` on the contiguous result (safe post-`as_contiguous()`)

## Test plan

- [x] `test_contiguous_on_noncontiguous` now verifies both structure (strides, contiguity) and values
- [x] No new files or imports needed — `assert_almost_equal` already in scope
- [x] Existing standalone value tests (`test_as_contiguous_values_correct`, `test_as_contiguous_3d_values_correct`) remain unchanged

Closes #3842

🤖 Generated with [Claude Code](https://claude.com/claude-code)