### PR TITLE
feat(core): add Tensor[dtype] overloads for elementwise, activation, matrix, reduction

### DIFF
--- a/shared/core/activation.mojo
+++ b/shared/core/activation.mojo
@@ -23,6 +23,7 @@ Issues covered:
 from math import exp, erf, sqrt, tanh as math_tanh, log as math_log
 from collections import List
 from .extensor import ExTensor, full, zeros_like
+from shared.tensor.tensor import Tensor, from_any_tensor
 from .arithmetic import add, subtract, multiply
 from .reduction import sum as tensor_sum, max as tensor_max
 from .elementwise import log
@@ -1579,3 +1580,74 @@ fn hard_tanh_backward(
         )
 
     return dispatch_hard_tanh_backward(grad_output, x, min_val, max_val)
+
+
+# ============================================================================
+# Tensor[dtype] typed overloads (wrapping AnyTensor implementations)
+# ============================================================================
+
+
+fn relu[dt: DType](input: Tensor[dt]) raises -> Tensor[dt]:
+    """ReLU activation (typed version).
+
+    Args:
+        input: Input tensor.
+
+    Returns:
+        A new Tensor[dt] with ReLU applied element-wise.
+    """
+    return from_any_tensor[dt](relu(input.as_any()))
+
+
+fn sigmoid[dt: DType](input: Tensor[dt]) raises -> Tensor[dt]:
+    """Sigmoid activation (typed version).
+
+    Args:
+        input: Input tensor.
+
+    Returns:
+        A new Tensor[dt] with sigmoid applied element-wise.
+    """
+    return from_any_tensor[dt](sigmoid(input.as_any()))
+
+
+fn tanh[dt: DType](input: Tensor[dt]) raises -> Tensor[dt]:
+    """Tanh activation (typed version).
+
+    Args:
+        input: Input tensor.
+
+    Returns:
+        A new Tensor[dt] with tanh applied element-wise.
+    """
+    return from_any_tensor[dt](tanh(input.as_any()))
+
+
+fn softmax[dt: DType](
+    input: Tensor[dt], axis: Int = -1
+) raises -> Tensor[dt]:
+    """Softmax activation (typed version).
+
+    Args:
+        input: Input tensor.
+        axis: Axis along which softmax is computed.
+
+    Returns:
+        A new Tensor[dt] with softmax applied.
+    """
+    return from_any_tensor[dt](softmax(input.as_any(), axis))
+
+
+fn gelu[dt: DType](
+    input: Tensor[dt], approximate: Bool = False
+) raises -> Tensor[dt]:
+    """GELU activation (typed version).
+
+    Args:
+        input: Input tensor.
+        approximate: Use tanh approximation if True.
+
+    Returns:
+        A new Tensor[dt] with GELU applied element-wise.
+    """
+    return from_any_tensor[dt](gelu(input.as_any(), approximate))

--- a/shared/core/comparison.mojo
+++ b/shared/core/comparison.mojo
@@ -5,6 +5,7 @@ Implements element-wise comparison operations following NumPy-style broadcasting
 
 from collections import List
 from .extensor import ExTensor
+from shared.tensor.tensor import Tensor, from_any_tensor
 from .broadcasting import broadcast_shapes, compute_broadcast_strides
 
 
@@ -730,3 +731,102 @@ fn greater_equal(a: ExTensor, b: ExTensor) raises -> ExTensor:
         result, a, b, strides_a, strides_b, result_shape, total_elems
     )
     return result^
+
+
+# ============================================================================
+# Tensor[dtype] typed overloads (wrapping AnyTensor implementations)
+# ============================================================================
+
+
+fn equal[dt: DType](
+    a: Tensor[dt], b: Tensor[dt]
+) raises -> Tensor[DType.bool]:
+    """Element-wise equality comparison (typed version).
+
+    Args:
+        a: First tensor.
+        b: Second tensor.
+
+    Returns:
+        A boolean Tensor with element-wise equality results.
+    """
+    return from_any_tensor[DType.bool](equal(a.as_any(), b.as_any()))
+
+
+fn not_equal[dt: DType](
+    a: Tensor[dt], b: Tensor[dt]
+) raises -> Tensor[DType.bool]:
+    """Element-wise inequality comparison (typed version).
+
+    Args:
+        a: First tensor.
+        b: Second tensor.
+
+    Returns:
+        A boolean Tensor with element-wise inequality results.
+    """
+    return from_any_tensor[DType.bool](not_equal(a.as_any(), b.as_any()))
+
+
+fn less[dt: DType](
+    a: Tensor[dt], b: Tensor[dt]
+) raises -> Tensor[DType.bool]:
+    """Element-wise less-than comparison (typed version).
+
+    Args:
+        a: First tensor.
+        b: Second tensor.
+
+    Returns:
+        A boolean Tensor with element-wise less-than results.
+    """
+    return from_any_tensor[DType.bool](less(a.as_any(), b.as_any()))
+
+
+fn less_equal[dt: DType](
+    a: Tensor[dt], b: Tensor[dt]
+) raises -> Tensor[DType.bool]:
+    """Element-wise less-than-or-equal comparison (typed version).
+
+    Args:
+        a: First tensor.
+        b: Second tensor.
+
+    Returns:
+        A boolean Tensor with element-wise less-or-equal results.
+    """
+    return from_any_tensor[DType.bool](
+        less_equal(a.as_any(), b.as_any())
+    )
+
+
+fn greater[dt: DType](
+    a: Tensor[dt], b: Tensor[dt]
+) raises -> Tensor[DType.bool]:
+    """Element-wise greater-than comparison (typed version).
+
+    Args:
+        a: First tensor.
+        b: Second tensor.
+
+    Returns:
+        A boolean Tensor with element-wise greater-than results.
+    """
+    return from_any_tensor[DType.bool](greater(a.as_any(), b.as_any()))
+
+
+fn greater_equal[dt: DType](
+    a: Tensor[dt], b: Tensor[dt]
+) raises -> Tensor[DType.bool]:
+    """Element-wise greater-than-or-equal comparison (typed version).
+
+    Args:
+        a: First tensor.
+        b: Second tensor.
+
+    Returns:
+        A boolean Tensor with element-wise greater-or-equal results.
+    """
+    return from_any_tensor[DType.bool](
+        greater_equal(a.as_any(), b.as_any())
+    )

