### PR TITLE
fix(core): add missing dtype guards in conv2d, batch_norm2d, attention

### DIFF
--- a/shared/core/attention.mojo
+++ b/shared/core/attention.mojo
@@ -125,6 +125,14 @@ fn scaled_dot_product_attention_masked(
     # Apply mask if provided (additive masking)
     var mask_shape = mask.shape()
     if len(mask_shape) > 0 and mask.numel() > 0:
+        if mask.dtype() != scaled_scores.dtype():
+            raise Error(
+                "attention: mask dtype ("
+                + String(mask.dtype())
+                + ") must match scores dtype ("
+                + String(scaled_scores.dtype())
+                + ")"
+            )
         scaled_scores = add(scaled_scores, mask)
 
     # Apply softmax along the last dimension (key sequence length)

--- a/shared/core/conv.mojo
+++ b/shared/core/conv.mojo
@@ -404,6 +404,16 @@ fn conv2d(
     if kernel_in_channels != in_channels:
         raise Error("Kernel in_channels must match input in_channels")
 
+    if x.dtype() != kernel.dtype() or x.dtype() != bias.dtype():
+        raise Error(
+            "conv2d: all tensors must have the same dtype. Got x: "
+            + String(x.dtype())
+            + ", kernel: "
+            + String(kernel.dtype())
+            + ", bias: "
+            + String(bias.dtype())
+        )
+
     # Compute output dimensions using shape computation helper
     var (out_h, out_w) = conv2d_output_shape(
         in_height, in_width, kH, kW, stride, padding

--- a/shared/core/normalization.mojo
+++ b/shared/core/normalization.mojo
@@ -108,6 +108,21 @@ fn batch_norm2d(
             "batch_norm2d requires 4D input (batch, channels, height, width)"
         )
 
+    if (
+        x.dtype() != gamma.dtype()
+        or x.dtype() != beta.dtype()
+        or x.dtype() != running_mean.dtype()
+        or x.dtype() != running_var.dtype()
+    ):
+        raise Error(
+            "batch_norm2d: all tensors must have the same dtype. Got x: "
+            + String(x.dtype())
+            + ", gamma: "
+            + String(gamma.dtype())
+            + ", beta: "
+            + String(beta.dtype())
+        )
+
     var batch = x_shape[0]
     var channels = x_shape[1]
     var height = x_shape[2]


### PR DESCRIPTION
## Summary

- Add dtype mismatch guards to `conv2d` (kernel/bias vs input)
- Add dtype mismatch guards to `batch_norm2d` (gamma/beta/running_stats vs input)
- Add dtype mismatch guard to `scaled_dot_product_attention` (mask vs scores)

These functions previously did silent bitcast pointer misreads when tensors of different dtypes were passed — no error, just wrong data.

Discovered during the ExTensor parametric migration audit (issue #4998).

## Test plan

- [x] `mojo package shared` compiles clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)