### PR TITLE
docs(readme): add Build badge for build-validation.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ maximum performance and type safety.
 [![CI](https://github.com/HomericIntelligence/ProjectOdyssey/actions/workflows/comprehensive-tests.yml/badge.svg?branch=main)](https://github.com/HomericIntelligence/ProjectOdyssey/actions/workflows/comprehensive-tests.yml)
 [![Pre-commit](https://github.com/HomericIntelligence/ProjectOdyssey/actions/workflows/pre-commit.yml/badge.svg?branch=main)](https://github.com/HomericIntelligence/ProjectOdyssey/actions/workflows/pre-commit.yml)
 [![Security](https://github.com/HomericIntelligence/ProjectOdyssey/actions/workflows/security.yml/badge.svg?branch=main)](https://github.com/HomericIntelligence/ProjectOdyssey/actions/workflows/security.yml)
+[![Build](https://github.com/HomericIntelligence/ProjectOdyssey/actions/workflows/build-validation.yml/badge.svg?branch=main)](https://github.com/HomericIntelligence/ProjectOdyssey/actions/workflows/build-validation.yml)
 
 ## What This Is
 


### PR DESCRIPTION
## Summary

- Adds a `[![Build](…)](…)` badge for `build-validation.yml` to the README badge block
- This is the only PR-critical workflow that had no badge; `CI`, `Pre-commit`, and `Security` already existed

## Changes Made

- **`README.md`** — inserted one badge line after the Security badge (line 15)

## Verification

- `pixi run pre-commit run --files README.md` exits 0 (markdownlint, trailing-whitespace, end-of-file-fixer all pass)
- Badge URL follows the exact pattern used by the three existing CI badges
- `build-validation.yml` confirmed to exist in `.github/workflows/`

Closes #3922

🤖 Generated with [Claude Code](https://claude.com/claude-code)