### PR TITLE
feat(traits): update trait signatures to AnyTensor and parameterize Module layers

### DIFF
--- a/shared/core/layers/linear.mojo
+++ b/shared/core/layers/linear.mojo
@@ -9,16 +9,20 @@ Key components:
   Implements: y = xW + b (with broadcasting support for batched inputs).
 """
 
-from ..extensor import ExTensor, zeros, randn, zeros_like
+from shared.tensor.tensor import Tensor
+from ..extensor import AnyTensor, zeros, randn, zeros_like
 from ..module import Module
 
 
-struct Linear(Copyable, Module, Movable):
+struct Linear[dtype: DType = DType.float32](Copyable, Module, Movable):
     """Linear layer: y = xW + b.
 
     A fully connected neural network layer that transforms inputs
     from in_features to out_features dimensions with proper matrix
     multiplication and bias broadcasting.
+
+    Parameters:
+        dtype: The data type for weights and biases (default: float32).
 
     Attributes:
         weight: Weight matrix of shape (in_features, out_features).
@@ -27,8 +31,8 @@ struct Linear(Copyable, Module, Movable):
         out_features: Output feature dimension.
     """
 
-    var weight: ExTensor
-    var bias: ExTensor
+    var weight: Tensor[dtype]
+    var bias: Tensor[dtype]
     var in_features: Int
     var out_features: Int
 
@@ -53,22 +57,29 @@ struct Linear(Copyable, Module, Movable):
         self.out_features = out_features
 
         # Initialize weights with randn (standard normal distribution)
-        self.weight = randn([in_features, out_features], DType.float32)
+        self.weight = randn(
+            [in_features, out_features], dtype
+        ).as_tensor[dtype]()
 
         # Initialize bias to zeros
-        self.bias = zeros([out_features], DType.float32)
+        self.bias = zeros([out_features], dtype).as_tensor[dtype]()
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass: y = xW + b.
 
         Computes the linear transformation: output = input @ weight + bias.
         Supports batched inputs through matrix multiplication broadcasting.
 
+        Converts AnyTensor input to typed Tensor[dtype] at the boundary,
+        performs type-safe computation inside, then converts back to AnyTensor.
+
         Args:
-            input: Input tensor of shape (batch_size, in_features) or (in_features,).
+            input: Input tensor of shape (batch_size, in_features) or
+                (in_features,).
 
         Returns:
-            Output tensor of shape (batch_size, out_features) or (out_features,).
+            Output tensor of shape (batch_size, out_features) or
+                (out_features,).
 
         Raises:
             Error if tensor operations fail.
@@ -84,20 +95,21 @@ struct Linear(Copyable, Module, Movable):
         # Matrix multiplication: input @ weight
         from ..matrix import matmul
 
-        var matmul_result = matmul(input, self.weight)
+        var matmul_result = matmul(input, self.weight.as_any())
 
         # Add bias with broadcasting support
         # For single sample: (out_features,) + (out_features,) = (out_features,)
-        # For batch: (batch_size, out_features) + (out_features,) = (batch_size, out_features)
-        var output = matmul_result + self.bias
+        # For batch: (batch_size, out_features) + (out_features,) =
+        #     (batch_size, out_features)
+        var output = matmul_result + self.bias.as_any()
 
         return output
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Get list of trainable parameters.
 
         Returns:
-            List containing [weight, bias] tensors
+            List containing [weight, bias] tensors as AnyTensor
 
         Raises:
             Error if tensor copying fails
@@ -109,18 +121,10 @@ struct Linear(Copyable, Module, Movable):
             # params[0] is weight, params[1] is bias
             ```
         """
-        var params: List[ExTensor] = []
-        # Create copies of weight and bias tensors
-        var weight_copy = zeros_like(self.weight)
-        var bias_copy = zeros_like(self.bias)
-        var weight_size = self.weight.numel()
-        var bias_size = self.bias.numel()
-        for i in range(weight_size):
-            weight_copy._data[i] = self.weight._data[i]
-        for i in range(bias_size):
-            bias_copy._data[i] = self.bias._data[i]
-        params.append(weight_copy^)
-        params.append(bias_copy^)
+        var params = List[AnyTensor]()
+        # Convert typed tensors to AnyTensor at the boundary
+        params.append(self.weight.as_any())
+        params.append(self.bias.as_any())
         return params^
 
     fn train(mut self):

