### PR TITLE
feat(tensor): add typed factory functions for Tensor[dtype]

### DIFF
--- a/shared/tensor/__init__.mojo
+++ b/shared/tensor/__init__.mojo
@@ -3,7 +3,25 @@
 Provides:
 - Tensor[dtype: DType]: Compile-time typed tensor with SIMD-like element access
 - TensorLike: Shared trait interface for all tensor types
+- Factory functions: zeros, ones, full, empty, arange, eye, linspace, randn,
+  zeros_like, ones_like, full_like, nan_tensor, inf_tensor, neg_inf_tensor
 """
 
 from shared.tensor.tensor_traits import TensorLike
 from shared.tensor.tensor import Tensor
+from shared.tensor.factories import (
+    zeros,
+    ones,
+    full,
+    empty,
+    arange,
+    eye,
+    linspace,
+    randn,
+    zeros_like,
+    ones_like,
+    full_like,
+    nan_tensor,
+    inf_tensor,
+    neg_inf_tensor,
+)

--- a/shared/tensor/factories.mojo
+++ b/shared/tensor/factories.mojo
@@ -1,0 +1,470 @@
+"""Typed factory functions for Tensor[dtype].
+
+Provides compile-time typed equivalents of the AnyTensor factory functions
+(zeros, ones, full, empty, arange, eye, linspace, randn, etc.).
+
+All functions return Tensor[dtype] with the dtype parameter on both the
+function and return type (B1 fix — explicit dtype parameter on all return
+types). Fill values use Scalar[dtype] instead of Float64 to avoid
+precision-losing round-trips.
+
+Example:
+    ```mojo
+    from shared.tensor.factories import zeros, ones, full
+
+    var z = zeros[DType.float32]([3, 4])       # 3x4 float32 zeros
+    var o = ones[DType.float64]([2, 2])         # 2x2 float64 ones
+    var f = full[DType.float32]([5], Scalar[DType.float32](0.5))  # [0.5, 0.5, ...]
+    ```
+"""
+
+from collections import List
+from math import sqrt, log, cos, sin
+from random import random_float64, seed as random_seed
+from utils.numerics import inf as numeric_inf, neg_inf as numeric_neg_inf
+
+from shared.tensor.tensor import Tensor
+
+
+# ------------------------------------------------------------------
+# Basic creation functions
+# ------------------------------------------------------------------
+
+
+fn zeros[dtype: DType](shape: List[Int]) raises -> Tensor[dtype]:
+    """Create a zero-filled tensor with compile-time dtype.
+
+    The Tensor constructor already zero-initializes memory, so no
+    additional fill is needed.
+
+    Args:
+        shape: The shape of the output tensor.
+
+    Returns:
+        A new Tensor[dtype] filled with zeros.
+
+    Raises:
+        Error: If tensor size exceeds MAX_TENSOR_BYTES.
+    """
+    var t = Tensor[dtype](shape)
+    return t^
+
+
+fn ones[dtype: DType](shape: List[Int]) raises -> Tensor[dtype]:
+    """Create a one-filled tensor with compile-time dtype.
+
+    Args:
+        shape: The shape of the output tensor.
+
+    Returns:
+        A new Tensor[dtype] filled with ones.
+
+    Raises:
+        Error: If tensor size exceeds MAX_TENSOR_BYTES.
+    """
+    var t = Tensor[dtype](shape)
+    var one = Scalar[dtype](1)
+    for i in range(t.numel()):
+        t[i] = one
+    return t^
+
+
+fn full[
+    dtype: DType
+](shape: List[Int], fill_value: Scalar[dtype]) raises -> Tensor[dtype]:
+    """Create a tensor filled with a specific value.
+
+    Uses Scalar[dtype] for the fill value to avoid precision-losing
+    Float64 round-trips.
+
+    Args:
+        shape: The shape of the output tensor.
+        fill_value: The typed value to fill the tensor with.
+
+    Returns:
+        A new Tensor[dtype] filled with fill_value.
+
+    Raises:
+        Error: If tensor size exceeds MAX_TENSOR_BYTES.
+    """
+    var t = Tensor[dtype](shape)
+    for i in range(t.numel()):
+        t[i] = fill_value
+    return t^
+
+
+fn empty[dtype: DType](shape: List[Int]) raises -> Tensor[dtype]:
+    """Create an uninitialized tensor (fast allocation).
+
+    The Tensor constructor zero-initializes memory. This function exists
+    for API consistency with NumPy/PyTorch. In practice, the returned
+    tensor will be zero-initialized.
+
+    Args:
+        shape: The shape of the output tensor.
+
+    Returns:
+        A new Tensor[dtype] with allocated memory.
+
+    Raises:
+        Error: If tensor size exceeds MAX_TENSOR_BYTES.
+    """
+    var t = Tensor[dtype](shape)
+    return t^
+
+
+# ------------------------------------------------------------------
+# Sequence creation functions
+# ------------------------------------------------------------------
+
+
+fn arange[
+    dtype: DType
+](
+    start: Scalar[dtype], stop: Scalar[dtype], step: Scalar[dtype]
+) raises -> Tensor[dtype]:
+    """Create 1D tensor with evenly spaced values.
+
+    Uses Scalar[dtype] for start/stop/step to preserve precision.
+
+    Args:
+        start: Start value (inclusive).
+        stop: End value (exclusive).
+        step: Spacing between values.
+
+    Returns:
+        A new 1D Tensor[dtype] with values in range [start, stop).
+
+    Raises:
+        Error: If step is zero or tensor size exceeds MAX_TENSOR_BYTES.
+    """
+    # Calculate number of elements using Float64 for the division
+    var start_f = Float64(start)
+    var stop_f = Float64(stop)
+    var step_f = Float64(step)
+    var num_elements = Int((stop_f - start_f) / step_f)
+
+    if num_elements < 0:
+        num_elements = 0
+
+    var shape = List[Int]()
+    shape.append(num_elements)
+
+    var t = Tensor[dtype](shape)
+
+    # Fill with sequence using typed arithmetic
+    var value = start
+    for i in range(num_elements):
+        t[i] = value
+        value = value + step
+
+    return t^
+
+
+fn eye[dtype: DType](n: Int, m: Int, k: Int) raises -> Tensor[dtype]:
+    """Create 2D tensor with ones on diagonal.
+
+    Args:
+        n: Number of rows.
+        m: Number of columns.
+        k: Diagonal offset (0 for main, >0 upper, <0 lower).
+
+    Returns:
+        A new 2D Tensor[dtype] with ones on the k-th diagonal.
+
+    Raises:
+        Error: If tensor size exceeds MAX_TENSOR_BYTES.
+    """
+    var shape = List[Int]()
+    shape.append(n)
+    shape.append(m)
+
+    # Tensor constructor zero-initializes, so only set diagonal
+    var t = Tensor[dtype](shape)
+    var one = Scalar[dtype](1)
+
+    for i in range(n):
+        var j = i + k
+        if j >= 0 and j < m:
+            var index = i * m + j
+            t[index] = one
+
+    return t^
+
+
+fn linspace[
+    dtype: DType
+](
+    start: Scalar[dtype],
+    stop: Scalar[dtype],
+    num: Int,
+    endpoint: Bool = True,
+) raises -> Tensor[dtype]:
+    """Create 1D tensor with evenly spaced values.
+
+    Uses Scalar[dtype] for start/stop to preserve precision.
+
+    Args:
+        start: Start value (inclusive).
+        stop: End value (inclusive if endpoint=True).
+        num: Number of values to generate.
+        endpoint: Whether to include stop value (default True).
+
+    Returns:
+        A new 1D Tensor[dtype] with num evenly spaced values.
+
+    Raises:
+        Error: If tensor size exceeds MAX_TENSOR_BYTES.
+    """
+    var shape = List[Int]()
+    shape.append(num)
+
+    var t = Tensor[dtype](shape)
+
+    if num == 0:
+        return t^
+
+    if num == 1:
+        t[0] = start
+        return t^
+
+    # Calculate step size using Float64 for precision
+    var start_f = Float64(start)
+    var stop_f = Float64(stop)
+    var divisor: Int
+    if endpoint:
+        divisor = num - 1
+    else:
+        divisor = num
+    var step_f = (stop_f - start_f) / Float64(divisor)
+
+    for i in range(num):
+        var value = start_f + step_f * Float64(i)
+        t[i] = Scalar[dtype](value)
+
+    return t^
+
+
+fn randn[
+    dtype: DType
+](shape: List[Int], seed: Int = 0) raises -> Tensor[dtype]:
+    """Create tensor filled with random values from standard normal distribution.
+
+    Uses Box-Muller transform to generate normally distributed random values
+    from uniform random values. Generates values with mean=0 and std=1.
+
+    For non-float dtypes, values are generated as Float64 then cast to the
+    target dtype.
+
+    Args:
+        shape: The shape of the output tensor.
+        seed: Random seed for reproducibility (default: 0 uses system randomness).
+
+    Returns:
+        A new Tensor[dtype] filled with random values from N(0, 1).
+
+    Raises:
+        Error: If tensor size exceeds MAX_TENSOR_BYTES.
+    """
+    if seed > 0:
+        random_seed(seed)
+
+    var t = Tensor[dtype](shape)
+
+    # Box-Muller transform: generates pairs of independent N(0,1) values
+    var i = 0
+    while i < t.numel():
+        var u1 = random_float64()
+        var u2 = random_float64()
+
+        # Ensure u1 is not zero (would cause log(0))
+        if u1 < 1e-10:
+            u1 = 1e-10
+
+        var magnitude = sqrt(-2.0 * log(u1))
+        var angle = 2.0 * 3.14159265358979323846 * u2
+
+        var z0 = magnitude * cos(angle)
+        var z1 = magnitude * sin(angle)
+
+        t[i] = Scalar[dtype](z0)
+        i += 1
+
+        if i < t.numel():
+            t[i] = Scalar[dtype](z1)
+            i += 1
+
+    return t^
+
+
+# ------------------------------------------------------------------
+# *_like functions — infer dtype from input tensor
+# ------------------------------------------------------------------
+
+
+fn zeros_like[
+    dtype: DType
+](t: Tensor[dtype]) raises -> Tensor[dtype]:
+    """Create a zero-filled tensor with same shape as input.
+
+    The dtype is inferred from the input tensor's compile-time parameter.
+
+    Args:
+        t: Template tensor to match shape.
+
+    Returns:
+        A new Tensor[dtype] filled with zeros, same shape as input.
+
+    Raises:
+        Error: If tensor creation fails.
+    """
+    return zeros[dtype](t.shape())
+
+
+fn ones_like[
+    dtype: DType
+](t: Tensor[dtype]) raises -> Tensor[dtype]:
+    """Create a one-filled tensor with same shape as input.
+
+    The dtype is inferred from the input tensor's compile-time parameter.
+
+    Args:
+        t: Template tensor to match shape.
+
+    Returns:
+        A new Tensor[dtype] filled with ones, same shape as input.
+
+    Raises:
+        Error: If tensor creation fails.
+    """
+    return ones[dtype](t.shape())
+
+
+fn full_like[
+    dtype: DType
+](t: Tensor[dtype], fill_value: Scalar[dtype]) raises -> Tensor[dtype]:
+    """Create a tensor filled with a value, same shape as input.
+
+    The dtype is inferred from the input tensor's compile-time parameter.
+
+    Args:
+        t: Template tensor to match shape.
+        fill_value: The typed value to fill the tensor with.
+
+    Returns:
+        A new Tensor[dtype] filled with fill_value, same shape as input.
+
+    Raises:
+        Error: If tensor creation fails.
+    """
+    return full[dtype](t.shape(), fill_value)
+
+
+# ------------------------------------------------------------------
+# Special value tensors (float types only)
+# ------------------------------------------------------------------
+
+
+fn nan_tensor[
+    dtype: DType
+](shape: List[Int]) raises -> Tensor[dtype]:
+    """Create a tensor filled with NaN values.
+
+    Only valid for floating-point dtypes (float16, float32, float64, bfloat16).
+
+    Args:
+        shape: The shape of the output tensor.
+
+    Returns:
+        A new Tensor[dtype] filled with NaN values.
+
+    Raises:
+        Error: If dtype is not floating-point, or if tensor size exceeds
+            MAX_TENSOR_BYTES.
+    """
+    # Compile-time check for float types
+    @parameter
+    if (
+        dtype != DType.float16
+        and dtype != DType.float32
+        and dtype != DType.float64
+        and dtype != DType.bfloat16
+    ):
+        raise Error("nan_tensor: only floating-point dtypes support NaN")
+
+    var t = Tensor[dtype](shape)
+    # IEEE 754 NaN
+    var nan_value = Scalar[dtype](0.0 / 0.0)
+    for i in range(t.numel()):
+        t[i] = nan_value
+    return t^
+
+
+fn inf_tensor[
+    dtype: DType
+](shape: List[Int]) raises -> Tensor[dtype]:
+    """Create a tensor filled with positive infinity values.
+
+    Only valid for floating-point dtypes (float16, float32, float64, bfloat16).
+
+    Args:
+        shape: The shape of the output tensor.
+
+    Returns:
+        A new Tensor[dtype] filled with positive infinity values.
+
+    Raises:
+        Error: If dtype is not floating-point, or if tensor size exceeds
+            MAX_TENSOR_BYTES.
+    """
+    @parameter
+    if (
+        dtype != DType.float16
+        and dtype != DType.float32
+        and dtype != DType.float64
+        and dtype != DType.bfloat16
+    ):
+        raise Error(
+            "inf_tensor: only floating-point dtypes support Inf"
+        )
+
+    var t = Tensor[dtype](shape)
+    var inf_val = Scalar[dtype](numeric_inf[DType.float64]())
+    for i in range(t.numel()):
+        t[i] = inf_val
+    return t^
+
+
+fn neg_inf_tensor[
+    dtype: DType
+](shape: List[Int]) raises -> Tensor[dtype]:
+    """Create a tensor filled with negative infinity values.
+
+    Only valid for floating-point dtypes (float16, float32, float64, bfloat16).
+
+    Args:
+        shape: The shape of the output tensor.
+
+    Returns:
+        A new Tensor[dtype] filled with negative infinity values.
+
+    Raises:
+        Error: If dtype is not floating-point, or if tensor size exceeds
+            MAX_TENSOR_BYTES.
+    """
+    @parameter
+    if (
+        dtype != DType.float16
+        and dtype != DType.float32
+        and dtype != DType.float64
+        and dtype != DType.bfloat16
+    ):
+        raise Error(
+            "neg_inf_tensor: only floating-point dtypes support Inf"
+        )
+
+    var t = Tensor[dtype](shape)
+    var neg_inf_val = Scalar[dtype](numeric_neg_inf[DType.float64]())
+    for i in range(t.numel()):
+        t[i] = neg_inf_val
+    return t^

--- a/shared/tensor/tensor.mojo
+++ b/shared/tensor/tensor.mojo
@@ -155,7 +155,7 @@ struct Tensor[dtype: DType = DType.float32](
 
     fn __init__(
         out self,
-        data: UnsafePointer[Scalar[dtype], origin=MutAnyOrigin],
+        data: UnsafePointer[Scalar[Self.dtype], origin=MutAnyOrigin],
         shape: List[Int],
         strides: List[Int],
         refcount: UnsafePointer[Int, origin=MutAnyOrigin],
@@ -334,7 +334,7 @@ struct Tensor[dtype: DType = DType.float32](
         """Return shape as list of dimension sizes (returns a copy)."""
         return self._shape.copy()
 
-    fn dtype(self) -> DType:
+    fn get_dtype(self) -> DType:
         """Return the element data type (compile-time constant)."""
         return Self.dtype
 
@@ -468,7 +468,7 @@ struct Tensor[dtype: DType = DType.float32](
         tensors (e.g., after transpose) display correct logical values.
 
         Returns:
-            String in the format: Tensor([v0, v1, ...], dtype=<dtype>)
+            String in the format: `Tensor([v0, v1, ...], dtype=<dtype>)`
         """
         var result = String("Tensor([")
         if self._numel > TENSOR_PRINT_THRESHOLD:

