### PR TITLE
fix(tests): add missing assert_shape import in test_lars_part1

### DIFF
--- a/tests/shared/training/test_lars_part1.mojo
+++ b/tests/shared/training/test_lars_part1.mojo
@@ -22,6 +22,7 @@ from tests.shared.conftest import (
     assert_almost_equal,
     assert_less,
     assert_greater,
+    assert_shape,
     create_test_vector,
     TestFixtures,
 )


### PR DESCRIPTION
## Summary
- Add missing `assert_shape` import from `tests.shared.conftest` in `test_lars_part1.mojo`
- Fixes compile error: `use of unknown declaration 'assert_shape'`

## Test plan
- [ ] CI build passes (the test file now compiles)
- [ ] `test_lars_initialization()` uses `assert_shape` successfully

Closes #21