### PR TITLE
test(traits): add TDD tests for trait signatures and Module layers

### DIFF
--- a/tests/shared/tensor/test_trait_signatures.mojo
+++ b/tests/shared/tensor/test_trait_signatures.mojo
@@ -1,0 +1,119 @@
+"""Tests for updated trait signatures using AnyTensor (Phase 5a).
+
+# ADR-009: This file is intentionally limited to <=10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Phase 5a changes trait signatures from ExTensor to AnyTensor:
+- Module.forward(mut self, input: AnyTensor) -> AnyTensor
+- Module.parameters(self) -> List[AnyTensor]
+- Differentiable.forward/backward -> AnyTensor
+- Parameterized.parameters/gradients -> List[AnyTensor]
+
+Constraint H7: Module.forward() stays on AnyTensor. Layers convert at
+boundaries internally, but the trait interface is type-erased.
+
+Tests cover:
+- Module.forward accepts AnyTensor input and returns AnyTensor
+- Module.parameters returns List[AnyTensor]
+- Module train/eval mode switching
+- Linear forward shape correctness through AnyTensor boundary
+- ReLU forward pass zeroes negative values via AnyTensor boundary
+"""
+
+from testing import assert_true, assert_almost_equal
+from shared.core.extensor import AnyTensor, zeros, ones
+from shared.core.module import Module
+from shared.core.layers.linear import Linear
+from shared.core.layers.relu import ReLULayer
+
+
+fn test_module_forward_accepts_anytensor() raises:
+    """Module.forward accepts AnyTensor input and returns AnyTensor."""
+    var layer = Linear(4, 2)
+    var input: AnyTensor = zeros([1, 4], DType.float32)
+    var output = layer.forward(input)
+    assert_true(output.numel() > 0, "forward produces output")
+    print("PASS: test_module_forward_accepts_anytensor")
+
+
+fn test_module_forward_returns_anytensor() raises:
+    """Module.forward return type is AnyTensor (H7 boundary)."""
+    var layer = Linear(4, 2)
+    var input = zeros([1, 4], DType.float32)
+    # The return value must be assignable to AnyTensor
+    var output: AnyTensor = layer.forward(input)
+    assert_true(output.dtype() == DType.float32, "output dtype preserved")
+    assert_true(output.numel() == 2, "output has correct numel")
+    print("PASS: test_module_forward_returns_anytensor")
+
+
+fn test_module_parameters_returns_anytensor_list() raises:
+    """Module.parameters() returns List[AnyTensor]."""
+    var layer = Linear(4, 2)
+    var params = layer.parameters()
+    assert_true(len(params) == 2, "Linear has weight and bias")
+    # Each parameter should be an AnyTensor with elements
+    for i in range(len(params)):
+        assert_true(params[i].numel() > 0, "param has elements")
+    print("PASS: test_module_parameters_returns_anytensor_list")
+
+
+fn test_module_train_mode() raises:
+    """Module train mode switching works without error."""
+    var layer = Linear(4, 2)
+    layer.train()
+    # Verify layer still works after mode switch
+    var input = zeros([1, 4], DType.float32)
+    var output = layer.forward(input)
+    assert_true(output.numel() > 0, "forward works after train mode")
+    print("PASS: test_module_train_mode")
+
+
+fn test_linear_forward_shape_batched() raises:
+    """Linear(4, 2) produces correct output shape [3, 2] for batch=3."""
+    var layer = Linear(4, 2)
+    var input = zeros([3, 4], DType.float32)
+    var output = layer.forward(input)
+    var s = output.shape()
+    assert_true(s[0] == 3, "batch dim preserved")
+    assert_true(s[1] == 2, "output features correct")
+    print("PASS: test_linear_forward_shape_batched")
+
+
+fn test_relu_forward_zeroes_negatives() raises:
+    """ReLU forward pass zeroes negative values via AnyTensor boundary."""
+    var layer = ReLULayer()
+    var input = zeros([4], DType.float32)
+    # Set test values: 1.0, -0.5, 0.25, -1.0
+    var data = input._data.bitcast[Float32]()
+    data[0] = 1.0
+    data[1] = -0.5
+    data[2] = 0.25
+    data[3] = -1.0
+    var output = layer.forward(input)
+    var out_data = output._data.bitcast[Float32]()
+    assert_almost_equal(out_data[0], Float32(1.0), atol=1e-6)
+    assert_almost_equal(out_data[1], Float32(0.0), atol=1e-6)
+    assert_almost_equal(out_data[2], Float32(0.25), atol=1e-6)
+    assert_almost_equal(out_data[3], Float32(0.0), atol=1e-6)
+    print("PASS: test_relu_forward_zeroes_negatives")
+
+
+fn test_relu_parameters_empty() raises:
+    """ReLU has no trainable parameters."""
+    var layer = ReLULayer()
+    var params = layer.parameters()
+    assert_true(len(params) == 0, "ReLU has no parameters")
+    print("PASS: test_relu_parameters_empty")
+
+
+fn main() raises:
+    test_module_forward_accepts_anytensor()
+    test_module_forward_returns_anytensor()
+    test_module_parameters_returns_anytensor_list()
+    test_module_train_mode()
+    test_linear_forward_shape_batched()
+    test_relu_forward_zeroes_negatives()
+    test_relu_parameters_empty()
+    print("\nAll 7 trait signature tests passed")

