### PR TITLE
feat(broadcasting): add ndim guard to are_shapes_broadcastable

### DIFF
--- a/shared/core/broadcasting.mojo
+++ b/shared/core/broadcasting.mojo
@@ -78,14 +78,24 @@ fn are_shapes_broadcastable(shape1: List[Int], shape2: List[Int]) -> Bool:
     Returns:
         True if shapes are broadcast-compatible, False otherwise.
 
+    Broadcasting cannot reduce the number of dimensions: if shape2 has fewer
+    dimensions than shape1, this function returns False immediately.
+
     Examples:
     ```
-        are_shapes_broadcastable([3, 4, 5], [4, 5]) -> True
-        are_shapes_broadcastable([3, 4], [5, 4]) -> False
+        are_shapes_broadcastable([3, 4, 5], [4, 5]) -> False  # ndim reduction
+        are_shapes_broadcastable([4, 5], [3, 4, 5]) -> True   # expanding dims OK
+        are_shapes_broadcastable([3, 4], [5, 4]) -> False      # incompatible dims
+        are_shapes_broadcastable([1, 4], [3, 4]) -> True       # broadcast dim 1
     ```
     """
     var ndim1 = len(shape1)
     var ndim2 = len(shape2)
+
+    # Broadcasting cannot reduce the number of dimensions
+    if ndim2 < ndim1:
+        return False
+
     var max_ndim = max(ndim1, ndim2)
 
     for i in range(max_ndim):

--- a/shared/core/shape.mojo
+++ b/shared/core/shape.mojo
@@ -1279,7 +1279,9 @@ fn broadcast_to(tensor: ExTensor, target_shape: List[Int]) raises -> ExTensor:
 
     var shape = tensor.shape()
 
-    # Cannot reduce number of dimensions (target must have >= dims than source)
+    # Cannot reduce number of dimensions (target must have >= dims than source).
+    # Note: are_shapes_broadcastable also enforces this guard, but we raise a
+    # descriptive Error here for better caller UX.
     if len(target_shape) < len(shape):
         raise Error("broadcast_to: cannot broadcast to fewer dimensions")
 

--- a/tests/shared/core/test_broadcasting_part5.mojo
+++ b/tests/shared/core/test_broadcasting_part5.mojo
@@ -1,0 +1,167 @@
+"""Tests for ExTensor broadcasting operations - Part 5: are_shapes_broadcastable ndim guard.
+
+# ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. Split from test_broadcasting.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Tests the ndim guard added to are_shapes_broadcastable() in Issue #3859.
+Broadcasting cannot reduce the number of dimensions: if shape2 has fewer
+dimensions than shape1, are_shapes_broadcastable must return False.
+"""
+
+from shared.core.broadcasting import are_shapes_broadcastable
+from testing import assert_true
+
+
+# ============================================================================
+# Tests for ndim guard: shape2 fewer dims than shape1 -> False
+# ============================================================================
+
+
+fn test_are_shapes_broadcastable_ndim_reduction_returns_false() raises:
+    """are_shapes_broadcastable([3,4,5], [4,5]) must return False (ndim reduction)."""
+    var shape1 = List[Int]()
+    shape1.append(3)
+    shape1.append(4)
+    shape1.append(5)
+    var shape2 = List[Int]()
+    shape2.append(4)
+    shape2.append(5)
+    assert_true(
+        not are_shapes_broadcastable(shape1, shape2),
+        "3D->2D ndim reduction must return False",
+    )
+
+
+fn test_are_shapes_broadcastable_1d_vs_2d_reduction() raises:
+    """are_shapes_broadcastable([3,4], [4]) must return False (ndim reduction)."""
+    var shape1 = List[Int]()
+    shape1.append(3)
+    shape1.append(4)
+    var shape2 = List[Int]()
+    shape2.append(4)
+    assert_true(
+        not are_shapes_broadcastable(shape1, shape2),
+        "2D->1D ndim reduction must return False",
+    )
+
+
+fn test_are_shapes_broadcastable_empty_target_returns_false() raises:
+    """are_shapes_broadcastable([3], []) must return False (empty target)."""
+    var shape1 = List[Int]()
+    shape1.append(3)
+    var shape2 = List[Int]()
+    assert_true(
+        not are_shapes_broadcastable(shape1, shape2),
+        "Non-empty source vs empty target must return False",
+    )
+
+
+# ============================================================================
+# Tests for valid broadcasting (expanding dims or same ndim)
+# ============================================================================
+
+
+fn test_are_shapes_broadcastable_expanding_ndim_ok() raises:
+    """are_shapes_broadcastable([4,5], [3,4,5]) must return True (expanding dims)."""
+    var shape1 = List[Int]()
+    shape1.append(4)
+    shape1.append(5)
+    var shape2 = List[Int]()
+    shape2.append(3)
+    shape2.append(4)
+    shape2.append(5)
+    assert_true(
+        are_shapes_broadcastable(shape1, shape2),
+        "2D->3D expansion must return True",
+    )
+
+
+fn test_are_shapes_broadcastable_same_ndim_compatible() raises:
+    """are_shapes_broadcastable([3,4], [3,4]) must return True (same shape)."""
+    var shape1 = List[Int]()
+    shape1.append(3)
+    shape1.append(4)
+    var shape2 = List[Int]()
+    shape2.append(3)
+    shape2.append(4)
+    assert_true(
+        are_shapes_broadcastable(shape1, shape2),
+        "Identical shapes must return True",
+    )
+
+
+fn test_are_shapes_broadcastable_broadcast_1_dim_ok() raises:
+    """are_shapes_broadcastable([1,4], [3,4]) must return True (dim-1 broadcast)."""
+    var shape1 = List[Int]()
+    shape1.append(1)
+    shape1.append(4)
+    var shape2 = List[Int]()
+    shape2.append(3)
+    shape2.append(4)
+    assert_true(
+        are_shapes_broadcastable(shape1, shape2),
+        "Dim-1 broadcast [1,4]->[3,4] must return True",
+    )
+
+
+fn test_are_shapes_broadcastable_incompatible_dims_unchanged() raises:
+    """are_shapes_broadcastable([3,4], [5,4]) must return False (incompatible dims)."""
+    var shape1 = List[Int]()
+    shape1.append(3)
+    shape1.append(4)
+    var shape2 = List[Int]()
+    shape2.append(5)
+    shape2.append(4)
+    assert_true(
+        not are_shapes_broadcastable(shape1, shape2),
+        "Incompatible dims [3,4] vs [5,4] must return False",
+    )
+
+
+fn test_are_shapes_broadcastable_scalar_source_empty_target() raises:
+    """are_shapes_broadcastable([], []) must return True (both empty/scalar)."""
+    var shape1 = List[Int]()
+    var shape2 = List[Int]()
+    assert_true(
+        are_shapes_broadcastable(shape1, shape2),
+        "Both empty shapes (scalar) must return True",
+    )
+
+
+fn test_are_shapes_broadcastable_scalar_source_to_1d() raises:
+    """are_shapes_broadcastable([], [3]) must return True (scalar to 1D)."""
+    var shape1 = List[Int]()
+    var shape2 = List[Int]()
+    shape2.append(3)
+    assert_true(
+        are_shapes_broadcastable(shape1, shape2),
+        "Scalar source to 1D target must return True",
+    )
+
+
+# ============================================================================
+# Main test runner
+# ============================================================================
+
+
+fn main() raises:
+    """Run broadcasting part 5 tests (ndim guard in are_shapes_broadcastable)."""
+    print("Running ExTensor broadcasting tests - Part 5...")
+
+    # ndim reduction cases (must return False)
+    print("  Testing ndim reduction returns False...")
+    test_are_shapes_broadcastable_ndim_reduction_returns_false()
+    test_are_shapes_broadcastable_1d_vs_2d_reduction()
+    test_are_shapes_broadcastable_empty_target_returns_false()
+
+    # Valid broadcasting cases
+    print("  Testing valid broadcasting cases...")
+    test_are_shapes_broadcastable_expanding_ndim_ok()
+    test_are_shapes_broadcastable_same_ndim_compatible()
+    test_are_shapes_broadcastable_broadcast_1_dim_ok()
+    test_are_shapes_broadcastable_incompatible_dims_unchanged()
+    test_are_shapes_broadcastable_scalar_source_empty_target()
+    test_are_shapes_broadcastable_scalar_source_to_1d()
+
+    print("All broadcasting part 5 tests completed!")


### PR DESCRIPTION
## Summary

- Add `if ndim2 < ndim1: return False` early-return guard inside `are_shapes_broadcastable()` so the helper self-documents the no-dimension-reduction rule
- Update docstring examples (old example `[3,4,5] vs [4,5] -> True` was the bug; now shows `-> False`)
- Add comment in `broadcast_to` noting the guard now lives in both places
- Add `tests/shared/core/test_broadcasting_part5.mojo` with 9 test functions covering ndim reduction, expanding dims, same-ndim, and edge cases (ADR-009 ≤10 per file)

## Test plan

- [ ] `test_are_shapes_broadcastable_ndim_reduction_returns_false` — `[3,4,5]` vs `[4,5]` → `False`
- [ ] `test_are_shapes_broadcastable_1d_vs_2d_reduction` — `[3,4]` vs `[4]` → `False`
- [ ] `test_are_shapes_broadcastable_empty_target_returns_false` — `[3]` vs `[]` → `False`
- [ ] `test_are_shapes_broadcastable_expanding_ndim_ok` — `[4,5]` vs `[3,4,5]` → `True`
- [ ] `test_are_shapes_broadcastable_same_ndim_compatible` — `[3,4]` vs `[3,4]` → `True`
- [ ] `test_are_shapes_broadcastable_broadcast_1_dim_ok` — `[1,4]` vs `[3,4]` → `True`
- [ ] `test_are_shapes_broadcastable_incompatible_dims_unchanged` — `[3,4]` vs `[5,4]` → `False`
- [ ] `test_are_shapes_broadcastable_scalar_source_empty_target` — `[]` vs `[]` → `True`
- [ ] `test_are_shapes_broadcastable_scalar_source_to_1d` — `[]` vs `[3]` → `True`

Closes #3859

🤖 Generated with [Claude Code](https://claude.com/claude-code)