### PR TITLE
feat(validate): extend checkout-order check to skip reusable workflow jobs

### DIFF
--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -33,5 +33,6 @@ jobs:
 
       - name: Validate checkout-first ordering for composite actions
         run: |
-          echo "Checking that all jobs using ./.github/actions/ have actions/checkout as a preceding step..."
+          echo "Checking that all steps-based jobs using ./.github/actions/ have actions/checkout as a preceding step..."
+          echo "(Reusable workflow jobs using ./.github/workflows/ are skipped — they run in their own VM with their own checkout.)"
           python3 scripts/validate_workflow_checkout_order.py .github/workflows/

--- a/scripts/validate_workflow_checkout_order.py
+++ b/scripts/validate_workflow_checkout_order.py
@@ -7,6 +7,11 @@ be checked out before they can be referenced. This script enforces that
 actions/checkout always appears as a step before any ./.github/actions/ reference
 within every job of every scanned workflow file.
 
+Reusable workflow jobs (jobs.<job>.uses: ./.github/workflows/some-workflow.yml)
+are intentionally skipped: they delegate execution to a separate workflow that
+runs in its own VM with its own checkout step. There are no caller-side steps to
+validate, so the checkout-first invariant does not apply at the caller level.
+
 Usage:
     python scripts/validate_workflow_checkout_order.py [path ...]
 
@@ -55,9 +60,29 @@ def _is_composite_action_step(step: object) -> bool:
     return isinstance(uses, str) and uses.startswith("./.github/actions/")
 
 
