### PR TITLE
refactor(tests): extract _make_test_conv2d_tensors() helper

### DIFF
--- a/tests/shared/core/test_backward_conv_pool.mojo
+++ b/tests/shared/core/test_backward_conv_pool.mojo
@@ -97,11 +97,12 @@ fn test_conv2d_backward_with_stride() raises:
     assert_equal(gi_shape[3], 8)
 
 
-fn test_conv2d_backward_grad_input_numerical() raises:
-    """Test conv2d_backward grad_input values via numerical gradient checking.
+fn _make_test_conv2d_tensors() raises -> (ExTensor, ExTensor, ExTensor):
+    """Create standard (1,1,4,4) input, (1,1,3,3) kernel, and (1,) bias tensors.
 
-    Uses small input (1,1,4,4) with kernel (1,1,3,3) as specified in issue #3281.
-    Verifies mathematical correctness of grad_input, not just shape.
+    Returns:
+        Tuple of (input, kernel, bias) tensors with non-uniform values for
+        meaningful gradient checking.
     """
     var input_shape = List[Int]()
     input_shape.append(1)
@@ -109,8 +110,6 @@ fn test_conv2d_backward_grad_input_numerical() raises:
     input_shape.append(4)
     input_shape.append(4)
     var x = zeros(input_shape, DType.float32)
-
-    # Initialize with non-uniform values for meaningful gradient check
     for i in range(16):
         x._data.bitcast[Float32]()[i] = Float32(i) * 0.1
 
@@ -120,14 +119,26 @@ fn test_conv2d_backward_grad_input_numerical() raises:
     kernel_shape.append(3)
     kernel_shape.append(3)
     var kernel = zeros(kernel_shape, DType.float32)
-
-    # Initialize kernel with non-uniform values
     for i in range(9):
         kernel._data.bitcast[Float32]()[i] = Float32(i) * 0.05 + 0.1
 
     var bias_shape = List[Int]()
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
+
+    return (x, kernel, bias)
+
+
+fn test_conv2d_backward_grad_input_numerical() raises:
+    """Test conv2d_backward grad_input values via numerical gradient checking.
+
+    Uses small input (1,1,4,4) with kernel (1,1,3,3) as specified in issue #3281.
+    Verifies mathematical correctness of grad_input, not just shape.
+    """
+    var tensors = _make_test_conv2d_tensors()
+    var x = tensors[0]
+    var kernel = tensors[1]
+    var bias = tensors[2]
 
     fn forward_input(inp: ExTensor) raises -> ExTensor:
         return conv2d(inp, kernel, bias, stride=1, padding=0)
@@ -149,31 +160,10 @@ fn test_conv2d_backward_grad_weights_numerical() raises:
     Uses small input (1,1,4,4) with kernel (1,1,3,3) as specified in issue #3281.
     Verifies mathematical correctness of grad_weights, not just shape.
     """
-    var input_shape = List[Int]()
-    input_shape.append(1)
-    input_shape.append(1)
-    input_shape.append(4)
-    input_shape.append(4)
-    var x = zeros(input_shape, DType.float32)
-
-    # Initialize with non-uniform values
-    for i in range(16):
-        x._data.bitcast[Float32]()[i] = Float32(i) * 0.1
-
-    var kernel_shape = List[Int]()
-    kernel_shape.append(1)
-    kernel_shape.append(1)
-    kernel_shape.append(3)
-    kernel_shape.append(3)
-    var kernel = zeros(kernel_shape, DType.float32)
-
-    # Initialize kernel with non-uniform values
-    for i in range(9):
-        kernel._data.bitcast[Float32]()[i] = Float32(i) * 0.05 + 0.1
-
-    var bias_shape = List[Int]()
-    bias_shape.append(1)
-    var bias = zeros(bias_shape, DType.float32)
+    var tensors = _make_test_conv2d_tensors()
+    var x = tensors[0]
+    var kernel = tensors[1]
+    var bias = tensors[2]
 
     # Treat kernel as the variable being perturbed; x is held fixed
     fn forward_weights(k: ExTensor) raises -> ExTensor:


### PR DESCRIPTION
## Summary

- Extracted `_make_test_conv2d_tensors()` helper in `test_backward_conv_pool.mojo`
- Eliminates duplicated tensor construction code shared between `test_conv2d_backward_grad_input_numerical` and `test_conv2d_backward_grad_weights_numerical`
- Pure refactoring — no behavioral changes, no new tests added

## Changes Made

- `tests/shared/core/test_backward_conv_pool.mojo`: Added `_make_test_conv2d_tensors()` helper that returns `(ExTensor, ExTensor, ExTensor)` for standard (1,1,4,4) input, (1,1,3,3) kernel, and (1,) bias tensors; replaced 25-line duplicate setup blocks in both consumers with 3-line destructuring

## Verification

- Pure refactoring: identical tensor values, same test logic, only construction is deduplicated
- ADR-009 test count limit respected: no new `fn test_` functions added (still 11 total)

Closes #3870