### PR TITLE
fix(ci): replace curl|sh with setup-pixi in validate-configs workflow

### DIFF
--- a/.github/workflows/validate-configs.yml
+++ b/.github/workflows/validate-configs.yml
@@ -120,16 +120,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - name: Install Modular CLI
-        run: |
-          curl -s https://get.modular.com | sh -
-          modular auth ${{ secrets.MODULAR_AUTH_TOKEN || 'dummy-token' }}
-        continue-on-error: true
-
-      - name: Install Mojo
-        run: |
-          modular install mojo
-        continue-on-error: true
+      - name: Set up Pixi (provides Mojo)
+        uses: ./.github/actions/setup-pixi
 
       - name: Test config loading (placeholder)
         run: |


### PR DESCRIPTION
## Summary

- Audited all `.github/workflows/*.yml` files for unverified `wget`/`curl` binary downloads
- Found one insecure pattern in `validate-configs.yml`: `curl -s https://get.modular.com | sh -` piped directly to `sh` with no version pinning or hash verification
- Replaced the two vulnerable steps (`Install Modular CLI`, `Install Mojo`) with the project-standard `setup-pixi` composite action, which uses pinned, hash-verified downloads via Pixi

## Changes Made

- `.github/workflows/validate-configs.yml`: removed `curl | sh` installer steps, replaced with `uses: ./.github/actions/setup-pixi`

## Security Impact

The `curl -s https://get.modular.com | sh -` pattern is a live URL redirect to a dynamically generated install script — impossible to verify by SHA256. This is a supply-chain risk if the CDN is compromised. The `setup-pixi` composite action eliminates this risk by using Pixi (itself downloaded with a pinned hash) which then installs Mojo at the version locked in `pixi.toml`.

## Verification

- All other workflows already use `setup-pixi` — this change brings `validate-configs.yml` into alignment
- The `test-config-loading` job placeholder test (`echo`) continues to work unchanged

Closes #3941