### PR TITLE
fix(ci): Docker Mojo stdlib + ExTensor.split() circular import

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,10 @@ RUN pixi run pip install --upgrade pip pre-commit
 # Install pre-commit hooks (cached unless .pre-commit-config.yaml changes)
 RUN pixi run pre-commit install --install-hooks || true
 
+# Copy entrypoint script for container initialization
+COPY --chown=${USER_NAME}:${USER_NAME} docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 # Copy the rest of the workspace (invalidates only layers after this)
 COPY --chown=${USER_NAME}:${USER_NAME} . .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,11 @@ services:
     image: projectodyssey:dev
     volumes:
       - .:/workspace:delegated
+      - workspace-pixi:/workspace/.pixi
       - pixi-cache:${HOME}/.pixi
       - pre-commit-cache:/home/dev/.cache/pre-commit
       - ${HOME}/.gitconfig:/home/dev/.gitconfig:ro
+    entrypoint: ["/usr/local/bin/entrypoint.sh"]
     environment:
       - HOME=/home/dev
       - USER_ID=${USER_ID}
@@ -40,7 +42,9 @@ services:
     image: projectodyssey:ci
     volumes:
       - .:/workspace
+      - workspace-pixi:/workspace/.pixi
       - pixi-cache:${HOME}/.pixi
+    entrypoint: ["/usr/local/bin/entrypoint.sh"]
     environment:
       - HOME=/home/dev
       - USER_ID=${USER_ID}
@@ -75,4 +79,6 @@ volumes:
   pixi-cache:
     driver: local
   pre-commit-cache:
+    driver: local
+  workspace-pixi:
     driver: local

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+# Ensure the workspace .pixi environment is functional.
+# The named volume at /workspace/.pixi shadows the bind-mounted host .pixi/,
+# but starts empty on first run. Run pixi install to populate it if needed.
+if [ ! -x ".pixi/envs/default/bin/mojo" ]; then
+    echo "Initializing pixi environment inside container..."
+    pixi install
+fi
+
+exec "$@"

--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -3438,7 +3438,7 @@ struct ExTensor(
             var parts = a.split(3)  # 3 parts of size 4 each
         ```
         """
-        from shared.core.shape import split as split_fn
+        from .shape import split as split_fn
 
         return split_fn(self, num_splits, axis)
 
@@ -3472,7 +3472,7 @@ struct ExTensor(
             # parts[2].shape() = (3,)  # indices 7-9
         ```
         """
-        from shared.core.shape import split_with_indices as split_with_indices_fn
+        from .shape import split_with_indices as split_with_indices_fn
 
         return split_with_indices_fn(self, split_indices, axis)
 


### PR DESCRIPTION
## Summary

- **Docker fix**: Add `workspace-pixi` named volume to shadow host `.pixi/` bind mount, preventing CI runner's native Mojo binaries from breaking `module 'std'` resolution inside containers. Add entrypoint script that runs `pixi install` on first container start.
- **Import fix**: Change `ExTensor.split()` and `split_with_indices()` from absolute imports (`from shared.core.shape import ...`) to relative imports (`from .shape import ...`), fixing type identity mismatch that caused `cannot be converted from 'ExTensor' to 'ExTensor'` errors.
- **Remove native execution from CI**: Remove `setup-pixi` and `NATIVE=1` from all workflows that route through Docker via justfile. All Mojo compilation and testing must run inside the container, not natively on the runner.

## Changes Made

| File | Change |
|------|--------|
| `docker/entrypoint.sh` | New entrypoint ensuring pixi env exists in container |
| `Dockerfile` | Copy entrypoint into image |
| `docker-compose.yml` | Add `workspace-pixi` volume + entrypoint to dev/ci services |
| `shared/core/extensor.mojo` | Relative imports for `split` and `split_with_indices` |
| `comprehensive-tests.yml` | Remove all `setup-pixi` steps, `NATIVE=1`, direct `pixi run mojo` calls |
| `build-validation.yml` | Remove `setup-pixi` step |
| `training-tests-weekly.yml` | Remove `setup-pixi` step |

## Test plan

- [ ] Comprehensive Tests workflow: no more `unable to locate module 'std'` errors
- [ ] Build Validation workflow: no more `ExTensor` type conversion errors
- [ ] All test jobs run inside Docker containers, not natively
- [ ] No `NATIVE=1` or `setup-pixi` in any workflow that uses `just` commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)