### PR TITLE
fix(tests): convert full() fill_value args to Float64 in test_hash

### DIFF
--- a/tests/shared/core/test_hash.mojo
+++ b/tests/shared/core/test_hash.mojo
@@ -430,8 +430,8 @@ fn test_hash_integer_dtype_distinct() raises:
     """Integer tensors with different values hash differently."""
     var shape = List[Int]()
     shape.append(3)
-    var a = full(shape, Int32(100), DType.int32)
-    var b = full(shape, Int32(101), DType.int32)
+    var a = full(shape, Float64(100), DType.int32)
+    var b = full(shape, Float64(101), DType.int32)
     if hash(a) == hash(b):
         raise Error("int32 tensors with different values should hash differently")
 


### PR DESCRIPTION
## Summary
- Fix compile error in `test_hash_integer_dtype_distinct()` where `full()` was called with `Int32` fill values instead of the required `Float64`

## Changes Made
- Wrap `Int32(100)` and `Int32(101)` with `Float64()` to match the `full()` function signature: `fn full(shape: List[Int], fill_value: Float64, dtype: DType) raises -> ExTensor`

## Files Modified
- `tests/shared/core/test_hash.mojo` (lines 433-434)

## Verification
- Error `'full': cannot convert 'Int32' to 'Float64'` is resolved by using `Float64(100)` and `Float64(101)`

Closes #10