--- a/shared/tensor/tensor_traits.mojo
+++ b/shared/tensor/tensor_traits.mojo
@@ -18,7 +18,7 @@ trait TensorLike(Copyable, Movable):
         """Return shape as list of dimension sizes."""
         ...
 
-    fn dtype(self) -> DType:
+    fn get_dtype(self) -> DType:
         """Return the element data type."""
         ...
 

--- a/tests/shared/tensor/test_tensor_any_conversion.mojo
+++ b/tests/shared/tensor/test_tensor_any_conversion.mojo
@@ -60,7 +60,7 @@ fn test_as_tensor_basic() raises:
     var any_t = zeros([4], DType.float32)
     var t = any_t.as_tensor[DType.float32]()
     assert_true(t.numel() == 4, "as_tensor preserves numel")
-    assert_true(t.dtype() == DType.float32, "as_tensor preserves dtype")
+    assert_true(t.get_dtype() == DType.float32, "as_tensor preserves dtype")
     print("PASS: test_as_tensor_basic")
 
 

--- a/tests/shared/tensor/test_tensor_element_access.mojo
+++ b/tests/shared/tensor/test_tensor_element_access.mojo
@@ -31,14 +31,14 @@ fn test_tensor_float64_creation() raises:
     """Tensor[DType.float64] can be created with a shape."""
     var t = Tensor[DType.float64]([2, 3])
     assert_true(t.numel() == 6, "numel should be 6")
