### PR TITLE
feat(core): add Tensor[dtype] overloads for shape and arithmetic ops

### DIFF
--- a/shared/core/arithmetic.mojo
+++ b/shared/core/arithmetic.mojo
@@ -9,6 +9,7 @@ from .extensor import ExTensor, full
 from .broadcasting import broadcast_shapes, compute_broadcast_strides
 from .shape import as_contiguous
 from .gradient_types import GradientPair
+from shared.tensor.tensor import Tensor
 from .dtype_ordinal import (
     dtype_to_ordinal,
     DTYPE_FLOAT16,
@@ -807,6 +808,164 @@ fn divide_backward(
 
 
 # ==============================================================================
+# ============================================================================
+# Tensor[dtype] Typed Overloads (Phase 3b)
+# ============================================================================
+# These wrap the existing ExTensor implementations via as_any() -> call ->
+# _any_to_tensor(). Correct and testable; optimization comes in later phases.
+
+
+fn _any_to_tensor[dt: DType](any_t: ExTensor) raises -> Tensor[dt]:
+    """Convert ExTensor to Tensor[dt] via zero-copy shared refcount.
+
+    Internal helper for typed overloads. Uses Tensor's internal constructor
+    which increments the shared refcount (B4 protocol).
+
+    Parameters:
+        dt: The compile-time DType to bitcast the data pointer to.
+
+    Args:
+        any_t: The ExTensor to convert (must have matching dtype).
+
+    Returns:
+        A Tensor[dt] sharing the same data and refcount.
+
+    Raises:
+        Error: If any_t's runtime dtype doesn't match dt.
+    """
+    if any_t._dtype != dt:
+        raise Error(
+            "_any_to_tensor: dtype mismatch — ExTensor has "
+            + String(any_t._dtype)
+            + " but requested "
+            + String(dt)
+        )
+    return Tensor[dt](
+        any_t._data.bitcast[Scalar[dt]](),
+        any_t._shape,
+        any_t._strides,
+        any_t._refcount,
+        any_t._numel,
+        any_t._is_view,
+        any_t._allocated_size,
+        any_t._original_numel_quantized,
+    )
+
+
+fn add[dt: DType](a: Tensor[dt], b: Tensor[dt]) raises -> Tensor[dt]:
+    """Element-wise addition (typed version).
+
+    Args:
+        a: First typed tensor.
+        b: Second typed tensor.
+
+    Returns:
+        A new typed tensor containing a + b.
+
+    Raises:
+        Error: If shapes are not broadcast-compatible.
+    """
+    var any_a = a.as_any()
+    var any_b = b.as_any()
+    var result_any = add(any_a, any_b)
+    return _any_to_tensor[dt](result_any)
+
+
+fn subtract[dt: DType](a: Tensor[dt], b: Tensor[dt]) raises -> Tensor[dt]:
+    """Element-wise subtraction (typed version).
+
+    Args:
+        a: First typed tensor.
+        b: Second typed tensor.
+
+    Returns:
+        A new typed tensor containing a - b.
+
+    Raises:
+        Error: If shapes are not broadcast-compatible.
+    """
+    var any_a = a.as_any()
+    var any_b = b.as_any()
+    var result_any = subtract(any_a, any_b)
+    return _any_to_tensor[dt](result_any)
+
+
+fn multiply[dt: DType](a: Tensor[dt], b: Tensor[dt]) raises -> Tensor[dt]:
+    """Element-wise multiplication (typed version).
+
+    Args:
+        a: First typed tensor.
+        b: Second typed tensor.
+
+    Returns:
+        A new typed tensor containing a * b.
+
+    Raises:
+        Error: If shapes are not broadcast-compatible.
+    """
+    var any_a = a.as_any()
+    var any_b = b.as_any()
+    var result_any = multiply(any_a, any_b)
+    return _any_to_tensor[dt](result_any)
+
+
+fn divide[dt: DType](a: Tensor[dt], b: Tensor[dt]) raises -> Tensor[dt]:
+    """Element-wise division (typed version).
+
+    Args:
+        a: First typed tensor (numerator).
+        b: Second typed tensor (denominator).
+
+    Returns:
+        A new typed tensor containing a / b.
+
+    Raises:
+        Error: If shapes are not broadcast-compatible.
+    """
+    var any_a = a.as_any()
+    var any_b = b.as_any()
+    var result_any = divide(any_a, any_b)
+    return _any_to_tensor[dt](result_any)
+
+
+fn floor_divide[dt: DType](a: Tensor[dt], b: Tensor[dt]) raises -> Tensor[dt]:
+    """Element-wise floor division (typed version).
+
+    Args:
+        a: First typed tensor (numerator).
+        b: Second typed tensor (denominator).
+
+    Returns:
+        A new typed tensor containing a // b.
+
+    Raises:
+        Error: If shapes are not broadcast-compatible.
+    """
+    var any_a = a.as_any()
+    var any_b = b.as_any()
+    var result_any = floor_divide(any_a, any_b)
+    return _any_to_tensor[dt](result_any)
+
+
+fn power[dt: DType](a: Tensor[dt], b: Tensor[dt]) raises -> Tensor[dt]:
+    """Element-wise exponentiation (typed version).
+
+    Args:
+        a: Base typed tensor.
+        b: Exponent typed tensor.
+
+    Returns:
+        A new typed tensor containing a ** b.
+
+    Raises:
+        Error: If shapes are not broadcast-compatible.
+    """
+    var any_a = a.as_any()
+    var any_b = b.as_any()
+    var result_any = power(any_a, any_b)
+    return _any_to_tensor[dt](result_any)
+
+
 # FUTURE WORK: Operator Overloading (out of scope for issues #219-220)
 # ==============================================================================
 #

--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -3404,12 +3404,17 @@ struct AnyTensor(
         Creates a Tensor[dtype] that shares the same data buffer and refcount.
         The dtype parameter must match self._dtype at runtime.
 
-        Args:
+        Note: Due to circular import constraints (extensor.mojo cannot import
+        shared.tensor.tensor at module level), this method cannot declare
+        Tensor[dtype] as a return type. Use the standalone `any_to_tensor()`
+        function from shared.core.tensor_conversion instead, or construct
+        Tensor[dtype] directly via its internal constructor.
+
+        Parameters:
             dtype: The compile-time DType parameter (must match self._dtype).
 
         Raises:
-            Error: If dtype doesn't match self._dtype, or if Tensor[dtype]
-                is not yet available.
+            Error: Always raises — use standalone conversion functions instead.
         """
         if self._dtype != dtype:
             raise Error(
@@ -3418,8 +3423,10 @@ struct AnyTensor(
                 + " but as_tensor called with "
                 + String(dtype)
             )
-        # TODO: Wire up after Tensor[dtype] is available in shared.tensor.tensor
-        raise Error("as_tensor: not yet implemented — awaiting Tensor[dtype] struct")
+        raise Error(
+            "as_tensor: use standalone any_to_tensor() from"
+            " shared.core.tensor_conversion instead"
+        )
 
     # ============================================================================
     # Utility Methods

--- a/shared/core/shape.mojo
+++ b/shared/core/shape.mojo
@@ -12,6 +12,7 @@ Optimizations:
 from collections import List
 from memory import memcpy, UnsafePointer
 from .extensor import ExTensor
+from shared.tensor.tensor import Tensor
 
 
 # ============================================================================
@@ -1433,3 +1434,172 @@ fn permute(tensor: ExTensor, dims: List[Int]) raises -> ExTensor:
         result._set_float64(i, val)
 
     return result^
+
+
+# ============================================================================
+# Tensor[dtype] Typed Overloads (Phase 3a)
+# ============================================================================
+# These wrap the existing ExTensor implementations via as_any() -> call ->
+# _any_to_tensor(). Correct and testable; optimization comes in later phases.
+
+
+fn _any_to_tensor[dt: DType](any_t: ExTensor) raises -> Tensor[dt]:
+    """Convert ExTensor to Tensor[dt] via zero-copy shared refcount.
+
+    Internal helper for typed overloads. Uses Tensor's internal constructor
+    which increments the shared refcount (B4 protocol).
+
+    Parameters:
+        dt: The compile-time DType to bitcast the data pointer to.
+
+    Args:
+        any_t: The ExTensor to convert (must have matching dtype).
+
+    Returns:
+        A Tensor[dt] sharing the same data and refcount.
+
+    Raises:
+        Error: If any_t's runtime dtype doesn't match dt.
+    """
+    if any_t._dtype != dt:
+        raise Error(
+            "_any_to_tensor: dtype mismatch — ExTensor has "
+            + String(any_t._dtype)
+            + " but requested "
+            + String(dt)
+        )
+    return Tensor[dt](
+        any_t._data.bitcast[Scalar[dt]](),
+        any_t._shape,
+        any_t._strides,
+        any_t._refcount,
+        any_t._numel,
+        any_t._is_view,
+        any_t._allocated_size,
+        any_t._original_numel_quantized,
+    )
+
+
+fn reshape[dt: DType](tensor: Tensor[dt], new_shape: List[Int]) raises -> Tensor[dt]:
+    """Reshape tensor to new shape (typed version).
+
+    Args:
+        tensor: Input typed tensor.
+        new_shape: Target shape (must have same total number of elements).
+
+    Returns:
+        A new typed tensor with the specified shape.
+
+    Raises:
+        Error: If new shape has different number of elements.
+    """
+    var any_t = tensor.as_any()
+    var result_any = reshape(any_t, new_shape)
+    return _any_to_tensor[dt](result_any)
+
+
+fn squeeze[dt: DType](tensor: Tensor[dt], axis: Int = -999) raises -> Tensor[dt]:
+    """Remove size-1 dimensions (typed version).
+
+    Args:
+        tensor: Input typed tensor.
+        axis: Specific dimension to squeeze (optional, default squeezes all size-1 dims).
+
+    Returns:
+        Typed tensor with size-1 dimensions removed.
+
+    Raises:
+        Error: If specified axis is not size 1.
+    """
+    var any_t = tensor.as_any()
+    var result_any = squeeze(any_t, axis)
+    return _any_to_tensor[dt](result_any)
+
+
+fn unsqueeze[dt: DType](tensor: Tensor[dt], axis: Int) raises -> Tensor[dt]:
+    """Add a size-1 dimension at specified position (typed version).
+
+    Args:
+        tensor: Input typed tensor.
+        axis: Position to insert new dimension (supports negative indexing).
+
+    Returns:
+        Typed tensor with additional size-1 dimension.
+
+    Raises:
+        Error: If operation fails.
+    """
+    var any_t = tensor.as_any()
+    var result_any = unsqueeze(any_t, axis)
+    return _any_to_tensor[dt](result_any)
+
+
+fn expand_dims[dt: DType](tensor: Tensor[dt], axis: Int) raises -> Tensor[dt]:
+    """Alias for unsqueeze(). Add a size-1 dimension at specified position (typed version).
+
+    Args:
+        tensor: Input typed tensor.
+        axis: Position to insert new dimension.
+
+    Returns:
+        Typed tensor with additional size-1 dimension.
+
+    Raises:
+        Error: If operation fails.
+    """
+    return unsqueeze[dt](tensor, axis)
+
+
+fn flatten[dt: DType](tensor: Tensor[dt]) raises -> Tensor[dt]:
+    """Flatten tensor to 1D (typed version).
+
+    Args:
+        tensor: Input typed tensor.
+
+    Returns:
+        1D typed tensor with all elements in row-major (C) order.
+
+    Raises:
+        Error: If operation fails.
+    """
+    var any_t = tensor.as_any()
+    var result_any = flatten(any_t)
+    return _any_to_tensor[dt](result_any)
+
+
+fn permute[dt: DType](tensor: Tensor[dt], dims: List[Int]) raises -> Tensor[dt]:
+    """Permute tensor dimensions (typed version).
+
+    Args:
+        tensor: Input typed tensor.
+        dims: Permutation of dimensions (must be valid permutation of [0..ndim-1]).
+
+    Returns:
+        Typed tensor with permuted dimensions.
+
+    Raises:
+        Error: If dims is not a valid permutation.
+    """
+    var any_t = tensor.as_any()
+    var result_any = permute(any_t, dims)
+    return _any_to_tensor[dt](result_any)
+
+
+fn broadcast_to[dt: DType](
+    tensor: Tensor[dt], target_shape: List[Int]
+) raises -> Tensor[dt]:
+    """Broadcast tensor to target shape (typed version).
+
+    Args:
+        tensor: Input typed tensor.
+        target_shape: Target shape to broadcast to.
+
+    Returns:
+        Typed broadcasted tensor.
+
+    Raises:
+        Error: If shapes are not broadcast-compatible.
+    """
+    var any_t = tensor.as_any()
+    var result_any = broadcast_to(any_t, target_shape)
+    return _any_to_tensor[dt](result_any)

--- a/shared/core/tensor_conversion.mojo
+++ b/shared/core/tensor_conversion.mojo
@@ -1,0 +1,55 @@
+"""Standalone conversion functions between AnyTensor (ExTensor) and Tensor[dt].
+
+Avoids circular import: extensor.mojo cannot import Tensor at module level
+because tensor.mojo imports ExTensor from extensor.mojo. This module breaks
+the cycle by importing both and providing free functions.
+
+Usage:
+    ```mojo
+    from shared.core.tensor_conversion import any_to_tensor
+
+    var any_t = zeros([3, 4], DType.float32)
+    var typed = any_to_tensor[DType.float32](any_t)
+    ```
+"""
+
+from shared.core.extensor import ExTensor
+from shared.tensor.tensor import Tensor
+
+
+fn any_to_tensor[dt: DType](any_t: ExTensor) raises -> Tensor[dt]:
+    """Convert ExTensor to Tensor[dt] via zero-copy shared refcount.
+
+    Uses Tensor's internal constructor which increments the shared refcount
+    (B4 protocol). Both the source ExTensor and returned Tensor share the
+    same underlying data buffer and refcount pointer.
+
+    Parameters:
+        dt: The compile-time DType to bitcast the data pointer to.
+
+    Args:
+        any_t: The ExTensor to convert (must have matching dtype).
+
+    Returns:
+        A Tensor[dt] sharing the same data and refcount.
+
+    Raises:
+        Error: If any_t's runtime dtype doesn't match dt.
+    """
+    if any_t._dtype != dt:
+        raise Error(
+            "any_to_tensor: dtype mismatch — ExTensor has "
+            + String(any_t._dtype)
+            + " but requested "
+            + String(dt)
+        )
+    return Tensor[dt](
+        any_t._data.bitcast[Scalar[dt]](),
+        any_t._shape,
+        any_t._strides,
+        any_t._refcount,
+        any_t._numel,
+        any_t._is_view,
+        any_t._allocated_size,
+        any_t._original_numel_quantized,
+    )

--- a/shared/tensor/tensor.mojo
+++ b/shared/tensor/tensor.mojo
@@ -1,9 +1,9 @@
-"""Tensor[dtype] — compile-time typed parametric tensor.
+"""Tensor[dt] — compile-time typed parametric tensor.
 
 Provides a tensor type parametric on DType, enabling typed element access via
-`__getitem__` that returns `Scalar[Self.dtype]` (no runtime dtype branching).
+`__getitem__` that returns `Scalar[Self.dt]` (no runtime dtype branching).
 
-Uses typed `UnsafePointer[Scalar[dtype]]` storage instead of type-erased
+Uses typed `UnsafePointer[Scalar[dt]]` storage instead of type-erased
 `UnsafePointer[UInt8]`. Pointer arithmetic auto-scales by element size (H1),
 so no manual `* dtype_size` is needed for element offsets.
 
@@ -35,7 +35,7 @@ comptime TENSOR_PRINT_THRESHOLD: Int = 1000  # Truncate if numel > threshold
 comptime TENSOR_PRINT_SHOW_ELEMENTS: Int = 3  # Show first/last N elements
 
 
-struct Tensor[dtype: DType = DType.float32](
+struct Tensor[dt: DType = DType.float32](
     Copyable,
     ImplicitlyCopyable,
     Movable,
@@ -46,8 +46,8 @@ struct Tensor[dtype: DType = DType.float32](
 ):
     """Compile-time typed tensor with SIMD-like element access.
 
-    Parametric on DType, enabling `__getitem__` to return `Scalar[Self.dtype]`
-    without runtime dtype branching. Uses typed `UnsafePointer[Scalar[dtype]]`
+    Parametric on DType, enabling `__getitem__` to return `Scalar[Self.dt]`
+    without runtime dtype branching. Uses typed `UnsafePointer[Scalar[dt]]`
     storage where pointer arithmetic auto-scales by element size.
 
     Memory Safety: Implements reference counting for safe shared ownership.
@@ -56,7 +56,7 @@ struct Tensor[dtype: DType = DType.float32](
     for zero-copy conversion via `as_any()`.
 
     Parameters:
-        dtype: The compile-time data type of tensor elements (default: float32).
+        dt: The compile-time data type of tensor elements (default: float32).
 
     Attributes:
         _data: Typed pointer to element storage (auto-scales pointer arithmetic).
@@ -69,7 +69,7 @@ struct Tensor[dtype: DType = DType.float32](
         _original_numel_quantized: For quantized tensors, original size before padding.
     """
 
-    var _data: UnsafePointer[Scalar[Self.dtype], origin=MutAnyOrigin]
+    var _data: UnsafePointer[Scalar[Self.dt], origin=MutAnyOrigin]
     """Typed pointer to element storage."""
     var _shape: List[Int]
     """List of dimension sizes."""
@@ -143,7 +143,7 @@ struct Tensor[dtype: DType = DType.float32](
 
         # Allocate through memory pool (returns UInt8 pointer), then bitcast
         # to typed pointer. _allocated_size is in BYTES.
-        self._data = pooled_alloc(total_bytes).bitcast[Scalar[Self.dtype]]()
+        self._data = pooled_alloc(total_bytes).bitcast[Scalar[Self.dt]]()
         self._allocated_size = total_bytes
 
         # Zero-initialize the memory
@@ -155,7 +155,7 @@ struct Tensor[dtype: DType = DType.float32](
 
     fn __init__(
         out self,
-        data: UnsafePointer[Scalar[dtype], origin=MutAnyOrigin],
+        data: UnsafePointer[Scalar[Self.dt], origin=MutAnyOrigin],
         shape: List[Int],
         strides: List[Int],
         refcount: UnsafePointer[Int, origin=MutAnyOrigin],
@@ -253,8 +253,8 @@ struct Tensor[dtype: DType = DType.float32](
     # Element access
     # ------------------------------------------------------------------
 
-    fn __getitem__(self, index: Int) raises -> Scalar[Self.dtype]:
-        """Get element at flat index — returns typed Scalar[Self.dtype].
+    fn __getitem__(self, index: Int) raises -> Scalar[Self.dt]:
+        """Get element at flat index — returns typed Scalar[Self.dt].
 
         For contiguous tensors, the flat index maps directly to a memory
         offset. For non-contiguous tensors (e.g., after transpose), the
@@ -268,7 +268,7 @@ struct Tensor[dtype: DType = DType.float32](
                 row-major order of the tensor's shape).
 
         Returns:
-            The value at the given index as Scalar[Self.dtype].
+            The value at the given index as Scalar[Self.dt].
 
         Raises:
             Error: If index is out of bounds.
@@ -294,8 +294,8 @@ struct Tensor[dtype: DType = DType.float32](
         # Contiguous — direct indexed access (auto-scales, no * dtype_size)
         return self._data[index]
 
-    fn __setitem__(mut self, index: Int, value: Scalar[Self.dtype]) raises:
-        """Set element at flat index — accepts typed Scalar[Self.dtype].
+    fn __setitem__(mut self, index: Int, value: Scalar[Self.dt]) raises:
+        """Set element at flat index — accepts typed Scalar[Self.dt].
 
         Args:
             index: The flat index to set.
@@ -336,7 +336,7 @@ struct Tensor[dtype: DType = DType.float32](
 
     fn dtype(self) -> DType:
         """Return the element data type (compile-time constant)."""
-        return Self.dtype
+        return Self.dt
 
     fn ndim(self) -> Int:
         """Return the number of dimensions (rank)."""
@@ -425,7 +425,7 @@ struct Tensor[dtype: DType = DType.float32](
         var shape_copy = List[Int]()
         for i in range(len(self._shape)):
             shape_copy.append(self._shape[i])
-        var result = ExTensor(shape_copy, Self.dtype)
+        var result = ExTensor(shape_copy, Self.dt)
 
         # --- Tear down the temporary ExTensor's independent allocation ---
         # Free the independently allocated data buffer (safe: result is the
@@ -496,7 +496,7 @@ struct Tensor[dtype: DType = DType.float32](
                     result += String(self[i])
                 except:
                     result += "?"
-        result += "], dtype=" + String(Self.dtype) + ")"
+        result += "], dtype=" + String(Self.dt) + ")"
         return result
 
     fn __repr__(self) -> String:
@@ -515,7 +515,7 @@ struct Tensor[dtype: DType = DType.float32](
             shape_str += String(self._shape[i])
         shape_str += "]"
         var result = String("Tensor(shape=") + shape_str
-        result += ", dtype=" + String(Self.dtype)
+        result += ", dtype=" + String(Self.dt)
         result += ", numel=" + String(self._numel)
         result += ", data=["
         if self._numel > TENSOR_PRINT_THRESHOLD:
@@ -558,25 +558,25 @@ struct Tensor[dtype: DType = DType.float32](
         Matches ExTensor._get_dtype_size_static() output for the same dtype.
         """
         # DType size lookup — same logic as ExTensor but resolved at
-        # compile time since Self.dtype is a parameter.
+        # compile time since Self.dt is a parameter.
         @parameter
-        if Self.dtype == DType.float16 or Self.dtype == DType.bfloat16:
+        if Self.dt == DType.float16 or Self.dt == DType.bfloat16:
             return 2
-        elif Self.dtype == DType.float32:
+        elif Self.dt == DType.float32:
             return 4
-        elif Self.dtype == DType.float64:
+        elif Self.dt == DType.float64:
             return 8
         elif (
-            Self.dtype == DType.int8
-            or Self.dtype == DType.uint8
-            or Self.dtype == DType.bool
+            Self.dt == DType.int8
+            or Self.dt == DType.uint8
+            or Self.dt == DType.bool
         ):
             return 1
-        elif Self.dtype == DType.int16 or Self.dtype == DType.uint16:
+        elif Self.dt == DType.int16 or Self.dt == DType.uint16:
             return 2
-        elif Self.dtype == DType.int32 or Self.dtype == DType.uint32:
+        elif Self.dt == DType.int32 or Self.dt == DType.uint32:
             return 4
-        elif Self.dtype == DType.int64 or Self.dtype == DType.uint64:
+        elif Self.dt == DType.int64 or Self.dt == DType.uint64:
             return 8
         else:
             return 4  # Default fallback

--- a/tests/shared/tensor/test_tensor_any_conversion.mojo
+++ b/tests/shared/tensor/test_tensor_any_conversion.mojo
@@ -18,6 +18,7 @@ Tests cover:
 from testing import assert_true, assert_almost_equal
 from shared.tensor.tensor import Tensor
 from shared.core.extensor import ExTensor, AnyTensor, zeros
+from shared.core.tensor_conversion import any_to_tensor
 
 
 fn test_anytensor_alias_works() raises:
@@ -56,20 +57,20 @@ fn test_as_any_preserves_shape() raises:
 
 
 fn test_as_tensor_basic() raises:
-    """AnyTensor.as_tensor[dtype]() returns a Tensor[dtype]."""
+    """Standalone any_to_tensor returns a Tensor[dtype]."""
     var any_t = zeros([4], DType.float32)
-    var t = any_t.as_tensor[DType.float32]()
+    var t = any_to_tensor[DType.float32](any_t)
     assert_true(t.numel() == 4, "as_tensor preserves numel")
     assert_true(t.dtype() == DType.float32, "as_tensor preserves dtype")
     print("PASS: test_as_tensor_basic")
 
 
 fn test_as_tensor_dtype_mismatch() raises:
-    """as_tensor with wrong dtype should raise."""
+    """any_to_tensor with wrong dtype should raise."""
     var any_t = zeros([4], DType.float32)
     var raised = False
     try:
-        var t = any_t.as_tensor[DType.float64]()
+        var t = any_to_tensor[DType.float64](any_t)
         _ = t  # suppress unused warning
     except:
         raised = True
@@ -86,7 +87,7 @@ fn test_roundtrip_tensor_any_tensor() raises:
 
     # Round-trip
     var any_t = t1.as_any()
-    var t2 = any_t.as_tensor[DType.float32]()
+    var t2 = any_to_tensor[DType.float32](any_t)
 
     assert_almost_equal(Float32(t2[0]), Float32(1.5), atol=1e-6)
     assert_almost_equal(Float32(t2[1]), Float32(0.25), atol=1e-6)

--- a/tests/shared/tensor/test_tensor_arithmetic.mojo
+++ b/tests/shared/tensor/test_tensor_arithmetic.mojo
@@ -1,0 +1,103 @@
+"""Tests for Tensor[dtype] typed arithmetic operation overloads.
+
+# ADR-009: This file is intentionally limited to <=10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Tests cover:
+- add element-wise
+- subtract element-wise
+- multiply element-wise
+- divide element-wise
+"""
+
+from testing import assert_true, assert_almost_equal
+from shared.tensor.tensor import Tensor
+from shared.core.arithmetic import add, subtract, multiply, divide
+
+
+fn test_add_typed() raises:
+    """Element-wise addition."""
+    var a = Tensor[DType.float32]([3])
+    var b = Tensor[DType.float32]([3])
+    a[0] = 1.0
+    a[1] = 2.0
+    a[2] = 3.0
+    b[0] = 10.0
+    b[1] = 20.0
+    b[2] = 30.0
+
+    var r = add(a, b)
+    assert_true(r.numel() == 3, "numel should be 3")
+    assert_true(r.dtype() == DType.float32, "dtype preserved")
+    assert_almost_equal(r[0], Scalar[DType.float32](11.0), msg="val 0")
+    assert_almost_equal(r[1], Scalar[DType.float32](22.0), msg="val 1")
+    assert_almost_equal(r[2], Scalar[DType.float32](33.0), msg="val 2")
+    print("PASS: test_add_typed")
+
+
+fn test_subtract_typed() raises:
+    """Element-wise subtraction."""
+    var a = Tensor[DType.float32]([3])
+    var b = Tensor[DType.float32]([3])
+    a[0] = 10.0
+    a[1] = 20.0
+    a[2] = 30.0
+    b[0] = 1.0
+    b[1] = 2.0
+    b[2] = 3.0
+
+    var r = subtract(a, b)
+    assert_true(r.numel() == 3, "numel should be 3")
+    assert_true(r.dtype() == DType.float32, "dtype preserved")
+    assert_almost_equal(r[0], Scalar[DType.float32](9.0), msg="val 0")
+    assert_almost_equal(r[1], Scalar[DType.float32](18.0), msg="val 1")
+    assert_almost_equal(r[2], Scalar[DType.float32](27.0), msg="val 2")
+    print("PASS: test_subtract_typed")
+
+
+fn test_multiply_typed() raises:
+    """Element-wise multiplication."""
+    var a = Tensor[DType.float32]([3])
+    var b = Tensor[DType.float32]([3])
+    a[0] = 2.0
+    a[1] = 3.0
+    a[2] = 4.0
+    b[0] = 5.0
+    b[1] = 6.0
+    b[2] = 7.0
+
+    var r = multiply(a, b)
+    assert_true(r.numel() == 3, "numel should be 3")
+    assert_true(r.dtype() == DType.float32, "dtype preserved")
+    assert_almost_equal(r[0], Scalar[DType.float32](10.0), msg="val 0")
+    assert_almost_equal(r[1], Scalar[DType.float32](18.0), msg="val 1")
+    assert_almost_equal(r[2], Scalar[DType.float32](28.0), msg="val 2")
+    print("PASS: test_multiply_typed")
+
+
+fn test_divide_typed() raises:
+    """Element-wise division."""
+    var a = Tensor[DType.float32]([3])
+    var b = Tensor[DType.float32]([3])
+    a[0] = 10.0
+    a[1] = 20.0
+    a[2] = 30.0
+    b[0] = 2.0
+    b[1] = 4.0
+    b[2] = 5.0
+
+    var r = divide(a, b)
+    assert_true(r.numel() == 3, "numel should be 3")
+    assert_true(r.dtype() == DType.float32, "dtype preserved")
+    assert_almost_equal(r[0], Scalar[DType.float32](5.0), msg="val 0")
+    assert_almost_equal(r[1], Scalar[DType.float32](5.0), msg="val 1")
+    assert_almost_equal(r[2], Scalar[DType.float32](6.0), msg="val 2")
+    print("PASS: test_divide_typed")
+
+
+fn main() raises:
+    test_add_typed()
+    test_subtract_typed()
+    test_multiply_typed()
+    test_divide_typed()

--- a/tests/shared/tensor/test_tensor_refcount.mojo
+++ b/tests/shared/tensor/test_tensor_refcount.mojo
@@ -16,6 +16,7 @@ Tests cover:
 from testing import assert_true, assert_almost_equal
 from shared.tensor.tensor import Tensor
 from shared.core.extensor import AnyTensor, zeros
+from shared.core.tensor_conversion import any_to_tensor
 
 
 fn test_refcount_shared_on_as_any() raises:
@@ -36,7 +37,7 @@ fn test_refcount_shared_on_as_tensor() raises:
     var any_t = zeros([4], DType.float32)
     any_t._set_float32(0, Float32(0.25))
 
-    var t = any_t.as_tensor[DType.float32]()
+    var t = any_to_tensor[DType.float32](any_t)
 
     assert_almost_equal(Float32(t[0]), Float32(0.25), atol=1e-6)
     print("PASS: test_refcount_shared_on_as_tensor")
@@ -47,7 +48,7 @@ fn _make_tensor_from_anytensor() raises -> Tensor[DType.float32]:
     var any_t = zeros([4], DType.float32)
     any_t._set_float32(0, Float32(1.5))
     any_t._set_float32(1, Float32(0.5))
-    return any_t.as_tensor[DType.float32]()
+    return any_to_tensor[DType.float32](any_t)
     # any_t is destroyed here — ASAP destruction
 
 
@@ -91,8 +92,8 @@ fn test_tensor_multiple_conversions() raises:
     var any_t = zeros([4], DType.float32)
     any_t._set_float32(0, Float32(0.5))
 
-    var t1 = any_t.as_tensor[DType.float32]()
-    var t2 = any_t.as_tensor[DType.float32]()
+    var t1 = any_to_tensor[DType.float32](any_t)
+    var t2 = any_to_tensor[DType.float32](any_t)
 
     assert_almost_equal(Float32(t1[0]), Float32(0.5), atol=1e-6)
     assert_almost_equal(Float32(t2[0]), Float32(0.5), atol=1e-6)

--- a/tests/shared/tensor/test_tensor_shape_ops.mojo
+++ b/tests/shared/tensor/test_tensor_shape_ops.mojo
@@ -1,0 +1,121 @@
+"""Tests for Tensor[dtype] typed shape operation overloads.
+
+# ADR-009: This file is intentionally limited to <=10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Tests cover:
+- reshape preserves dtype and values
+- squeeze removes size-1 dims
+- unsqueeze adds dimension
+- flatten to 1D
+- expand_dims adds dimension at position
+"""
+
+from testing import assert_true, assert_almost_equal
+from shared.tensor.tensor import Tensor
+from shared.core.shape import (
+    reshape,
+    squeeze,
+    unsqueeze,
+    expand_dims,
+    flatten,
+)
+
+
+fn test_reshape_typed() raises:
+    """Reshape preserves dtype and values."""
+    var t = Tensor[DType.float32]([2, 3])
+    # Set some values
+    t[0] = 1.0
+    t[1] = 2.0
+    t[2] = 3.0
+    t[3] = 4.0
+    t[4] = 5.0
+    t[5] = 6.0
+
+    var r = reshape(t, [3, 2])
+    assert_true(r.numel() == 6, "numel should be 6")
+    assert_true(r.ndim() == 2, "ndim should be 2")
+    var s = r.shape()
+    assert_true(s[0] == 3, "dim 0 should be 3")
+    assert_true(s[1] == 2, "dim 1 should be 2")
+    assert_true(r.dtype() == DType.float32, "dtype preserved")
+    assert_almost_equal(r[0], Scalar[DType.float32](1.0), msg="val 0")
+    assert_almost_equal(r[5], Scalar[DType.float32](6.0), msg="val 5")
+    print("PASS: test_reshape_typed")
+
+
+fn test_squeeze_typed() raises:
+    """Squeeze removes size-1 dims."""
+    var t = Tensor[DType.float32]([1, 3, 1, 4])
+    for i in range(12):
+        t[i] = Scalar[DType.float32](i)
+
+    var r = squeeze(t)
+    assert_true(r.ndim() == 2, "ndim should be 2 after squeeze")
+    var s = r.shape()
+    assert_true(s[0] == 3, "dim 0 should be 3")
+    assert_true(s[1] == 4, "dim 1 should be 4")
+    assert_true(r.dtype() == DType.float32, "dtype preserved")
+    assert_almost_equal(r[0], Scalar[DType.float32](0.0), msg="val 0")
+    assert_almost_equal(r[11], Scalar[DType.float32](11.0), msg="val 11")
+    print("PASS: test_squeeze_typed")
+
+
+fn test_unsqueeze_typed() raises:
+    """Unsqueeze adds dimension."""
+    var t = Tensor[DType.float32]([3, 4])
+    for i in range(12):
+        t[i] = Scalar[DType.float32](i)
+
+    var r = unsqueeze(t, axis=0)
+    assert_true(r.ndim() == 3, "ndim should be 3")
+    var s = r.shape()
+    assert_true(s[0] == 1, "dim 0 should be 1")
+    assert_true(s[1] == 3, "dim 1 should be 3")
+    assert_true(s[2] == 4, "dim 2 should be 4")
+    assert_true(r.dtype() == DType.float32, "dtype preserved")
+    assert_almost_equal(r[0], Scalar[DType.float32](0.0), msg="val 0")
+    print("PASS: test_unsqueeze_typed")
+
+
+fn test_flatten_typed() raises:
+    """Flatten to 1D."""
+    var t = Tensor[DType.float64]([2, 3])
+    for i in range(6):
+        t[i] = Scalar[DType.float64](i + 1)
+
+    var r = flatten(t)
+    assert_true(r.ndim() == 1, "ndim should be 1")
+    var s = r.shape()
+    assert_true(s[0] == 6, "dim 0 should be 6")
+    assert_true(r.dtype() == DType.float64, "dtype preserved")
+    assert_almost_equal(r[0], Scalar[DType.float64](1.0), msg="val 0")
+    assert_almost_equal(r[5], Scalar[DType.float64](6.0), msg="val 5")
+    print("PASS: test_flatten_typed")
+
+
+fn test_expand_dims_typed() raises:
+    """Expand_dims adds dimension at position."""
+    var t = Tensor[DType.float32]([4])
+    for i in range(4):
+        t[i] = Scalar[DType.float32](i)
+
+    var r = expand_dims(t, axis=0)
+    assert_true(r.ndim() == 2, "ndim should be 2")
+    var s = r.shape()
+    assert_true(s[0] == 1, "dim 0 should be 1")
+    assert_true(s[1] == 4, "dim 1 should be 4")
+    assert_true(r.dtype() == DType.float32, "dtype preserved")
+    assert_almost_equal(r[0], Scalar[DType.float32](0.0), msg="val 0")
+    assert_almost_equal(r[3], Scalar[DType.float32](3.0), msg="val 3")
+    print("PASS: test_expand_dims_typed")
+
+
+fn main() raises:
+    test_reshape_typed()
+    test_squeeze_typed()
+    test_unsqueeze_typed()
+    test_flatten_typed()
+    test_expand_dims_typed()


### PR DESCRIPTION
## Summary

- Add typed `Tensor[dt]` overloads for 7 shape ops (reshape, squeeze, unsqueeze, expand_dims, flatten, permute, broadcast_to) and 6 arithmetic ops (add, subtract, multiply, divide, floor_divide, power)
- Create `shared/core/tensor_conversion.mojo` with standalone `any_to_tensor[dt]()` for zero-copy ExTensor-to-Tensor conversion (avoids circular import between extensor.mojo and tensor.mojo)
- Fix Tensor struct parameter name collision: rename `dtype` to `dt` so the `dtype()` method required by `TensorLike` trait compiles (Mojo v0.26.1 limitation)

## Changes Made

**Phase 3a (Shape Ops)** in `shared/core/shape.mojo`:
- `reshape[dt]`, `squeeze[dt]`, `unsqueeze[dt]`, `expand_dims[dt]`, `flatten[dt]`, `permute[dt]`, `broadcast_to[dt]`
- Each wraps existing ExTensor implementation via `as_any() -> call -> _any_to_tensor[dt]()`

**Phase 3b (Arithmetic Ops)** in `shared/core/arithmetic.mojo`:
- `add[dt]`, `subtract[dt]`, `multiply[dt]`, `divide[dt]`, `floor_divide[dt]`, `power[dt]`
- Same wrapping pattern as shape ops

**Infrastructure**:
- `shared/core/tensor_conversion.mojo`: Standalone `any_to_tensor[dt]()` function
- `shared/tensor/tensor.mojo`: Struct parameter `dtype` -> `dt` (fixes compilation)
- `shared/core/extensor.mojo`: Updated `as_tensor` stub to reference standalone function
- Updated existing test files to use `any_to_tensor` instead of `AnyTensor.as_tensor()`

## Tests

- `tests/shared/tensor/test_tensor_shape_ops.mojo` (5 tests): reshape, squeeze, unsqueeze, flatten, expand_dims
- `tests/shared/tensor/test_tensor_arithmetic.mojo` (4 tests): add, subtract, multiply, divide
- All 32 tests across 5 tensor test files pass locally

Part of #4998