+def _is_reusable_workflow_job(job_data: object) -> bool:
+    """Return True if this job delegates to a reusable workflow (job-level uses).
+
+    Reusable workflow caller jobs have a top-level ``uses`` key pointing to
+    ``./.github/workflows/``.  They contain no ``steps`` list — execution is
+    delegated to the callee workflow, which runs in its own VM and handles its
+    own checkout.  The checkout-first invariant therefore does not apply at the
+    caller level and these jobs should be skipped by the validator.
+    """
+    if not isinstance(job_data, dict):
+        return False
+    uses = job_data.get("uses", "")
+    return isinstance(uses, str) and uses.startswith("./.github/workflows/")
+
+
 def validate_workflow(workflow_file: Path) -> List[Violation]:
     """
     Validate checkout-first ordering for all jobs in a workflow file.
+
+    Jobs that delegate to a reusable workflow via a job-level ``uses:
+    ./.github/workflows/`` key are skipped: they have no steps of their own
+    and the callee is responsible for its own checkout.  Only steps-based jobs
+    are checked.
 
     Args:
         workflow_file: Path to the workflow YAML file.
@@ -88,6 +113,9 @@ def validate_workflow(workflow_file: Path) -> List[Violation]:
     for job_name, job_data in jobs.items():
         if not isinstance(job_data, dict):
             continue
+
+        if _is_reusable_workflow_job(job_data):
+            continue  # Callee runs in its own VM and handles its own checkout
 
         steps = job_data.get("steps")
         if not isinstance(steps, list):

--- a/tests/scripts/test_validate_workflow_checkout_order.py
+++ b/tests/scripts/test_validate_workflow_checkout_order.py
@@ -14,6 +14,7 @@ import pytest
 # Add scripts directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 from validate_workflow_checkout_order import (
+    _is_reusable_workflow_job,
     collect_workflow_files,
     main,
     validate_workflow,
@@ -389,3 +390,111 @@ class TestMain:
         )
         result = main([str(good), str(bad)])
         assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# _is_reusable_workflow_job helper
+# ---------------------------------------------------------------------------
+
+
+class TestIsReusableWorkflowJobHelper:
+    """Unit tests for the _is_reusable_workflow_job() helper."""
+
+    def test_local_workflow_path_is_reusable(self) -> None:
+        """Job-level uses pointing to ./.github/workflows/ is reusable."""
+        assert _is_reusable_workflow_job({"uses": "./.github/workflows/foo.yml"}) is True
+
+    def test_composite_action_step_is_not_reusable(self) -> None:
+        """Step-level uses for a composite action is not a reusable workflow job."""
+        assert _is_reusable_workflow_job({"uses": "./.github/actions/setup-pixi"}) is False
+
+    def test_external_action_is_not_reusable(self) -> None:
+        """External action reference is not a reusable workflow job."""
+        assert _is_reusable_workflow_job({"uses": "actions/checkout@v4"}) is False
+
+    def test_no_uses_key_is_not_reusable(self) -> None:
+        """Job dict without a uses key is not a reusable workflow job."""
+        assert _is_reusable_workflow_job({"steps": []}) is False
+
+    def test_non_dict_returns_false(self) -> None:
+        """Non-dict input returns False without raising."""
+        assert _is_reusable_workflow_job(None) is False
+        assert _is_reusable_workflow_job("string") is False
+        assert _is_reusable_workflow_job(42) is False
+
+
+# ---------------------------------------------------------------------------
+# Reusable workflow jobs in validate_workflow
+# ---------------------------------------------------------------------------
+
+
+class TestReusableWorkflowJobs:
+    """Reusable workflow caller jobs should be skipped by validate_workflow()."""
+
+    def test_reusable_workflow_job_is_skipped(self, tmp_path: Path) -> None:
+        """A job with only a job-level uses produces no violations."""
+        wf = write_workflow(
+            tmp_path,
+            "reusable_caller.yml",
+            """
+            jobs:
+              call-reusable:
+                uses: ./.github/workflows/reusable-build.yml
+                with:
+                  environment: staging
+            """,
+        )
+        assert validate_workflow(wf) == []
+
+    def test_reusable_job_mixed_with_clean_steps_job(self, tmp_path: Path) -> None:
+        """Reusable caller job is skipped; clean steps-based job passes."""
+        wf = write_workflow(
+            tmp_path,
+            "mixed_clean.yml",
+            """
+            jobs:
+              call-reusable:
+                uses: ./.github/workflows/reusable-build.yml
+              steps-job:
+                steps:
+                  - uses: actions/checkout@v4
+                  - uses: ./.github/actions/setup-pixi
+            """,
+        )
+        assert validate_workflow(wf) == []
+
+    def test_reusable_job_mixed_with_violating_steps_job(self, tmp_path: Path) -> None:
+        """Reusable caller job is skipped; violation in steps-based job is detected."""
+        wf = write_workflow(
+            tmp_path,
+            "mixed_violation.yml",
+            """
+            jobs:
+              call-reusable:
+                uses: ./.github/workflows/reusable-build.yml
+              bad-job:
+                steps:
+                  - uses: ./.github/actions/setup-pixi
+                  - uses: actions/checkout@v4
+            """,
+        )
+        violations = validate_workflow(wf)
+        assert len(violations) == 1
+        assert violations[0].job_name == "bad-job"
+        assert violations[0].composite_action == "./.github/actions/setup-pixi"
+
+    def test_reusable_workflow_job_no_steps_key_no_crash(self, tmp_path: Path) -> None:
+        """Absence of steps key in a reusable job does not raise an exception."""
+        wf = write_workflow(
+            tmp_path,
+            "reusable_no_steps.yml",
+            """
+            jobs:
+              call-reusable:
+                uses: ./.github/workflows/foo.yml
+                secrets: inherit
+            """,
+        )
+        # Must not raise; must return empty violations list
+        result = validate_workflow(wf)
+        assert result == []


### PR DESCRIPTION
## Summary

- Add `_is_reusable_workflow_job()` helper that detects job-level `uses: ./.github/workflows/` references
- Skip reusable workflow caller jobs in `validate_workflow()` — they have no steps; the callee handles its own checkout in its own VM
- Update module and function docstrings to document the skipping behaviour
- Update the `validate-workflows.yml` step comment to reflect extended scope

## Changes Made

- `scripts/validate_workflow_checkout_order.py` — new helper + skip guard + docstring updates
- `tests/scripts/test_validate_workflow_checkout_order.py` — 9 new tests (2 new classes: `TestIsReusableWorkflowJobHelper`, `TestReusableWorkflowJobs`); 31 total, all passing
- `.github/workflows/validate-workflows.yml` — updated echo comment

## Verification

```
pytest tests/scripts/test_validate_workflow_checkout_order.py -v
# 31 passed in 0.19s
```

Closes #3987