### PR TITLE
test(extensor): add bfloat16 regression tests for _get_float32/_set_float32

### DIFF
--- a/tests/shared/core/test_extensor_getset_float32.mojo
+++ b/tests/shared/core/test_extensor_getset_float32.mojo
@@ -35,6 +35,41 @@ fn test_get_float32_dtype_conversions() raises:
     assert_almost_equal(Float64(val_f64), 1.5, tolerance=1e-6)
 
 
+fn test_get_float32_bfloat16() raises:
+    """Test _get_float32() on a bfloat16 tensor returns correct value.
+
+    Regression test for issue #3910: _get_float32 previously had no bfloat16
+    branch, falling through to _get_int64 and returning garbage values.
+    """
+    var t = zeros([1], DType.bfloat16)
+    t._set_float64(0, 1.5)
+    var got = t._get_float32(0)
+    # Zero-guard: detects the pre-fix silent-read failure
+    assert_true(
+        Float64(got) != 0.0,
+        "bfloat16 _get_float32 returned 0 — bfloat16 branch missing",
+    )
+    # 1.5 is exactly representable in bfloat16; tolerance 1e-2 covers mantissa precision
+    assert_almost_equal(Float64(got), 1.5, tolerance=1e-2)
+
+
+fn test_get_float32_bfloat16_roundtrip() raises:
+    """Test _set_float32 -> _get_float32 roundtrip on a bfloat16 tensor.
+
+    Regression test for issue #3910: both set and get must have bfloat16
+    branches for the roundtrip to preserve values.
+    """
+    var t = zeros([4], DType.bfloat16)
+    t._set_float32(0, Float32(1.0))
+    t._set_float32(1, Float32(2.0))
+    t._set_float32(2, Float32(0.5))
+    t._set_float32(3, Float32(-1.0))
+    assert_almost_equal(Float64(t._get_float32(0)), 1.0, tolerance=1e-2)
+    assert_almost_equal(Float64(t._get_float32(1)), 2.0, tolerance=1e-2)
+    assert_almost_equal(Float64(t._get_float32(2)), 0.5, tolerance=1e-2)
+    assert_almost_equal(Float64(t._get_float32(3)), -1.0, tolerance=1e-2)
+
+
 fn test_set_float32_basic() raises:
     """Test _set_float32() stores values correctly in Float32 tensor."""
     var tensor = zeros([3, 4], DType.float32)
@@ -70,6 +105,23 @@ fn test_set_float32_dtype_conversions() raises:
     assert_almost_equal(val_f64, 1.5, tolerance=1e-6)
 
 
+fn test_set_float32_bfloat16() raises:
+    """Test _set_float32() on a bfloat16 tensor stores value correctly.
+
+    Regression test for issue #3910: _set_float32 previously had no bfloat16
+    branch, silently doing nothing (writing to the wrong pointer or no-op).
+    """
+    var t = zeros([1], DType.bfloat16)
+    t._set_float32(0, Float32(1.5))
+    var got = t._get_float64(0)
+    # Zero-guard: detects the pre-fix silent-write failure
+    assert_true(
+        got != 0.0,
+        "bfloat16 _set_float32 silently wrote zero — bfloat16 branch missing",
+    )
+    assert_almost_equal(got, 1.5, tolerance=1e-2)
+
+
 fn test_set_get_float32_roundtrip() raises:
     """Test _set_float32() -> _get_float32() roundtrip preserves values."""
     var tensor = zeros([20], DType.float32)
@@ -87,10 +139,17 @@ fn main() raises:
     test_get_float32_basic()
     test_get_float32_dtype_conversions()
 
+    print("Running _get_float32 bfloat16 tests (regression for #3910)...")
+    test_get_float32_bfloat16()
+    test_get_float32_bfloat16_roundtrip()
+
     print("Running _set_float32 tests...")
     test_set_float32_basic()
     test_set_float32_all_elements()
     test_set_float32_dtype_conversions()
     test_set_get_float32_roundtrip()
+
+    print("Running _set_float32 bfloat16 tests (regression for #3910)...")
+    test_set_float32_bfloat16()
 
     print("All _get/_set_float32 tests passed!")


### PR DESCRIPTION
## Summary

- Adds 3 bfloat16 regression tests to `test_extensor_getset_float32.mojo`
- `test_get_float32_bfloat16`: verifies `_get_float32` reads bfloat16 values correctly (not garbage via `_get_int64` fallthrough)
- `test_get_float32_bfloat16_roundtrip`: verifies full `_set_float32` → `_get_float32` roundtrip on a bfloat16 tensor
- `test_set_float32_bfloat16`: verifies `_set_float32` writes bfloat16 values correctly (not a silent no-op)

The code fix was already applied in commit `3c1b07fa` (from issue #3301 follow-up). This PR adds the missing regression coverage to prevent regressions.

## Test plan

- [x] All new tests use zero-guards to detect the original silent-failure mode
- [x] Tolerance set to 1e-2 (appropriate for bfloat16's ~7-bit mantissa)
- [x] Test values (1.0, 1.5, 2.0, 0.5, -1.0) are exactly representable in bfloat16
- [x] Follows ADR-009 pattern (file already split to stay under ~15 cumulative tests)

Closes #3910

🤖 Generated with [Claude Code](https://claude.com/claude-code)