### PR TITLE
feat(layers): parameterize non-Module layers with Tensor[dtype]

### DIFF
--- a/shared/core/attention.mojo
+++ b/shared/core/attention.mojo
@@ -901,3 +901,108 @@ fn multi_head_attention_backward(
     return MultiHeadAttentionBackwardResult(
         grad_query, grad_key, grad_value, grad_wq, grad_wk, grad_wv, grad_wo
     )
+
+
+# ============================================================================
+# Typed Tensor[dtype] overloads — wrap AnyTensor versions via as_any/as_tensor
+# ============================================================================
+
+from shared.tensor.tensor import Tensor
+
+
+fn scaled_dot_product_attention[
+    dt: DType
+](
+    query: Tensor[dt],
+    key: Tensor[dt],
+    value: Tensor[dt],
+    dropout_p: Float64 = 0.0,
+) raises -> Tensor[dt]:
+    """Scaled dot-product attention without mask (typed version).
+
+    Args:
+        query: Query tensor.
+        key: Key tensor.
+        value: Value tensor.
+        dropout_p: Dropout probability.
+
+    Returns:
+        Attention output tensor.
+    """
+    return scaled_dot_product_attention(
+        query.as_any(), key.as_any(), value.as_any(), dropout_p
+    ).as_tensor[dt]()
+
+
+fn scaled_dot_product_attention_masked[
+    dt: DType
+](
+    query: Tensor[dt],
+    key: Tensor[dt],
+    value: Tensor[dt],
+    mask: Tensor[dt],
+    dropout_p: Float64 = 0.0,
+) raises -> Tensor[dt]:
+    """Scaled dot-product attention with mask (typed version).
+
+    Args:
+        query: Query tensor.
+        key: Key tensor.
+        value: Value tensor.
+        mask: Attention mask tensor.
+        dropout_p: Dropout probability.
+
+    Returns:
+        Attention output tensor.
+    """
+    return scaled_dot_product_attention_masked(
+        query.as_any(),
+        key.as_any(),
+        value.as_any(),
+        mask.as_any(),
+        dropout_p,
+    ).as_tensor[dt]()
+
+
+fn scaled_dot_product_attention_backward[
+    dt: DType
+](
+    grad_output: Tensor[dt],
+    query: Tensor[dt],
+    key: Tensor[dt],
+    value: Tensor[dt],
+    attention_weights: Tensor[dt],
+) raises -> GradientTriple:
+    """Backward pass for scaled dot-product attention (typed version).
+
+    Args:
+        grad_output: Gradient w.r.t. attention output.
+        query: Original query tensor.
+        key: Original key tensor.
+        value: Original value tensor.
+        attention_weights: Attention weights from forward pass.
+
+    Returns:
+        GradientTriple containing gradients for query, key, and value.
+    """
+    return scaled_dot_product_attention_backward(
+        grad_output.as_any(),
+        query.as_any(),
+        key.as_any(),
+        value.as_any(),
+        attention_weights.as_any(),
+    )
+
+
+fn create_causal_mask[
+    dt: DType
+](seq_len: Int) raises -> Tensor[dt]:
+    """Create a causal (lower-triangular) attention mask (typed version).
+
+    Args:
+        seq_len: Sequence length for the mask.
+
+    Returns:
+        Mask tensor of shape (seq_len, seq_len).
+    """
+    return create_causal_mask(seq_len, dt).as_tensor[dt]()

--- a/shared/core/layers/batchnorm.mojo
+++ b/shared/core/layers/batchnorm.mojo
@@ -13,31 +13,35 @@ Key components:
 
 from ..extensor import ExTensor, zeros, ones, zeros_like, ones_like
 from ..normalization_simd import batch_norm2d_fused
+from shared.tensor.tensor import Tensor
 
 
-struct BatchNorm2dLayer(Copyable, Movable):
-    """2D Batch Normalization layer.
+struct BatchNorm2dLayer[dtype: DType = DType.float32](Copyable, Movable):
+    """2D Batch Normalization layer parameterized on dtype.
 
-    Normalizes activations across the batch dimension for each channel
-    Maintains running statistics for use during inference
+    Normalizes activations across the batch dimension for each channel.
+    Maintains running statistics for use during inference.
+
+    Parameters:
+        dtype: The data type for all internal tensors (default: float32).
 
     Attributes:
-        gamma: Scale parameter of shape (channels,)
-        beta: Shift parameter of shape (channels,)
-        running_mean: Running mean of shape (channels,)
-        running_var: Running variance of shape (channels,)
-        num_channels: Number of channels to normalize
-        momentum: Momentum for running statistics update
-        eps: Small constant for numerical stability
+        gamma: Scale parameter of shape (channels,).
+        beta: Shift parameter of shape (channels,).
+        running_mean: Running mean of shape (channels,).
+        running_var: Running variance of shape (channels,).
+        num_channels: Number of channels to normalize.
+        momentum: Momentum for running statistics update.
+        eps: Small constant for numerical stability.
     """
 
-    var gamma: ExTensor
+    var gamma: Tensor[dtype]
     """Scale parameter of shape (channels,)."""
-    var beta: ExTensor
+    var beta: Tensor[dtype]
     """Shift parameter of shape (channels,)."""
-    var running_mean: ExTensor
+    var running_mean: Tensor[dtype]
     """Running mean of shape (channels,)."""
-    var running_var: ExTensor
+    var running_var: Tensor[dtype]
     """Running variance of shape (channels,)."""
     var num_channels: Int
     """Number of channels to normalize."""
@@ -66,12 +70,15 @@ struct BatchNorm2dLayer(Copyable, Movable):
                 (default: 1e-5).
 
         Raises:
-            Error if tensor creation fails
+            Error if tensor creation fails.
 
         Example:
             ```mojo
             # Normalize 16 channels from Conv2d output
             var bn = BatchNorm2dLayer(16, momentum=0.1)
+
+            # FP16 batch norm
+            var bn16 = BatchNorm2dLayer[DType.float16](16)
             ```
         """
         self.num_channels = num_channels
@@ -82,37 +89,37 @@ struct BatchNorm2dLayer(Copyable, Movable):
         # Shape: (channels,)
         var gamma_shape = List[Int]()
         gamma_shape.append(num_channels)
-        self.gamma = ones(gamma_shape, DType.float32)
+        self.gamma = ones(gamma_shape, dtype).as_tensor[dtype]()
 
         # Initialize beta (shift) to 0.0
         # Shape: (channels,)
         var beta_shape = List[Int]()
         beta_shape.append(num_channels)
-        self.beta = zeros(beta_shape, DType.float32)
+        self.beta = zeros(beta_shape, dtype).as_tensor[dtype]()
 
         # Initialize running_mean to 0.0
         # Shape: (channels,)
         var running_mean_shape = List[Int]()
         running_mean_shape.append(num_channels)
-        self.running_mean = zeros(running_mean_shape, DType.float32)
+        self.running_mean = zeros(running_mean_shape, dtype).as_tensor[dtype]()
 
         # Initialize running_var to 1.0
         # Shape: (channels,)
         var running_var_shape = List[Int]()
         running_var_shape.append(num_channels)
-        self.running_var = ones(running_var_shape, DType.float32)
+        self.running_var = ones(running_var_shape, dtype).as_tensor[dtype]()
 
     fn forward(
-        mut self, input: ExTensor, training: Bool = True
-    ) raises -> ExTensor:
+        mut self, input: Tensor[dtype], training: Bool = True
+    ) raises -> Tensor[dtype]:
         """Forward pass with batch normalization.
 
-        In training mode: computes batch statistics and updates running statistics
-        In inference mode: uses running statistics for normalization
+        In training mode: computes batch statistics and updates running statistics.
+        In inference mode: uses running statistics for normalization.
 
         Args:
             input: Input tensor of shape (batch, channels, height, width).
-            training: If True, use batch statistics and update running stats
+            training: If True, use batch statistics and update running stats.
                      If False, use running statistics (default: True).
 
         Returns:
@@ -126,7 +133,8 @@ struct BatchNorm2dLayer(Copyable, Movable):
             when training=True to track exponential moving averages.
 
         Formula (training):
-        ```
+
+        ```text
             mean = mean(x, axis=(0, 2, 3))  # Per channel
             var = var(x, axis=(0, 2, 3))
             x_norm = (x - mean) / sqrt(var + eps)
@@ -136,7 +144,8 @@ struct BatchNorm2dLayer(Copyable, Movable):
         ```
 
         Formula (inference):
-        ```
+
+        ```text
             x_norm = (x - running_mean) / sqrt(running_var + eps)
             output = gamma * x_norm + beta
         ```
@@ -153,12 +162,13 @@ struct BatchNorm2dLayer(Copyable, Movable):
             var output = bn.forward(input, training=False)
             ```
         """