-    assert_true(t.dtype() == DType.float64, "dtype should be float64")
+    assert_true(t.get_dtype() == DType.float64, "dtype should be float64")
     print("PASS: test_tensor_float64_creation")
 
 
 fn test_tensor_default_dtype() raises:
     """Tensor with no dtype parameter defaults to float32."""
     var t = Tensor([5])
-    assert_true(t.dtype() == DType.float32, "default dtype should be float32")
+    assert_true(t.get_dtype() == DType.float32, "default dtype should be float32")
     print("PASS: test_tensor_default_dtype")
 
 

--- a/tests/shared/tensor/test_tensor_factories.mojo
+++ b/tests/shared/tensor/test_tensor_factories.mojo
@@ -1,0 +1,170 @@
+"""Tests for typed Tensor[dtype] factory functions (part 1).
+
+# ADR-009: This file is intentionally limited to <=10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Tests cover:
+- zeros creates zero-filled tensor
+- ones creates one-filled tensor
+- full with typed fill value
+- empty allocates tensor
+- zeros_like preserves shape
+- ones_like preserves shape
+- full_like preserves shape with value
+- arange produces correct sequence
+- eye produces identity matrix
+- factory float64 precision
+"""
+
+from testing import assert_true, assert_almost_equal
+from shared.tensor.tensor import Tensor
+from shared.tensor.factories import (
+    zeros,
+    ones,
+    full,
+    empty,
+    zeros_like,
+    ones_like,
+    full_like,
+    arange,
+    eye,
+)
+
+
+fn test_zeros_creates_zero_tensor() raises:
+    """Verify zeros[dtype] creates a tensor filled with zeros."""
+    var t = zeros[DType.float32]([3, 4])
+    assert_true(t.numel() == 12, "numel should be 12")
+    assert_true(t.ndim() == 2, "ndim should be 2")
+    for i in range(t.numel()):
+        assert_almost_equal(t[i], Scalar[DType.float32](0.0), msg="element should be 0")
+    print("PASS: test_zeros_creates_zero_tensor")
+
+
+fn test_ones_creates_one_tensor() raises:
+    """Verify ones[dtype] creates a tensor filled with ones."""
+    var t = ones[DType.float32]([2, 3])
+    assert_true(t.numel() == 6, "numel should be 6")
+    for i in range(t.numel()):
+        assert_almost_equal(t[i], Scalar[DType.float32](1.0), msg="element should be 1")
+    print("PASS: test_ones_creates_one_tensor")
+
+
+fn test_full_with_value() raises:
+    """Verify full[dtype] fills tensor with a specific typed value."""
+    var t = full[DType.float32]([3], Scalar[DType.float32](0.5))
+    assert_true(t.numel() == 3, "numel should be 3")
+    for i in range(t.numel()):
+        assert_almost_equal(t[i], Scalar[DType.float32](0.5), msg="element should be 0.5")
+    print("PASS: test_full_with_value")
+
+
+fn test_empty_allocates_tensor() raises:
+    """Verify empty[dtype] allocates a tensor with correct shape."""
+    var t = empty[DType.float64]([4, 5])
+    assert_true(t.numel() == 20, "numel should be 20")
+    assert_true(t.ndim() == 2, "ndim should be 2")
+    var s = t.shape()
+    assert_true(s[0] == 4, "dim 0 should be 4")
+    assert_true(s[1] == 5, "dim 1 should be 5")
+    print("PASS: test_empty_allocates_tensor")
+
+
+fn test_zeros_like_preserves_shape() raises:
+    """Verify zeros_like creates zero tensor with same shape as input."""
+    var original = ones[DType.float32]([2, 3, 4])
+    var t = zeros_like(original)
+    assert_true(t.numel() == 24, "numel should be 24")
+    assert_true(t.ndim() == 3, "ndim should be 3")
+    var s = t.shape()
+    assert_true(s[0] == 2, "dim 0")
+    assert_true(s[1] == 3, "dim 1")
+    assert_true(s[2] == 4, "dim 2")
+    for i in range(t.numel()):
+        assert_almost_equal(t[i], Scalar[DType.float32](0.0), msg="element should be 0")
+    print("PASS: test_zeros_like_preserves_shape")
+
+
+fn test_ones_like_preserves_shape() raises:
+    """Verify ones_like creates one tensor with same shape as input."""
+    var original = zeros[DType.float64]([5, 2])
+    var t = ones_like(original)
+    assert_true(t.numel() == 10, "numel should be 10")
+    var s = t.shape()
+    assert_true(s[0] == 5, "dim 0")
+    assert_true(s[1] == 2, "dim 1")
+    for i in range(t.numel()):
+        assert_almost_equal(t[i], Scalar[DType.float64](1.0), msg="element should be 1")
+    print("PASS: test_ones_like_preserves_shape")
+
+
+fn test_full_like_preserves_shape() raises:
+    """Verify full_like creates tensor with same shape filled with value."""
+    var original = zeros[DType.float32]([3, 3])
+    var t = full_like(original, Scalar[DType.float32](0.25))
+    assert_true(t.numel() == 9, "numel should be 9")
+    for i in range(t.numel()):
+        assert_almost_equal(t[i], Scalar[DType.float32](0.25), msg="element should be 0.25")
+    print("PASS: test_full_like_preserves_shape")
+
+
+fn test_arange_values() raises:
+    """Verify arange produces correct sequence values."""
+    var t = arange[DType.float32](
+        Scalar[DType.float32](0.0),
+        Scalar[DType.float32](5.0),
+        Scalar[DType.float32](1.0),
+    )
+    assert_true(t.numel() == 5, "should have 5 elements")
+    assert_almost_equal(t[0], Scalar[DType.float32](0.0), msg="element 0")
+    assert_almost_equal(t[1], Scalar[DType.float32](1.0), msg="element 1")
+    assert_almost_equal(t[2], Scalar[DType.float32](2.0), msg="element 2")
+    assert_almost_equal(t[3], Scalar[DType.float32](3.0), msg="element 3")
+    assert_almost_equal(t[4], Scalar[DType.float32](4.0), msg="element 4")
+    print("PASS: test_arange_values")
+
+
+fn test_eye_identity() raises:
+    """Verify eye creates correct identity matrix."""
+    var t = eye[DType.float32](3, 3, 0)
+    assert_true(t.numel() == 9, "should have 9 elements")
+    # Check diagonal is 1, off-diagonal is 0
+    for i in range(3):
+        for j in range(3):
+            var idx = i * 3 + j
+            if i == j:
+                assert_almost_equal(
+                    t[idx], Scalar[DType.float32](1.0), msg="diagonal should be 1"
+                )
+            else:
+                assert_almost_equal(
+                    t[idx], Scalar[DType.float32](0.0), msg="off-diagonal should be 0"
+                )
+    print("PASS: test_eye_identity")
+
+
+fn test_factory_float64_precision() raises:
+    """Verify float64 factory functions preserve full precision."""
+    # Use a value that would lose precision if round-tripped through float32
+    var precise_val = Scalar[DType.float64](1.0000000000000002)
+    var t = full[DType.float64]([1], precise_val)
+    # Direct comparison — should be exact for float64
+    assert_true(
+        t[0] == precise_val,
+        "float64 should preserve full precision",
+    )
+    print("PASS: test_factory_float64_precision")
+
+
+fn main() raises:
+    test_zeros_creates_zero_tensor()
+    test_ones_creates_one_tensor()
+    test_full_with_value()
+    test_empty_allocates_tensor()
+    test_zeros_like_preserves_shape()
+    test_ones_like_preserves_shape()
+    test_full_like_preserves_shape()
+    test_arange_values()
+    test_eye_identity()
+    test_factory_float64_precision()

