### PR TITLE
fix(tests): use /tmp for temp files in test_integration_part2

### DIFF
--- a/tests/configs/test_integration_part2.mojo
+++ b/tests/configs/test_integration_part2.mojo
@@ -118,7 +118,7 @@ fn test_config_save_and_reload() raises:
     var config = load_experiment_config("lenet5", "baseline")
 
     # Save to temporary file
-    var temp_path = "tests/configs/fixtures/temp_config.yaml"
+    var temp_path = "/tmp/temp_config.yaml"
     config.to_yaml(temp_path)
 
     # Reload and verify


### PR DESCRIPTION
## Summary
- Fix `Permission denied: temp_config.yaml` error in Docker by writing temp files to `/tmp/` instead of the working directory

## Changes Made
- Changed `test_config_save_and_reload()` temp file path from `tests/configs/fixtures/temp_config.yaml` to `/tmp/temp_config.yaml`

## Test plan
- [ ] CI passes with the updated path
- [ ] `test_config_save_and_reload` no longer fails with permission errors in Docker

Closes #39