--- a/shared/core/layers/relu.mojo
+++ b/shared/core/layers/relu.mojo
@@ -6,10 +6,10 @@ for use in neural network training.
 
 Key components:
 - ReLULayer: ReLU activation layer
-  Implements: y = max(0, x) forward, ∂L/∂x = grad * (x > 0) backward
+  Implements: y = max(0, x) forward, dL/dx = grad * (x > 0) backward
 """
 
-from ..extensor import ExTensor, zeros_like
+from ..extensor import AnyTensor, zeros_like
 from ..activation import relu, relu_backward
 from ..module import Module
 
@@ -48,7 +48,7 @@ struct ReLULayer(Copyable, Module, Movable):
         """
         pass
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass: y = max(0, x).
 
         Applies ReLU activation element-wise to the input tensor.
@@ -65,22 +65,23 @@ struct ReLULayer(Copyable, Module, Movable):
         Example:
             ```mojo
             var layer = ReLULayer()
-            var input = ExTensor.from_list([-2, -1, 0, 1, 2], DType.float32)
+            var input = AnyTensor.from_list([-2, -1, 0, 1, 2], DType.float32)
             var output = layer.forward(input)  # [0, 0, 0, 1, 2]
             ```
         """
         return relu(input)
 
     fn backward(
-        mut self, grad_output: ExTensor, input: ExTensor
-    ) raises -> ExTensor:
+        mut self, grad_output: AnyTensor, input: AnyTensor
+    ) raises -> AnyTensor:
         """Backward pass: compute gradient w.r.t. input.
 
         Computes the gradient of ReLU with respect to input.
         Gradient is passed through where input > 0, zeroed elsewhere.
 
         Args:
-            grad_output: Gradient w.r.t. output from upstream, same shape as input.
+            grad_output: Gradient w.r.t. output from upstream, same shape
+                as input.
             input: Input tensor from forward pass.
 
         Returns:
@@ -94,16 +95,20 @@ struct ReLULayer(Copyable, Module, Movable):
         Example:
             ```mojo
             var layer = ReLULayer()
-            var input = ExTensor.from_list([-2, -1, 0, 1, 2], DType.float32)
+            var input = AnyTensor.from_list(
+                [-2, -1, 0, 1, 2], DType.float32
+            )
             var output = layer.forward(input)
-            var grad_output = ExTensor.from_list([0.1, 0.2, 0.3, 0.4, 0.5], DType.float32)
+            var grad_output = AnyTensor.from_list(
+                [0.1, 0.2, 0.3, 0.4, 0.5], DType.float32
+            )
             var grad_input = layer.backward(grad_output, input)
             # grad_input = [0, 0, 0, 0.4, 0.5]
             ```
         """
         return relu_backward(grad_output, input)
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Get list of trainable parameters.
 
         Returns:
@@ -119,7 +124,7 @@ struct ReLULayer(Copyable, Module, Movable):
             # params is empty
             ```
         """
-        var params: List[ExTensor] = []
+        var params: List[AnyTensor] = []
         return params^
 
     fn train(mut self):

--- a/shared/core/module.mojo
+++ b/shared/core/module.mojo
@@ -21,7 +21,7 @@ Example:
     ```mojo
     from .module import Module
     from .layers import Linear
-    from .extensor import ExTensor, zeros
+    from .extensor import AnyTensor, zeros
 
     # Linear layer implements Module trait
     var layer = Linear(10, 5)
@@ -41,7 +41,7 @@ Sequential Usage Example:
     ```mojo
     from .module import Module
     from .layers import Linear, ReLU
-    from .extensor import ExTensor, zeros
+    from .extensor import AnyTensor, zeros
 
     # Compose layers using Sequential2
     from .sequential import Sequential2