+        # Delegate to ExTensor-based fused implementation via as_any/as_tensor
         var (output, new_running_mean, new_running_var) = batch_norm2d_fused(
-            input,
-            self.gamma,
-            self.beta,
-            self.running_mean,
-            self.running_var,
+            input.as_any(),
+            self.gamma.as_any(),
+            self.beta.as_any(),
+            self.running_mean.as_any(),
+            self.running_var.as_any(),
             training,
             Float64(self.momentum),
             Float64(self.eps),
@@ -166,20 +176,20 @@ struct BatchNorm2dLayer(Copyable, Movable):
 
         # Update running statistics if training
         if training:
-            self.running_mean = new_running_mean^
-            self.running_var = new_running_var^
+            self.running_mean = new_running_mean.as_tensor[dtype]()
+            self.running_var = new_running_var.as_tensor[dtype]()
 
-        return output^
+        return output.as_tensor[dtype]()
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[Tensor[dtype]]:
         """Get list of trainable parameters.
 
         Returns:
-            List containing [gamma, beta] tensors that need gradients
-            (Running statistics are not trainable parameters)
+            List containing [gamma, beta] tensors that need gradients.
+            (Running statistics are not trainable parameters.)
 
         Raises:
-            Error if tensor copying fails
+            Error if tensor copying fails.
 
         Example:
             ```mojo
@@ -188,19 +198,19 @@ struct BatchNorm2dLayer(Copyable, Movable):
             # params[0] is gamma (scale), params[1] is beta (shift)
             ```
         """
-        var params: List[ExTensor] = []
+        var params = List[Tensor[dtype]]()
 
-        # Create copies of gamma and beta tensors
-        var gamma_copy = zeros_like(self.gamma)
-        var beta_copy = zeros_like(self.beta)
+        # Create copies of gamma and beta via ExTensor round-trip
+        var gamma_any = zeros_like(self.gamma.as_any())
+        var beta_any = zeros_like(self.beta.as_any())
 
         var gamma_size = self.gamma.numel()
         var beta_size = self.beta.numel()
 
-        var gamma_src = self.gamma._data.bitcast[Float32]()
-        var gamma_dst = gamma_copy._data.bitcast[Float32]()
-        var beta_src = self.beta._data.bitcast[Float32]()
-        var beta_dst = beta_copy._data.bitcast[Float32]()
+        var gamma_src = self.gamma.as_any()._data.bitcast[Float32]()
+        var gamma_dst = gamma_any._data.bitcast[Float32]()
+        var beta_src = self.beta.as_any()._data.bitcast[Float32]()
+        var beta_dst = beta_any._data.bitcast[Float32]()
 
         for i in range(gamma_size):
             gamma_dst[i] = gamma_src[i]
@@ -208,19 +218,21 @@ struct BatchNorm2dLayer(Copyable, Movable):
         for i in range(beta_size):
             beta_dst[i] = beta_src[i]
 
-        params.append(gamma_copy^)
-        params.append(beta_copy^)
+        params.append(gamma_any.as_tensor[dtype]())
+        params.append(beta_any.as_tensor[dtype]())
         return params^
 
-    fn get_running_stats(self) raises -> Tuple[ExTensor, ExTensor]:
+    fn get_running_stats(
+        self,
+    ) raises -> Tuple[Tensor[dtype], Tensor[dtype]]:
         """Get current running statistics.
 
         Returns:
             Tuple of (running_mean, running_var) for use during inference
-            or checkpointing
+            or checkpointing.
 
         Raises:
-            Error if tensor copying fails
+            Error if tensor copying fails.
 
         Example:
             ```mojo
@@ -229,16 +241,16 @@ struct BatchNorm2dLayer(Copyable, Movable):
             var (mean, var) = bn.get_running_stats()
             ```
         """
-        var mean_copy = zeros_like(self.running_mean)
-        var var_copy = zeros_like(self.running_var)
+        var mean_any = zeros_like(self.running_mean.as_any())
+        var var_any = zeros_like(self.running_var.as_any())
 
         var mean_size = self.running_mean.numel()
         var var_size = self.running_var.numel()
 
-        var mean_src = self.running_mean._data.bitcast[Float32]()
-        var mean_dst = mean_copy._data.bitcast[Float32]()
-        var var_src = self.running_var._data.bitcast[Float32]()
-        var var_dst = var_copy._data.bitcast[Float32]()
+        var mean_src = self.running_mean.as_any()._data.bitcast[Float32]()
+        var mean_dst = mean_any._data.bitcast[Float32]()
+        var var_src = self.running_var.as_any()._data.bitcast[Float32]()
+        var var_dst = var_any._data.bitcast[Float32]()
 
         for i in range(mean_size):
             mean_dst[i] = mean_src[i]
@@ -246,10 +258,15 @@ struct BatchNorm2dLayer(Copyable, Movable):
         for i in range(var_size):
             var_dst[i] = var_src[i]
 
-        return Tuple[ExTensor, ExTensor](mean_copy^, var_copy^)
+        return (
+            mean_any.as_tensor[dtype](),
+            var_any.as_tensor[dtype](),
+        )
 
     fn set_running_stats(
-        mut self, running_mean: ExTensor, running_var: ExTensor
+        mut self,
+        running_mean: Tensor[dtype],
+        running_var: Tensor[dtype],
     ) raises:
         """Set running statistics (for loading from checkpoint).
 
@@ -277,16 +294,19 @@ struct BatchNorm2dLayer(Copyable, Movable):
         if var_size != self.running_var.numel():
             raise Error("Running variance size mismatch")
 
-        self.running_mean = zeros_like(self.running_mean)
-        self.running_var = zeros_like(self.running_var)
+        var new_mean_any = zeros_like(self.running_mean.as_any())
+        var new_var_any = zeros_like(self.running_var.as_any())
 
-        var mean_src = running_mean._data.bitcast[Float32]()
-        var mean_dst = self.running_mean._data.bitcast[Float32]()
-        var var_src = running_var._data.bitcast[Float32]()
-        var var_dst = self.running_var._data.bitcast[Float32]()
+        var mean_src = running_mean.as_any()._data.bitcast[Float32]()
+        var mean_dst = new_mean_any._data.bitcast[Float32]()
+        var var_src = running_var.as_any()._data.bitcast[Float32]()
+        var var_dst = new_var_any._data.bitcast[Float32]()
 
         for i in range(mean_size):
             mean_dst[i] = mean_src[i]
 
         for i in range(var_size):
             var_dst[i] = var_src[i]
+
+        self.running_mean = new_mean_any.as_tensor[dtype]()
+        self.running_var = new_var_any.as_tensor[dtype]()

--- a/shared/core/layers/conv2d.mojo
+++ b/shared/core/layers/conv2d.mojo
@@ -12,13 +12,19 @@ Key components:
 from ..extensor import ExTensor, zeros, randn, zeros_like
 from ..initializers import kaiming_uniform
 from ..conv import conv2d, conv2d_backward
+from shared.tensor.tensor import Tensor
 
 
-struct Conv2dLayer(Copyable, Movable):
-    """2D Convolutional layer: y = conv2d(x, weight, bias, stride, padding).
+struct Conv2dLayer[dtype: DType = DType.float32](Copyable, Movable):
+    """2D Convolutional layer parameterized on dtype.
+
+    y = conv2d(x, weight, bias, stride, padding).
 
     A 2D convolutional neural network layer that applies learnable filters
     to spatially structured inputs (images).
+
+    Parameters:
+        dtype: The data type for weight and bias tensors (default: float32).
 
     Attributes:
         weight: Filter weights of shape (out_channels, in_channels, kernel_h, kernel_w).
@@ -31,9 +37,9 @@ struct Conv2dLayer(Copyable, Movable):
         padding: Zero-padding added to input.
     """
 
-    var weight: ExTensor
+    var weight: Tensor[dtype]
     """Filter weights of shape (out_channels, in_channels, kernel_h, kernel_w)."""
-    var bias: ExTensor
+    var bias: Tensor[dtype]
     """Bias vector of shape (out_channels,)."""
     var in_channels: Int
     """Number of input channels."""
@@ -77,6 +83,9 @@ struct Conv2dLayer(Copyable, Movable):
             ```mojo
             # 3x3 convolution: 3 input channels -> 16 output channels
             var layer = Conv2dLayer(3, 16, 3, 3, stride=1, padding=1)
+
+            # FP16 convolution
+            var layer16 = Conv2dLayer[DType.float16](3, 16, 3, 3)
             ```
         """
         self.in_channels = in_channels
@@ -99,16 +108,16 @@ struct Conv2dLayer(Copyable, Movable):
         # Fan-out for conv2d: out_channels * kernel_h * kernel_w
         var fan_out = out_channels * kernel_h * kernel_w
         self.weight = kaiming_uniform(
-            fan_in, fan_out, weight_shape, "fan_in", DType.float32
-        )
+            fan_in, fan_out, weight_shape, "fan_in", dtype
+        ).as_tensor[dtype]()
 
         # Initialize bias to zeros
         # Shape: (out_channels,)
         var bias_shape = List[Int]()
         bias_shape.append(out_channels)
-        self.bias = zeros(bias_shape, DType.float32)
+        self.bias = zeros(bias_shape, dtype).as_tensor[dtype]()
 
-    fn forward(self, input: ExTensor) raises -> ExTensor:
+    fn forward(self, input: Tensor[dtype]) raises -> Tensor[dtype]:
         """Forward pass: y = conv2d(x, weight, bias, stride, padding).
 
         Applies the learned convolutional filters to the input.
@@ -134,11 +143,17 @@ struct Conv2dLayer(Copyable, Movable):
             var output = layer.forward(input)  # Shape: [1, 16, 32, 32]
             ```
         """
-        return conv2d(input, self.weight, self.bias, self.stride, self.padding)
+        return conv2d(
+            input.as_any(),
+            self.weight.as_any(),
+            self.bias.as_any(),
+            self.stride,
+            self.padding,
+        ).as_tensor[dtype]()
 
     fn backward(
-        self, grad_output: ExTensor, input: ExTensor
-    ) raises -> Tuple[ExTensor, ExTensor, ExTensor]:
+        self, grad_output: Tensor[dtype], input: Tensor[dtype]
+    ) raises -> Tuple[Tensor[dtype], Tensor[dtype], Tensor[dtype]]:
         """Backward pass: compute gradients w.r.t. input, weight, and bias.
 
         Computes gradients needed for training via backpropagation.
@@ -168,18 +183,26 @@ struct Conv2dLayer(Copyable, Movable):
             ```
         """
         var result = conv2d_backward(
-            grad_output, input, self.weight, self.stride, self.padding
+            grad_output.as_any(),
+            input.as_any(),
+            self.weight.as_any(),
+            self.stride,
+            self.padding,
         )
-        return (result.grad_input, result.grad_weights, result.grad_bias)
+        return (
+            result.grad_input.as_tensor[dtype](),
+            result.grad_weights.as_tensor[dtype](),
+            result.grad_bias.as_tensor[dtype](),
+        )
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[Tensor[dtype]]:
         """Get list of trainable parameters.
 
         Returns:
-            List containing [weight, bias] tensors that need gradients
+            List containing [weight, bias] tensors that need gradients.
 
         Raises:
-            Error if tensor copying fails
+            Error if tensor copying fails.
 
         Example:
             ```mojo
@@ -188,21 +211,21 @@ struct Conv2dLayer(Copyable, Movable):
             # params[0] is weight, params[1] is bias
             ```
         """
-        var params: List[ExTensor] = []
+        var params = List[Tensor[dtype]]()
 
-        # Create copies of weight and bias tensors
-        var weight_copy = zeros_like(self.weight)
-        var bias_copy = zeros_like(self.bias)
+        # Create copies via ExTensor round-trip
+        var weight_any = zeros_like(self.weight.as_any())
+        var bias_any = zeros_like(self.bias.as_any())
 
         var weight_size = self.weight.numel()
         var bias_size = self.bias.numel()
 
         for i in range(weight_size):
-            weight_copy._data[i] = self.weight._data[i]
+            weight_any._data[i] = self.weight.as_any()._data[i]
 
         for i in range(bias_size):
-            bias_copy._data[i] = self.bias._data[i]
+            bias_any._data[i] = self.bias.as_any()._data[i]
 
-        params.append(weight_copy^)
-        params.append(bias_copy^)
+        params.append(weight_any.as_tensor[dtype]())
+        params.append(bias_any.as_tensor[dtype]())
         return params^

--- a/shared/core/layers/dropout.mojo
+++ b/shared/core/layers/dropout.mojo
@@ -11,11 +11,12 @@ Key components:
 """
 
 from ..extensor import ExTensor, zeros_like, full
+from shared.tensor.tensor import Tensor
 from random import random_float64
 
 
-struct DropoutLayer(Copyable, Movable):
-    """Dropout layer for regularization.
+struct DropoutLayer[dtype: DType = DType.float32](Copyable, Movable):
+    """Dropout layer for regularization, parameterized on dtype.
 
     Dropout randomly sets input elements to zero during training to prevent
     co-adaptation and reduce overfitting. The remaining elements are scaled
@@ -24,9 +25,12 @@ struct DropoutLayer(Copyable, Movable):
     During inference (training=False), the layer is disabled and passes input
     through unchanged.
 
+    Parameters:
+        dtype: The data type for mask and I/O tensors (default: float32).
+
     Attributes:
-        dropout_rate: Probability of dropping each element (default: 0.5)
-        training: Whether layer is in training mode (default: False)
+        dropout_rate: Probability of dropping each element (default: 0.5).
+        training: Whether layer is in training mode (default: False).
 
     Example:
         ```mojo
@@ -44,7 +48,7 @@ struct DropoutLayer(Copyable, Movable):
 
     var dropout_rate: Float32
     var training: Bool
-    var last_mask: ExTensor  # Store mask for backward pass
+    var last_mask: ExTensor  # Store mask for backward pass (kept as ExTensor)
 
     fn __init__(out self, dropout_rate: Float32 = 0.5) raises:
         """Initialize dropout layer.
@@ -91,7 +95,7 @@ struct DropoutLayer(Copyable, Movable):
         """
         self.training = training
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: Tensor[dtype]) raises -> Tensor[dtype]:
         """Forward pass: apply dropout during training, pass through during inference.
 
         During training (training=True):
@@ -130,25 +134,28 @@ struct DropoutLayer(Copyable, Movable):
             # During inference, return input unchanged
             return input
 
-        # Generate random mask: elements > dropout_rate are kept, others dropped
-        var mask = ExTensor(input._shape, DType.float32)
+        # Convert to ExTensor for internal computation
+        var input_any = input.as_any()
 
-        if input._dtype == DType.float32:
-            for i in range(input._numel):
+        # Generate random mask: elements > dropout_rate are kept, others dropped
+        var mask = ExTensor(input_any._shape, DType.float32)
+
+        if input_any._dtype == DType.float32:
+            for i in range(input_any._numel):
                 # Generate random value in [0, 1)
                 var rand_val = Float32(random_float64())
                 # Keep element if rand_val > dropout_rate, else drop it
                 mask[i] = Float32(1.0) if (
                     rand_val > Float32(self.dropout_rate)
                 ) else Float32(0.0)
-        elif input._dtype == DType.float64:
-            for i in range(input._numel):
+        elif input_any._dtype == DType.float64:
+            for i in range(input_any._numel):
                 var rand_val = random_float64()
                 mask.set(i, 1.0 if (
                     rand_val > Float64(self.dropout_rate)
                 ) else 0.0)
-        elif input._dtype == DType.float16:
-            for i in range(input._numel):
+        elif input_any._dtype == DType.float16:
+            for i in range(input_any._numel):
                 var rand_val = Float32(random_float64())
                 mask[i] = Float32(1.0) if (
                     rand_val > Float32(self.dropout_rate)
@@ -161,29 +168,31 @@ struct DropoutLayer(Copyable, Movable):
 
         # Apply mask and scale: output = mask * input / (1 - dropout_rate)
         var scale = Float32(1.0) / (Float32(1.0) - self.dropout_rate)
-        var result = ExTensor(input._shape, input._dtype)
+        var result = ExTensor(input_any._shape, input_any._dtype)
 
-        if input._dtype == DType.float32:
-            for i in range(input._numel):
-                var input_val = input._data.bitcast[Float32]()[i]
+        if input_any._dtype == DType.float32:
+            for i in range(input_any._numel):
+                var input_val = input_any._data.bitcast[Float32]()[i]
                 var mask_val = mask._data.bitcast[Float32]()[i]
                 result[i] = Float32(mask_val * input_val * scale)
-        elif input._dtype == DType.float64:
-            for i in range(input._numel):
-                var input_val = input._data.bitcast[Float64]()[i]
+        elif input_any._dtype == DType.float64:
+            for i in range(input_any._numel):
+                var input_val = input_any._data.bitcast[Float64]()[i]
                 var mask_val = Float64(mask._data.bitcast[Float32]()[i])
                 result.set(i, mask_val * input_val * Float64(scale))
-        elif input._dtype == DType.float16:
-            for i in range(input._numel):
-                var input_val = input._data.bitcast[Float16]()[i]
+        elif input_any._dtype == DType.float16:
+            for i in range(input_any._numel):
+                var input_val = input_any._data.bitcast[Float16]()[i]
                 var mask_val = Float16(mask._data.bitcast[Float32]()[i])
                 result.set(i, Float16(mask_val * input_val * Float16(scale)))
         else:
             raise Error("dropout: only float16/32/64 dtypes supported")
 
-        return result
+        return result.as_tensor[dtype]()
 
-    fn backward(self, grad_output: ExTensor, mask: ExTensor) raises -> ExTensor:
+    fn backward(
+        self, grad_output: Tensor[dtype], mask: ExTensor
+    ) raises -> Tensor[dtype]:
         """Backward pass: apply same mask as forward pass.
 
         During training, propagates gradient through kept elements only,
@@ -210,34 +219,35 @@ struct DropoutLayer(Copyable, Movable):
             var grad_input = layer.backward(grad_output, layer.last_mask)
             ```
         """
+        var grad_any = grad_output.as_any()
         var scale = Float32(1.0) / (Float32(1.0) - self.dropout_rate)
-        var result = ExTensor(grad_output._shape, grad_output._dtype)
+        var result = ExTensor(grad_any._shape, grad_any._dtype)
 
-        if grad_output._dtype == DType.float32:
-            for i in range(grad_output._numel):
-                var grad_val = grad_output._data.bitcast[Float32]()[i]
+        if grad_any._dtype == DType.float32:
+            for i in range(grad_any._numel):
+                var grad_val = grad_any._data.bitcast[Float32]()[i]
                 var mask_val = mask._data.bitcast[Float32]()[i]
                 result[i] = Float32(mask_val * grad_val * scale)
-        elif grad_output._dtype == DType.float64:
-            for i in range(grad_output._numel):
-                var grad_val = grad_output._data.bitcast[Float64]()[i]
+        elif grad_any._dtype == DType.float64:
+            for i in range(grad_any._numel):
+                var grad_val = grad_any._data.bitcast[Float64]()[i]
                 var mask_val = Float64(mask._data.bitcast[Float32]()[i])
                 result.set(i, mask_val * grad_val * Float64(scale))
-        elif grad_output._dtype == DType.float16:
-            for i in range(grad_output._numel):
-                var grad_val = grad_output._data.bitcast[Float16]()[i]
+        elif grad_any._dtype == DType.float16:
+            for i in range(grad_any._numel):
+                var grad_val = grad_any._data.bitcast[Float16]()[i]
                 var mask_val = Float16(mask._data.bitcast[Float32]()[i])
                 result.set(i, Float16(mask_val * grad_val * Float16(scale)))
         else:
             raise Error("dropout backward: only float16/32/64 dtypes supported")
 
-        return result
+        return result.as_tensor[dtype]()
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[Tensor[dtype]]:
         """Get list of trainable parameters.
 
         Returns:
-            Empty list since Dropout has no learnable parameters
+            Empty list since Dropout has no learnable parameters.
 
         Raises:
             Error: If operation fails.
@@ -249,5 +259,5 @@ struct DropoutLayer(Copyable, Movable):
             # params is empty
             ```
         """
-        var params = List[ExTensor]()
+        var params = List[Tensor[dtype]]()
         return params^

--- a/shared/core/loss.mojo
+++ b/shared/core/loss.mojo
@@ -1023,3 +1023,285 @@ fn kl_divergence_backward(
 
     # Chain rule: multiply by upstream gradient
     return multiply(grad_output, grad)
+
+
+# ============================================================================
+# Typed Tensor[dtype] overloads — wrap AnyTensor versions via as_any/as_tensor
+# ============================================================================
+
+from shared.tensor.tensor import Tensor
+
+
+fn binary_cross_entropy[
+    dt: DType
+](
+    predictions: Tensor[dt],
+    targets: Tensor[dt],
+    epsilon: Float64 = 1e-7,
+) raises -> Tensor[dt]:
+    """Binary cross-entropy loss (typed version).
+
+    Args:
+        predictions: Predicted probabilities.
+        targets: Ground truth binary labels.
+        epsilon: Small constant for numerical stability.
+
+    Returns:
+        Element-wise loss tensor.
+    """
+    return binary_cross_entropy(
+        predictions.as_any(), targets.as_any(), epsilon
+    ).as_tensor[dt]()
+
+
+fn binary_cross_entropy_backward[
+    dt: DType
+](
+    grad_output: Tensor[dt],
+    predictions: Tensor[dt],
+    targets: Tensor[dt],
+    epsilon: Float64 = 1e-7,
+) raises -> Tensor[dt]:
+    """Backward pass for binary cross-entropy (typed version).
+
+    Args:
+        grad_output: Gradient from upstream.
+        predictions: Original predictions.
+        targets: Original targets.
+        epsilon: Small constant for numerical stability.
+
+    Returns:
+        Gradient w.r.t. predictions.
+    """
+    return binary_cross_entropy_backward(
+        grad_output.as_any(),
+        predictions.as_any(),
+        targets.as_any(),
+        epsilon,
+    ).as_tensor[dt]()
+
+
+fn mean_squared_error[
+    dt: DType
+](predictions: Tensor[dt], targets: Tensor[dt]) raises -> Tensor[dt]:
+    """Mean squared error loss (typed version).
+
+    Args:
+        predictions: Predicted values.
+        targets: Ground truth values.
+
+    Returns:
+        Squared error tensor.
+    """
+    return mean_squared_error(
+        predictions.as_any(), targets.as_any()
+    ).as_tensor[dt]()
+
+
+fn mean_squared_error_backward[
+    dt: DType
+](
+    grad_output: Tensor[dt],
+    predictions: Tensor[dt],
+    targets: Tensor[dt],
+) raises -> Tensor[dt]:
+    """Backward pass for MSE loss (typed version).
+
+    Args:
+        grad_output: Gradient from upstream.
+        predictions: Original predictions.
+        targets: Original targets.
+
+    Returns:
+        Gradient w.r.t. predictions.
+    """
+    return mean_squared_error_backward(
+        grad_output.as_any(), predictions.as_any(), targets.as_any()
+    ).as_tensor[dt]()
+
+
+fn cross_entropy[
+    dt: DType
+](
+    logits: Tensor[dt],
+    targets: Tensor[dt],
+    axis: Int = -1,
+    epsilon: Float64 = 1e-7,
+) raises -> Tensor[dt]:
+    """Cross-entropy loss for multi-class classification (typed version).
+
+    Args:
+        logits: Raw model outputs (pre-softmax).
+        targets: One-hot encoded targets.
+        axis: Axis for softmax computation.
+        epsilon: Small constant for numerical stability.
+
+    Returns:
+        Per-sample loss tensor.
+    """
+    return cross_entropy(
+        logits.as_any(), targets.as_any(), axis, epsilon
+    ).as_tensor[dt]()
+
+
+fn cross_entropy_backward[
+    dt: DType
+](
+    grad_output: Tensor[dt],
+    logits: Tensor[dt],
+    targets: Tensor[dt],
+    epsilon: Float64 = 1e-7,
+) raises -> Tensor[dt]:
+    """Backward pass for cross-entropy loss (typed version).
+
+    Args:
+        grad_output: Gradient from upstream.
+        logits: Original logits.
+        targets: Original targets.
+        epsilon: Small constant for numerical stability.
+
+    Returns:
+        Gradient w.r.t. logits.
+    """
+    return cross_entropy_backward(
+        grad_output.as_any(), logits.as_any(), targets.as_any(), epsilon
+    ).as_tensor[dt]()
+
+
+fn hinge_loss[
+    dt: DType
+](predictions: Tensor[dt], targets: Tensor[dt]) raises -> Tensor[dt]:
+    """Hinge loss for SVMs (typed version).
+
+    Args:
+        predictions: Predicted values.
+        targets: Ground truth labels (+1 or -1).
+
+    Returns:
+        Element-wise hinge loss tensor.
+    """
+    return hinge_loss(
+        predictions.as_any(), targets.as_any()
+    ).as_tensor[dt]()
+
+
+fn hinge_loss_backward[
+    dt: DType
+](
+    grad_output: Tensor[dt],
+    predictions: Tensor[dt],
+    targets: Tensor[dt],
+) raises -> Tensor[dt]:
+    """Backward pass for hinge loss (typed version).
+
+    Args:
+        grad_output: Gradient from upstream.
+        predictions: Original predictions.
+        targets: Original targets.
+
+    Returns:
+        Gradient w.r.t. predictions.
+    """
+    return hinge_loss_backward(
+        grad_output.as_any(), predictions.as_any(), targets.as_any()
+    ).as_tensor[dt]()
+
+
+fn focal_loss[
+    dt: DType
+](
+    predictions: Tensor[dt],
+    targets: Tensor[dt],
+    alpha: Float32 = 0.25,
+    gamma_param: Float32 = 2.0,
+) raises -> Tensor[dt]:
+    """Focal loss for class imbalance (typed version).
+
+    Args:
+        predictions: Predicted probabilities.
+        targets: Ground truth binary labels.
+        alpha: Weighting factor.
+        gamma_param: Focusing parameter.
+
+    Returns:
+        Element-wise focal loss tensor.
+    """
+    return focal_loss(
+        predictions.as_any(), targets.as_any(), alpha, gamma_param
+    ).as_tensor[dt]()
+
+
+fn focal_loss_backward[
+    dt: DType
+](
+    grad_output: Tensor[dt],
+    predictions: Tensor[dt],
+    targets: Tensor[dt],
+    alpha: Float32 = 0.25,
+    gamma_param: Float32 = 2.0,
+) raises -> Tensor[dt]:
+    """Backward pass for focal loss (typed version).
+
+    Args:
+        grad_output: Gradient from upstream.
+        predictions: Original predictions.
+        targets: Original targets.
+        alpha: Weighting factor.
+        gamma_param: Focusing parameter.
+
+    Returns:
+        Gradient w.r.t. predictions.
+    """
+    return focal_loss_backward(
+        grad_output.as_any(),
+        predictions.as_any(),
+        targets.as_any(),
+        alpha,
+        gamma_param,
+    ).as_tensor[dt]()
+
+
+fn kl_divergence[
+    dt: DType
+](
+    p: Tensor[dt],
+    q: Tensor[dt],
+    epsilon: Float64 = 1e-7,
+) raises -> Tensor[dt]:
+    """KL divergence loss (typed version).
+
+    Args:
+        p: True distribution.
+        q: Approximate distribution.
+        epsilon: Small constant for numerical stability.
+
+    Returns:
+        Element-wise KL divergence tensor.
+    """
+    return kl_divergence(
+        p.as_any(), q.as_any(), epsilon
+    ).as_tensor[dt]()
+
+
+fn kl_divergence_backward[
+    dt: DType
+](
+    grad_output: Tensor[dt],
+    p: Tensor[dt],
+    q: Tensor[dt],
+    epsilon: Float64 = 1e-7,
+) raises -> Tensor[dt]:
+    """Backward pass for KL divergence (typed version).
+
+    Args:
+        grad_output: Gradient from upstream.
+        p: True distribution.
+        q: Approximate distribution.
+        epsilon: Small constant for numerical stability.
+
+    Returns:
+        Gradient w.r.t. q.
+    """
+    return kl_divergence_backward(
+        grad_output.as_any(), p.as_any(), q.as_any(), epsilon
+    ).as_tensor[dt]()

--- a/shared/core/normalization.mojo
+++ b/shared/core/normalization.mojo
@@ -2846,3 +2846,242 @@ fn instance_norm_backward(
         raise Error("instance_norm_backward: only float32/64 dtypes supported")
 
     return (grad_input, grad_gamma, grad_beta)
+
+
+# ============================================================================
+# Typed Tensor[dtype] overloads — wrap AnyTensor versions via as_any/as_tensor
+# ============================================================================
+
+from shared.tensor.tensor import Tensor
+
+
+fn batch_norm2d[
+    dt: DType
+](
+    x: Tensor[dt],
+    gamma: Tensor[dt],
+    beta: Tensor[dt],
+    running_mean: Tensor[dt],
+    running_var: Tensor[dt],
+    training: Bool,
+    momentum: Float64 = 0.1,
+    epsilon: Float64 = 1e-5,
+) raises -> Tuple[Tensor[dt], Tensor[dt], Tensor[dt]]:
+    """Functional 2D batch normalization (typed version).
+
+    Args:
+        x: Input tensor of shape (batch, channels, height, width).
+        gamma: Scale parameter of shape (channels,).
+        beta: Shift parameter of shape (channels,).
+        running_mean: Running mean of shape (channels,).
+        running_var: Running variance of shape (channels,).
+        training: If True, use batch statistics and update running stats.
+        momentum: Momentum for running statistics update.
+        epsilon: Small constant for numerical stability.
+
+    Returns:
+        Tuple of (output, new_running_mean, new_running_var).
+    """
+    var (out, new_mean, new_var) = batch_norm2d(
+        x.as_any(),
+        gamma.as_any(),
+        beta.as_any(),
+        running_mean.as_any(),
+        running_var.as_any(),
+        training,
+        momentum,
+        epsilon,
+    )
+    return (
+        out.as_tensor[dt](),
+        new_mean.as_tensor[dt](),
+        new_var.as_tensor[dt](),
+    )
+
+
+fn batch_norm2d_backward[
+    dt: DType
+](
+    grad_output: Tensor[dt],
+    x: Tensor[dt],
+    gamma: Tensor[dt],
+    running_mean: Tensor[dt],
+    running_var: Tensor[dt],
+    training: Bool,
+    epsilon: Float64 = 1e-5,
+) raises -> Tuple[Tensor[dt], Tensor[dt], Tensor[dt]]:
+    """Backward pass for 2D batch normalization (typed version).
+
+    Args:
+        grad_output: Gradient w.r.t. output.
+        x: Original input tensor.
+        gamma: Scale parameter.
+        running_mean: Running mean.
+        running_var: Running variance.
+        training: Whether in training mode.
+        epsilon: Small constant for numerical stability.
+
+    Returns:
+        Tuple of (grad_input, grad_gamma, grad_beta).
+    """
+    var (gi, gg, gb) = batch_norm2d_backward(
+        grad_output.as_any(),
+        x.as_any(),
+        gamma.as_any(),
+        running_mean.as_any(),
+        running_var.as_any(),
+        training,
+        epsilon,
+    )
+    return (gi.as_tensor[dt](), gg.as_tensor[dt](), gb.as_tensor[dt]())
+
+
+fn layer_norm[
+    dt: DType
+](
+    x: Tensor[dt],
+    gamma: Tensor[dt],
+    beta: Tensor[dt],
+    epsilon: Float64 = 1e-5,
+) raises -> Tensor[dt]:
+    """Functional layer normalization (typed version).
+
+    Args:
+        x: Input tensor.
+        gamma: Scale parameter.
+        beta: Shift parameter.
+        epsilon: Small constant for numerical stability.
+
+    Returns:
+        Normalized tensor.
+    """
+    return layer_norm(
+        x.as_any(), gamma.as_any(), beta.as_any(), epsilon
+    ).as_tensor[dt]()
+
+
+fn layer_norm_backward[
+    dt: DType
+](
+    grad_output: Tensor[dt],
+    x: Tensor[dt],
+    gamma: Tensor[dt],
+    epsilon: Float64 = 1e-5,
+) raises -> Tuple[Tensor[dt], Tensor[dt], Tensor[dt]]:
+    """Backward pass for layer normalization (typed version).
+
+    Args:
+        grad_output: Gradient w.r.t. output.
+        x: Original input tensor.
+        gamma: Scale parameter.
+        epsilon: Small constant for numerical stability.
+
+    Returns:
+        Tuple of (grad_input, grad_gamma, grad_beta).
+    """
+    var (gi, gg, gb) = layer_norm_backward(
+        grad_output.as_any(), x.as_any(), gamma.as_any(), epsilon
+    )
+    return (gi.as_tensor[dt](), gg.as_tensor[dt](), gb.as_tensor[dt]())
+
+
+fn group_norm[
+    dt: DType
+](
+    x: Tensor[dt],
+    num_groups: Int,
+    gamma: Tensor[dt],
+    beta: Tensor[dt],
+    epsilon: Float64 = 1e-5,
+) raises -> Tensor[dt]:
+    """Functional group normalization (typed version).
+
+    Args:
+        x: Input tensor.
+        num_groups: Number of groups.
+        gamma: Scale parameter.
+        beta: Shift parameter.
+        epsilon: Small constant for numerical stability.
+
+    Returns:
+        Normalized tensor.
+    """
+    return group_norm(
+        x.as_any(), num_groups, gamma.as_any(), beta.as_any(), epsilon
+    ).as_tensor[dt]()
+
+
+fn group_norm_backward[
+    dt: DType
+](
+    grad_output: Tensor[dt],
+    x: Tensor[dt],
+    num_groups: Int,
+    gamma: Tensor[dt],
+    epsilon: Float64 = 1e-5,
+) raises -> Tuple[Tensor[dt], Tensor[dt], Tensor[dt]]:
+    """Backward pass for group normalization (typed version).
+
+    Args:
+        grad_output: Gradient w.r.t. output.
+        x: Original input tensor.
+        num_groups: Number of groups.
+        gamma: Scale parameter.
+        epsilon: Small constant for numerical stability.
+
+    Returns:
+        Tuple of (grad_input, grad_gamma, grad_beta).
+    """
+    var (gi, gg, gb) = group_norm_backward(
+        grad_output.as_any(), x.as_any(), num_groups, gamma.as_any(), epsilon
+    )
+    return (gi.as_tensor[dt](), gg.as_tensor[dt](), gb.as_tensor[dt]())
+
+
+fn instance_norm[
+    dt: DType
+](
+    x: Tensor[dt],
+    gamma: Tensor[dt],
+    beta: Tensor[dt],
+    epsilon: Float64 = 1e-5,
+) raises -> Tensor[dt]:
+    """Functional instance normalization (typed version).
+
+    Args:
+        x: Input tensor.
+        gamma: Scale parameter.
+        beta: Shift parameter.
+        epsilon: Small constant for numerical stability.
+
+    Returns:
+        Normalized tensor.
+    """
+    return instance_norm(
+        x.as_any(), gamma.as_any(), beta.as_any(), epsilon
+    ).as_tensor[dt]()
+
+
+fn instance_norm_backward[
+    dt: DType
+](
+    grad_output: Tensor[dt],
+    x: Tensor[dt],
+    gamma: Tensor[dt],
+    epsilon: Float64 = 1e-5,
+) raises -> Tuple[Tensor[dt], Tensor[dt], Tensor[dt]]:
+    """Backward pass for instance normalization (typed version).
+
+    Args:
+        grad_output: Gradient w.r.t. output.
+        x: Original input tensor.
+        gamma: Scale parameter.
+        epsilon: Small constant for numerical stability.
+
+    Returns:
+        Tuple of (grad_input, grad_gamma, grad_beta).
+    """
+    var (gi, gg, gb) = instance_norm_backward(
+        grad_output.as_any(), x.as_any(), gamma.as_any(), epsilon
+    )
+    return (gi.as_tensor[dt](), gg.as_tensor[dt](), gb.as_tensor[dt]())

--- a/shared/core/numerical_safety.mojo
+++ b/shared/core/numerical_safety.mojo
@@ -618,3 +618,173 @@ fn clip_grad_global_norm_(
                 grad._set_float64(elem_idx, val * scale_factor)
 
     return global_norm
+
+
+# ============================================================================
+# Typed Tensor[dtype] overloads — wrap AnyTensor versions via as_any/as_tensor
+# ============================================================================
+
+from shared.tensor.tensor import Tensor
+
+
+fn has_nan[dt: DType](tensor: Tensor[dt]) raises -> Bool:
+    """Check if tensor contains any NaN values (typed version).
+
+    Args:
+        tensor: Input typed tensor to check.
+
+    Returns:
+        True if any element is NaN, False otherwise.
+
+    Raises:
+        Error: If conversion fails.
+    """
+    return has_nan(tensor.as_any())
+
+
+fn has_inf[dt: DType](tensor: Tensor[dt]) raises -> Bool:
+    """Check if tensor contains any Inf values (typed version).
+
+    Args:
+        tensor: Input typed tensor to check.
+
+    Returns:
+        True if any element is Inf or -Inf, False otherwise.
+
+    Raises:
+        Error: If conversion fails.
+    """
+    return has_inf(tensor.as_any())
+
+
+fn count_nan[dt: DType](tensor: Tensor[dt]) raises -> Int:
+    """Count number of NaN values in tensor (typed version).
+
+    Args:
+        tensor: Input typed tensor to check.
+
+    Returns:
+        Number of NaN elements.
+
+    Raises:
+        Error: If conversion fails.
+    """
+    return count_nan(tensor.as_any())
+
+
+fn count_inf[dt: DType](tensor: Tensor[dt]) raises -> Int:
+    """Count number of Inf values in tensor (typed version).
+
+    Args:
+        tensor: Input typed tensor to check.
+
+    Returns:
+        Number of Inf/-Inf elements.
+
+    Raises:
+        Error: If conversion fails.
+    """
+    return count_inf(tensor.as_any())
+
+
+fn tensor_min[dt: DType](tensor: Tensor[dt]) raises -> Float64:
+    """Find minimum value in tensor (typed version).
+
+    Args:
+        tensor: Input typed tensor.
+
+    Returns:
+        Minimum value as Float64.
+
+    Raises:
+        Error: If conversion fails.
+    """
+    return tensor_min(tensor.as_any())
+
+
+fn tensor_max[dt: DType](tensor: Tensor[dt]) raises -> Float64:
+    """Find maximum value in tensor (typed version).
+
+    Args:
+        tensor: Input typed tensor.
+
+    Returns:
+        Maximum value as Float64.
+
+    Raises:
+        Error: If conversion fails.
+    """
+    return tensor_max(tensor.as_any())
+
+
+fn check_tensor_range[dt: DType](
+    tensor: Tensor[dt],
+    min_val: Float64,
+    max_val: Float64,
+    name: String = "tensor",
+) raises:
+    """Check if all tensor values are within [min_val, max_val] (typed version).
+
+    Args:
+        tensor: Typed tensor to check.
+        min_val: Minimum allowed value.
+        max_val: Maximum allowed value.
+        name: Name for error message.
+
+    Raises:
+        Error: If any value is outside the range.
+    """
+    check_tensor_range(tensor.as_any(), min_val, max_val, name)
+
+
+fn compute_tensor_l2_norm[dt: DType](
+    tensor: Tensor[dt],
+) raises -> Float64:
+    """Compute L2 norm of tensor (typed version).
+
+    Args:
+        tensor: Input typed tensor.
+
+    Returns:
+        L2 norm as Float64.
+
+    Raises:
+        Error: If conversion fails.
+    """
+    return compute_tensor_l2_norm(tensor.as_any())
+
+
+fn check_gradient_norm[dt: DType](
+    gradient: Tensor[dt],
+    max_norm: Float64 = 1000.0,
+    name: String = "gradient",
+) raises:
+    """Check if gradient L2 norm exceeds threshold (typed version).
+
+    Args:
+        gradient: Gradient typed tensor to check.
+        max_norm: Maximum allowed L2 norm.
+        name: Name for error message.
+
+    Raises:
+        Error: If gradient norm exceeds max_norm.
+    """
+    check_gradient_norm(gradient.as_any(), max_norm, name)
+
+
+fn check_gradient_vanishing[dt: DType](
+    gradient: Tensor[dt],
+    min_norm: Float64 = 1e-7,
+    name: String = "gradient",
+) raises:
+    """Check if gradient L2 norm is too small (typed version).
+
+    Args:
+        gradient: Gradient typed tensor to check.
+        min_norm: Minimum expected L2 norm.
+        name: Name for error message.
+
+    Raises:
+        Error: If gradient norm is below min_norm.
+    """
+    check_gradient_vanishing(gradient.as_any(), min_norm, name)

--- a/shared/core/pooling.mojo
+++ b/shared/core/pooling.mojo
@@ -811,3 +811,165 @@ fn global_avgpool2d_backward(
                     grad_input[grad_in_idx] = Float32(grad_per_position)
 
     return grad_input^
+
+
+# ============================================================================
+# Typed Tensor[dtype] overloads — wrap AnyTensor versions via as_any/as_tensor
+# ============================================================================
+
+from shared.tensor.tensor import Tensor
+
+
+fn maxpool2d[
+    dt: DType
+](
+    x: Tensor[dt],
+    kernel_size: Int,
+    stride: Int = 0,
+    padding: Int = 0,
+    method: String = "direct",
+) raises -> Tensor[dt]:
+    """Functional 2D max pooling (typed version).
+
+    Args:
+        x: Input tensor of shape (batch, channels, height, width).
+        kernel_size: Size of the pooling window.
+        stride: Stride for pooling (default: kernel_size if 0).
+        padding: Zero-padding added to input.
+        method: Implementation method.
+
+    Returns:
+        Pooled output tensor.
+    """
+    return maxpool2d(
+        x.as_any(), kernel_size, stride, padding, method
+    ).as_tensor[dt]()
+
+
+fn avgpool2d[
+    dt: DType
+](
+    x: Tensor[dt],
+    kernel_size: Int,
+    stride: Int = 0,
+    padding: Int = 0,
+    method: String = "direct",
+) raises -> Tensor[dt]:
+    """Functional 2D average pooling (typed version).
+
+    Args:
+        x: Input tensor of shape (batch, channels, height, width).
+        kernel_size: Size of the pooling window.
+        stride: Stride for pooling (default: kernel_size if 0).
+        padding: Zero-padding added to input.
+        method: Implementation method.
+
+    Returns:
+        Pooled output tensor.
+    """
+    return avgpool2d(
+        x.as_any(), kernel_size, stride, padding, method
+    ).as_tensor[dt]()
+
+
+fn global_avgpool2d[
+    dt: DType
+](x: Tensor[dt], method: String = "direct") raises -> Tensor[dt]:
+    """Functional global average pooling (typed version).
+
+    Args:
+        x: Input tensor of shape (batch, channels, height, width).
+        method: Implementation method.
+
+    Returns:
+        Pooled output tensor of shape (batch, channels, 1, 1).
+    """
+    return global_avgpool2d(x.as_any(), method).as_tensor[dt]()
+
+
+fn maxpool2d_backward[
+    dt: DType
+](
+    grad_output: Tensor[dt],
+    x: Tensor[dt],
+    kernel_size: Int,
+    stride: Int = 0,
+    padding: Int = 0,
+    method: String = "direct",
+) raises -> Tensor[dt]:
+    """Backward pass for 2D max pooling (typed version).
+
+    Args:
+        grad_output: Gradient w.r.t. output.
+        x: Input from forward pass.
+        kernel_size: Size of the pooling window.
+        stride: Stride used in forward pass.
+        padding: Padding used in forward pass.
+        method: Implementation method.
+
+    Returns:
+        Gradient w.r.t. input.
+    """
+    return maxpool2d_backward(
+        grad_output.as_any(),
+        x.as_any(),
+        kernel_size,
+        stride,
+        padding,
+        method,
+    ).as_tensor[dt]()
+
+
+fn avgpool2d_backward[
+    dt: DType
+](
+    grad_output: Tensor[dt],
+    x: Tensor[dt],
+    kernel_size: Int,
+    stride: Int = 0,
+    padding: Int = 0,
+    method: String = "direct",
+) raises -> Tensor[dt]:
+    """Backward pass for 2D average pooling (typed version).
+
+    Args:
+        grad_output: Gradient w.r.t. output.
+        x: Input from forward pass.
+        kernel_size: Size of the pooling window.
+        stride: Stride used in forward pass.
+        padding: Padding used in forward pass.
+        method: Implementation method.
+
+    Returns:
+        Gradient w.r.t. input.
+    """
+    return avgpool2d_backward(
+        grad_output.as_any(),
+        x.as_any(),
+        kernel_size,
+        stride,
+        padding,
+        method,
+    ).as_tensor[dt]()
+
+
+fn global_avgpool2d_backward[
+    dt: DType
+](
+    grad_output: Tensor[dt],
+    x: Tensor[dt],
+    method: String = "direct",
+) raises -> Tensor[dt]:
+    """Backward pass for global average pooling (typed version).
+
+    Args:
+        grad_output: Gradient w.r.t. output.
+        x: Input from forward pass.
+        method: Implementation method.
+
+    Returns:
+        Gradient w.r.t. input.
+    """
+    return global_avgpool2d_backward(
+        grad_output.as_any(), x.as_any(), method
+    ).as_tensor[dt]()


### PR DESCRIPTION
## Summary
- Parameterize `BatchNorm2dLayer`, `Conv2dLayer`, `DropoutLayer` with `dtype: DType = DType.float32` parameter
- Change internal tensor fields from `ExTensor` to `Tensor[dtype]` for compile-time type safety
- Add typed `Tensor[dtype]` overloads for normalization, pooling, attention, loss, and numerical safety operations
- Forward/backward methods accept and return `Tensor[dtype]`, delegating to existing ExTensor implementations via `as_any()`/`as_tensor[dtype]()` boundary conversions

## Test plan
- [ ] Existing tests continue to pass (default `DType.float32` preserves backward compatibility)
- [ ] New typed overloads correctly wrap ExTensor versions and return proper types
- [ ] Layer struct parameterization compiles with non-default dtypes (e.g., `DType.float16`)

Part of #4998

🤖 Generated with [Claude Code](https://claude.com/claude-code)