--- a/tests/shared/tensor/test_typed_linear.mojo
+++ b/tests/shared/tensor/test_typed_linear.mojo
@@ -1,0 +1,148 @@
+"""Tests for Linear[dtype] with typed Tensor weights (Phase 4b).
+
+# ADR-009: This file is intentionally limited to <=10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Phase 4b parameterizes Linear[dtype: DType = DType.float32]:
+- Internal weights stored as Tensor[dtype] for type safety
+- forward() accepts AnyTensor, returns AnyTensor (H7 boundary)
+- parameters() returns List[AnyTensor] (Module trait compliance)
+- Supports multiple dtype instantiations (float32, float64)
+
+Tests cover:
+- Default dtype (float32)
+- Explicit float64 parameterization
+- parameters() returns List[AnyTensor] (Module trait compliance)
+- forward() AnyTensor boundary (H7 constraint)
+- Numerical correctness with identity weights and known bias
+"""
+
+from testing import assert_true, assert_almost_equal
+from shared.core.layers.linear import Linear
+from shared.core.extensor import AnyTensor, zeros, ones
+
+
+fn test_linear_default_dtype() raises:
+    """Linear defaults to float32 weights."""
+    var layer = Linear(4, 2)
+    # Weight dtype should be float32 by default
+    var params = layer.parameters()
+    assert_true(params[0].dtype() == DType.float32, "default weight dtype is float32")
+    assert_true(params[1].dtype() == DType.float32, "default bias dtype is float32")
+    print("PASS: test_linear_default_dtype")
+
+
+fn test_linear_float64() raises:
+    """Linear[DType.float64] uses float64 weights."""
+    var layer = Linear[DType.float64](4, 2)
+    var params = layer.parameters()
+    assert_true(params[0].dtype() == DType.float64, "weight dtype is float64")
+    assert_true(params[1].dtype() == DType.float64, "bias dtype is float64")
+    print("PASS: test_linear_float64")
+
+
+fn test_linear_parameters_as_anytensor() raises:
+    """parameters() returns List[AnyTensor] (Module trait compliance)."""
+    var layer = Linear(4, 2)
+    var params = layer.parameters()
+    assert_true(len(params) == 2, "has weight and bias params")
+    # Weight shape: (4, 2)
+    var ws = params[0].shape()
+    assert_true(ws[0] == 4, "weight rows")
+    assert_true(ws[1] == 2, "weight cols")
+    # Bias shape: (2,)
+    var bs = params[1].shape()
+    assert_true(bs[0] == 2, "bias size")
+    print("PASS: test_linear_parameters_as_anytensor")
+
+
+fn test_linear_forward_anytensor_boundary() raises:
+    """forward() accepts AnyTensor, returns AnyTensor (H7 boundary)."""
+    var layer = Linear(4, 2)
+    var input: AnyTensor = zeros([1, 4], DType.float32)
+    var output: AnyTensor = layer.forward(input)
+    assert_true(output.dtype() == DType.float32, "output dtype preserved")
+    var s = output.shape()
+    assert_true(s[0] == 1, "batch dim")
+    assert_true(s[1] == 2, "output features")
+    print("PASS: test_linear_forward_anytensor_boundary")
+
+
+fn test_linear_identity_weight_correctness() raises:
+    """Linear with identity weights and known bias produces correct output.
+
+    Input: [1.0, 0.5] (1x2)
+    Weight: [[1, 0], [0, 1]] (2x2 identity)
+    Bias: [0.25, 0.5]
+    Expected: [1.25, 1.0]
+    """
+    var layer = Linear(2, 2)
+
+    # Set weight to identity
+    var weight_data = layer.weight._data.bitcast[Float32]()
+    weight_data[0] = 1.0
+    weight_data[1] = 0.0
+    weight_data[2] = 0.0
+    weight_data[3] = 1.0
+
+    # Set bias to [0.25, 0.5]
+    var bias_data = layer.bias._data.bitcast[Float32]()
+    bias_data[0] = 0.25
+    bias_data[1] = 0.5
+
+    # Create input [1.0, 0.5]
+    var input = ones([1, 2], DType.float32)
+    var in_data = input._data.bitcast[Float32]()
+    in_data[0] = 1.0
+    in_data[1] = 0.5
+
+    var output = layer.forward(input)
+    var out_data = output._data.bitcast[Float32]()
+    # Expected: [1.0*1 + 0.5*0 + 0.25, 1.0*0 + 0.5*1 + 0.5] = [1.25, 1.0]
+    assert_almost_equal(out_data[0], Float32(1.25), atol=1e-5)
+    assert_almost_equal(out_data[1], Float32(1.0), atol=1e-5)
+    print("PASS: test_linear_identity_weight_correctness")
+
+
+fn test_linear_zero_bias() raises:
+    """Linear with zero bias produces matmul-only output."""
+    var layer = Linear(3, 2)
+
+    # Zero out bias
+    var bias_data = layer.bias._data.bitcast[Float32]()
+    bias_data[0] = 0.0
+    bias_data[1] = 0.0
+
+    # Set weight to known values: [[1, 0], [0, 1], [1, 1]]
+    var weight_data = layer.weight._data.bitcast[Float32]()
+    weight_data[0] = 1.0
+    weight_data[1] = 0.0
+    weight_data[2] = 0.0
+    weight_data[3] = 1.0
+    weight_data[4] = 1.0
+    weight_data[5] = 1.0
+
+    # Input: [1.0, 0.5, 0.25]
+    var input = zeros([1, 3], DType.float32)
+    var in_data = input._data.bitcast[Float32]()
+    in_data[0] = 1.0
+    in_data[1] = 0.5
+    in_data[2] = 0.25
+
+    var output = layer.forward(input)
+    var out_data = output._data.bitcast[Float32]()
+    # Expected: [1*1 + 0.5*0 + 0.25*1, 1*0 + 0.5*1 + 0.25*1] = [1.25, 0.75]
+    assert_almost_equal(out_data[0], Float32(1.25), atol=1e-5)
+    assert_almost_equal(out_data[1], Float32(0.75), atol=1e-5)
+    print("PASS: test_linear_zero_bias")
+
+
+fn main() raises:
+    test_linear_default_dtype()
+    test_linear_float64()
+    test_linear_parameters_as_anytensor()
+    test_linear_forward_anytensor_boundary()
+    test_linear_identity_weight_correctness()
+    test_linear_zero_bias()
+    print("\nAll 6 typed linear tests passed")

