### PR TITLE
fix(tests): remove unexpected character in gradient checker noncont test

### DIFF
--- a/tests/shared/testing/test_gradient_checker_noncont_tensors.mojo
+++ b/tests/shared/testing/test_gradient_checker_noncont_tensors.mojo
@@ -57,7 +57,7 @@ fn relu_backward(grad_out: ExTensor, x: ExTensor) raises -> ExTensor:
     for i in range(x.numel()):
         var grad = grad_out._get_float64(i)
         var x_val = x._get_float64(i)
-        result._set_float64(i, x_val > 0.0 ? grad : 0.0)
+        result._set_float64(i, grad if x_val > 0.0 else 0.0)
     return result^
 
 


### PR DESCRIPTION
## Summary
- Fix syntax error on line 60 of `test_gradient_checker_noncont_tensors.mojo`
- Replace C-style ternary operator (`x_val > 0.0 ? grad : 0.0`) with Mojo's if/else expression (`grad if x_val > 0.0 else 0.0`)

## Test plan
- [ ] CI passes compilation of the test file without "unexpected character" error
- [ ] Existing gradient checker tests continue to pass

Closes #28