--- a/tests/shared/tensor/test_tensor_factories_part2.mojo
+++ b/tests/shared/tensor/test_tensor_factories_part2.mojo
@@ -1,0 +1,150 @@
+"""Tests for typed Tensor[dtype] factory functions (part 2).
+
+# ADR-009: This file is intentionally limited to <=10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Tests cover:
+- linspace produces evenly spaced values
+- linspace without endpoint
+- randn produces values (deterministic with seed)
+- nan_tensor fills with NaN
+- inf_tensor fills with positive infinity
+- neg_inf_tensor fills with negative infinity
+- eye with diagonal offset
+- arange with step 0.5
+"""
+
+from testing import assert_true, assert_almost_equal
+from math import isnan
+from shared.tensor.tensor import Tensor
+from shared.tensor.factories import (
+    linspace,
+    randn,
+    nan_tensor,
+    inf_tensor,
+    neg_inf_tensor,
+    eye,
+    arange,
+)
+
+
+fn test_linspace_values() raises:
+    """Verify linspace produces evenly spaced values including endpoint."""
+    var t = linspace[DType.float64](
+        Scalar[DType.float64](0.0),
+        Scalar[DType.float64](1.0),
+        5,
+    )
+    assert_true(t.numel() == 5, "should have 5 elements")
+    assert_almost_equal(t[0], Scalar[DType.float64](0.0), msg="element 0")
+    assert_almost_equal(t[1], Scalar[DType.float64](0.25), msg="element 1")
+    assert_almost_equal(t[2], Scalar[DType.float64](0.5), msg="element 2")
+    assert_almost_equal(t[3], Scalar[DType.float64](0.75), msg="element 3")
+    assert_almost_equal(t[4], Scalar[DType.float64](1.0), msg="element 4")
+    print("PASS: test_linspace_values")
+
+
+fn test_linspace_no_endpoint() raises:
+    """Verify linspace without endpoint excludes the stop value."""
+    var t = linspace[DType.float64](
+        Scalar[DType.float64](0.0),
+        Scalar[DType.float64](1.0),
+        4,
+        endpoint=False,
+    )
+    assert_true(t.numel() == 4, "should have 4 elements")
+    assert_almost_equal(t[0], Scalar[DType.float64](0.0), msg="element 0")
+    assert_almost_equal(t[1], Scalar[DType.float64](0.25), msg="element 1")
+    assert_almost_equal(t[2], Scalar[DType.float64](0.5), msg="element 2")
+    assert_almost_equal(t[3], Scalar[DType.float64](0.75), msg="element 3")
+    print("PASS: test_linspace_no_endpoint")
+
+
+fn test_randn_produces_values() raises:
+    """Verify randn produces values with deterministic seed."""
+    var t = randn[DType.float32]([10], seed=42)
+    assert_true(t.numel() == 10, "should have 10 elements")
+    # Verify values are not all zero (would indicate broken RNG)
+    var has_nonzero = False
+    for i in range(t.numel()):
+        if t[i] != Scalar[DType.float32](0.0):
+            has_nonzero = True
+            break
+    assert_true(has_nonzero, "randn should produce non-zero values")
+    print("PASS: test_randn_produces_values")
+
+
+fn test_nan_tensor_fills_nan() raises:
+    """Verify nan_tensor fills all elements with NaN."""
+    var t = nan_tensor[DType.float32]([2, 3])
+    assert_true(t.numel() == 6, "numel should be 6")
+    for i in range(t.numel()):
+        assert_true(isnan(t[i]), "element should be NaN")
+    print("PASS: test_nan_tensor_fills_nan")
+
+
+fn test_inf_tensor_fills_inf() raises:
+    """Verify inf_tensor fills all elements with positive infinity."""
+    var t = inf_tensor[DType.float32]([4])
+    assert_true(t.numel() == 4, "numel should be 4")
+    for i in range(t.numel()):
+        assert_true(t[i] > Scalar[DType.float32](1e30), "element should be very large (inf)")
+    print("PASS: test_inf_tensor_fills_inf")
+
+
+fn test_neg_inf_tensor_fills_neg_inf() raises:
+    """Verify neg_inf_tensor fills all elements with negative infinity."""
+    var t = neg_inf_tensor[DType.float32]([4])
+    assert_true(t.numel() == 4, "numel should be 4")
+    for i in range(t.numel()):
+        assert_true(t[i] < Scalar[DType.float32](-1e30), "element should be very negative (neg inf)")
+    print("PASS: test_neg_inf_tensor_fills_neg_inf")
+
+
+fn test_eye_with_offset() raises:
+    """Verify eye with k=1 places ones on upper diagonal."""
+    var t = eye[DType.float32](3, 4, 1)
+    assert_true(t.numel() == 12, "should have 12 elements")
+    # Row 0: [0, 1, 0, 0]
+    assert_almost_equal(t[0], Scalar[DType.float32](0.0), msg="[0,0]")
+    assert_almost_equal(t[1], Scalar[DType.float32](1.0), msg="[0,1]")
+    assert_almost_equal(t[2], Scalar[DType.float32](0.0), msg="[0,2]")
+    assert_almost_equal(t[3], Scalar[DType.float32](0.0), msg="[0,3]")
+    # Row 1: [0, 0, 1, 0]
+    assert_almost_equal(t[4], Scalar[DType.float32](0.0), msg="[1,0]")
+    assert_almost_equal(t[5], Scalar[DType.float32](0.0), msg="[1,1]")
+    assert_almost_equal(t[6], Scalar[DType.float32](1.0), msg="[1,2]")
+    assert_almost_equal(t[7], Scalar[DType.float32](0.0), msg="[1,3]")
+    # Row 2: [0, 0, 0, 1]
+    assert_almost_equal(t[8], Scalar[DType.float32](0.0), msg="[2,0]")
+    assert_almost_equal(t[9], Scalar[DType.float32](0.0), msg="[2,1]")
+    assert_almost_equal(t[10], Scalar[DType.float32](0.0), msg="[2,2]")
+    assert_almost_equal(t[11], Scalar[DType.float32](1.0), msg="[2,3]")
+    print("PASS: test_eye_with_offset")
+
+
+fn test_arange_fractional_step() raises:
+    """Verify arange with step=0.5 produces correct fractional sequence."""
+    var t = arange[DType.float64](
+        Scalar[DType.float64](0.0),
+        Scalar[DType.float64](2.0),
+        Scalar[DType.float64](0.5),
+    )
+    assert_true(t.numel() == 4, "should have 4 elements")
+    assert_almost_equal(t[0], Scalar[DType.float64](0.0), msg="element 0")
+    assert_almost_equal(t[1], Scalar[DType.float64](0.5), msg="element 1")
+    assert_almost_equal(t[2], Scalar[DType.float64](1.0), msg="element 2")
+    assert_almost_equal(t[3], Scalar[DType.float64](1.5), msg="element 3")
+    print("PASS: test_arange_fractional_step")
+
+
+fn main() raises:
+    test_linspace_values()
+    test_linspace_no_endpoint()
+    test_randn_produces_values()
+    test_nan_tensor_fills_nan()
+    test_inf_tensor_fills_inf()
+    test_neg_inf_tensor_fills_neg_inf()
+    test_eye_with_offset()
+    test_arange_fractional_step()


