### PR TITLE
feat(security): upgrade Gitleaks from v8.18.0 to v8.30.0

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -43,11 +43,11 @@ jobs:
 
       - name: Run Gitleaks
         run: |
-          # Pinned to v8.18.0 — update hash when upgrading version (see #3316)
-          wget -q https://github.com/gitleaks/gitleaks/releases/download/v8.18.0/gitleaks_8.18.0_linux_x64.tar.gz
-          # Verify integrity before execution — SHA256 from https://github.com/gitleaks/gitleaks/releases/download/v8.18.0/gitleaks_8.18.0_checksums.txt
-          echo "6e19050a3ee0688265ed3be4c46a0362487d20456ecd547e8c7328eaed3980cb  gitleaks_8.18.0_linux_x64.tar.gz" | sha256sum --check
-          tar -xzf gitleaks_8.18.0_linux_x64.tar.gz
+          # Pinned to v8.30.0 — update hash when upgrading version (see #3316)
+          wget -q https://github.com/gitleaks/gitleaks/releases/download/v8.30.0/gitleaks_8.30.0_linux_x64.tar.gz
+          # Verify integrity before execution — SHA256 from https://github.com/gitleaks/gitleaks/releases/download/v8.30.0/gitleaks_8.30.0_checksums.txt
+          echo "79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e  gitleaks_8.30.0_linux_x64.tar.gz" | sha256sum --check
+          tar -xzf gitleaks_8.30.0_linux_x64.tar.gz
           chmod +x gitleaks
 
           if [ -f .gitleaks.toml ]; then

--- a/tests/workflows/test_security_workflow.py
+++ b/tests/workflows/test_security_workflow.py
@@ -14,9 +14,9 @@ from pathlib import Path
 import pytest
 
 WORKFLOW = Path(__file__).parents[2] / ".github" / "workflows" / "security.yml"
-GITLEAKS_VERSION = "v8.18.0"
-GITLEAKS_TARBALL = "gitleaks_8.18.0_linux_x64.tar.gz"
-EXPECTED_SHA256 = "6e19050a3ee0688265ed3be4c46a0362487d20456ecd547e8c7328eaed3980cb"
+GITLEAKS_VERSION = "v8.30.0"
+GITLEAKS_TARBALL = "gitleaks_8.30.0_linux_x64.tar.gz"
+EXPECTED_SHA256 = "79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e"
 
 
 @pytest.fixture(scope="module")
@@ -51,7 +51,7 @@ def test_sha256_value_is_real_hex_digest(workflow_content: str) -> None:
 
 
 def test_sha256_value_matches_expected(workflow_content: str) -> None:
-    """The hardcoded SHA256 must match the official checksum for gitleaks_8.18.0_linux_x64.tar.gz."""
+    """The hardcoded SHA256 must match the official checksum for gitleaks_8.30.0_linux_x64.tar.gz."""
     match = re.search(r"([0-9a-f]{64})\s+" + re.escape(GITLEAKS_TARBALL), workflow_content)
     assert match is not None, f"SHA256 line for {GITLEAKS_TARBALL} not found"
     actual = match.group(1)


### PR DESCRIPTION
## Summary

- Upgrades Gitleaks binary from v8.18.0 (2023) to v8.30.0 (2025-11-26, latest stable)
- Updates download URL and tarball filename in `security.yml`
- Updates inline version comment and SHA256 integrity check line
- Updates regression test constants (`GITLEAKS_VERSION`, `GITLEAKS_TARBALL`, `EXPECTED_SHA256`)

## Changes Made

- `.github/workflows/security.yml`: 5 occurrences of v8.18.0 → v8.30.0 + new SHA256 digest
- `tests/workflows/test_security_workflow.py`: Updated 3 constants + docstring

## Verification

All 6 regression tests pass:

```
tests/workflows/test_security_workflow.py::test_workflow_file_exists PASSED
tests/workflows/test_security_workflow.py::test_gitleaks_version_pinned PASSED
tests/workflows/test_security_workflow.py::test_gitleaks_sha256_check_present PASSED
tests/workflows/test_security_workflow.py::test_sha256_value_is_real_hex_digest PASSED
tests/workflows/test_security_workflow.py::test_sha256_value_matches_expected PASSED
tests/workflows/test_security_workflow.py::test_fetch_depth_zero_present PASSED
```

SHA256 sourced from the official `gitleaks_8.30.0_checksums.txt` release artifact.

Closes #3939

🤖 Generated with [Claude Code](https://claude.com/claude-code)