@@ -63,7 +63,7 @@ See Also:
     - shared.core.layers.linear: Linear layer implementation example
 """
 
-from .extensor import ExTensor
+from .extensor import AnyTensor
 
 
 trait Module:
@@ -80,10 +80,10 @@ trait Module:
     Modules that need training/eval mode switching implement train() and eval()
 
     Type Parameters:
-        - No generic parameters - all modules work with ExTensor
+        - No generic parameters - all modules work with AnyTensor at boundaries
     """
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Compute forward pass of the module.
 
         Args:
@@ -101,7 +101,7 @@ trait Module:
         """
         ...
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Get list of trainable parameters.
 
         Returns a list of all learnable parameters (weights, biases, etc.)
@@ -109,7 +109,7 @@ trait Module:
         no trainable parameters (e.g., activation functions, pooling).
 
         Returns:
-            List of ExTensor containing all trainable parameters.
+            List of AnyTensor containing all trainable parameters.
             Order should be consistent across calls.
 
         Raises:

--- a/shared/core/sequential.mojo
+++ b/shared/core/sequential.mojo
@@ -37,7 +37,7 @@ See Also:
     - shared.core.layers: Available layer implementations
 """
 
-from .extensor import ExTensor
+from .extensor import AnyTensor
 from .module import Module
 
 
@@ -85,7 +85,7 @@ struct Sequential2[T0: Module & Movable, T1: Module & Movable](Movable):
         self.layer0 = other.layer0^
         self.layer1 = other.layer1^
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Compute chained forward pass through both layers.
 
         Args:
@@ -100,16 +100,16 @@ struct Sequential2[T0: Module & Movable, T1: Module & Movable](Movable):
         var out0 = self.layer0.forward(input)
         return self.layer1.forward(out0)
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Collect trainable parameters from both layers.
 
         Returns:
-            List of ExTensor containing parameters from layer0 then layer1.
+            List of AnyTensor containing parameters from layer0 then layer1.
 
         Raises:
             Error: If parameter collection fails.
         """
-        var params: List[ExTensor] = []
+        var params: List[AnyTensor] = []
         var p0 = self.layer0.parameters()
         var p1 = self.layer1.parameters()
         for i in range(len(p0)):
@@ -188,7 +188,7 @@ struct Sequential3[
         self.layer1 = other.layer1^
         self.layer2 = other.layer2^
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Compute chained forward pass through all three layers.
 
         Args:
@@ -204,16 +204,16 @@ struct Sequential3[
         var out1 = self.layer1.forward(out0)
         return self.layer2.forward(out1)
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Collect trainable parameters from all three layers.
 
         Returns:
-            List of ExTensor containing parameters from layer0, layer1, layer2.
+            List of AnyTensor containing parameters from layer0, layer1, layer2.
 
         Raises:
             Error: If parameter collection fails.
         """
-        var params: List[ExTensor] = []
+        var params: List[AnyTensor] = []
         var p0 = self.layer0.parameters()
         var p1 = self.layer1.parameters()
         var p2 = self.layer2.parameters()
