### PR TITLE
fix(tests): suppress unused variable warning in test_cifar_loader_part1

### DIFF
--- a/tests/shared/data/formats/test_cifar_loader_part1.mojo
+++ b/tests/shared/data/formats/test_cifar_loader_part1.mojo
@@ -38,7 +38,7 @@ fn create_cifar10_test_file(num_images: Int) -> String:
     Returns:
         String containing binary format data (concatenated image records).
     """
-    var total_bytes = num_images * CIFAR10_BYTES_PER_IMAGE
+    var _total_bytes = num_images * CIFAR10_BYTES_PER_IMAGE
     var result = ""
 
     # Create binary data as string of characters (1 byte per character)
@@ -65,7 +65,7 @@ fn create_cifar100_test_file(num_images: Int) -> String:
     Returns:
         String containing binary format data (concatenated image records).
     """
-    var total_bytes = num_images * CIFAR100_BYTES_PER_IMAGE
+    var _total_bytes = num_images * CIFAR100_BYTES_PER_IMAGE
     var result = ""
 
     # Create binary data as string of characters (1 byte per character)


### PR DESCRIPTION
## Summary
- Rename `total_bytes` to `_total_bytes` in `create_cifar10_test_file` and `create_cifar100_test_file` helper functions to suppress the "assignment was never used" warning that becomes an error under `--Werror`

## Changes Made
- `tests/shared/data/formats/test_cifar_loader_part1.mojo`: Prefixed two unused `total_bytes` variables with `_` to signal intentional non-use

## Test plan
- [ ] CI passes with no `-Werror` failures on this file
- [ ] Existing CIFAR loader tests still pass

Closes #45