### PR TITLE
fix(ci): resolve main branch CI failures

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -43,13 +43,13 @@ jobs:
       - name: Build shared package (debug mode)
         run: |
           echo "Building shared Mojo package in debug mode..."
-          just build
+          NATIVE=1 just build
           echo "✓ Build succeeded"
 
       - name: Validate package compilation
         run: |
           echo "Running validation-only package compilation..."
-          just package
+          NATIVE=1 just package
           echo "✓ Package validation succeeded"
 
       - name: Report build status

--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -238,7 +238,7 @@ jobs:
                           # split it into two separate entries. See Issue #3357 for monitoring
                           # guidance and ADR-009 for heap corruption splitting constraints.
     strategy:
-      fail-fast: true  # Stop early on first failure to save compute
+      fail-fast: false  # Run all test groups even if one fails
       matrix:
         test-group:
           # IMPORTANT: The 'pattern' field accepts space-separated LITERAL filenames only,
@@ -718,10 +718,10 @@ jobs:
         uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b  # v3
 
       - name: Build project
-        run: just build
+        run: NATIVE=1 just build
 
       - name: Validate package
-        run: just package
+        run: NATIVE=1 just package
 
   # ============================================================================
   # Gradient Checking Tests (absorbed from test-gradients.yml)

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -199,10 +199,10 @@ jobs:
 
       - name: Lint notebook markdown
         run: |
-          echo "Checking notebook markdown..."
+          echo "Checking notebook structure..."
           for notebook in notebooks/*.ipynb; do
             if [ -f "$notebook" ]; then
-              python3 check_notebooks.py "$notebook" || exit 1
+              python3 -c "import json; json.load(open('$notebook'))" || { echo "❌ Invalid JSON: $notebook"; exit 1; }
             fi
           done
           echo "✅ Notebook markdown looks good"


### PR DESCRIPTION
## Summary
- **Fix 1A**: Replace missing `check_notebooks.py` reference in pre-commit workflow with inline JSON validation (the test suite already does comprehensive notebook validation)
- **Fix 1B**: Change `fail-fast: true` to `fail-fast: false` in comprehensive-tests matrix to match workflow smoke test assertion
- **Fix 1C**: Add `NATIVE=1` to build-validation jobs in both `comprehensive-tests.yml` and `build-validation.yml` to avoid broken Docker Mojo stdlib

## Test plan
- [ ] Pre-commit Checks workflow passes (lint-notebooks step no longer references missing script)
- [ ] Workflow Smoke Tests pass (fail-fast: false is now present)
- [ ] Build Validation job passes in comprehensive-tests (NATIVE=1 uses host Mojo)
- [ ] Standalone build-validation workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)