### PR TITLE
fix(mojo): replace deprecated alias with comptime in extensor.mojo

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -54,8 +54,8 @@ comptime WARN_TENSOR_BYTES: Int = 500_000_000  # 500 MB warning threshold
 
 # Print options for ExTensor.__str__ and __repr__ truncation
 # Can be modified globally to control output behavior (e.g., in test utilities)
-alias EXTENSOR_PRINT_THRESHOLD: Int = 1000  # Truncate if numel > threshold
-alias EXTENSOR_PRINT_SHOW_ELEMENTS: Int = 3  # Show first/last N elements
+comptime EXTENSOR_PRINT_THRESHOLD: Int = 1000  # Truncate if numel > threshold
+comptime EXTENSOR_PRINT_SHOW_ELEMENTS: Int = 3  # Show first/last N elements
 
 
 struct ExTensor(


### PR DESCRIPTION
## Summary
- Replace deprecated `alias` keyword with `comptime` for module-level constants in `shared/core/extensor.mojo`
- Fixes `--Werror` compilation failures in build-validation CI where deprecation warnings are treated as errors

## Test plan
- [ ] Build Validation CI passes (no more `alias` deprecation errors with `--Werror`)
- [ ] Mojo Package Compilation still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)