### PR DESCRIPTION
## Summary

- Add 14 typed factory functions (`zeros`, `ones`, `full`, `empty`, `arange`, `eye`, `linspace`, `randn`, `zeros_like`, `ones_like`, `full_like`, `nan_tensor`, `inf_tensor`, `neg_inf_tensor`) in `shared/tensor/factories.mojo` returning `Tensor[dtype]` with compile-time typing (B1 fix)
- Fix pre-existing compilation errors: rename `TensorLike.dtype()` to `get_dtype()` to resolve name collision with struct parameter, fix unqualified `dtype` reference in internal constructor
- Add 18 tests across 2 files (ADR-009 compliant)

## Key Design Decisions

- `Scalar[dtype]` for fill values — no precision-losing `Float64` round-trips
- `*_like` functions infer dtype from input tensor's compile-time parameter
- `nan_tensor`/`inf_tensor`/`neg_inf_tensor` use `@parameter` compile-time float-type checks
- `randn` uses Box-Muller transform with `random_float64`, cast to target dtype

## Files Modified

- `shared/tensor/factories.mojo` — **NEW** 14 typed factory functions
- `shared/tensor/__init__.mojo` — re-export all factory functions
- `shared/tensor/tensor.mojo` — fix `Self.dtype` reference, rename `dtype()` -> `get_dtype()`
- `shared/tensor/tensor_traits.mojo` — rename trait method `dtype()` -> `get_dtype()`
- `tests/shared/tensor/test_tensor_factories.mojo` — **NEW** 10 tests (part 1)
- `tests/shared/tensor/test_tensor_factories_part2.mojo` — **NEW** 8 tests (part 2)
- `tests/shared/tensor/test_tensor_element_access.mojo` — update `.dtype()` -> `.get_dtype()`
- `tests/shared/tensor/test_tensor_any_conversion.mojo` — update `.dtype()` -> `.get_dtype()`

## Verification

- Package builds clean: `pixi run mojo package shared/tensor`
- Part 1 tests compile, link, and pass (10/10 PASS)
- Part 2 tests compile but cannot link locally (GLIBC `sincos` symbol — CI will handle)
- Existing tests (`test_tensor_element_access`) still compile and pass (9/9 PASS)
- All pre-commit hooks pass

Part of #4998

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>