### PR TITLE
fix: address repository audit findings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# EditorConfig — cross-editor formatting consistency
+# https://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.{json,toml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[justfile]
+indent_style = space
+indent_size = 4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -73,6 +73,7 @@ jobs:
         run: pip install semgrep
 
       - name: Run Semgrep
+        id: semgrep
         run: semgrep scan --config auto --sarif --output semgrep.sarif .
         continue-on-error: true
 
@@ -83,6 +84,11 @@ jobs:
             echo "⚠️ Semgrep did not produce SARIF output, created empty SARIF file"
           fi
           ls -la semgrep.sarif
+
+      - name: Warn on Semgrep findings
+        if: steps.semgrep.outcome == 'failure'
+        run: |
+          echo "::warning::Semgrep found potential security issues — review SARIF results in the Security tab"
 
       - name: Upload SARIF results
         if: always()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -160,13 +160,6 @@ repos:
         language: system
         files: ^README\.md$
         pass_filenames: false
-      - id: check-test-count-badge
-        name: Check Test Count Badge
-        description: Validate README.md test count badge matches actual test_*.mojo count
-        entry: python3 scripts/check_test_count_badge.py
-        language: system
-        files: ^README\.md$
-        pass_filenames: false
       - id: validate-adr009-headers
         name: Validate ADR-009 Headers
         description: Ensure all test_*_part*.mojo files have ADR-009 split docstring (Issue #2942)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ ML Odyssey is a research platform with two goals:
 2. **Provide a reusable shared library** of ML components that paper implementations build on
 
 The project currently has ~198K lines of Mojo code, 7 fully-implemented neural network
-architectures, and 223+ tests across layerwise unit tests and end-to-end integration tests.
+architectures, and 498+ tests across layerwise unit tests and end-to-end integration tests.
 
 ## Implemented Architectures
 


### PR DESCRIPTION
## Summary

- **Remove duplicate pre-commit hook**: `check-test-count-badge` was defined twice identically in `.pre-commit-config.yaml` (lines 156-169), running the same check twice per commit. Removed the duplicate (DRY violation from audit Section 4).
- **Fix README test count inconsistency**: Prose stated "223+ tests" while badge showed "498+". Updated prose to match badge (audit Section 2 finding).
- **Add `.editorconfig`**: Cross-editor formatting consistency for indent style, line endings, charset. Covers Mojo, Python, YAML, JSON, Markdown, and Makefiles (audit Section 13 finding).
- **Surface Semgrep SAST findings**: Added a warning annotation step after Semgrep scan so findings appear in CI annotations rather than being silently swallowed by `continue-on-error: true` (audit Section 8 finding).

## Test plan

- [x] Pre-commit hooks pass locally (all 23 hooks)
- [x] `check-test-count-badge` hook validates badge/prose consistency
- [ ] CI workflows pass on this PR
- [ ] Verify Semgrep warning step produces `::warning::` annotation when findings exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)