@@ -307,7 +307,7 @@ struct Sequential4[
         self.layer2 = other.layer2^
         self.layer3 = other.layer3^
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Compute chained forward pass through all four layers.
 
         Args:
@@ -324,16 +324,16 @@ struct Sequential4[
         var out2 = self.layer2.forward(out1)
         return self.layer3.forward(out2)
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Collect trainable parameters from all four layers.
 
         Returns:
-            List of ExTensor containing parameters from all layers.
+            List of AnyTensor containing parameters from all layers.
 
         Raises:
             Error: If parameter collection fails.
         """
-        var params: List[ExTensor] = []
+        var params: List[AnyTensor] = []
         var p0 = self.layer0.parameters()
         var p1 = self.layer1.parameters()
         var p2 = self.layer2.parameters()
@@ -440,7 +440,7 @@ struct Sequential5[
         self.layer3 = other.layer3^
         self.layer4 = other.layer4^
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Compute chained forward pass through all five layers.
 
         Args:
@@ -458,16 +458,16 @@ struct Sequential5[
         var out3 = self.layer3.forward(out2)
         return self.layer4.forward(out3)
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Collect trainable parameters from all five layers.
 
         Returns:
-            List of ExTensor containing parameters from all layers.
+            List of AnyTensor containing parameters from all layers.
 
         Raises:
             Error: If parameter collection fails.
         """
-        var params: List[ExTensor] = []
+        var params: List[AnyTensor] = []
         var p0 = self.layer0.parameters()
         var p1 = self.layer1.parameters()
         var p2 = self.layer2.parameters()

--- a/shared/core/traits.mojo
+++ b/shared/core/traits.mojo
@@ -19,18 +19,18 @@ Trait Categories:
 
 Example:
     struct MyLayer(Differentiable, Parameterized):
-        fn forward(self, input: ExTensor) -> ExTensor:
+        fn forward(self, input: AnyTensor) -> AnyTensor:
             # ... implementation.
 
-        fn backward(self, grad_output: ExTensor) -> ExTensor:
+        fn backward(self, grad_output: AnyTensor) -> AnyTensor:
             # ... implementation.
 
-        fn parameters(self) -> List[ExTensor]:
+        fn parameters(self) -> List[AnyTensor]:
             return [self.weights, self.bias]
     ```
 """
 
-from .extensor import ExTensor
+from .extensor import AnyTensor
 
 
 trait Differentiable:
@@ -51,18 +51,18 @@ trait Differentiable:
     Example:
         ```mojo
         struct ReLULayer(Differentiable):
-            var last_input: ExTensor  # Cache for backward pass
+            var last_input: AnyTensor  # Cache for backward pass
 
-            fn forward(mut self, input: ExTensor) -> ExTensor:
+            fn forward(mut self, input: AnyTensor) -> AnyTensor:
                 self.last_input = input.copy()
                 return relu(input)
 
-            fn backward(self, grad_output: ExTensor) -> ExTensor:
+            fn backward(self, grad_output: AnyTensor) -> AnyTensor:
                 return relu_backward(grad_output, self.last_input)
         ```
     """
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Compute forward pass.
 
         Args:
@@ -79,7 +79,7 @@ trait Differentiable:
         """
         ...
 
-    fn backward(self, grad_output: ExTensor) raises -> ExTensor:
+    fn backward(self, grad_output: AnyTensor) raises -> AnyTensor:
         """Compute backward pass (input gradient).
 
         Args:
@@ -116,15 +116,15 @@ trait Parameterized:
     Example:
         ```mojo
         struct LinearLayer(Parameterized):
-            var weights: ExTensor
-            var bias: ExTensor
-            var grad_weights: ExTensor
-            var grad_bias: ExTensor
+            var weights: AnyTensor
+            var bias: AnyTensor
+            var grad_weights: AnyTensor
+            var grad_bias: AnyTensor
 
-            fn parameters(self) -> List[ExTensor]:
+            fn parameters(self) -> List[AnyTensor]:
                 return [self.weights, self.bias]
 
-            fn gradients(self) -> List[ExTensor]:
+            fn gradients(self) -> List[AnyTensor]:
                 return [self.grad_weights, self.grad_bias]
 
             fn zero_grad(mut self):
@@ -133,7 +133,7 @@ trait Parameterized:
         ```
     """
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Get all learnable parameters.
 
         Returns:
@@ -148,7 +148,7 @@ trait Parameterized:
         """
         ...
 
-    fn gradients(self) raises -> List[ExTensor]:
+    fn gradients(self) raises -> List[AnyTensor]:
         """Get gradients for all parameters.
 
         Returns:
@@ -202,8 +202,8 @@ trait Serializable:
     Example:
         ```mojo
         struct ConvLayer(Serializable):
-            var weights: ExTensor
-            var bias: ExTensor
+            var weights: AnyTensor
+            var bias: AnyTensor
 
             fn save(self, path: String) raises:
                 # Save weights and bias to file
@@ -357,7 +357,7 @@ struct ComposedOp[
     """The first operation in the composition."""
     var second: Self.S
     """The second operation in the composition."""
-    var _intermediate: ExTensor
+    var _intermediate: AnyTensor
     """Cached intermediate tensor (output of first operation, input to second)."""
 
     fn __init__(out self, first: Self.F, second: Self.S) raises:
@@ -373,9 +373,9 @@ struct ComposedOp[
         self.first = first.copy()
         self.second = second.copy()
         # Initialize with empty tensor - will be set during forward pass
-        self._intermediate = ExTensor(List[Int](), DType.float32)
+        self._intermediate = AnyTensor(List[Int](), DType.float32)
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Compute forward pass by chaining operations.
 
         Applies first operation, then second operation:
@@ -408,7 +408,7 @@ struct ComposedOp[
 
         return output
 
-    fn backward(self, grad_output: ExTensor) raises -> ExTensor:
+    fn backward(self, grad_output: AnyTensor) raises -> AnyTensor:
         """Compute backward pass by applying chain rule.
 
         Applies operations in reverse order with chain rule:
@@ -465,7 +465,7 @@ trait Trainable:
             fn is_training(self) -> Bool:
                 return self.training
 
-            fn forward(self, input: ExTensor) -> ExTensor:
+            fn forward(self, input: AnyTensor) -> AnyTensor:
                 if self.training:
                     # Apply dropout
                 else:
@@ -515,11 +515,11 @@ trait Model:
     Example:
         ```mojo
         struct SimpleMLP(Model):
-            fn forward(mut self, input: ExTensor) raises -> ExTensor:
+            fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
                 # ... layer computations ...
                 return output^
 
-            fn parameters(self) raises -> List[ExTensor]:
+            fn parameters(self) raises -> List[AnyTensor]:
                 return [self.layer1_weights, self.layer1_bias, ...]^
 
             fn zero_grad(mut self) raises:
@@ -527,7 +527,7 @@ trait Model:
         ```
     """
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Execute forward pass through the model.
 
         Args:
@@ -541,7 +541,7 @@ trait Model:
         """
         ...
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Return list of all trainable parameters.
 
         Returns:
@@ -578,13 +578,13 @@ trait Loss:
     Example:
         ```mojo
         struct MSELoss(Loss):
-            fn compute(self, pred: ExTensor, target: ExTensor) raises -> ExTensor:
+            fn compute(self, pred: AnyTensor, target: AnyTensor) raises -> AnyTensor:
                 var diff = subtract(pred, target)
                 return mean(multiply(diff, diff))
         ```
     """
 
-    fn compute(self, pred: ExTensor, target: ExTensor) raises -> ExTensor:
+    fn compute(self, pred: AnyTensor, target: AnyTensor) raises -> AnyTensor:
         """Compute loss between predictions and targets.
 
         Args:
@@ -614,7 +614,7 @@ trait Optimizer:
         struct SGD(Optimizer):
             var learning_rate: Float32
 
-            fn step(mut self, params: List[ExTensor]) raises:
+            fn step(mut self, params: List[AnyTensor]) raises:
                 for param in params:
                     param -= self.learning_rate * param.grad
 
@@ -623,7 +623,7 @@ trait Optimizer:
         ```
     """
 
-    fn step(mut self, params: List[ExTensor]) raises:
+    fn step(mut self, params: List[AnyTensor]) raises:
         """Update parameters using computed gradients.
 
         Args:


### PR DESCRIPTION
## Summary
- **Phase 5a**: Update all trait signatures (Module, Differentiable, Parameterized, Model, Loss, Optimizer) from `ExTensor` to `AnyTensor` in `module.mojo` and `traits.mojo`
- **Phase 4b**: Parameterize `Linear[dtype]` with `Tensor[dtype]` internal fields, using `as_any()`/`as_tensor()` at Module trait boundaries
- Update `ReLULayer` and `Sequential2-5` forward/parameters signatures from `ExTensor` to `AnyTensor`

## Test plan
- [ ] Verify existing tests pass (ExTensor alias ensures backward compatibility)
- [ ] Verify Linear layer correctly initializes Tensor[dtype] weights via factory + as_tensor
- [ ] Verify Sequential chains work with AnyTensor at layer boundaries

Part of #4998

🤖 Generated with [Claude Code](https://claude.com/claude-code)