--- a/tests/shared/tensor/test_typed_sequential.mojo
+++ b/tests/shared/tensor/test_typed_sequential.mojo
@@ -1,0 +1,146 @@
+"""Tests for Sequential with AnyTensor boundaries (Phase 4b).
+
+# ADR-009: This file is intentionally limited to <=10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Phase 4b updates Sequential2-5 to chain layers through AnyTensor:
+- Sequential.forward accepts and returns AnyTensor
+- Sequential.parameters returns List[AnyTensor]
+- Inter-layer communication uses AnyTensor (H7 boundary)
+- train/mode propagated to sub-layers
+
+Tests cover:
+- Sequential2 forward pass chaining Linear + ReLU
+- Sequential2 parameter collection from sub-layers
+- Sequential2 train mode propagation
+- Sequential2 output shape correctness
+- Sequential3 forward pass chaining three layers
+"""
+
+from testing import assert_true, assert_almost_equal
+from shared.core.sequential import Sequential2, Sequential3
+from shared.core.layers.linear import Linear
+from shared.core.layers.relu import ReLULayer
+from shared.core.extensor import AnyTensor, zeros, ones
+
+
+fn test_sequential2_forward_linear_relu() raises:
+    """Sequential2 chains Linear + ReLU via AnyTensor boundary."""
+    var model = Sequential2[Linear, ReLULayer](
+        Linear(4, 2),
+        ReLULayer(),
+    )
+    var input = zeros([1, 4], DType.float32)
+    var output = model.forward(input)
+    assert_true(output.numel() > 0, "produces output")
+    # Output shape should be [1, 2] after Linear(4, 2)
+    var s = output.shape()
+    assert_true(s[0] == 1, "batch dim preserved")
+    assert_true(s[1] == 2, "output features from Linear")
+    print("PASS: test_sequential2_forward_linear_relu")
+
+
+fn test_sequential2_parameters_collected() raises:
+    """Sequential2 collects parameters from all layers."""
+    var model = Sequential2[Linear, ReLULayer](
+        Linear(4, 2),
+        ReLULayer(),
+    )
+    var params = model.parameters()
+    # Linear has weight + bias = 2 params, ReLU has 0
+    assert_true(len(params) == 2, "has 2 parameters from Linear")
+    # Weight shape: (4, 2)
+    var ws = params[0].shape()
+    assert_true(ws[0] == 4, "weight rows")
+    assert_true(ws[1] == 2, "weight cols")
+    print("PASS: test_sequential2_parameters_collected")
+
+
+fn test_sequential2_train_propagation() raises:
+    """Sequential2 propagates train mode to sub-layers."""
+    var model = Sequential2[Linear, ReLULayer](
+        Linear(4, 2),
+        ReLULayer(),
+    )
+    # Should not raise
+    model.train()
+    # Verify model still works after mode switch
+    var input = zeros([1, 4], DType.float32)
+    var output = model.forward(input)
+    assert_true(output.numel() > 0, "forward works after train mode")
+    print("PASS: test_sequential2_train_propagation")
+
+
+fn test_sequential2_output_dtype_preserved() raises:
+    """Sequential2 output preserves dtype through AnyTensor chain."""
+    var model = Sequential2[Linear, ReLULayer](
+        Linear(4, 2),
+        ReLULayer(),
+    )
+    var input = zeros([1, 4], DType.float32)
+    var output = model.forward(input)
+    assert_true(output.dtype() == DType.float32, "dtype preserved through chain")
+    print("PASS: test_sequential2_output_dtype_preserved")
+
+
+fn test_sequential2_relu_clips_negatives() raises:
+    """Sequential2[Linear, ReLU] produces non-negative outputs.
+
+    After ReLU, all output values must be >= 0.
+    Uses ones input to get deterministic matmul output from Linear,
+    then verifies ReLU zeroes any negative values.
+    """
+    var model = Sequential2[Linear, ReLULayer](
+        Linear(4, 2),
+        ReLULayer(),
+    )
+    var input = ones([1, 4], DType.float32)
+    var output = model.forward(input)
+    var n = output.numel()
+    var out_data = output._data.bitcast[Float32]()
+    for i in range(n):
+        assert_true(
+            out_data[i] >= 0.0,
+            "ReLU output must be non-negative",
+        )
+    print("PASS: test_sequential2_relu_clips_negatives")
+
+
+fn test_sequential3_forward_chain() raises:
+    """Sequential3 chains Linear + ReLU + Linear via AnyTensor."""
+    var model = Sequential3[Linear, ReLULayer, Linear](
+        Linear(4, 3),
+        ReLULayer(),
+        Linear(3, 2),
+    )
+    var input = zeros([1, 4], DType.float32)
+    var output = model.forward(input)
+    var s = output.shape()
+    assert_true(s[0] == 1, "batch dim")
+    assert_true(s[1] == 2, "output features from final Linear")
+    print("PASS: test_sequential3_forward_chain")
+
+
+fn test_sequential3_parameters_combined() raises:
+    """Sequential3 collects parameters from all sub-layers."""
+    var model = Sequential3[Linear, ReLULayer, Linear](
+        Linear(4, 3),
+        ReLULayer(),
+        Linear(3, 2),
+    )
+    var params = model.parameters()
+    # Linear(4,3): weight + bias = 2; ReLU: 0; Linear(3,2): weight + bias = 2
+    assert_true(len(params) == 4, "has 4 parameters total (2 per Linear)")
+    print("PASS: test_sequential3_parameters_combined")
+
+
+fn main() raises:
+    test_sequential2_forward_linear_relu()
+    test_sequential2_parameters_collected()
+    test_sequential2_train_propagation()
+    test_sequential2_output_dtype_preserved()
+    test_sequential2_relu_clips_negatives()
+    test_sequential3_forward_chain()
+    test_sequential3_parameters_combined()
+    print("\nAll 7 sequential tests passed")


### PR DESCRIPTION
## Summary
- Add 20 TDD tests across 3 files for PR 7 (Phases 5a + 4b)
- `test_trait_signatures.mojo` (7 tests): Module trait with AnyTensor signatures
- `test_typed_linear.mojo` (6 tests): Linear[dtype] parameterization with AnyTensor boundary
- `test_typed_sequential.mojo` (7 tests): Sequential2/3 chaining through AnyTensor (H7)

## Test plan
- [ ] Tests currently pass against existing ExTensor-aliased API (since `comptime ExTensor = AnyTensor`)
- [ ] `test_linear_float64` will fail until Linear[dtype] is parameterized (Phase 4b TDD target)
- [ ] All files respect ADR-009 limit of 10 tests per file

Part of #4998

Generated with [Claude Code](https://claude.com/claude-code)