--- a/shared/core/elementwise.mojo
+++ b/shared/core/elementwise.mojo
@@ -5,6 +5,7 @@ Implements mathematical functions like exp, log, sqrt, trigonometric functions, 
 
 from collections import List
 from .extensor import ExTensor
+from shared.tensor.tensor import Tensor, from_any_tensor
 from .dtype_dispatch import (
     dispatch_unary,
     dispatch_binary,
@@ -1603,3 +1604,108 @@ fn log2_backward(grad_output: ExTensor, x: ExTensor) raises -> ExTensor:
     var result = ExTensor(grad_output.shape(), grad_output.dtype())
     _dispatch_log2_backward(result, grad_output, x, grad_output.numel())
     return result
+
+
+# ============================================================================
+# Tensor[dtype] typed overloads (wrapping AnyTensor implementations)
+# ============================================================================
+
+
+fn exp[dt: DType](tensor: Tensor[dt]) raises -> Tensor[dt]:
+    """Element-wise exponential (typed version).
+
+    Args:
+        tensor: Input tensor.
+
+    Returns:
+        A new Tensor[dt] with exp applied element-wise.
+    """
+    return from_any_tensor[dt](exp(tensor.as_any()))
+
+
+fn log[dt: DType](tensor: Tensor[dt]) raises -> Tensor[dt]:
+    """Element-wise natural logarithm (typed version).
+
+    Args:
+        tensor: Input tensor.
+
+    Returns:
+        A new Tensor[dt] with log applied element-wise.
+    """
+    return from_any_tensor[dt](log(tensor.as_any()))
+
+
+fn sqrt[dt: DType](tensor: Tensor[dt]) raises -> Tensor[dt]:
+    """Element-wise square root (typed version).
+
+    Args:
+        tensor: Input tensor.
+
+    Returns:
+        A new Tensor[dt] with sqrt applied element-wise.
+    """
+    return from_any_tensor[dt](sqrt(tensor.as_any()))
+
+
+fn abs[dt: DType](tensor: Tensor[dt]) raises -> Tensor[dt]:
+    """Element-wise absolute value (typed version).
+
+    Args:
+        tensor: Input tensor.
+
+    Returns:
+        A new Tensor[dt] with abs applied element-wise.
+    """
+    return from_any_tensor[dt](abs(tensor.as_any()))
+
+
+fn clip[dt: DType](
+    tensor: Tensor[dt], min_val: Float64, max_val: Float64
+) raises -> Tensor[dt]:
+    """Clip (clamp) values to a range element-wise (typed version).
+
+    Args:
+        tensor: Input tensor.
+        min_val: Minimum value.
+        max_val: Maximum value.
+
+    Returns:
+        A new Tensor[dt] with clipped values.
+    """
+    return from_any_tensor[dt](clip(tensor.as_any(), min_val, max_val))
+
+
+fn sin[dt: DType](tensor: Tensor[dt]) raises -> Tensor[dt]:
+    """Element-wise sine (typed version).
+
+    Args:
+        tensor: Input tensor.
+
+    Returns:
+        A new Tensor[dt] with sin applied element-wise.
+    """
+    return from_any_tensor[dt](sin(tensor.as_any()))
+
+
+fn cos[dt: DType](tensor: Tensor[dt]) raises -> Tensor[dt]:
+    """Element-wise cosine (typed version).
+
+    Args:
+        tensor: Input tensor.
+
+    Returns:
+        A new Tensor[dt] with cos applied element-wise.
+    """
+    return from_any_tensor[dt](cos(tensor.as_any()))
+
+
+fn tanh[dt: DType](tensor: Tensor[dt]) raises -> Tensor[dt]:
+    """Element-wise hyperbolic tangent (typed version).
+
+    Args:
+        tensor: Input tensor.
+
+    Returns:
+        A new Tensor[dt] with tanh applied element-wise.
+    """
+    return from_any_tensor[dt](tanh(tensor.as_any()))

--- a/shared/core/extensor.mojo
+++ b/shared/core/extensor.mojo
@@ -3404,22 +3404,19 @@ struct AnyTensor(
         Creates a Tensor[dtype] that shares the same data buffer and refcount.
         The dtype parameter must match self._dtype at runtime.
 
+        Note: Use shared.tensor.tensor.from_any_tensor[dtype](any_tensor) instead.
+        This method cannot return Tensor[dtype] directly due to circular imports
+        (AnyTensor is defined in shared.core, Tensor is in shared.tensor).
+
         Args:
             dtype: The compile-time DType parameter (must match self._dtype).
 
         Raises:
-            Error: If dtype doesn't match self._dtype, or if Tensor[dtype]
-                is not yet available.
+            Error: Always — use from_any_tensor() free function instead.
         """
-        if self._dtype != dtype:
-            raise Error(
-                "DType mismatch: tensor has dtype "
-                + String(self._dtype)
-                + " but as_tensor called with "
-                + String(dtype)
-            )
-        # TODO: Wire up after Tensor[dtype] is available in shared.tensor.tensor
-        raise Error("as_tensor: not yet implemented — awaiting Tensor[dtype] struct")
+        raise Error(
+            "as_tensor: use shared.tensor.tensor.from_any_tensor[dtype]() instead"
+        )
 
     # ============================================================================
     # Utility Methods

--- a/shared/core/matrix.mojo
+++ b/shared/core/matrix.mojo
@@ -13,6 +13,7 @@ Includes:
 from collections import List
 from memory import memcpy
 from .extensor import ExTensor
+from shared.tensor.tensor import Tensor, from_any_tensor
 from .gradient_types import GradientPair
 from .shape import as_contiguous
 
@@ -1612,3 +1613,68 @@ fn transpose_backward(
 
     # Apply inverse permutation to gradient
     return transpose(grad_output, inverse_perm^)
+
+
+# ============================================================================
+# Tensor[dtype] typed overloads (wrapping AnyTensor implementations)
+# ============================================================================
+
+
+fn matmul[dt: DType](
+    a: Tensor[dt], b: Tensor[dt]
+) raises -> Tensor[dt]:
+    """Matrix multiplication (typed version).
+
+    Args:
+        a: First tensor.
+        b: Second tensor.
+
+    Returns:
+        A new Tensor[dt] with the matrix product.
+    """
+    return from_any_tensor[dt](matmul(a.as_any(), b.as_any()))
+
+
+fn transpose[dt: DType](
+    tensor: Tensor[dt], axes: Optional[List[Int]] = None
+) raises -> Tensor[dt]:
+    """Transpose tensor dimensions (typed version).
+
+    Args:
+        tensor: Input tensor.
+        axes: Optional permutation of axes. If None, reverses all axes.
+
+    Returns:
+        A new Tensor[dt] with transposed dimensions.
+    """
+    return from_any_tensor[dt](transpose(tensor.as_any(), axes))
+
+
+fn dot[dt: DType](
+    a: Tensor[dt], b: Tensor[dt]
+) raises -> Tensor[dt]:
+    """Dot product of tensors (typed version).
+
+    Args:
+        a: First tensor.
+        b: Second tensor.
+
+    Returns:
+        Dot product result as Tensor[dt].
+    """
+    return from_any_tensor[dt](dot(a.as_any(), b.as_any()))
+
+
+fn outer[dt: DType](
+    a: Tensor[dt], b: Tensor[dt]
+) raises -> Tensor[dt]:
+    """Outer product of two vectors (typed version).
+
+    Args:
+        a: First 1D tensor.
+        b: Second 1D tensor.
+
+    Returns:
+        A 2D Tensor[dt] containing the outer product.
+    """
+    return from_any_tensor[dt](outer(a.as_any(), b.as_any()))

--- a/shared/core/reduction.mojo
+++ b/shared/core/reduction.mojo
@@ -5,6 +5,7 @@ Implements operations that reduce tensors along specified axes
 
 from collections import List
 from .extensor import ExTensor
+from shared.tensor.tensor import Tensor, from_any_tensor
 from .shape import as_contiguous
 from .reduction_utils import (
     compute_strides,
@@ -1238,3 +1239,76 @@ fn percentile_backward(
                 result._set_float64(upper_input_idx, fraction * grad_val)
 
     return result^
+
+
+# ============================================================================
+# Tensor[dtype] typed overloads (wrapping AnyTensor implementations)
+# ============================================================================
+
+
+fn sum[dt: DType](
+    tensor: Tensor[dt], axis: Int = -1, keepdims: Bool = False
+) raises -> Tensor[dt]:
+    """Sum tensor elements along an axis (typed version).
+
+    Args:
+        tensor: Input tensor.
+        axis: Axis to reduce (-1 for all axes).
+        keepdims: Whether to keep reduced dimensions as size 1.
+
+    Returns:
+        A new Tensor[dt] with sum along specified axis.
+    """
+    return from_any_tensor[dt](sum(tensor.as_any(), axis, keepdims))
+
+
+fn mean[dt: DType](
+    tensor: Tensor[dt], axis: Int = -1, keepdims: Bool = False
+) raises -> Tensor[dt]:
+    """Compute mean of tensor elements along an axis (typed version).
+
+    Args:
+        tensor: Input tensor.
+        axis: Axis to reduce (-1 for all axes).
+        keepdims: Whether to keep reduced dimensions as size 1.
+
+    Returns:
+        A new Tensor[dt] with mean along specified axis.
+    """
+    return from_any_tensor[dt](mean(tensor.as_any(), axis, keepdims))
+
+
+fn max_reduce[dt: DType](
+    tensor: Tensor[dt], axis: Int = -1, keepdims: Bool = False
+) raises -> Tensor[dt]:
+    """Find maximum of tensor elements along an axis (typed version).
+
+    Args:
+        tensor: Input tensor.
+        axis: Axis to reduce (-1 for all axes).
+        keepdims: Whether to keep reduced dimensions as size 1.
+
+    Returns:
+        A new Tensor[dt] with max along specified axis.
+    """
+    return from_any_tensor[dt](
+        max_reduce(tensor.as_any(), axis, keepdims)
+    )
+
+
+fn min_reduce[dt: DType](
+    tensor: Tensor[dt], axis: Int = -1, keepdims: Bool = False
+) raises -> Tensor[dt]:
+    """Find minimum of tensor elements along an axis (typed version).
+
+    Args:
+        tensor: Input tensor.
+        axis: Axis to reduce (-1 for all axes).
+        keepdims: Whether to keep reduced dimensions as size 1.
+
+    Returns:
+        A new Tensor[dt] with min along specified axis.
+    """
+    return from_any_tensor[dt](
+        min_reduce(tensor.as_any(), axis, keepdims)
+    )

--- a/shared/tensor/__init__.mojo
+++ b/shared/tensor/__init__.mojo
@@ -6,4 +6,4 @@ Provides:
 """
 
 from shared.tensor.tensor_traits import TensorLike
-from shared.tensor.tensor import Tensor
+from shared.tensor.tensor import Tensor, from_any_tensor

--- a/shared/tensor/tensor.mojo
+++ b/shared/tensor/tensor.mojo
@@ -1,9 +1,9 @@
-"""Tensor[dtype] — compile-time typed parametric tensor.
+"""Tensor[dt] — compile-time typed parametric tensor.
 
 Provides a tensor type parametric on DType, enabling typed element access via
-`__getitem__` that returns `Scalar[Self.dtype]` (no runtime dtype branching).
+`__getitem__` that returns `Scalar[Self.dt]` (no runtime dtype branching).
 
-Uses typed `UnsafePointer[Scalar[dtype]]` storage instead of type-erased
+Uses typed `UnsafePointer[Scalar[dt]]` storage instead of type-erased
 `UnsafePointer[UInt8]`. Pointer arithmetic auto-scales by element size (H1),
 so no manual `* dtype_size` is needed for element offsets.
 
@@ -35,7 +35,7 @@ comptime TENSOR_PRINT_THRESHOLD: Int = 1000  # Truncate if numel > threshold
 comptime TENSOR_PRINT_SHOW_ELEMENTS: Int = 3  # Show first/last N elements
 
 
-struct Tensor[dtype: DType = DType.float32](
+struct Tensor[dt: DType = DType.float32](
     Copyable,
     ImplicitlyCopyable,
     Movable,
@@ -46,8 +46,8 @@ struct Tensor[dtype: DType = DType.float32](
 ):
     """Compile-time typed tensor with SIMD-like element access.
 
-    Parametric on DType, enabling `__getitem__` to return `Scalar[Self.dtype]`
-    without runtime dtype branching. Uses typed `UnsafePointer[Scalar[dtype]]`
+    Parametric on DType, enabling `__getitem__` to return `Scalar[Self.dt]`
+    without runtime dtype branching. Uses typed `UnsafePointer[Scalar[dt]]`
     storage where pointer arithmetic auto-scales by element size.
 
     Memory Safety: Implements reference counting for safe shared ownership.
@@ -56,7 +56,7 @@ struct Tensor[dtype: DType = DType.float32](
     for zero-copy conversion via `as_any()`.
 
     Parameters:
-        dtype: The compile-time data type of tensor elements (default: float32).
+        dt: The compile-time data type of tensor elements (default: float32).
 
     Attributes:
         _data: Typed pointer to element storage (auto-scales pointer arithmetic).
@@ -69,7 +69,7 @@ struct Tensor[dtype: DType = DType.float32](
         _original_numel_quantized: For quantized tensors, original size before padding.
     """
 
-    var _data: UnsafePointer[Scalar[Self.dtype], origin=MutAnyOrigin]
+    var _data: UnsafePointer[Scalar[Self.dt], origin=MutAnyOrigin]
     """Typed pointer to element storage."""
     var _shape: List[Int]
     """List of dimension sizes."""
@@ -143,7 +143,7 @@ struct Tensor[dtype: DType = DType.float32](
 
         # Allocate through memory pool (returns UInt8 pointer), then bitcast
         # to typed pointer. _allocated_size is in BYTES.
-        self._data = pooled_alloc(total_bytes).bitcast[Scalar[Self.dtype]]()
+        self._data = pooled_alloc(total_bytes).bitcast[Scalar[Self.dt]]()
         self._allocated_size = total_bytes
 
         # Zero-initialize the memory
@@ -155,7 +155,7 @@ struct Tensor[dtype: DType = DType.float32](
 
     fn __init__(
         out self,
-        data: UnsafePointer[Scalar[dtype], origin=MutAnyOrigin],
+        data: UnsafePointer[Scalar[Self.dt], origin=MutAnyOrigin],
         shape: List[Int],
         strides: List[Int],
         refcount: UnsafePointer[Int, origin=MutAnyOrigin],
@@ -253,8 +253,8 @@ struct Tensor[dtype: DType = DType.float32](
     # Element access
     # ------------------------------------------------------------------
 
-    fn __getitem__(self, index: Int) raises -> Scalar[Self.dtype]:
-        """Get element at flat index — returns typed Scalar[Self.dtype].
+    fn __getitem__(self, index: Int) raises -> Scalar[Self.dt]:
+        """Get element at flat index — returns typed Scalar[Self.dt].
 
         For contiguous tensors, the flat index maps directly to a memory
         offset. For non-contiguous tensors (e.g., after transpose), the
@@ -268,7 +268,7 @@ struct Tensor[dtype: DType = DType.float32](
                 row-major order of the tensor's shape).
 
         Returns:
-            The value at the given index as Scalar[Self.dtype].
+            The value at the given index as Scalar[Self.dt].
 
         Raises:
             Error: If index is out of bounds.
@@ -294,8 +294,8 @@ struct Tensor[dtype: DType = DType.float32](
         # Contiguous — direct indexed access (auto-scales, no * dtype_size)
         return self._data[index]
 
-    fn __setitem__(mut self, index: Int, value: Scalar[Self.dtype]) raises:
-        """Set element at flat index — accepts typed Scalar[Self.dtype].
+    fn __setitem__(mut self, index: Int, value: Scalar[Self.dt]) raises:
+        """Set element at flat index — accepts typed Scalar[Self.dt].
 
         Args:
             index: The flat index to set.
@@ -336,7 +336,7 @@ struct Tensor[dtype: DType = DType.float32](
 
     fn dtype(self) -> DType:
         """Return the element data type (compile-time constant)."""
-        return Self.dtype
+        return Self.dt
 
     fn ndim(self) -> Int:
         """Return the number of dimensions (rank)."""
@@ -425,7 +425,7 @@ struct Tensor[dtype: DType = DType.float32](
         var shape_copy = List[Int]()
         for i in range(len(self._shape)):
             shape_copy.append(self._shape[i])
-        var result = ExTensor(shape_copy, Self.dtype)
+        var result = ExTensor(shape_copy, Self.dt)
 
         # --- Tear down the temporary ExTensor's independent allocation ---
         # Free the independently allocated data buffer (safe: result is the
@@ -496,7 +496,7 @@ struct Tensor[dtype: DType = DType.float32](
                     result += String(self[i])
                 except:
                     result += "?"
-        result += "], dtype=" + String(Self.dtype) + ")"
+        result += "], dtype=" + String(Self.dt) + ")"
         return result
 
     fn __repr__(self) -> String:
@@ -515,7 +515,7 @@ struct Tensor[dtype: DType = DType.float32](
             shape_str += String(self._shape[i])
         shape_str += "]"
         var result = String("Tensor(shape=") + shape_str
-        result += ", dtype=" + String(Self.dtype)
+        result += ", dtype=" + String(Self.dt)
         result += ", numel=" + String(self._numel)
         result += ", data=["
         if self._numel > TENSOR_PRINT_THRESHOLD:
@@ -558,25 +558,68 @@ struct Tensor[dtype: DType = DType.float32](
         Matches ExTensor._get_dtype_size_static() output for the same dtype.
         """
         # DType size lookup — same logic as ExTensor but resolved at
-        # compile time since Self.dtype is a parameter.
+        # compile time since Self.dt is a parameter.
         @parameter
-        if Self.dtype == DType.float16 or Self.dtype == DType.bfloat16:
+        if Self.dt == DType.float16 or Self.dt == DType.bfloat16:
             return 2
-        elif Self.dtype == DType.float32:
+        elif Self.dt == DType.float32:
             return 4
-        elif Self.dtype == DType.float64:
+        elif Self.dt == DType.float64:
             return 8
         elif (
-            Self.dtype == DType.int8
-            or Self.dtype == DType.uint8
-            or Self.dtype == DType.bool
+            Self.dt == DType.int8
+            or Self.dt == DType.uint8
+            or Self.dt == DType.bool
         ):
             return 1
-        elif Self.dtype == DType.int16 or Self.dtype == DType.uint16:
+        elif Self.dt == DType.int16 or Self.dt == DType.uint16:
             return 2
-        elif Self.dtype == DType.int32 or Self.dtype == DType.uint32:
+        elif Self.dt == DType.int32 or Self.dt == DType.uint32:
             return 4
-        elif Self.dtype == DType.int64 or Self.dtype == DType.uint64:
+        elif Self.dt == DType.int64 or Self.dt == DType.uint64:
             return 8
         else:
             return 4  # Default fallback
+
+
+# ------------------------------------------------------------------
+# Free function: AnyTensor -> Tensor[dt] conversion
+# ------------------------------------------------------------------
+
+
+fn from_any_tensor[dt: DType](any: ExTensor) raises -> Tensor[dt]:
+    """Zero-copy conversion from runtime-typed AnyTensor to Tensor[dt].
+
+    Creates a Tensor[dt] sharing the same underlying data via a shared
+    refcount pointer. The dt parameter must match the AnyTensor's runtime
+    dtype.
+
+    Parameters:
+        dt: The compile-time DType for the resulting Tensor.
+
+    Args:
+        any: The AnyTensor (ExTensor) to convert.
+
+    Returns:
+        A Tensor[dt] sharing the same data and refcount.
+
+    Raises:
+        Error: If the AnyTensor's dtype doesn't match the requested dtype.
+    """
+    if any.dtype() != dt:
+        raise Error(
+            "DType mismatch: AnyTensor has dtype "
+            + String(any.dtype())
+            + " but from_any_tensor called with "
+            + String(dt)
+        )
+    return Tensor[dt](
+        data=any._data.bitcast[Scalar[dt]](),
+        shape=any._shape,
+        strides=any._strides,
+        refcount=any._refcount,
+        numel=any._numel,
+        is_view=any._is_view,
+        allocated_size=any._allocated_size,
+        original_numel_quantized=any._original_numel_quantized,
+    )

--- a/tests/shared/tensor/test_tensor_any_conversion.mojo
+++ b/tests/shared/tensor/test_tensor_any_conversion.mojo
@@ -16,7 +16,7 @@ Tests cover:
 """
 
 from testing import assert_true, assert_almost_equal
-from shared.tensor.tensor import Tensor
+from shared.tensor.tensor import Tensor, from_any_tensor
 from shared.core.extensor import ExTensor, AnyTensor, zeros
 
 
@@ -44,7 +44,7 @@ fn test_as_any_basic() raises:
 
 
 fn test_as_any_preserves_shape() raises:
-    """as_any preserves full shape."""
+    """As_any() preserves full shape."""
     var t = Tensor[DType.float64]([2, 3, 4])
     var any_t = t.as_any()
     var s = any_t.shape()
@@ -56,24 +56,24 @@ fn test_as_any_preserves_shape() raises:
 
 
 fn test_as_tensor_basic() raises:
-    """AnyTensor.as_tensor[dtype]() returns a Tensor[dtype]."""
+    """From_any_tensor converts AnyTensor to Tensor[dtype]."""
     var any_t = zeros([4], DType.float32)
-    var t = any_t.as_tensor[DType.float32]()
-    assert_true(t.numel() == 4, "as_tensor preserves numel")
-    assert_true(t.dtype() == DType.float32, "as_tensor preserves dtype")
+    var t = from_any_tensor[DType.float32](any_t)
+    assert_true(t.numel() == 4, "from_any_tensor preserves numel")
+    assert_true(t.dtype() == DType.float32, "from_any_tensor preserves dtype")
     print("PASS: test_as_tensor_basic")
 
 
 fn test_as_tensor_dtype_mismatch() raises:
-    """as_tensor with wrong dtype should raise."""
+    """From_any_tensor with wrong dtype should raise."""
     var any_t = zeros([4], DType.float32)
     var raised = False
     try:
-        var t = any_t.as_tensor[DType.float64]()
+        var t = from_any_tensor[DType.float64](any_t)
         _ = t  # suppress unused warning
     except:
         raised = True
-    assert_true(raised, "as_tensor with wrong dtype should raise")
+    assert_true(raised, "from_any_tensor with wrong dtype should raise")
     print("PASS: test_as_tensor_dtype_mismatch")
 
 
@@ -86,7 +86,7 @@ fn test_roundtrip_tensor_any_tensor() raises:
 
     # Round-trip
     var any_t = t1.as_any()
-    var t2 = any_t.as_tensor[DType.float32]()
+    var t2 = from_any_tensor[DType.float32](any_t)
 
     assert_almost_equal(Float32(t2[0]), Float32(1.5), atol=1e-6)
     assert_almost_equal(Float32(t2[1]), Float32(0.25), atol=1e-6)

--- a/tests/shared/tensor/test_tensor_elementwise.mojo
+++ b/tests/shared/tensor/test_tensor_elementwise.mojo
@@ -1,0 +1,113 @@
+"""Tests for Tensor[dtype] typed elementwise and activation overloads.
+
+# ADR-009: This file is intentionally limited to <=10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Tests cover:
+- exp[dt] on known values
+- log[dt] on known values
+- sqrt[dt] on known values
+- relu[dt] zeroes negatives
+- sigmoid[dt] of 0 is 0.5
+"""
+
+from testing import assert_true, assert_almost_equal
+from shared.tensor.tensor import Tensor
+from shared.core.elementwise import exp, log, sqrt
+from shared.core.activation import relu, sigmoid
+from math import exp as math_exp, log as math_log, sqrt as math_sqrt
+
+
+fn test_exp_typed() raises:
+    """Exp typed overload computes element-wise exponential."""
+    var t = Tensor[DType.float32]([3])
+    t[0] = Float32(0.0)
+    t[1] = Float32(0.5)
+    t[2] = Float32(1.0)
+    var result = exp(t)
+    assert_true(result.numel() == 3, "numel preserved")
+    assert_almost_equal(
+        Float64(result[0]), Float64(math_exp(Float32(0.0))), atol=1e-6
+    )
+    assert_almost_equal(
+        Float64(result[1]), Float64(math_exp(Float32(0.5))), atol=1e-6
+    )
+    assert_almost_equal(
+        Float64(result[2]), Float64(math_exp(Float32(1.0))), atol=1e-6
+    )
+    print("PASS: test_exp_typed")
+
+
+fn test_log_typed() raises:
+    """Log typed overload computes element-wise natural log."""
+    var t = Tensor[DType.float32]([3])
+    t[0] = Float32(0.5)
+    t[1] = Float32(1.0)
+    t[2] = Float32(1.5)
+    var result = log(t)
+    assert_true(result.numel() == 3, "numel preserved")
+    assert_almost_equal(
+        Float64(result[0]), Float64(math_log(Float32(0.5))), atol=1e-6
+    )
+    assert_almost_equal(
+        Float64(result[1]), Float64(math_log(Float32(1.0))), atol=1e-6
+    )
+    assert_almost_equal(
+        Float64(result[2]), Float64(math_log(Float32(1.5))), atol=1e-6
+    )
+    print("PASS: test_log_typed")
+
+
+fn test_sqrt_typed() raises:
+    """Sqrt typed overload computes element-wise square root."""
+    var t = Tensor[DType.float32]([3])
+    t[0] = Float32(0.25)
+    t[1] = Float32(1.0)
+    t[2] = Float32(1.5)
+    var result = sqrt(t)
+    assert_true(result.numel() == 3, "numel preserved")
+    assert_almost_equal(
+        Float64(result[0]), Float64(math_sqrt(Float32(0.25))), atol=1e-6
+    )
+    assert_almost_equal(
+        Float64(result[1]), Float64(math_sqrt(Float32(1.0))), atol=1e-6
+    )
+    assert_almost_equal(
+        Float64(result[2]), Float64(math_sqrt(Float32(1.5))), atol=1e-6
+    )
+    print("PASS: test_sqrt_typed")
+
+
+fn test_relu_typed() raises:
+    """ReLU typed overload zeroes negative values."""
+    var t = Tensor[DType.float32]([4])
+    t[0] = Float32(-1.0)
+    t[1] = Float32(-0.5)
+    t[2] = Float32(0.0)
+    t[3] = Float32(1.5)
+    var result = relu(t)
+    assert_true(result.numel() == 4, "numel preserved")
+    assert_almost_equal(Float64(result[0]), 0.0, atol=1e-6)
+    assert_almost_equal(Float64(result[1]), 0.0, atol=1e-6)
+    assert_almost_equal(Float64(result[2]), 0.0, atol=1e-6)
+    assert_almost_equal(Float64(result[3]), 1.5, atol=1e-6)
+    print("PASS: test_relu_typed")
+
+
+fn test_sigmoid_typed() raises:
+    """Sigmoid typed overload of 0 is 0.5."""
+    var t = Tensor[DType.float32]([1])
+    t[0] = Float32(0.0)
+    var result = sigmoid(t)
+    assert_true(result.numel() == 1, "numel preserved")
+    assert_almost_equal(Float64(result[0]), 0.5, atol=1e-6)
+    print("PASS: test_sigmoid_typed")
+
+
+fn main() raises:
+    test_exp_typed()
+    test_log_typed()
+    test_sqrt_typed()
+    test_relu_typed()
+    test_sigmoid_typed()

--- a/tests/shared/tensor/test_tensor_matrix.mojo
+++ b/tests/shared/tensor/test_tensor_matrix.mojo
@@ -1,0 +1,103 @@
+"""Tests for Tensor[dtype] typed matrix and reduction overloads.
+
+# ADR-009: This file is intentionally limited to <=10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Tests cover:
+- matmul[dt] matrix multiply
+- transpose[dt] swap dimensions
+- sum[dt] sum all elements
+- mean[dt] mean of elements
+"""
+
+from testing import assert_true, assert_almost_equal
+from shared.tensor.tensor import Tensor
+from shared.core.matrix import matmul, transpose
+from shared.core.reduction import sum, mean
+
+
+fn test_matmul_typed() raises:
+    """Matmul typed overload computes matrix product."""
+    # 2x2 @ 2x2
+    var a = Tensor[DType.float32]([2, 2])
+    a[0] = Float32(1.0)
+    a[1] = Float32(0.5)
+    a[2] = Float32(0.25)
+    a[3] = Float32(1.0)
+
+    var b = Tensor[DType.float32]([2, 2])
+    b[0] = Float32(1.0)
+    b[1] = Float32(0.0)
+    b[2] = Float32(0.0)
+    b[3] = Float32(1.0)
+
+    var result = matmul(a, b)
+    var s = result.shape()
+    assert_true(s[0] == 2 and s[1] == 2, "shape preserved")
+    # Identity multiplication: result should equal a
+    assert_almost_equal(Float64(result[0]), 1.0, atol=1e-6)
+    assert_almost_equal(Float64(result[1]), 0.5, atol=1e-6)
+    assert_almost_equal(Float64(result[2]), 0.25, atol=1e-6)
+    assert_almost_equal(Float64(result[3]), 1.0, atol=1e-6)
+    print("PASS: test_matmul_typed")
+
+
+fn test_transpose_typed() raises:
+    """Transpose typed overload swaps dimensions."""
+    var t = Tensor[DType.float32]([2, 3])
+    # Fill with distinguishable values
+    t[0] = Float32(1.0)
+    t[1] = Float32(0.5)
+    t[2] = Float32(0.25)
+    t[3] = Float32(1.5)
+    t[4] = Float32(-1.0)
+    t[5] = Float32(-0.5)
+
+    var result = transpose(t)
+    var s = result.shape()
+    assert_true(s[0] == 3, "transposed dim 0")
+    assert_true(s[1] == 2, "transposed dim 1")
+    # Check transposed values: result[col, row] == original[row, col]
+    # Original [0,0]=1.0 -> result[0,0]=1.0
+    assert_almost_equal(Float64(result[0]), 1.0, atol=1e-6)
+    # Original [1,0]=1.5 -> result[0,1]=1.5
+    assert_almost_equal(Float64(result[1]), 1.5, atol=1e-6)
+    # Original [0,1]=0.5 -> result[1,0]=0.5
+    assert_almost_equal(Float64(result[2]), 0.5, atol=1e-6)
+    print("PASS: test_transpose_typed")
+
+
+fn test_sum_typed() raises:
+    """Sum typed overload sums all elements."""
+    var t = Tensor[DType.float32]([4])
+    t[0] = Float32(0.5)
+    t[1] = Float32(1.0)
+    t[2] = Float32(1.5)
+    t[3] = Float32(0.25)
+
+    var result = sum(t)
+    # Sum of all: 0.5 + 1.0 + 1.5 + 0.25 = 3.25
+    assert_almost_equal(Float64(result[0]), 3.25, atol=1e-6)
+    print("PASS: test_sum_typed")
+
+
+fn test_mean_typed() raises:
+    """Mean typed overload computes mean of all elements."""
+    var t = Tensor[DType.float32]([4])
+    t[0] = Float32(0.5)
+    t[1] = Float32(1.0)
+    t[2] = Float32(1.5)
+    t[3] = Float32(0.25)
+
+    var result = mean(t)
+    # Mean: 3.25 / 4 = 0.8125
+    assert_almost_equal(Float64(result[0]), 0.8125, atol=1e-6)
+    print("PASS: test_mean_typed")
+
+
+fn main() raises:
+    test_matmul_typed()
+    test_transpose_typed()
+    test_sum_typed()
+    test_mean_typed()

--- a/tests/shared/tensor/test_tensor_refcount.mojo
+++ b/tests/shared/tensor/test_tensor_refcount.mojo
@@ -6,7 +6,7 @@
 
 Tests cover:
 - as_any() shares refcount (same data)
-- as_tensor() shares refcount (same data)
+- from_any_tensor() shares refcount (same data)
 - B4 regression: source destroyed, converted tensor still valid
 - Reverse B4: Tensor[dtype] destroyed, AnyTensor still valid
 - Copy increments refcount
@@ -14,12 +14,12 @@ Tests cover:
 """
 
 from testing import assert_true, assert_almost_equal
-from shared.tensor.tensor import Tensor
+from shared.tensor.tensor import Tensor, from_any_tensor
 from shared.core.extensor import AnyTensor, zeros
 
 
 fn test_refcount_shared_on_as_any() raises:
-    """as_any() shares refcount -- both tensors access same data."""
+    """As_any() shares refcount -- both tensors access same data."""
     var t = Tensor[DType.float32]([4])
     t._data[0] = Scalar[DType.float32](1.5)
 
@@ -31,23 +31,23 @@ fn test_refcount_shared_on_as_any() raises:
     print("PASS: test_refcount_shared_on_as_any")
 
 
-fn test_refcount_shared_on_as_tensor() raises:
-    """as_tensor() shares refcount -- both tensors access same data."""
+fn test_refcount_shared_on_from_any_tensor() raises:
+    """From_any_tensor() shares refcount -- both tensors access same data."""
     var any_t = zeros([4], DType.float32)
     any_t._set_float32(0, Float32(0.25))
 
-    var t = any_t.as_tensor[DType.float32]()
+    var t = from_any_tensor[DType.float32](any_t)
 
     assert_almost_equal(Float32(t[0]), Float32(0.25), atol=1e-6)
-    print("PASS: test_refcount_shared_on_as_tensor")
+    print("PASS: test_refcount_shared_on_from_any_tensor")
 
 
 fn _make_tensor_from_anytensor() raises -> Tensor[DType.float32]:
-    """Helper: create AnyTensor, convert to Tensor, return Tensor (AnyTensor destroyed on return)."""
+    """Helper: create AnyTensor, convert to Tensor, return (AnyTensor destroyed)."""
     var any_t = zeros([4], DType.float32)
     any_t._set_float32(0, Float32(1.5))
     any_t._set_float32(1, Float32(0.5))
-    return any_t.as_tensor[DType.float32]()
+    return from_any_tensor[DType.float32](any_t)
     # any_t is destroyed here — ASAP destruction
 
 
@@ -61,7 +61,7 @@ fn test_refcount_survives_source_destruction() raises:
 
 
 fn _make_anytensor_from_tensor() raises -> AnyTensor:
-    """Helper: create Tensor, convert to AnyTensor, return AnyTensor (Tensor destroyed on return)."""
+    """Helper: create Tensor, convert to AnyTensor, return (Tensor destroyed)."""
     var t = Tensor[DType.float32]([4])
     t._data[0] = Scalar[DType.float32](0.125)
     return t.as_any()
@@ -91,8 +91,8 @@ fn test_tensor_multiple_conversions() raises:
     var any_t = zeros([4], DType.float32)
     any_t._set_float32(0, Float32(0.5))
 
-    var t1 = any_t.as_tensor[DType.float32]()
-    var t2 = any_t.as_tensor[DType.float32]()
+    var t1 = from_any_tensor[DType.float32](any_t)
+    var t2 = from_any_tensor[DType.float32](any_t)
 
     assert_almost_equal(Float32(t1[0]), Float32(0.5), atol=1e-6)
     assert_almost_equal(Float32(t2[0]), Float32(0.5), atol=1e-6)
@@ -101,7 +101,7 @@ fn test_tensor_multiple_conversions() raises:
 
 fn main() raises:
     test_refcount_shared_on_as_any()
-    test_refcount_shared_on_as_tensor()
+    test_refcount_shared_on_from_any_tensor()
     test_refcount_survives_source_destruction()
     test_refcount_survives_tensor_destruction()
     test_tensor_copy_increments_refcount()


### PR DESCRIPTION
## Summary

- Add `Tensor[dt]` typed overloads for core operations (elementwise, activation, comparison, matrix, reduction) wrapping existing AnyTensor implementations
- Implement `from_any_tensor[dt]()` free function for zero-copy AnyTensor -> Tensor[dt] conversion
- Fix Tensor struct parameter name conflict (`dtype` -> `dt`) that prevented compilation of the `dtype()` method

## Changes Made

### Phase 3c: Elementwise + Activation + Comparison
- **elementwise.mojo**: `exp`, `log`, `sqrt`, `abs`, `clip`, `sin`, `cos`, `tanh` typed overloads
- **activation.mojo**: `relu`, `sigmoid`, `tanh`, `softmax`, `gelu` typed overloads
- **comparison.mojo**: `equal`, `not_equal`, `less`, `less_equal`, `greater`, `greater_equal` typed overloads (return `Tensor[DType.bool]`)

### Phase 3d: Matrix + Reduction
- **matrix.mojo**: `matmul`, `transpose`, `dot`, `outer` typed overloads
- **reduction.mojo**: `sum`, `mean`, `max_reduce`, `min_reduce` typed overloads

### Infrastructure
- **tensor.mojo**: Add `from_any_tensor[dt]()` free function; rename struct parameter `dtype` -> `dt` to fix method name collision
- **extensor.mojo**: Update `as_tensor` stub to redirect to `from_any_tensor`
- **Existing tests**: Update `test_tensor_any_conversion.mojo` and `test_tensor_refcount.mojo` to use `from_any_tensor`

### New Tests
- **test_tensor_elementwise.mojo**: 5 tests (exp, log, sqrt, relu, sigmoid)
- **test_tensor_matrix.mojo**: 4 tests (matmul, transpose, sum, mean)

Part of #4998