### PR TITLE
fix(tests): correct transpose_view import in test_arithmetic_noncontiguous_part1

### DIFF
--- a/tests/shared/core/test_arithmetic_noncontiguous_part1.mojo
+++ b/tests/shared/core/test_arithmetic_noncontiguous_part1.mojo
@@ -19,7 +19,8 @@ from tests.shared.conftest import (
 )
 from shared.core.extensor import ExTensor, zeros, ones, full, arange
 from shared.core.arithmetic import add, subtract, multiply, divide
-from shared.core.shape import transpose_view, as_contiguous
+from shared.core.matrix import transpose_view
+from shared.core.shape import as_contiguous
 
 
 fn _make_noncontiguous_2x3() raises -> ExTensor:


### PR DESCRIPTION
## Summary
- Fix incorrect import: `transpose_view` is in `shared.core.matrix`, not `shared.core.shape`
- Split single import into two: `transpose_view` from `matrix`, `as_contiguous` from `shape`

## Test plan
- [ ] CI passes compilation of `test_arithmetic_noncontiguous_part1.mojo`
- [ ] Existing test suite remains green

🤖 Generated with [Claude Code](https://claude.com/claude-code)