### PR TITLE
fix(tests): add missing kernel_w argument in test_packaging

### DIFF
--- a/tests/shared/integration/test_packaging.mojo
+++ b/tests/shared/integration/test_packaging.mojo
@@ -114,7 +114,7 @@ fn test_layer_root_level_imports() raises:
     assert_true(out_shape[1] == 2, "Linear output features should be 2")
 
     # Smoke-test: Conv2D alias resolves to Conv2dLayer
-    var conv = Conv2D(1, 4, 3)
+    var conv = Conv2D(1, 4, 3, 3)
     assert_true(True, "Conv2D alias should resolve to Conv2dLayer")
 
     # Smoke-test: ReLU alias resolves to ReLULayer


### PR DESCRIPTION
## Summary
- Conv2dLayer constructor now requires separate `kernel_h` and `kernel_w` parameters
- The `Conv2D` smoke test in `test_layer_root_level_imports` was passing only 3 positional args (`in_channels`, `out_channels`, `kernel_h`) but missing `kernel_w`
- Fixed by adding the fourth argument: `Conv2D(1, 4, 3, 3)`

## Test plan
- [ ] CI passes the `test_packaging.mojo` integration tests
- [ ] No other Conv2dLayer constructor calls are missing `kernel_w`

🤖 Generated with [Claude Code](https://claude.com/claude-code)