### PR TITLE
fix(extensor): add int8 branch to _set_float64 and _set_float32 with truncation semantics

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -1163,11 +1163,14 @@ struct ExTensor(
             return Float64(self._get_int64(index))
 
     fn _set_float64(self, index: Int, value: Float64):
-        """Internal: Set value at index (assumes float-compatible dtype).
+        """Internal: Set value at index, truncating to the tensor's dtype.
 
         Args:
             index: The element index to set.
             value: The value to set (as Float64).
+
+        Note:
+            For int8, value is truncated (Float64 -> Int8 cast).
         """
         var dtype_size = self._get_dtype_size()
         var offset = index * dtype_size
@@ -1184,6 +1187,9 @@ struct ExTensor(
         elif self._dtype == DType.float64:
             var ptr = (self._data + offset).bitcast[Float64]()
             ptr[] = value
+        elif self._dtype == DType.int8:
+            var ptr = (self._data + offset).bitcast[Int8]()
+            ptr[] = value.cast[DType.int8]()
 
     fn _get_float32(self, index: Int) -> Float32:
         """Internal: Get value at index as Float32 (assumes float-compatible dtype).
@@ -1244,6 +1250,9 @@ struct ExTensor(
         elif self._dtype == DType.bfloat16:
             var ptr = (self._data + offset).bitcast[BFloat16]()
             ptr[] = value.cast[DType.bfloat16]()
+        elif self._dtype == DType.int8:
+            var ptr = (self._data + offset).bitcast[Int8]()
+            ptr[] = value.cast[DType.int8]()
 
     fn _get_int64(self, index: Int) -> Int64:
         """Internal: Get value at index as Int64 (assumes integer-compatible dtype).

--- a/tests/shared/core/test_extensor_dtype_roundtrip.mojo
+++ b/tests/shared/core/test_extensor_dtype_roundtrip.mojo
@@ -149,11 +149,9 @@ fn test_bfloat16_dtype_size_is_2_bytes() raises:
 
 
 # ============================================================================
-# int8 — integer type: _set_float64 has no int8 branch (silent no-op).
+# int8 — integer type: _set_float64 and _set_float32 truncate Float to Int8.
 # _get_float64 falls through to _get_int64 which works for integer-safe values.
 # Only integer-representable values (1.0, -1.0, 0.0) are meaningful; 1.5 truncates.
-# TODO(#3301): _set_float64 does not write to int8 tensors (no branch exists).
-#              Use _set_int64 for int8 tensors instead.
 # ============================================================================
 
 
@@ -175,23 +173,40 @@ fn test_int8_get_float64_via_int64_path() raises:
     assert_almost_equal(t._get_float64(2), 0.0, tolerance=1e-9)
 
 
-fn test_int8_set_float64_is_noop() raises:
-    """Int8: _set_float64 silently does nothing (no int8 branch in implementation).
+fn test_int8_set_float64_truncates_to_int8() raises:
+    """Int8: _set_float64 truncates Float64 to Int8 via cast.
 
-    This documents the known limitation: _set_float64 has no int8 branch, so
-    calling it on an int8 tensor is a silent no-op. The value remains unchanged.
-
-    TODO(#3301): Consider adding int8 support to _set_float64 with truncation
-    semantics (Float64 -> Int8 cast), or raise an error for unsupported dtypes
-    to make this failure mode explicit rather than silent.
+    Verifies that _set_float64 now correctly writes to int8 tensors by
+    truncating the Float64 value to Int8 (Float64 -> Int8 cast).
     """
-    var t = zeros([1], DType.int8)
-    t._set_float64(0, 1.0)
-    # int8 has no branch in _set_float64 — the write is silently ignored.
-    # Value stays 0 (the zero-initialized value).
-    var got = t._get_float64(0)
-    # Document the current behavior: silent no-op leaves value at 0
-    assert_almost_equal(got, 0.0, tolerance=1e-9)
+    var t = zeros([4], DType.int8)
+    t._set_float64(0, 42.0)
+    t._set_float64(1, -1.0)
+    t._set_float64(2, 0.0)
+    t._set_float64(3, 127.9)
+    assert_almost_equal(t._get_float64(0), 42.0, tolerance=1e-9)
+    assert_almost_equal(t._get_float64(1), -1.0, tolerance=1e-9)
+    assert_almost_equal(t._get_float64(2), 0.0, tolerance=1e-9)
+    # 127.9 truncates to 127 (max int8 is 127)
+    assert_almost_equal(t._get_float64(3), 127.0, tolerance=1e-9)
+
+
+fn test_int8_set_float32_truncates_to_int8() raises:
+    """Int8: _set_float32 truncates Float32 to Int8 via cast.
+
+    Verifies that _set_float32 correctly writes to int8 tensors by
+    truncating the Float32 value to Int8 (Float32 -> Int8 cast).
+    """
+    var t = zeros([4], DType.int8)
+    t._set_float32(0, 42.0)
+    t._set_float32(1, -1.0)
+    t._set_float32(2, 0.0)
+    t._set_float32(3, 127.9)
+    assert_almost_equal(t._get_float64(0), 42.0, tolerance=1e-9)
+    assert_almost_equal(t._get_float64(1), -1.0, tolerance=1e-9)
+    assert_almost_equal(t._get_float64(2), 0.0, tolerance=1e-9)
+    # 127.9 truncates to 127 (max int8 is 127)
+    assert_almost_equal(t._get_float64(3), 127.0, tolerance=1e-9)
 
 
 fn test_dtype_sizes() raises:
@@ -285,8 +300,9 @@ fn main() raises:
     test_bfloat16_nonzero_after_set()
     test_bfloat16_dtype_size_is_2_bytes()
 
-    print("Running int8 tests (documents known limitation of _set_float64)...")
+    print("Running int8 tests...")
     test_int8_get_float64_via_int64_path()
-    test_int8_set_float64_is_noop()
+    test_int8_set_float64_truncates_to_int8()
+    test_int8_set_float32_truncates_to_int8()
 
     print("All dtype round-trip tests passed!")


### PR DESCRIPTION
## Summary

- Add `int8` branch to `_set_float64` in `shared/core/extensor.mojo` — truncates `Float64` to `Int8` via `value.cast[DType.int8]()`
- Add `int8` branch to `_set_float32` — same truncation pattern
- Replace `test_int8_set_float64_is_noop` (which documented the bug) with `test_int8_set_float64_truncates_to_int8`
- Add new `test_int8_set_float32_truncates_to_int8`

## Test plan

- [x] `test_int8_set_float64_truncates_to_int8`: verifies 42.0, -1.0, 0.0, 127.9→127.0 round-trips
- [x] `test_int8_set_float32_truncates_to_int8`: same values via `_set_float32`
- [x] Existing `test_int8_get_float64_via_int64_path` still passes

Closes #3909

🤖 Generated with [Claude Code](https://claude.com/claude-code)