### PR TITLE
docs(tests): update test_dtypes_bfloat16 docstring to reflect bfloat16 full support

### DIFF
--- a/tests/shared/testing/test_special_values_part2.mojo
+++ b/tests/shared/testing/test_special_values_part2.mojo
@@ -122,7 +122,16 @@ fn test_dtypes_float16() raises:
 
 
 fn test_dtypes_bfloat16() raises:
-    """Test special values work with bfloat16."""
+    """Test special values work with bfloat16.
+
+    Verifies DType.bfloat16 is fully supported in Mojo's DType enum
+    and integrates correctly with the ExTensor special values API.
+
+    Tests:
+    - Tensor creation with DType.bfloat16 dtype
+    - dtype assertion confirms bfloat16 is preserved
+    - Special value invariants hold for value 1.0 (FP-representable)
+    """
     var tensor = create_special_value_tensor([2, 2], DType.bfloat16, 1.0)
     assert_dtype(tensor, DType.bfloat16, "Should be bfloat16")
     verify_special_value_invariants(tensor, 1.0)


### PR DESCRIPTION
## Summary

- Enriches the sparse one-liner docstring of `test_dtypes_bfloat16()` with a descriptive multi-line docstring
- Documents that `DType.bfloat16` is now fully supported in Mojo's DType enum
- Lists the three things the test actually validates (tensor creation, dtype assertion, special value invariants)

## Changes Made

- `tests/shared/testing/test_special_values_part2.mojo`: Updated docstring of `test_dtypes_bfloat16()` at line 124

## Verification

- Documentation-only change — no logic, no signatures modified
- Docstring lines are ≤ 80 chars (within `mojo format` tolerance)
- Existing test body unchanged; CI test run will confirm `test_dtypes_bfloat16` still passes

Closes #3904

🤖 Generated with [Claude Code](https://claude.com/claude-code)