### PR TITLE
fix(tests): add missing check_gradients_verbose import

### DIFF
--- a/tests/shared/testing/test_gradient_checker_meta_part2.mojo
+++ b/tests/shared/testing/test_gradient_checker_meta_part2.mojo
@@ -29,6 +29,7 @@ References:
 from testing import assert_true, assert_equal
 from shared.testing import (
     check_gradients,
+    check_gradients_verbose,
     compute_numerical_gradient,
     relative_error,
 )


### PR DESCRIPTION
## Summary
- Add missing `check_gradients_verbose` import to `test_gradient_checker_meta_part2.mojo`

The test file calls `check_gradients_verbose` on line 312 but never imported it, causing a compile error: `use of unknown declaration 'check_gradients_verbose'`. The function exists in `shared/testing/gradient_checker.mojo` and is already exported via `shared/testing/__init__.mojo` -- it simply needed to be added to the test file's import list.

## Files Modified
- `tests/shared/testing/test_gradient_checker_meta_part2.mojo` -- added `check_gradients_verbose` to imports

## Test plan
- [ ] CI compiles `test_gradient_checker_meta_part2.mojo` without errors
- [ ] All gradient checker meta-tests pass

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)