### PR TITLE
test(layers): add TDD tests for parameterized non-Module layers

### DIFF
--- a/tests/shared/tensor/test_typed_batchnorm.mojo
+++ b/tests/shared/tensor/test_typed_batchnorm.mojo
@@ -1,0 +1,143 @@
+# ADR-009: This file is intentionally limited to <=10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for parameterized BatchNorm2dLayer[dtype].
+
+TDD tests for Phase 4a (PR 6, epic #4998): parameterize non-Module layers.
+BatchNorm2dLayer becomes BatchNorm2dLayer[dtype: DType = DType.float32] with
+Tensor[dtype] weights (gamma, beta, running_mean, running_var).
+
+Tests cover:
+- Default dtype (float32) constructor
+- Explicit float64 parameterization
+- Parameter shapes (gamma, beta)
+- Running statistics shapes
+- Forward pass preserves dtype
+- Forward pass output shape (NCHW)
+- Inference mode uses running stats
+"""
+
+from testing import assert_true, assert_almost_equal
+from shared.core.layers.batchnorm import BatchNorm2dLayer
+from shared.tensor.tensor import Tensor
+
+
+fn test_batchnorm_default_dtype() raises:
+    """BatchNorm2dLayer defaults to float32 weights."""
+    var bn = BatchNorm2dLayer(num_channels=4)
+    # gamma and beta should be Tensor[DType.float32]
+    assert_true(bn.gamma.dtype() == DType.float32, "gamma dtype should be float32")
+    assert_true(bn.beta.dtype() == DType.float32, "beta dtype should be float32")
+    print("PASS: test_batchnorm_default_dtype")
+
+
+fn test_batchnorm_float64() raises:
+    """BatchNorm2dLayer[DType.float64] uses float64 tensors."""
+    var bn = BatchNorm2dLayer[DType.float64](num_channels=4)
+    assert_true(bn.gamma.dtype() == DType.float64, "gamma dtype should be float64")
+    assert_true(bn.beta.dtype() == DType.float64, "beta dtype should be float64")
+    print("PASS: test_batchnorm_float64")
+
+
+fn test_batchnorm_gamma_shape() raises:
+    """Gamma has shape (num_channels,) and is initialized to ones."""
+    var bn = BatchNorm2dLayer(num_channels=8)
+    assert_true(bn.gamma.numel() == 8, "gamma should have 8 elements")
+    # Gamma initialized to 1.0
+    assert_almost_equal(Float32(bn.gamma[0]), Float32(1.0), atol=1e-6)
+    assert_almost_equal(Float32(bn.gamma[7]), Float32(1.0), atol=1e-6)
+    print("PASS: test_batchnorm_gamma_shape")
+
+
+fn test_batchnorm_beta_shape() raises:
+    """Beta has shape (num_channels,) and is initialized to zeros."""
+    var bn = BatchNorm2dLayer(num_channels=8)
+    assert_true(bn.beta.numel() == 8, "beta should have 8 elements")
+    # Beta initialized to 0.0
+    assert_almost_equal(Float32(bn.beta[0]), Float32(0.0), atol=1e-6)
+    assert_almost_equal(Float32(bn.beta[7]), Float32(0.0), atol=1e-6)
+    print("PASS: test_batchnorm_beta_shape")
+
+
+fn test_batchnorm_running_stats_shape() raises:
+    """Running mean/var have shape (num_channels,) with correct init."""
+    var bn = BatchNorm2dLayer(num_channels=4)
+    assert_true(bn.running_mean.numel() == 4, "running_mean should have 4 elements")
+    assert_true(bn.running_var.numel() == 4, "running_var should have 4 elements")
+    # running_mean initialized to 0.0, running_var to 1.0
+    assert_almost_equal(Float32(bn.running_mean[0]), Float32(0.0), atol=1e-6)
+    assert_almost_equal(Float32(bn.running_var[0]), Float32(1.0), atol=1e-6)
+    print("PASS: test_batchnorm_running_stats_shape")
+
+
+fn test_batchnorm_running_stats_float64() raises:
+    """Running stats use the parameterized dtype."""
+    var bn = BatchNorm2dLayer[DType.float64](num_channels=4)
+    assert_true(
+        bn.running_mean.dtype() == DType.float64,
+        "running_mean dtype should be float64",
+    )
+    assert_true(
+        bn.running_var.dtype() == DType.float64,
+        "running_var dtype should be float64",
+    )
+    print("PASS: test_batchnorm_running_stats_float64")
+
+
+fn test_batchnorm_forward_typed() raises:
+    """Forward pass accepts and returns Tensor[dtype]."""
+    var bn = BatchNorm2dLayer[DType.float32](num_channels=2)
+    var input = Tensor[DType.float32]([1, 2, 3, 3])  # NCHW
+    # Set some values to avoid all-zeros (batch_norm needs variance != 0)
+    input._data[0] = Scalar[DType.float32](0.5)
+    input._data[1] = Scalar[DType.float32](1.0)
+    input._data[9] = Scalar[DType.float32](1.5)
+    input._data[10] = Scalar[DType.float32](0.25)
+    var output = bn.forward(input)
+    assert_true(output.dtype() == DType.float32, "output dtype should be float32")
+    # Output should have same shape as input: [1, 2, 3, 3]
+    var s = output.shape()
+    assert_true(s[0] == 1, "batch dim")
+    assert_true(s[1] == 2, "channel dim")
+    assert_true(s[2] == 3, "height dim")
+    assert_true(s[3] == 3, "width dim")
+    print("PASS: test_batchnorm_forward_typed")
+
+
+fn test_batchnorm_forward_inference() raises:
+    """Forward with training=False uses running stats, not batch stats."""
+    var bn = BatchNorm2dLayer(num_channels=2)
+    var input = Tensor[DType.float32]([1, 2, 3, 3])
+    # Set input to all 1.0 for predictable output
+    for i in range(input.numel()):
+        input._data[i] = Scalar[DType.float32](1.0)
+    # In inference mode with running_mean=0, running_var=1, gamma=1, beta=0:
+    # output = gamma * (input - running_mean) / sqrt(running_var + eps) + beta
+    # output = 1 * (1 - 0) / sqrt(1 + 1e-5) + 0 ~ 1.0
+    var output = bn.forward(input, training=False)
+    assert_true(output.numel() == 18, "output should have 18 elements")
+    assert_almost_equal(Float32(output[0]), Float32(1.0), atol=1e-4)
+    print("PASS: test_batchnorm_forward_inference")
+
+
+fn test_batchnorm_parameters_typed() raises:
+    """parameters() returns List[Tensor[dtype]] with gamma and beta."""
+    var bn = BatchNorm2dLayer(num_channels=4)
+    var params = bn.parameters()
+    assert_true(len(params) == 2, "should have 2 parameters (gamma, beta)")
+    assert_true(params[0].numel() == 4, "gamma should have 4 elements")
+    assert_true(params[1].numel() == 4, "beta should have 4 elements")
+    print("PASS: test_batchnorm_parameters_typed")
+
+
+fn main() raises:
+    test_batchnorm_default_dtype()
+    test_batchnorm_float64()
+    test_batchnorm_gamma_shape()
+    test_batchnorm_beta_shape()
+    test_batchnorm_running_stats_shape()
+    test_batchnorm_running_stats_float64()
+    test_batchnorm_forward_typed()
+    test_batchnorm_forward_inference()
+    test_batchnorm_parameters_typed()
+    print("All 9 typed batchnorm tests passed!")

--- a/tests/shared/tensor/test_typed_conv2d.mojo
+++ b/tests/shared/tensor/test_typed_conv2d.mojo
@@ -1,0 +1,175 @@
+# ADR-009: This file is intentionally limited to <=10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for parameterized Conv2dLayer[dtype].
+
+TDD tests for Phase 4a (PR 6, epic #4998): parameterize non-Module layers.
+Conv2dLayer becomes Conv2dLayer[dtype: DType = DType.float32] with
+Tensor[dtype] weight and bias fields.
+
+Tests cover:
+- Default dtype (float32) constructor
+- Explicit float64 parameterization
+- Weight shape (out_ch, in_ch, kH, kW)
+- Bias shape (out_ch,)
+- Forward pass preserves dtype
+- Forward pass output shape
+- Parameters list
+- Backward pass dtype preservation
+"""
+
+from testing import assert_true, assert_almost_equal
+from shared.core.layers.conv2d import Conv2dLayer
+from shared.tensor.tensor import Tensor
+
+
+fn test_conv2d_default_dtype() raises:
+    """Conv2dLayer defaults to float32 weights."""
+    var layer = Conv2dLayer(
+        in_channels=1, out_channels=2, kernel_h=3, kernel_w=3
+    )
+    assert_true(layer.weight.dtype() == DType.float32, "weight dtype should be float32")
+    assert_true(layer.bias.dtype() == DType.float32, "bias dtype should be float32")
+    print("PASS: test_conv2d_default_dtype")
+
+
+fn test_conv2d_float64() raises:
+    """Conv2dLayer[DType.float64] uses float64 tensors."""
+    var layer = Conv2dLayer[DType.float64](
+        in_channels=1, out_channels=2, kernel_h=3, kernel_w=3
+    )
+    assert_true(layer.weight.dtype() == DType.float64, "weight dtype should be float64")
+    assert_true(layer.bias.dtype() == DType.float64, "bias dtype should be float64")
+    print("PASS: test_conv2d_float64")
+
+
+fn test_conv2d_weight_shape() raises:
+    """Weight has shape (out_channels, in_channels, kernel_h, kernel_w)."""
+    var layer = Conv2dLayer(
+        in_channels=3, out_channels=16, kernel_h=5, kernel_w=5
+    )
+    var s = layer.weight.shape()
+    assert_true(len(s) == 4, "weight should be 4D")
+    assert_true(s[0] == 16, "out_channels")
+    assert_true(s[1] == 3, "in_channels")
+    assert_true(s[2] == 5, "kernel_h")
+    assert_true(s[3] == 5, "kernel_w")
+    assert_true(layer.weight.numel() == 16 * 3 * 5 * 5, "weight numel")
+    print("PASS: test_conv2d_weight_shape")
+
+
+fn test_conv2d_bias_shape() raises:
+    """Bias has shape (out_channels,) and is initialized to zeros."""
+    var layer = Conv2dLayer(
+        in_channels=3, out_channels=16, kernel_h=3, kernel_w=3
+    )
+    assert_true(layer.bias.numel() == 16, "bias should have out_channels elements")
+    # Bias initialized to 0.0
+    assert_almost_equal(Float32(layer.bias[0]), Float32(0.0), atol=1e-6)
+    assert_almost_equal(Float32(layer.bias[15]), Float32(0.0), atol=1e-6)
+    print("PASS: test_conv2d_bias_shape")
+
+
+fn test_conv2d_forward_typed() raises:
+    """Forward pass accepts and returns Tensor[dtype]."""
+    var layer = Conv2dLayer[DType.float32](
+        in_channels=1, out_channels=2, kernel_h=3, kernel_w=3, padding=1
+    )
+    var input = Tensor[DType.float32]([1, 1, 5, 5])  # NCHW
+    # Set some input values using FP-representable values
+    input._data[0] = Scalar[DType.float32](0.5)
+    input._data[1] = Scalar[DType.float32](1.0)
+    input._data[12] = Scalar[DType.float32](1.5)
+    var output = layer.forward(input)
+    assert_true(output.dtype() == DType.float32, "output dtype should be float32")
+    # With padding=1, stride=1, kernel 3x3: output = [1, 2, 5, 5]
+    var s = output.shape()
+    assert_true(s[0] == 1, "batch dim")
+    assert_true(s[1] == 2, "out_channels dim")
+    assert_true(s[2] == 5, "height dim (padding=1 preserves)")
+    assert_true(s[3] == 5, "width dim (padding=1 preserves)")
+    print("PASS: test_conv2d_forward_typed")
+
+
+fn test_conv2d_forward_output_shape_no_padding() raises:
+    """Forward pass computes correct output shape without padding."""
+    var layer = Conv2dLayer(
+        in_channels=1, out_channels=4, kernel_h=3, kernel_w=3
+    )
+    var input = Tensor[DType.float32]([1, 1, 8, 8])
+    var output = layer.forward(input)
+    # out_h = (8 + 0 - 3) // 1 + 1 = 6
+    # out_w = (8 + 0 - 3) // 1 + 1 = 6
+    var s = output.shape()
+    assert_true(s[0] == 1, "batch dim")
+    assert_true(s[1] == 4, "out_channels dim")
+    assert_true(s[2] == 6, "out_height: (8 - 3) // 1 + 1 = 6")
+    assert_true(s[3] == 6, "out_width: (8 - 3) // 1 + 1 = 6")
+    print("PASS: test_conv2d_forward_output_shape_no_padding")
+
+
+fn test_conv2d_parameters_typed() raises:
+    """parameters() returns List with weight and bias."""
+    var layer = Conv2dLayer(
+        in_channels=1, out_channels=2, kernel_h=3, kernel_w=3
+    )
+    var params = layer.parameters()
+    assert_true(len(params) == 2, "should have 2 parameters (weight, bias)")
+    assert_true(params[0].numel() == 2 * 1 * 3 * 3, "weight numel")
+    assert_true(params[1].numel() == 2, "bias numel")
+    print("PASS: test_conv2d_parameters_typed")
+
+
+fn test_conv2d_backward_typed() raises:
+    """Backward pass returns typed gradient tensors."""
+    var layer = Conv2dLayer[DType.float32](
+        in_channels=1, out_channels=2, kernel_h=3, kernel_w=3, padding=1
+    )
+    var input = Tensor[DType.float32]([1, 1, 5, 5])
+    for i in range(input.numel()):
+        input._data[i] = Scalar[DType.float32](0.5)
+    var output = layer.forward(input)
+    var grad_output = Tensor[DType.float32](output.shape())
+    for i in range(grad_output.numel()):
+        grad_output._data[i] = Scalar[DType.float32](1.0)
+    var (grad_input, grad_weight, grad_bias) = layer.backward(
+        grad_output, input
+    )
+    # grad_input should match input shape
+    assert_true(grad_input.numel() == input.numel(), "grad_input numel")
+    assert_true(grad_input.dtype() == DType.float32, "grad_input dtype")
+    # grad_weight should match weight shape
+    assert_true(
+        grad_weight.numel() == layer.weight.numel(), "grad_weight numel"
+    )
+    # grad_bias should match bias shape
+    assert_true(grad_bias.numel() == layer.bias.numel(), "grad_bias numel")
+    print("PASS: test_conv2d_backward_typed")
+
+
+fn test_conv2d_stride() raises:
+    """Conv2d with stride=2 halves spatial dimensions."""
+    var layer = Conv2dLayer(
+        in_channels=1, out_channels=2, kernel_h=3, kernel_w=3, stride=2
+    )
+    var input = Tensor[DType.float32]([1, 1, 8, 8])
+    var output = layer.forward(input)
+    # out_h = (8 + 0 - 3) // 2 + 1 = 3
+    # out_w = (8 + 0 - 3) // 2 + 1 = 3
+    var s = output.shape()
+    assert_true(s[2] == 3, "out_height with stride=2")
+    assert_true(s[3] == 3, "out_width with stride=2")
+    print("PASS: test_conv2d_stride")
+
+
+fn main() raises:
+    test_conv2d_default_dtype()
+    test_conv2d_float64()
+    test_conv2d_weight_shape()
+    test_conv2d_bias_shape()
+    test_conv2d_forward_typed()
+    test_conv2d_forward_output_shape_no_padding()
+    test_conv2d_parameters_typed()
+    test_conv2d_backward_typed()
+    test_conv2d_stride()
+    print("All 9 typed conv2d tests passed!")

--- a/tests/shared/tensor/test_typed_dropout.mojo
+++ b/tests/shared/tensor/test_typed_dropout.mojo
@@ -1,0 +1,161 @@
+# ADR-009: This file is intentionally limited to <=10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+"""Tests for DropoutLayer with typed Tensor[dtype] inputs.
+
+TDD tests for Phase 4a (PR 6, epic #4998): parameterize non-Module layers.
+DropoutLayer has no ExTensor weight fields, so it does not need dtype
+parameterization on the struct. However, its forward() and backward()
+signatures must accept and return Tensor[dtype] instead of ExTensor.
+
+Tests cover:
+- Forward preserves dtype (float32)
+- Forward preserves dtype (float64)
+- Inference mode passes input through unchanged
+- Training mode zeros some elements
+- Training mode scales kept elements by 1/(1-p)
+- Backward applies same mask
+- No trainable parameters
+"""
+
+from testing import assert_true, assert_almost_equal
+from shared.core.layers.dropout import DropoutLayer
+from shared.tensor.tensor import Tensor
+
+
+fn test_dropout_forward_preserves_dtype_f32() raises:
+    """Forward pass preserves float32 dtype."""
+    var layer = DropoutLayer(dropout_rate=0.5)
+    layer.set_training(False)
+    var input = Tensor[DType.float32]([2, 4])
+    for i in range(input.numel()):
+        input._data[i] = Scalar[DType.float32](1.0)
+    var output = layer.forward(input)
+    assert_true(output.dtype() == DType.float32, "output dtype should be float32")
+    assert_true(output.numel() == 8, "output should have same numel")
+    print("PASS: test_dropout_forward_preserves_dtype_f32")
+
+
+fn test_dropout_forward_preserves_dtype_f64() raises:
+    """Forward pass preserves float64 dtype."""
+    var layer = DropoutLayer(dropout_rate=0.5)
+    layer.set_training(False)
+    var input = Tensor[DType.float64]([2, 4])
+    for i in range(input.numel()):
+        input._data[i] = Scalar[DType.float64](1.0)
+    var output = layer.forward(input)
+    assert_true(output.dtype() == DType.float64, "output dtype should be float64")
+    print("PASS: test_dropout_forward_preserves_dtype_f64")
+
+
+fn test_dropout_inference_passthrough() raises:
+    """In inference mode (training=False), output equals input exactly."""
+    var layer = DropoutLayer(dropout_rate=0.5)
+    layer.set_training(False)
+    var input = Tensor[DType.float32]([4])
+    input._data[0] = Scalar[DType.float32](0.5)
+    input._data[1] = Scalar[DType.float32](1.0)
+    input._data[2] = Scalar[DType.float32](1.5)
+    input._data[3] = Scalar[DType.float32](0.25)
+    var output = layer.forward(input)
+    assert_almost_equal(Float32(output[0]), Float32(0.5), atol=1e-6)
+    assert_almost_equal(Float32(output[1]), Float32(1.0), atol=1e-6)
+    assert_almost_equal(Float32(output[2]), Float32(1.5), atol=1e-6)
+    assert_almost_equal(Float32(output[3]), Float32(0.25), atol=1e-6)
+    print("PASS: test_dropout_inference_passthrough")
+
+
+fn test_dropout_training_zeros_elements() raises:
+    """In training mode, some elements are zeroed (stochastic)."""
+    var layer = DropoutLayer(dropout_rate=0.5)
+    layer.set_training(True)
+    # Use a large enough tensor that statistically some will be zeroed
+    var input = Tensor[DType.float32]([100])
+    for i in range(100):
+        input._data[i] = Scalar[DType.float32](1.0)
+    var output = layer.forward(input)
+    var zero_count = 0
+    var nonzero_count = 0
+    for i in range(100):
+        if Float32(output[i]) == Float32(0.0):
+            zero_count += 1
+        else:
+            nonzero_count += 1
+    # With p=0.5 and 100 elements, expect roughly 50 zeros
+    # Allow wide margin for stochastic test: at least 10 of each
+    assert_true(zero_count >= 10, "should have some zeroed elements")
+    assert_true(nonzero_count >= 10, "should have some kept elements")
+    print("PASS: test_dropout_training_zeros_elements")
+
+
+fn test_dropout_training_scale_factor() raises:
+    """Kept elements are scaled by 1/(1-p) to preserve expected value."""
+    var layer = DropoutLayer(dropout_rate=0.5)
+    layer.set_training(True)
+    var input = Tensor[DType.float32]([100])
+    for i in range(100):
+        input._data[i] = Scalar[DType.float32](1.0)
+    var output = layer.forward(input)
+    # Non-zero elements should be scaled by 1/(1-0.5) = 2.0
+    var scale = Float32(1.0) / (Float32(1.0) - Float32(0.5))
+    for i in range(100):
+        var val = Float32(output[i])
+        if val != Float32(0.0):
+            assert_almost_equal(val, scale, atol=1e-6)
+    print("PASS: test_dropout_training_scale_factor")
+
+
+fn test_dropout_zero_rate() raises:
+    """Dropout with rate=0.0 keeps all elements (no dropout)."""
+    var layer = DropoutLayer(dropout_rate=0.0)
+    layer.set_training(True)
+    var input = Tensor[DType.float32]([4])
+    input._data[0] = Scalar[DType.float32](0.5)
+    input._data[1] = Scalar[DType.float32](1.0)
+    input._data[2] = Scalar[DType.float32](1.5)
+    input._data[3] = Scalar[DType.float32](0.25)
+    var output = layer.forward(input)
+    # With rate=0, scale = 1/(1-0) = 1.0, all elements kept
+    assert_almost_equal(Float32(output[0]), Float32(0.5), atol=1e-6)
+    assert_almost_equal(Float32(output[1]), Float32(1.0), atol=1e-6)
+    assert_almost_equal(Float32(output[2]), Float32(1.5), atol=1e-6)
+    assert_almost_equal(Float32(output[3]), Float32(0.25), atol=1e-6)
+    print("PASS: test_dropout_zero_rate")
+
+
+fn test_dropout_backward_typed() raises:
+    """Backward pass applies mask and returns Tensor[dtype]."""
+    var layer = DropoutLayer(dropout_rate=0.5)
+    layer.set_training(True)
+    var input = Tensor[DType.float32]([10])
+    for i in range(10):
+        input._data[i] = Scalar[DType.float32](1.0)
+    # Forward to generate mask
+    var output = layer.forward(input)
+    var grad_output = Tensor[DType.float32]([10])
+    for i in range(10):
+        grad_output._data[i] = Scalar[DType.float32](1.0)
+    var grad_input = layer.backward(grad_output, layer.last_mask)
+    assert_true(grad_input.dtype() == DType.float32, "grad_input dtype")
+    assert_true(grad_input.numel() == 10, "grad_input numel")
+    print("PASS: test_dropout_backward_typed")
+
+
+fn test_dropout_no_parameters() raises:
+    """Dropout has no trainable parameters."""
+    var layer = DropoutLayer(dropout_rate=0.5)
+    var params = layer.parameters()
+    assert_true(len(params) == 0, "dropout should have 0 parameters")
+    print("PASS: test_dropout_no_parameters")
+
+
+fn main() raises:
+    test_dropout_forward_preserves_dtype_f32()
+    test_dropout_forward_preserves_dtype_f64()
+    test_dropout_inference_passthrough()
+    test_dropout_training_zeros_elements()
+    test_dropout_training_scale_factor()
+    test_dropout_zero_rate()
+    test_dropout_backward_typed()
+    test_dropout_no_parameters()
+    print("All 8 typed dropout tests passed!")


### PR DESCRIPTION
## Summary

- Add TDD tests for parameterized `BatchNorm2dLayer[dtype]` (9 tests)
- Add TDD tests for parameterized `Conv2dLayer[dtype]` (9 tests)
- Add TDD tests for `DropoutLayer` with typed `Tensor[dtype]` inputs (8 tests)
- All files respect ADR-009 limit of 10 tests per file

## Test plan

- [ ] Tests define the expected API for Phase 4a parameterization
- [ ] `BatchNorm2dLayer[dtype]` tests cover: default dtype, float64, gamma/beta shapes, running stats, forward pass typing, inference mode, parameters()
- [ ] `Conv2dLayer[dtype]` tests cover: default dtype, float64, weight/bias shapes, forward typing, output shapes with/without padding, backward typing, stride
- [ ] `DropoutLayer` tests cover: dtype preservation (f32/f64), inference passthrough, training zeroing/scaling, backward, zero-rate edge case, no parameters

Part of #4998

🤖 Generated with [Claude Code](https://claude.com/claude-code)