### PR TITLE
fix(tests): use /tmp for temp directories in test_model_utils

### DIFF
--- a/tests/shared/test_model_utils.mojo
+++ b/tests/shared/test_model_utils.mojo
@@ -36,7 +36,7 @@ fn test_save_load_model_weights() raises:
     names.append("fc1_weights")
 
     # Create temp directory
-    var tmpdir = "test_model_weights"
+    var tmpdir = "/tmp/test_model_weights"
 
     try:
         # Save weights


### PR DESCRIPTION
## Summary
- Fix Docker permission error (`Failed to create directory: test_model_weights`) by using `/tmp/test_model_weights` instead of a relative path

## Changes
- `tests/shared/test_model_utils.mojo` line 39: changed `"test_model_weights"` to `"/tmp/test_model_weights"`

## Test plan
- [ ] CI passes (test_model_utils no longer fails with directory creation error in Docker)

Closes #41