### PR TITLE
test(shape): add numel assertions to squeeze and stack tests

### DIFF
--- a/tests/shared/core/test_shape.mojo
+++ b/tests/shared/core/test_shape.mojo
@@ -136,6 +136,7 @@ fn test_squeeze_specific_dim() raises:
 
     # Result should be (3, 4)
     assert_dim(b, 2, "Should remove dim 0")
+    assert_numel(b, 12, "Should have 12 elements")
     assert_all_values(
         b, 1.0, message="squeeze_specific_dim should preserve values"
     )
@@ -321,6 +322,7 @@ fn test_stack_axis_1() raises:
 
     # Result should be 2x2x3 (stacked along axis 1)
     assert_dim(c, 3, "Should be 3D")
+    assert_numel(c, 12, "Should have 12 elements (2*2*3)")
     # Spot-check: first element from a (1.0), first element from b's slice (2.0)
     assert_value_at(
         c, 0, 1.0, message="stack_axis_1 index 0 should be from a (1.0)"


### PR DESCRIPTION
## Summary

- Add missing `assert_numel` to `test_squeeze_specific_dim` (verifies 12 elements after removing dim 0)
- Add missing `assert_numel` to `test_stack_axis_1` (verifies 12 elements after stacking 2x2x3)

All value assertions (`assert_value_at` / `assert_all_values`) for the tests listed in #3847 were already present in `main` via PR #3845. This PR completes structural coverage by adding the missing `assert_numel` checks to `test_squeeze_specific_dim` and `test_stack_axis_1`.

## Files Modified

- `tests/shared/core/test_shape.mojo` — +2 lines

## Verification

- Pre-commit hooks pass (trailing whitespace, end-of-file, YAML, large files)
- All shape tests covered: reshape, squeeze, unsqueeze, expand_dims, flatten, ravel, concatenate, stack

Closes #3847