### PR TITLE
fix(tests): convert full() fill_value args to Float64 in test_extensor_int_str

### DIFF
--- a/tests/shared/core/test_extensor_int_str.mojo
+++ b/tests/shared/core/test_extensor_int_str.mojo
@@ -20,7 +20,7 @@ fn test_str_int8() raises:
 
 fn test_str_int16() raises:
     """Test __str__ for int16 tensor."""
-    var t = full([3], Int16(1000), DType.int16)
+    var t = full([3], Float64(1000), DType.int16)
     var s = String(t)
     assert_true(s.startswith("ExTensor(["))
     assert_true("1000" in s)
@@ -29,7 +29,7 @@ fn test_str_int16() raises:
 
 fn test_str_int32() raises:
     """Test __str__ for int32 tensor."""
-    var t = full([3], Int32(100000), DType.int32)
+    var t = full([3], Float64(100000), DType.int32)
     var s = String(t)
     assert_true(s.startswith("ExTensor(["))
     assert_true("100000" in s)
@@ -38,7 +38,7 @@ fn test_str_int32() raises:
 
 fn test_str_int64() raises:
     """Test __str__ for int64 tensor."""
-    var t = full([3], Int64(9999999999), DType.int64)
+    var t = full([3], Float64(9999999999), DType.int64)
     var s = String(t)
     assert_true(s.startswith("ExTensor(["))
     assert_true("9999999999" in s)
@@ -56,7 +56,7 @@ fn test_str_uint8() raises:
 
 fn test_str_uint16() raises:
     """Test __str__ for uint16 tensor."""
-    var t = full([3], UInt16(65535), DType.uint16)
+    var t = full([3], Float64(65535), DType.uint16)
     var s = String(t)
     assert_true(s.startswith("ExTensor(["))
     assert_true("65535" in s)
@@ -65,7 +65,7 @@ fn test_str_uint16() raises:
 
 fn test_str_uint32() raises:
     """Test __str__ for uint32 tensor."""
-    var t = full([3], UInt32(4294967295), DType.uint32)
+    var t = full([3], Float64(4294967295), DType.uint32)
     var s = String(t)
     assert_true(s.startswith("ExTensor(["))
     assert_true("4294967295" in s)
@@ -74,7 +74,7 @@ fn test_str_uint32() raises:
 
 fn test_str_uint64() raises:
     """Test __str__ for uint64 tensor."""
-    var t = full([3], UInt64(18446744073709551615), DType.uint64)
+    var t = full([3], Float64(18446744073709551615), DType.uint64)
     var s = String(t)
     assert_true(s.startswith("ExTensor(["))
     assert_true("18446744073709551615" in s)


### PR DESCRIPTION
## Summary
- Wrap non-Float64 fill values with `Float64()` in `full()` calls in `test_extensor_int_str.mojo`
- Fixes compile error: `'full': cannot convert 'Int16' to 'Float64'`
- 6 calls fixed: Int16, Int32, Int64, UInt16, UInt32, UInt64 all converted to Float64

## Test plan
- [ ] CI passes `mojo build` on the test file without type conversion errors
- [ ] Existing test logic unchanged -- only the fill_value wrapper differs

Generated with [Claude Code](https://claude.com/claude-code)