### PR TITLE
fix(tests): update multidim step test for current slicing behavior

### DIFF
--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -1146,28 +1146,35 @@ struct ExTensor(
                 + ")"
             )
 
-        # Compute per-dimension starts and result shape
+        # Compute per-dimension starts, steps, and result shape
         var starts = List[Int]()
+        var steps = List[Int]()
         var result_shape = List[Int]()
         for dim in range(num_dims):
             var s = slices[dim]
             var size = self._shape[dim]
 
-            var start = s.start.or_else(0)
-            var end = s.end.or_else(size)
+            var step = s.step.or_else(1)
+            if step == 0:
+                raise Error(
+                    "Slice step cannot be zero for dimension " + String(dim)
+                )
 
-            # Normalize negative indices
-            if start < 0:
-                start = size + start
-            if end < 0:
-                end = size + end
+            var start: Int
+            var end: Int
+            if step < 0:
+                start = s.start.or_else(size - 1)
+                end = s.end.or_else(-size - 1)
+            else:
+                start = s.start.or_else(0)
+                end = s.end.or_else(size)
 
-            # Clamp to valid range
-            start = max(0, min(start, size))
-            end = max(0, min(end, size))
-
-            starts.append(start)
-            result_shape.append(max(0, end - start))
+            var normalized = self._normalize_slice_indices(
+                start, end, step, size
+            )
+            starts.append(normalized[0])
+            steps.append(normalized[2])
+            result_shape.append(normalized[3])
 
         # Allocate result tensor (independent copy, not a view)
         var result = Self(result_shape, self._dtype)
