### PR TITLE
fix(extensor): Extend NaN canonicalization to bfloat16 in _get_float64

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -1337,8 +1337,14 @@ struct ExTensor(
             var ptr = (self._data + offset).bitcast[Float16]()
             return ptr[].cast[DType.float64]()
         elif self._dtype == DType.bfloat16:
-            var ptr = (self._data + offset).bitcast[BFloat16]()
-            return Float64(Float32(ptr[]))
+            # BF16 occupies the upper 16 bits of Float32 (same sign + exponent layout).
+            # Read raw UInt16 bits and reconstruct Float32 via bitcast to preserve all
+            # NaN mantissa bits — numeric cast via Float32(BFloat16) may canonicalize NaN.
+            var raw_ptr = (self._data + offset).bitcast[UInt16]()
+            var raw: UInt16 = raw_ptr[]
+            var f32_bits: UInt32 = UInt32(raw) << 16
+            var f32_val = UnsafePointer[UInt32](to=f32_bits).bitcast[Float32]()[]
+            return Float64(f32_val)
         elif self._dtype == DType.float32:
             var ptr = (self._data + offset).bitcast[Float32]()
             return ptr[].cast[DType.float64]()

--- a/tests/shared/core/test_utility.mojo
+++ b/tests/shared/core/test_utility.mojo
@@ -845,6 +845,89 @@ fn test_hash_empty_tensor_dtype_differs() raises:
         )
 
 
+fn make_bf16_nan_tensor(raw_bits: UInt16) raises -> ExTensor:
+    """Create a scalar BF16 tensor with the given raw NaN bit pattern.
+
+    Bypasses _set_float64 by writing raw UInt16 bits directly via pointer cast,
+    since nan_tensor() uses _set_float64 which may not preserve unusual NaN bit
+    patterns for bfloat16.
+
+    BF16 bit layout (16 bits): 1 sign | 8 exponent | 7 mantissa.
+    NaN requires all-one exponent (0xFF) and non-zero mantissa.
+    Canonical quiet NaN: 0x7FC0 (positive, mantissa msb set).
+    Negative quiet NaN:  0xFFC0 (negative, mantissa msb set).
+    Note: 0xFF80 has zero mantissa — that is negative infinity, not NaN.
+
+    Args:
+        raw_bits: Raw UInt16 bit pattern for a BF16 NaN value.
+
+    Returns:
+        Scalar ExTensor with DType.bfloat16 containing the given bit pattern.
+    """
+    var shape = List[Int]()
+    shape.append(1)
+    var tensor = ExTensor(shape, DType.bfloat16)
+    var ptr = tensor._data.bitcast[UInt16]()
+    ptr[] = raw_bits
+    return tensor^
+
+
+fn test_hash_bf16_nan_canonical() raises:
+    """Test that canonical BF16 NaN (0x7FC0) hashes consistently.
+
+    Two tensors with the same canonical NaN bit pattern must produce identical
+    hashes — NaN canonicalization must not depend on object identity.
+    """
+    var a = make_bf16_nan_tensor(0x7FC0)
+    var b = make_bf16_nan_tensor(0x7FC0)
+    var hash_a = hash(a)
+    var hash_b = hash(b)
+    assert_equal_int(
+        Int(hash_a),
+        Int(hash_b),
+        "Canonical BF16 NaN should hash consistently",
+    )
+
+
+fn test_hash_bf16_nan_negative() raises:
+    """Test that negative BF16 NaN (0xFFC0) hashes consistently.
+
+    0xFFC0 is a negative quiet NaN: sign=1, exponent=all-ones, mantissa=0x40.
+    Two tensors with the same negative NaN bit pattern must produce identical
+    hashes.
+    """
+    var a = make_bf16_nan_tensor(0xFFC0)
+    var b = make_bf16_nan_tensor(0xFFC0)
+    var hash_a = hash(a)
+    var hash_b = hash(b)
+    assert_equal_int(
+        Int(hash_a),
+        Int(hash_b),
+        "Negative BF16 NaN should hash consistently",
+    )
+
+
+fn test_hash_bf16_nan_canonicalization() raises:
+    """Test that canonical and negative BF16 NaN hash to the same value.
+
+    IEEE 754 NaN canonicalization: all NaN variants should produce the same
+    hash so tensors containing NaN behave correctly in sets/dicts. The
+    __hash__ implementation calls _get_float64 (which reinterprets BF16 raw
+    bits as Float32 via bit shift then promotes to Float64) then checks
+    isnan() to canonicalize before hashing. Both 0x7FC0 (positive quiet NaN)
+    and 0xFFC0 (negative quiet NaN) should map to the same hash value.
+    """
+    var canonical_nan = make_bf16_nan_tensor(0x7FC0)
+    var negative_nan = make_bf16_nan_tensor(0xFFC0)
+    var hash_canonical = hash(canonical_nan)
+    var hash_negative = hash(negative_nan)
+    assert_equal_int(
+        Int(hash_canonical),
+        Int(hash_negative),
+        "All BF16 NaN variants should canonicalize to same hash",
+    )
+
+
 # ============================================================================
 # Test diff() - consecutive differences
 # ============================================================================
@@ -964,6 +1047,12 @@ fn main() raises:
     test_hash_integer_dtype_consistent()
     test_hash_same_values_different_dtype()
     test_hash_empty_tensor_dtype_differs()
+
+    # __hash__ BF16 NaN canonicalization
+    print("  Testing __hash__ BF16 NaN canonicalization...")
+    test_hash_bf16_nan_canonical()
+    test_hash_bf16_nan_negative()
+    test_hash_bf16_nan_canonicalization()
 
     # diff()
     print("  Testing diff()...")


### PR DESCRIPTION
## Summary

- Fix `_get_float64` for bfloat16 to use raw bit manipulation instead of
  `Float64(Float32(BFloat16))` numeric cast, which could silently canonicalize
  unusual NaN mantissa bits before they reach the `isnan()` check in `__hash__`
- Add `make_bf16_nan_tensor` test helper that writes raw UInt16 bits directly
  via pointer cast (bypasses `_set_float64`) to create tensors with specific
  BF16 NaN bit patterns
- Add three tests confirming end-to-end BF16 NaN canonicalization works:
  - `test_hash_bf16_nan_canonical` — 0x7FC0 (positive quiet NaN) hashes consistently
  - `test_hash_bf16_nan_negative` — 0xFFC0 (negative quiet NaN) hashes consistently
  - `test_hash_bf16_nan_canonicalization` — both variants canonicalize to same hash

## Root Cause

BF16 occupies the upper 16 bits of Float32. The old conversion path
`Float32(BFloat16)` applied a numeric conversion that could lose NaN mantissa
bits. The fix reads the raw UInt16 bits, shifts left by 16, and bitcasts to
Float32 — preserving the full IEEE 754 NaN bit pattern through to the
`isnan()` check in `__hash__`.

**Important correction from the issue plan**: `0xFF80` in BF16 is negative
infinity (zero mantissa), not a NaN. Correct negative quiet NaN is `0xFFC0`
(sign=1, exp=all-ones, mantissa msb set).

## Test plan

- [x] `test_hash_bf16_nan_canonical` passes
- [x] `test_hash_bf16_nan_negative` passes
- [x] `test_hash_bf16_nan_canonicalization` passes
- [x] All existing hash tests continue to pass
- [x] Pre-commit hooks pass

Closes #4060

🤖 Generated with [Claude Code](https://claude.com/claude-code)