### PR TITLE
fix(tests): split test_vgg16_e2e.mojo to avoid JIT heap corruption

### DIFF
--- a/notes/blog/03-16-2026/artifacts/bug_repro_vgg16_e2e_part1_pre_fix.mojo.bug
+++ b/notes/blog/03-16-2026/artifacts/bug_repro_vgg16_e2e_part1_pre_fix.mojo.bug
@@ -1,7 +1,11 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_vgg16_e2e.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
+<<<<<<<< HEAD:notes/blog/03-16-2026/artifacts/bug_repro_vgg16_e2e_part1_pre_fix.mojo.bug
 """End-to-end tests for VGG-16 model on CIFAR-10 (Part 1 of 2).
+========
+"""End-to-end tests for VGG-16 model on CIFAR-10 (Part 2 of 2).
+>>>>>>>> 94996312 (fix(tests): split test_vgg16_e2e.mojo to avoid JIT heap corruption):tests/models/test_vgg16_e2e_part2.mojo
 
 VGG-16 Architecture:
 - Input: (batch, 3, 32, 32) CIFAR-10 images
@@ -17,6 +21,7 @@ VGG-16 Architecture:
   * FC 256 -> 256 + ReLU
   * FC 256 -> 10 (CIFAR-10 classes)
 
+<<<<<<<< HEAD:notes/blog/03-16-2026/artifacts/bug_repro_vgg16_e2e_part1_pre_fix.mojo.bug
 Part 1 Tests (forward pass and training):
 - Forward pass with realistic input shapes
 - Output shape verification (batch, 10)
@@ -27,6 +32,16 @@ Part 1 Tests (forward pass and training):
 
 See test_vgg16_e2e_part2.mojo for gradient flow, output range, shape
 progression, and numerical stability tests.
+========
+Part 2 Tests (gradient flow, output analysis, numerical stability):
+- Gradient flow through full model
+- Output range verification
+- Shape progression through blocks
+- NaN detection
+- Inf detection
+
+See test_vgg16_e2e_part1.mojo for forward pass and training tests.
+>>>>>>>> 94996312 (fix(tests): split test_vgg16_e2e.mojo to avoid JIT heap corruption):tests/models/test_vgg16_e2e_part2.mojo
 
 All tests use CIFAR-10 compatible shapes: (batch, 3, 32, 32)
 Batch sizes: 4 (inference) and 2 (training, small for speed)
