### PR TITLE
fix(tests): add missing assert_shape import in test_optimizers_part1

### DIFF
--- a/tests/shared/training/test_optimizers_part1.mojo
+++ b/tests/shared/training/test_optimizers_part1.mojo
@@ -22,6 +22,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_almost_equal,
     assert_less,
+    assert_shape,
     create_test_vector,
     TestFixtures,
 )


### PR DESCRIPTION
## Summary
- Add missing `assert_shape` import from `tests.shared.conftest` in `test_optimizers_part1.mojo`
- Fixes `use of unknown declaration 'assert_shape'` compile error

## Test plan
- [ ] CI build validation passes (the file now compiles without the unknown declaration error)

Closes #22

Generated with [Claude Code](https://claude.com/claude-code)