@@ -1189,7 +1196,7 @@ struct ExTensor(
             for dim in range(num_dims):
                 var out_idx = remaining // result._strides[dim]
                 remaining = remaining % result._strides[dim]
-                var src_idx = starts[dim] + out_idx
+                var src_idx = starts[dim] + out_idx * steps[dim]
                 src_flat += src_idx * self._strides[dim]
 
             # Copy element byte-by-byte

--- a/tests/shared/core/test_extensor_multidim_step.mojo
+++ b/tests/shared/core/test_extensor_multidim_step.mojo
@@ -1,11 +1,11 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split per file convention. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor multi-dimensional slicing step validation (issue #4463).
+"""Tests for ExTensor multi-dimensional slicing with step support.
 
-The *slices overload of __getitem__ previously ignored the step field,
-silently returning wrong results for e.g. tensor[::2, :].  These tests
-verify that a non-unit step now raises an Error (fail-fast, option 1).
+The *slices overload of __getitem__ now supports non-unit steps on all
+dimensions, consistent with the 1D __getitem__(Slice) overload.  These
+tests verify that step slicing produces correct shapes and values.
 """
 
 from shared.core.extensor import ExTensor, zeros, arange
@@ -13,75 +13,92 @@ from tests.shared.conftest import assert_true, assert_equal
 
 
 # ============================================================================
-# Step-validation tests for __getitem__(*slices: Slice)
+# Step support tests for __getitem__(*slices: Slice)
 # ============================================================================
 
 
-fn test_multidim_step2_first_dim_raises() raises:
-    """Step=2 on first dimension must raise Error. Closes #4463."""
+fn test_multidim_step2_first_dim() raises:
+    """Step=2 on first dimension selects every other row."""
     var t = arange(0.0, 20.0, 1.0, DType.float32)
     var t2d = t.reshape([5, 4])
 
-    var raised = False
-    try:
-        # tensor[::2, :] — step=2 should be rejected
-        var _ = t2d[::2, :]
-    except:
-        raised = True
+    # tensor[::2, :] — rows 0, 2, 4 -> shape [3, 4]
+    var sliced = t2d[::2, :]
+    var shape = sliced.shape()
+    assert_equal(len(shape), 2)
+    assert_equal(shape[0], 3)
+    assert_equal(shape[1], 4)
 
-    assert_true(raised, "Expected Error for step=2 on first dim")
-    print("PASS: test_multidim_step2_first_dim_raises")
+    # Verify values via flat indexing on the result tensor:
+    # row 0 (orig row 0) = [0,1,2,3], row 1 (orig row 2) = [8,9,10,11],
+    # row 2 (orig row 4) = [16,17,18,19]
+    assert_equal(Int(sliced[0]), 0)
+    assert_equal(Int(sliced[3]), 3)
+    assert_equal(Int(sliced[4]), 8)
+    assert_equal(Int(sliced[7]), 11)
+    assert_equal(Int(sliced[8]), 16)
+    assert_equal(Int(sliced[11]), 19)
+    print("PASS: test_multidim_step2_first_dim")
 
 
-fn test_multidim_step2_second_dim_raises() raises:
-    """Step=2 on second dimension must raise Error. Closes #4463."""
+fn test_multidim_step2_second_dim() raises:
+    """Step=2 on second dimension selects every other column."""
     var t = arange(0.0, 20.0, 1.0, DType.float32)
     var t2d = t.reshape([5, 4])
 
-    var raised = False
-    try:
-        # tensor[:, ::2] — step=2 on second dim should be rejected
-        var _ = t2d[:, ::2]
-    except:
-        raised = True
+    # tensor[:, ::2] — columns 0, 2 -> shape [5, 2]
+    var sliced = t2d[:, ::2]
+    var shape = sliced.shape()
+    assert_equal(len(shape), 2)
+    assert_equal(shape[0], 5)
+    assert_equal(shape[1], 2)
 
-    assert_true(raised, "Expected Error for step=2 on second dim")
-    print("PASS: test_multidim_step2_second_dim_raises")
+    # Verify values: row 0 cols 0,2 = [0,2]; row 1 cols 0,2 = [4,6]
+    assert_equal(Int(sliced[0]), 0)
+    assert_equal(Int(sliced[1]), 2)
+    assert_equal(Int(sliced[2]), 4)
+    assert_equal(Int(sliced[3]), 6)
+    print("PASS: test_multidim_step2_second_dim")
 
 
-fn test_multidim_negative_step_raises() raises:
-    """Negative step on any dimension must raise Error. Closes #4463."""
+fn test_multidim_negative_step() raises:
+    """Negative step on first dimension reverses row order."""
     var t = arange(0.0, 20.0, 1.0, DType.float32)
     var t2d = t.reshape([5, 4])
 
-    var raised = False
-    try:
-        # tensor[::-1, :] — negative step should be rejected
-        var _ = t2d[::-1, :]
-    except:
-        raised = True
+    # tensor[::-1, :] — rows in reverse: 4, 3, 2, 1, 0 -> shape [5, 4]
+    var sliced = t2d[::-1, :]
+    var shape = sliced.shape()
+    assert_equal(len(shape), 2)
+    assert_equal(shape[0], 5)
+    assert_equal(shape[1], 4)
 
-    assert_true(raised, "Expected Error for negative step on first dim")
-    print("PASS: test_multidim_negative_step_raises")
+    # First row of result = original row 4 = [16,17,18,19]
+    assert_equal(Int(sliced[0]), 16)
+    assert_equal(Int(sliced[3]), 19)
+    # Last row of result = original row 0 = [0,1,2,3]
+    assert_equal(Int(sliced[16]), 0)
+    assert_equal(Int(sliced[19]), 3)
+    print("PASS: test_multidim_negative_step")
 
 
-fn test_multidim_step3_3d_raises() raises:
-    """Step=3 in 3D tensor must raise Error. Closes #4463."""
+fn test_multidim_step3_3d() raises:
+    """Step=3 in 3D tensor selects every 3rd element along first dim."""
     var t = arange(0.0, 24.0, 1.0, DType.float32)
     var t3d = t.reshape([4, 3, 2])
 
-    var raised = False
-    try:
-        var _ = t3d[::3, :, :]
-    except:
-        raised = True
-
-    assert_true(raised, "Expected Error for step=3 on first dim of 3D tensor")
-    print("PASS: test_multidim_step3_3d_raises")
+    # tensor[::3, :, :] — indices 0, 3 along first dim -> shape [2, 3, 2]
+    var sliced = t3d[::3, :, :]
+    var shape = sliced.shape()
+    assert_equal(len(shape), 3)
+    assert_equal(shape[0], 2)
+    assert_equal(shape[1], 3)
+    assert_equal(shape[2], 2)
+    print("PASS: test_multidim_step3_3d")
 
 
 fn test_multidim_step1_does_not_raise() raises:
-    """Explicit step=1 on all dimensions must NOT raise Error. Closes #4463."""
+    """Explicit step=1 on all dimensions must NOT raise Error."""
     var t = arange(0.0, 20.0, 1.0, DType.float32)
     var t2d = t.reshape([5, 4])
 
@@ -95,7 +112,7 @@ fn test_multidim_step1_does_not_raise() raises:
 
 
 fn test_multidim_no_step_does_not_raise() raises:
-    """Omitted step (defaults to 1) must NOT raise Error. Closes #4463."""
+    """Omitted step (defaults to 1) must NOT raise Error."""
     var t = arange(0.0, 20.0, 1.0, DType.float32)
     var t2d = t.reshape([5, 4])
 
@@ -108,12 +125,28 @@ fn test_multidim_no_step_does_not_raise() raises:
     print("PASS: test_multidim_no_step_does_not_raise")
 
 
+fn test_multidim_step0_raises() raises:
+    """Step=0 must raise Error (invalid step)."""
+    var t = arange(0.0, 20.0, 1.0, DType.float32)
+    var t2d = t.reshape([5, 4])
+
+    var raised = False
+    try:
+        var _ = t2d[::0, :]
+    except:
+        raised = True
+
+    assert_true(raised, "Expected Error for step=0 on first dim")
+    print("PASS: test_multidim_step0_raises")
+
+
 fn main() raises:
     """Run all multi-dim step validation tests."""
-    test_multidim_step2_first_dim_raises()
-    test_multidim_step2_second_dim_raises()
-    test_multidim_negative_step_raises()
-    test_multidim_step3_3d_raises()
+    test_multidim_step2_first_dim()
+    test_multidim_step2_second_dim()
+    test_multidim_negative_step()
+    test_multidim_step3_3d()
     test_multidim_step1_does_not_raise()
     test_multidim_no_step_does_not_raise()
+    test_multidim_step0_raises()
     print("All multi-dim step validation tests passed!")


### PR DESCRIPTION
## Summary

- Implemented step support in `ExTensor.__getitem__(*slices)` multi-dimensional slicing, which previously silently ignored the step field
- Updated tests to verify correct output (shapes and values) for non-unit steps instead of expecting errors
- Added new test for step=0 which must still raise an error

## Changes Made

**`shared/core/extensor.mojo`**: The `__getitem__(*slices)` method now extracts and uses the step field from each slice via the existing `_normalize_slice_indices` helper. This properly handles positive steps (striding), negative steps (reverse iteration), and step=0 (error).

**`tests/shared/core/test_extensor_multidim_step.mojo`**: Replaced 4 tests that expected errors for non-unit steps with tests that verify correct shapes and element values. Added `test_multidim_step0_raises` for the one case that should still error.

## Test plan

- [ ] CI passes all test groups including `test_extensor_multidim_step.mojo`
- [ ] Existing step=1 and no-step tests continue to pass unchanged
- [ ] New step=2, step=3, negative step tests verify correct element values
- [ ] Step=0 test verifies error is raised

Generated with [Claude Code](https://claude.com/claude-code)