@@ -181,6 +196,7 @@ fn vgg16_forward(
 
 
 # ============================================================================
+<<<<<<<< HEAD:notes/blog/03-16-2026/artifacts/bug_repro_vgg16_e2e_part1_pre_fix.mojo.bug
 # E2E Forward Pass Tests
 # ============================================================================
 
@@ -283,6 +299,22 @@ fn test_vgg16_e2e_forward_backward() raises:
 
     Note: Full parameter gradient computation is complex. This test
     validates that backward pass completes without error.
+========
+# Gradient Flow Tests
+# ============================================================================
+
+
+fn test_vgg16_e2e_gradient_flow() raises:
+    """Test that gradients can flow through VGG-16.
+
+    This is a simplified test checking:
+    - Forward pass completes
+    - Output is differentiable (not constant)
+    - Loss computation possible
+
+    Full gradient computation is complex and tested in
+    test_vgg16_layers.mojo in detail.
+>>>>>>>> 94996312 (fix(tests): split test_vgg16_e2e.mojo to avoid JIT heap corruption):tests/models/test_vgg16_e2e_part2.mojo
     """
     var batch_size = 2
 
@@ -294,6 +326,7 @@ fn test_vgg16_e2e_forward_backward() raises:
     input_shape.append(32)
     var input = ones(input_shape, DType.float32)
 
+<<<<<<<< HEAD:notes/blog/03-16-2026/artifacts/bug_repro_vgg16_e2e_part1_pre_fix.mojo.bug
     # Create target labels (0-9 for CIFAR-10)
     var target_shape = List[Int]()
     target_shape.append(batch_size)
@@ -356,3 +389,174 @@ fn main() raises:
     test_vgg16_e2e_inference_mode()
     print(" OK")
     print("All VGG16 E2E Tests (Part 1) passed!")
+========
+    # Forward pass
+    var output = vgg16_forward(input)
+
+    # Create gradient w.r.t. output (uniform gradients for simplicity)
+    var grad_output = ones(output.shape(), DType.float32)
+
+    # Gradient values should be non-trivial
+    var grad_output_sum = Float32(0.0)
+    var grad_output_data = grad_output._data.bitcast[Float32]()
+    for i in range(batch_size * 10):
+        grad_output_sum += grad_output_data[i]
+
+    # Verify gradients are meaningful (not zero)
+    assert_greater(grad_output_sum, Float32(0.0))
+
+
+# ============================================================================
+# Output Distribution Tests
+# ============================================================================
+
+
+fn test_vgg16_e2e_output_range() raises:
+    """Test VGG-16 produces outputs in reasonable range.
+
+    For logits, values should not be extreme (not NaN/inf).
+    Typical range: (-100, 100) for cross-entropy loss computation.
+    """
+    var batch_size = 2
+
+    # Create input
+    var input_shape = List[Int]()
+    input_shape.append(batch_size)
+    input_shape.append(3)
+    input_shape.append(32)
+    input_shape.append(32)
+    var input = ones(input_shape, DType.float32)
+
+    # Forward pass
+    var output = vgg16_forward(input)
+
+    # Check all output values are finite and in reasonable range
+    var output_data = output._data.bitcast[Float32]()
+    for i in range(batch_size * 10):
+        var val = output_data[i]
+        # Check not NaN (NaN != NaN)
+        assert_true(val == val)
+        # Check not too extreme
+        assert_less(val, Float32(1e6))
+        assert_greater(val, Float32(-1e6))
+
+
+# ============================================================================
+# E2E Shape Propagation Tests
+# ============================================================================
+
+
+fn test_vgg16_e2e_shape_progression() raises:
+    """Test shape changes through VGG-16 blocks.
+
+    Tracks shape transformations:
+    Input (b, 3, 32, 32)
+    -> Block1 (b, 64, 32, 32) -> Pool (b, 64, 16, 16)
+    -> Block2 (b, 128, 16, 16) -> Pool (b, 128, 8, 8)
+    -> Block3 (b, 256, 8, 8) -> Pool (b, 256, 4, 4)
+    -> Block4 (b, 512, 4, 4) -> Pool (b, 512, 2, 2)
+    -> Block5 (b, 512, 2, 2) -> Pool (b, 512, 1, 1)
+    -> FC layers
+    -> Output (b, 10)
+    """
+    var batch_size = 2
+
+    # Create input: (2, 3, 32, 32)
+    var input_shape = List[Int]()
+    input_shape.append(batch_size)
+    input_shape.append(3)
+    input_shape.append(32)
+    input_shape.append(32)
+    var input = ones(input_shape, DType.float32)
+
+    # Test full forward pass
+    var output = vgg16_forward(input)
+
+    # Verify final shape
+    var final_shape = output.shape()
+    assert_equal(final_shape[0], batch_size)
+    assert_equal(final_shape[1], 10)
+
+
+# ============================================================================
+# Numerical Stability Tests
+# ============================================================================
+
+
+fn test_vgg16_e2e_no_nans() raises:
+    """Test VGG-16 forward pass doesn't produce NaNs.
+
+    This is a critical smoke test for numerical stability.
+    """
+    var batch_size = 2
+
+    # Create input
+    var input_shape = List[Int]()
+    input_shape.append(batch_size)
+    input_shape.append(3)
+    input_shape.append(32)
+    input_shape.append(32)
+    var input = ones(input_shape, DType.float32)
+
+    # Forward pass
+    var output = vgg16_forward(input)
+
+    # Check no NaNs
+    var output_data = output._data.bitcast[Float32]()
+    for i in range(batch_size * 10):
+        var val = output_data[i]
+        # NaN != NaN check
+        assert_true(val == val)
+
+
+fn test_vgg16_e2e_no_infs() raises:
+    """Test VGG-16 forward pass doesn't produce Infs.
+
+    Prevents overflow from deep network.
+    """
+    var batch_size = 2
+
+    # Create input with normalized values
+    var input_shape = List[Int]()
+    input_shape.append(batch_size)
+    input_shape.append(3)
+    input_shape.append(32)
+    input_shape.append(32)
+    var input = zeros(input_shape, DType.float32)
+
+    # Fill with normalized values [0, 1]
+    var input_data = input._data.bitcast[Float32]()
+    for i in range(batch_size * 3 * 32 * 32):
+        input_data[i] = Float32(0.5)
+
+    # Forward pass
+    var output = vgg16_forward(input)
+
+    # Check no infinities
+    var output_data = output._data.bitcast[Float32]()
+    for i in range(batch_size * 10):
+        var val = output_data[i]
+        # Check finite
+        assert_less(val, Float32(1e10))
+        assert_greater(val, Float32(-1e10))
+
+
+fn main() raises:
+    print("Starting VGG16 E2E Tests (Part 2)...")
+    print("  test_vgg16_e2e_gradient_flow...", end="")
+    test_vgg16_e2e_gradient_flow()
+    print(" OK")
+    print("  test_vgg16_e2e_output_range...", end="")
+    test_vgg16_e2e_output_range()
+    print(" OK")
+    print("  test_vgg16_e2e_shape_progression...", end="")
+    test_vgg16_e2e_shape_progression()
+    print(" OK")
+    print("  test_vgg16_e2e_no_nans...", end="")
+    test_vgg16_e2e_no_nans()
+    print(" OK")
+    print("  test_vgg16_e2e_no_infs...", end="")
+    test_vgg16_e2e_no_infs()
+    print(" OK")
+    print("All VGG16 E2E Tests (Part 2) passed!")
+>>>>>>>> 94996312 (fix(tests): split test_vgg16_e2e.mojo to avoid JIT heap corruption):tests/models/test_vgg16_e2e_part2.mojo

--- a/tests/models/test_vgg16_e2e_part1.mojo
+++ b/tests/models/test_vgg16_e2e_part1.mojo
@@ -63,14 +63,16 @@ fn conv_block(
     """Apply a VGG conv block: sequential conv layers with ReLU.
 
     Args:
-        input_tensor: Input tensor.
-        out_channels: Output channels for conv layers.
-        num_convs: Number of consecutive conv layers to apply.
+        input_tensor: Input tensor
+        out_channels: Output channels for conv layers
+        num_convs: Number of consecutive conv layers to apply
 
     Returns:
-        Output tensor after all convolutions and ReLU activations.
+        Output tensor after all convolutions and ReLU activations
     """
     var in_channels = input_tensor.shape()[1]
+    var height = input_tensor.shape()[2]
+    var width = input_tensor.shape()[3]
     var result = input_tensor
 
     for _ in range(num_convs):
@@ -105,10 +107,10 @@ fn vgg16_forward(
     """Forward pass through VGG-16 model.
 
     Args:
-        input_tensor: Input batch (batch, 3, 32, 32).
+        input_tensor: Input batch (batch, 3, 32, 32)
 
     Returns:
-        Logits for 10 classes (batch, 10).
+        Logits for 10 classes (batch, 10)
     """
     var x = input_tensor
 
@@ -254,9 +256,10 @@ fn test_vgg16_e2e_forward_varying_values() raises:
     var input = zeros(input_shape, DType.float32)
 
     # Fill with mixed values (simulating normalized pixel values)
+    var input_data = input._data.bitcast[Float32]()
     for i in range(batch_size * 3 * 32 * 32):
         # Normalize to [0, 1] range roughly
-        input[i] = Float32((i % 256)) / 256.0
+        input_data[i] = Float32((i % 256)) / 256.0
 
     # Forward pass
     var output = vgg16_forward(input)
@@ -297,15 +300,18 @@ fn test_vgg16_e2e_forward_backward() raises:
     var target_shape = List[Int]()
     target_shape.append(batch_size)
     var target = zeros(target_shape, DType.float32)
-    target[0] = Float32(0.0)
-    target[1] = Float32(1.0)
+    var target_data = target._data.bitcast[Float32]()
+    target_data[0] = 0.0
+    target_data[1] = 1.0
 
     # Forward pass
     var logits = vgg16_forward(input)
 
     # Loss computation (simplified cross-entropy approximation)
     # Using MSE as proxy since cross_entropy_loss may not be available
-    # Verify logits have valid shape
+    var loss = logits  # Placeholder for loss computation
+
+    # Verify loss has valid shape
     assert_equal(logits.shape()[0], batch_size)
     assert_equal(logits.shape()[1], 10)
 

--- a/tests/models/test_vgg16_e2e_part2.mojo
+++ b/tests/models/test_vgg16_e2e_part2.mojo
@@ -45,7 +45,7 @@ from shared.core.linear import linear, linear_backward
 from shared.core.activation import relu, relu_backward
 from shared.core.pooling import maxpool2d, maxpool2d_backward
 from shared.core.loss import cross_entropy
-from shared.core.reduction import mean
+from shared.core import mean
 
 
 # ============================================================================
@@ -61,14 +61,16 @@ fn conv_block(
     """Apply a VGG conv block: sequential conv layers with ReLU.
 
     Args:
-        input_tensor: Input tensor.
-        out_channels: Output channels for conv layers.
-        num_convs: Number of consecutive conv layers to apply.
+        input_tensor: Input tensor
+        out_channels: Output channels for conv layers
+        num_convs: Number of consecutive conv layers to apply
 
     Returns:
-        Output tensor after all convolutions and ReLU activations.
+        Output tensor after all convolutions and ReLU activations
     """
     var in_channels = input_tensor.shape()[1]
+    var height = input_tensor.shape()[2]
+    var width = input_tensor.shape()[3]
     var result = input_tensor
 
     for _ in range(num_convs):
@@ -103,10 +105,10 @@ fn vgg16_forward(
     """Forward pass through VGG-16 model.
 
     Args:
-        input_tensor: Input batch (batch, 3, 32, 32).
+        input_tensor: Input batch (batch, 3, 32, 32)
 
     Returns:
-        Logits for 10 classes (batch, 10).
+        Logits for 10 classes (batch, 10)
     """
     var x = input_tensor
 
@@ -212,8 +214,9 @@ fn test_vgg16_e2e_gradient_flow() raises:
 
     # Gradient values should be non-trivial
     var grad_output_sum = Float32(0.0)
+    var grad_output_data = grad_output._data.bitcast[Float32]()
     for i in range(batch_size * 10):
-        grad_output_sum += grad_output[i]
+        grad_output_sum += grad_output_data[i]
 
     # Verify gradients are meaningful (not zero)
     assert_greater(grad_output_sum, Float32(0.0))
@@ -227,9 +230,8 @@ fn test_vgg16_e2e_gradient_flow() raises:
 fn test_vgg16_e2e_output_range() raises:
     """Test VGG-16 produces outputs in reasonable range.
 
-    Note: With all-ones weights, values grow exponentially through 13 conv
-    layers. We check that outputs are not NaN. Large finite values are
-    expected with non-trained weights.
+    For logits, values should not be extreme (not NaN/inf).
+    Typical range: (-100, 100) for cross-entropy loss computation.
     """
     var batch_size = 2
 
@@ -244,10 +246,15 @@ fn test_vgg16_e2e_output_range() raises:
     # Forward pass
     var output = vgg16_forward(input)
 
-    # Check output shape and that values are not NaN
-    var output_shape = output.shape()
-    assert_equal(output_shape[0], batch_size)
-    assert_equal(output_shape[1], 10)
+    # Check all output values are finite and in reasonable range
+    var output_data = output._data.bitcast[Float32]()
+    for i in range(batch_size * 10):
+        var val = output_data[i]
+        # Check not NaN (NaN != NaN)
+        assert_true(val == val)
+        # Check not too extreme
+        assert_less(val, Float32(1e6))
+        assert_greater(val, Float32(-1e6))
 
 
 # ============================================================================
@@ -311,18 +318,17 @@ fn test_vgg16_e2e_no_nans() raises:
     var output = vgg16_forward(input)
 
     # Check no NaNs
+    var output_data = output._data.bitcast[Float32]()
     for i in range(batch_size * 10):
-        var val = output[i]
+        var val = output_data[i]
         # NaN != NaN check
         assert_true(val == val)
 
 
 fn test_vgg16_e2e_no_infs() raises:
-    """Test VGG-16 forward pass completes with varied input.
+    """Test VGG-16 forward pass doesn't produce Infs.
 
-    Note: With all-ones weights, values grow exponentially through 13 conv
-    layers regardless of input scaling. We verify the forward pass
-    completes and produces the correct output shape.
+    Prevents overflow from deep network.
     """
     var batch_size = 2
 
@@ -335,16 +341,20 @@ fn test_vgg16_e2e_no_infs() raises:
     var input = zeros(input_shape, DType.float32)
 
     # Fill with normalized values [0, 1]
+    var input_data = input._data.bitcast[Float32]()
     for i in range(batch_size * 3 * 32 * 32):
-        input[i] = Float32(0.5)
+        input_data[i] = Float32(0.5)
 
     # Forward pass
     var output = vgg16_forward(input)
 
-    # Verify output shape
-    var output_shape = output.shape()
-    assert_equal(output_shape[0], batch_size)
-    assert_equal(output_shape[1], 10)
+    # Check no infinities
+    var output_data = output._data.bitcast[Float32]()
+    for i in range(batch_size * 10):
+        var val = output_data[i]
+        # Check finite
+        assert_less(val, Float32(1e10))
+        assert_greater(val, Float32(-1e10))
 
 
 fn main() raises:


### PR DESCRIPTION
## Summary

- Split `tests/models/test_vgg16_e2e.mojo` (10 tests) into two files of 5 tests each, following the ADR-009 workaround pattern already applied to `test_vgg16_layers.mojo`
- The crash at the 4th sequential `vgg16_forward()` call is caused by Mojo v0.26.1 JIT heap corruption (`libKGENCompilerRTShared.so`) under high test load
- No CI workflow changes needed — the `"Models"` matrix job uses `pattern: "test_*.mojo"` which auto-discovers both part files

## Changes Made

- **Created** `tests/models/test_vgg16_e2e_part1.mojo` — 5 tests: forward inference, small batch, varying values, forward+backward, inference mode
- **Created** `tests/models/test_vgg16_e2e_part2.mojo` — 5 tests: gradient flow, output range, shape progression, no NaNs, no Infs
- **Deleted** `tests/models/test_vgg16_e2e.mojo` — replaced by the two part files

Both new files include the ADR-009 header comment and duplicate the shared `conv_block` / `vgg16_forward` helpers (Mojo has no `include` mechanism).

## Verification

```bash
grep -c "^fn test_" tests/models/test_vgg16_e2e_part1.mojo  # 5
grep -c "^fn test_" tests/models/test_vgg16_e2e_part2.mojo  # 5
```

CI will run both files via `pattern: "test_*.mojo"` auto-discovery.

Closes #4511