### PR TITLE
fix(tests): add missing subtract/multiply imports in test_training_loop

### DIFF
--- a/tests/shared/training/test_training_loop.mojo
+++ b/tests/shared/training/test_training_loop.mojo
@@ -33,7 +33,7 @@ from tests.shared.conftest import (
 from shared.training import SGD, MSELoss, TrainingLoop
 from shared.training.trainer_interface import DataLoader
 from shared.core.extensor import ExTensor
-from shared.core import ones, zeros, randn
+from shared.core import ones, zeros, randn, subtract, multiply
 from shared.testing import SimpleMLP
 
 # TrainingLoop is generic with trait bounds for compile-time type safety.


### PR DESCRIPTION
## Summary
- Add missing `subtract` and `multiply` imports from `shared.core` in `test_training_loop.mojo`
- These functions are used in `test_run_epoch_with_batches` (lines 736-737) but were not imported, causing `use of unknown declaration` compilation errors

## Files Modified
- `tests/shared/training/test_training_loop.mojo` - Added `subtract, multiply` to the `shared.core` import line

## Test plan
- [ ] CI compilation passes for `test_training_loop.mojo`
- [ ] `test_run_epoch_with_batches` resolves `subtract` and `multiply` without error

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)