### PR TITLE
fix(tests): use /tmp for temp files in test_serialization

### DIFF
--- a/tests/shared/test_serialization.mojo
+++ b/tests/shared/test_serialization.mojo
@@ -93,8 +93,8 @@ fn test_single_tensor_serialization() raises:
     var shape: List[Int] = [2, 3]
     var tensor = full(shape, 3.14, DType.float32)
 
-    # Create temp file
-    var tmpfile = "test_tensor_serialization.tmp"
+    # Create temp file in /tmp to avoid Docker permission issues
+    var tmpfile = "/tmp/test_tensor_serialization.tmp"
 
     try:
         # Save tensor
@@ -132,7 +132,7 @@ fn test_tensor_with_name() raises:
     var shape: List[Int] = [2, 2]
     var tensor = ones(shape, DType.float32)
 
-    var tmpfile = "test_named_tensor.tmp"
+    var tmpfile = "/tmp/test_named_tensor.tmp"
 
     try:
         # Save with name


### PR DESCRIPTION
## Summary
- Fix `Permission denied: test_tensor_serialization.tmp` error in Docker by using `/tmp/` prefix for temp file paths in `test_single_tensor_serialization` and `test_tensor_with_name`

## Changes Made
- `tests/shared/test_serialization.mojo`: Changed temp file paths from relative (`test_tensor_serialization.tmp`, `test_named_tensor.tmp`) to absolute (`/tmp/test_tensor_serialization.tmp`, `/tmp/test_named_tensor.tmp`)
- Other tests in the same file already used `_create_temp_dir()` which writes to `/tmp/`, so this makes the two outlier tests consistent

## Test plan
- [ ] CI passes with the updated temp file paths
- [ ] No permission denied errors in Docker test runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)