### PR TITLE
feat(validate_test_coverage): surface stale warnings in PR comment

### DIFF
--- a/tests/scripts/test_validate_test_coverage.py
+++ b/tests/scripts/test_validate_test_coverage.py
@@ -144,9 +144,7 @@ class TestGenerateReportStalePatterns:
 
     def test_stale_section_appended_when_patterns_exist(self) -> None:
         """Non-empty stale_patterns appends a stale section with all names."""
-        report = generate_report(
-            set(), [], self._make_coverage(), stale_patterns=["Alpha Tests", "Zebra Tests"]
-        )
+        report = generate_report(set(), [], self._make_coverage(), stale_patterns=["Alpha Tests", "Zebra Tests"])
         assert "### Stale CI Patterns" in report
         assert "- Alpha Tests" in report
         assert "- Zebra Tests" in report
@@ -166,9 +164,7 @@ class TestGenerateReportStalePatterns:
 
     def test_stale_only_no_uncovered(self) -> None:
         """Only stale patterns (no uncovered files) still produces the stale section."""
-        report = generate_report(
-            set(), [], self._make_coverage(), stale_patterns=["Deleted Group"]
-        )
+        report = generate_report(set(), [], self._make_coverage(), stale_patterns=["Deleted Group"])
         assert "### Stale CI Patterns" in report
         assert "- Deleted Group" in report
 


### PR DESCRIPTION
## Summary

- Added `check_stale_patterns()` to detect CI groups that match zero test files
- Added `stale_patterns: Optional[List[str]] = None` parameter to `generate_report()` — appends a `### Stale CI Patterns` section when non-empty
- Wired `check_stale_patterns()` into `main()` so stale warnings appear in both stderr output and the PR comment body
- Changed `post_to_pr()` guard from `if uncovered:` to fire when either uncovered files **or** stale patterns exist
- Added `TestGenerateReportStalePatterns` (5 test cases) to `tests/scripts/test_validate_test_coverage.py`

## Test plan

- [x] All 18 tests pass (`pixi run python -m pytest tests/scripts/test_validate_test_coverage.py -v`)
- [x] `test_no_stale_section_when_none_passed` — `None` → no heading
- [x] `test_no_stale_section_when_empty_list` — `[]` → no heading
- [x] `test_stale_section_appended_when_patterns_exist` — names appear in output
- [x] `test_stale_section_with_uncovered_files` — both sections present
- [x] `test_stale_only_no_uncovered` — stale section appears even with no uncovered files

Closes #4010

🤖 Generated with [Claude Code](https://claude.com/claude-code)