### PR TITLE
fix(tests): correct transpose_view import in test_arithmetic_noncontiguous_part2

### DIFF
--- a/tests/shared/core/test_arithmetic_noncontiguous_part2.mojo
+++ b/tests/shared/core/test_arithmetic_noncontiguous_part2.mojo
@@ -20,7 +20,8 @@ from tests.shared.conftest import (
 )
 from shared.core.extensor import ExTensor, zeros, ones, full, arange
 from shared.core.arithmetic import add, subtract, multiply
-from shared.core.shape import transpose_view, as_contiguous
+from shared.core.matrix import transpose_view
+from shared.core.shape import as_contiguous
 
 
 fn _make_nc_2x3() raises -> ExTensor:


### PR DESCRIPTION
## Summary
- Fix compilation error `module 'shape' does not contain 'transpose_view'` in `test_arithmetic_noncontiguous_part2.mojo`
- `transpose_view` lives in `shared.core.matrix`, not `shared.core.shape`; split the import accordingly

## Changes Made
- Split `from shared.core.shape import transpose_view, as_contiguous` into two imports:
  - `from shared.core.matrix import transpose_view`
  - `from shared.core.shape import as_contiguous`

## Test plan
- [ ] CI passes: the test file compiles and all 9 tests in `test_arithmetic_noncontiguous_part2` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)