### PR TITLE
fix(tests): use /tmp for temp files in test_io_helpers_part2

### DIFF
--- a/tests/shared/fixtures/io_helpers.mojo
+++ b/tests/shared/fixtures/io_helpers.mojo
@@ -46,8 +46,12 @@ fn create_temp_dir(prefix: String = "ml_odyssey_test_") raises -> String:
         in test teardown or try/finally block.
     """
     # Use Python's tempfile.mkdtemp for atomic directory creation
+    # Explicitly use /tmp as base to avoid permission issues in Docker
+    # containers where TMPDIR may point to a non-writable directory
     var tempfile = Python.import_module("tempfile")
-    var temp_path = tempfile.mkdtemp(prefix=PythonObject(prefix))
+    var temp_path = tempfile.mkdtemp(
+        prefix=PythonObject(prefix), dir=PythonObject("/tmp")
+    )
     return String(temp_path)
 
 
@@ -86,8 +90,9 @@ fn cleanup_temp_dir(path: String) raises:
     var tempfile = Python.import_module("tempfile")
     var temp_base = String(tempfile.gettempdir())
 
-    # Verify the path is within the system temp directory
-    if not path.startswith(temp_base):
+    # Verify the path is within the system temp directory or /tmp
+    # (create_temp_dir explicitly uses /tmp which may differ from gettempdir)
+    if not path.startswith(temp_base) and not path.startswith("/tmp"):
         raise Error(
             "cleanup_temp_dir only works with system temp paths for safety. "
             "Expected path within: "


### PR DESCRIPTION
## Summary
- Explicitly pass `dir="/tmp"` to `tempfile.mkdtemp()` in `create_temp_dir()` to avoid permission denied errors in Docker containers where `TMPDIR` may point to a non-writable directory
- Update `cleanup_temp_dir()` safety check to accept `/tmp` paths even when `gettempdir()` returns a different base

## Test plan
- [ ] CI passes test_io_helpers_part2 in Docker container
- [ ] cleanup_temp_dir still rejects non-temp paths (test_cleanup_temp_dir_safety_check)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)