### PR TITLE
ci(security): migrate to gitleaks/gitleaks-action official action

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,21 +42,11 @@ jobs:
           fetch-depth: 0  # Required: full history needed for gitleaks git-log mode (do not remove, see #3316)
 
       - name: Run Gitleaks
-        run: |
-          # Pinned to v8.30.0 — update hash when upgrading version (see #3316)
-          wget -q https://github.com/gitleaks/gitleaks/releases/download/v8.30.0/gitleaks_8.30.0_linux_x64.tar.gz
-          # Verify integrity before execution — SHA256 from https://github.com/gitleaks/gitleaks/releases/download/v8.30.0/gitleaks_8.30.0_checksums.txt
-          echo "79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e  gitleaks_8.30.0_linux_x64.tar.gz" | sha256sum --check
-          tar -xzf gitleaks_8.30.0_linux_x64.tar.gz
-          chmod +x gitleaks
-
-          if [ -f .gitleaks.toml ]; then
-            echo "Using .gitleaks.toml configuration"
-            ./gitleaks detect --source=. --config=.gitleaks.toml --verbose --exit-code=1
-          else
-            echo "No .gitleaks.toml found, using default configuration"
-            ./gitleaks detect --source=. --verbose --exit-code=1
-          fi
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config: .gitleaks.toml
 
   # ============================================================================
   # SAST Scanning

--- a/shared/core/matrix.mojo
+++ b/shared/core/matrix.mojo
@@ -893,9 +893,9 @@ fn transpose_view(
         Error: If axes is invalid (duplicates, wrong range, or wrong length).
 
     See Also:
-        - transpose(): Zero-copy view with stride permutation (production API)
-        - ExTensor.reshape(): Another zero-copy view operation
-        - docs/dev/extensor-view-contract.md: View semantics reference.
+        - `transpose()`: Zero-copy view with stride permutation (production API)
+        - `ExTensor.reshape()`: Another zero-copy view operation
+        - `docs/dev/extensor-view-contract.md`: View semantics reference
     """
     var ndim = tensor.dim()
     var input_shape = tensor.shape()


### PR DESCRIPTION
## Summary

- Replace manual wget download and SHA256 verification of gitleaks binary with the official `gitleaks/gitleaks-action` (v2.3.9, pinned to commit SHA)
- Eliminates manual hash maintenance burden — the action handles version pinning internally
- Custom `.gitleaks.toml` config passed via action's config input

Closes #3940

## Test plan

- [ ] CI security workflow passes with the new action
- [ ] Gitleaks scan runs correctly with custom config

🤖 Generated with [Claude Code](https://claude.com/claude-code)