### PR TITLE
fix(core): add integer type support to _set_float64 and _set_float32

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -1256,6 +1256,9 @@ struct ExTensor(
         elif self._dtype == DType.float64:
             var ptr = (self._data + offset).bitcast[Float64]()
             ptr[] = value
+        else:
+            # For integer types, truncate Float64 to Int64 and delegate
+            self._set_int64(index, Int64(value))
 
     fn _get_float32(self, index: Int) -> Float32:
         """Internal: Get value at index as Float32 (assumes float-compatible dtype).
@@ -1316,6 +1319,9 @@ struct ExTensor(
         elif self._dtype == DType.bfloat16:
             var ptr = (self._data + offset).bitcast[BFloat16]()
             ptr[] = value.cast[DType.bfloat16]()
+        else:
+            # For integer types, truncate Float32 to Int64 and delegate
+            self._set_int64(index, Int64(value))
 
     fn _get_int64(self, index: Int) -> Int64:
         """Internal: Get value at index as Int64 (assumes integer-compatible dtype).


### PR DESCRIPTION
## Summary

- `ExTensor._set_float64()` and `_set_float32()` were missing `else` branches for integer dtypes (int8, int16, int32, int64, uint8, etc.), causing writes to silently do nothing
- This broke `test_int8_set_float64_truncates_to_int8` and `test_int8_set_float32_truncates_to_int8` in `test_extensor_dtype_roundtrip.mojo` -- writing `42.0` to an int8 tensor via `_set_float64` was ignored, reading back `0.0`
- The fix adds `else` branches that delegate to `_set_int64()` with `Int64(value)` truncation, matching the existing pattern already used elsewhere in ExTensor

## Test plan

- [ ] CI passes `test_extensor_dtype_roundtrip.mojo` -- specifically `test_int8_set_float64_truncates_to_int8` and `test_int8_set_float32_truncates_to_int8`
- [ ] No regressions in other dtype roundtrip tests (float16, float32, float64, bfloat16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)