### PR TITLE
test(training): add import tests for DataLoader/DataBatch package export

### DIFF
--- a/tests/shared/test_imports.mojo
+++ b/tests/shared/test_imports.mojo
@@ -259,6 +259,28 @@ fn test_training_loops_imports() raises:
     print("✓ Training loops imports test passed")
 
 
+fn test_training_dataloader_imports() raises:
+    """Test DataLoader and DataBatch are importable from shared.training package.
+
+    Verifies Issue #3851: DataLoader and DataBatch exported from
+    shared/training/__init__.mojo via the trainer_interface submodule.
+    """
+    from shared.training import DataLoader, DataBatch
+
+    print("✓ Training DataLoader/DataBatch package imports test passed")
+
+
+fn test_training_dataloader_direct_imports() raises:
+    """Test DataLoader and DataBatch are importable directly from trainer_interface.
+
+    Validates the direct import path as documented fallback:
+        from shared.training.trainer_interface import DataLoader, DataBatch
+    """
+    from shared.training.trainer_interface import DataLoader, DataBatch
+
+    print("✓ Training DataLoader/DataBatch direct imports test passed")
+
+
 # ============================================================================
 # Data Package Imports
 # ============================================================================
@@ -484,6 +506,8 @@ fn main() raises:
     test_training_loops_direct_imports()
     test_training_callbacks_direct_imports()
     test_training_loops_imports()
+    test_training_dataloader_imports()
+    test_training_dataloader_direct_imports()
 
     # Data package tests
     print("\nTesting Data Package...")

--- a/tests/shared/test_imports_part1.mojo
+++ b/tests/shared/test_imports_part1.mojo
@@ -117,6 +117,17 @@ fn test_training_metrics_imports() raises:
     print("✓ Training metrics imports test passed")
 
 
+fn test_training_dataloader_imports() raises:
+    """Test DataLoader and DataBatch are importable from shared.training package.
+
+    Verifies Issue #3851: DataLoader and DataBatch exported from
+    shared/training/__init__.mojo via the trainer_interface submodule.
+    """
+    from shared.training import DataLoader, DataBatch
+
+    print("✓ Training DataLoader/DataBatch package imports test passed")
+
+
 # ============================================================================
 # Main Test Runner
 # ============================================================================
@@ -141,6 +152,7 @@ fn main() raises:
     test_training_optimizers_imports()
     test_training_schedulers_imports()
     test_training_metrics_imports()
+    test_training_dataloader_imports()
 
     # Summary
     print("\n" + "=" * 70)


### PR DESCRIPTION
## Summary

- Adds `test_training_dataloader_imports()` to `tests/shared/test_imports_part1.mojo` verifying `from shared.training import DataLoader, DataBatch` compiles
- Adds `test_training_dataloader_imports()` and `test_training_dataloader_direct_imports()` to `tests/shared/test_imports.mojo`
- The exports were already present in `shared/training/__init__.mojo` (lines 93-97, added with `# Issue #3851` comment); this PR adds the missing test coverage

## Test plan

- [ ] `test_training_dataloader_imports()` — verifies `from shared.training import DataLoader, DataBatch` resolves
- [ ] `test_training_dataloader_direct_imports()` — verifies `from shared.training.trainer_interface import DataLoader, DataBatch` resolves
- [ ] All existing import tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #3851