### PR TITLE
test(infra): add tests for collection ops and optimizer AnyTensor migration

### DIFF
--- a/tests/shared/tensor/test_collection_ops_anytensor.mojo
+++ b/tests/shared/tensor/test_collection_ops_anytensor.mojo
@@ -1,0 +1,142 @@
+"""Tests for collection operations with AnyTensor.
+
+# ADR-009: This file is intentionally limited to <=10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Tests verify that collection ops (concatenate, stack, split) work correctly
+when called with AnyTensor values. Since ExTensor is now an alias for AnyTensor,
+these tests confirm the migration preserves correct behavior.
+
+Tests cover:
+- concatenate: Join tensors along existing axis
+- concatenate axis=1: Join along non-default axis
+- stack: Join tensors along new axis
+- split: Divide tensor into equal parts
+- split axis=1: Split along non-default axis
+"""
+
+from testing import assert_true, assert_almost_equal
+from shared.core.extensor import AnyTensor, zeros, ones
+from shared.core.shape import concatenate, stack, split
+
+
+fn test_concatenate_axis0() raises:
+    """concatenate joins AnyTensor list along axis 0."""
+    var a: AnyTensor = ones([2, 3], DType.float32)
+    var b: AnyTensor = ones([3, 3], DType.float32)
+    var tensors = List[AnyTensor]()
+    tensors.append(a)
+    tensors.append(b)
+    var result = concatenate(tensors, axis=0)
+    var s = result.shape()
+    assert_true(s[0] == 5, "concatenated dim should be 2+3=5")
+    assert_true(s[1] == 3, "other dim preserved")
+    assert_true(result.numel() == 15, "total elements 5*3=15")
+    assert_true(result.dtype() == DType.float32, "dtype preserved")
+    print("PASS: test_concatenate_axis0")
+
+
+fn test_concatenate_axis1() raises:
+    """concatenate joins AnyTensor list along axis 1."""
+    var a: AnyTensor = ones([2, 3], DType.float32)
+    var b: AnyTensor = ones([2, 4], DType.float32)
+    var tensors = List[AnyTensor]()
+    tensors.append(a)
+    tensors.append(b)
+    var result = concatenate(tensors, axis=1)
+    var s = result.shape()
+    assert_true(s[0] == 2, "non-concat dim preserved")
+    assert_true(s[1] == 7, "concatenated dim should be 3+4=7")
+    print("PASS: test_concatenate_axis1")
+
+
+fn test_concatenate_single_tensor() raises:
+    """concatenate with single tensor returns equivalent tensor."""
+    var a: AnyTensor = zeros([3, 4], DType.float32)
+    var tensors = List[AnyTensor]()
+    tensors.append(a)
+    var result = concatenate(tensors, axis=0)
+    var s = result.shape()
+    assert_true(s[0] == 3, "shape preserved dim 0")
+    assert_true(s[1] == 4, "shape preserved dim 1")
+    print("PASS: test_concatenate_single_tensor")
+
+
+fn test_stack_axis0() raises:
+    """stack creates new axis 0 from AnyTensor list."""
+    var a: AnyTensor = ones([3, 4], DType.float32)
+    var b: AnyTensor = ones([3, 4], DType.float32)
+    var tensors = List[AnyTensor]()
+    tensors.append(a)
+    tensors.append(b)
+    var result = stack(tensors, axis=0)
+    var s = result.shape()
+    assert_true(s[0] == 2, "stacked dim should be 2")
+    assert_true(s[1] == 3, "original dim 0")
+    assert_true(s[2] == 4, "original dim 1")
+    assert_true(result.dtype() == DType.float32, "dtype preserved")
+    print("PASS: test_stack_axis0")
+
+
+fn test_stack_1d_tensors() raises:
+    """stack 1D AnyTensors creates 2D result."""
+    var a: AnyTensor = zeros([4], DType.float32)
+    var b: AnyTensor = zeros([4], DType.float32)
+    var c: AnyTensor = zeros([4], DType.float32)
+    var tensors = List[AnyTensor]()
+    tensors.append(a)
+    tensors.append(b)
+    tensors.append(c)
+    var result = stack(tensors, axis=0)
+    var s = result.shape()
+    assert_true(s[0] == 3, "stacked 3 tensors")
+    assert_true(s[1] == 4, "original length")
+    print("PASS: test_stack_1d_tensors")
+
+
+fn test_split_equal_parts() raises:
+    """split divides AnyTensor into equal parts along axis 0."""
+    var t: AnyTensor = ones([6, 4], DType.float32)
+    var parts = split(t, 3, axis=0)
+    assert_true(len(parts) == 3, "should produce 3 parts")
+    for i in range(len(parts)):
+        var s = parts[i].shape()
+        assert_true(s[0] == 2, "split dim should be 6/3=2")
+        assert_true(s[1] == 4, "other dim preserved")
+    print("PASS: test_split_equal_parts")
+
+
+fn test_split_axis1() raises:
+    """split along axis 1 produces correct shapes."""
+    var t: AnyTensor = ones([4, 6], DType.float32)
+    var parts = split(t, 2, axis=1)
+    assert_true(len(parts) == 2, "should produce 2 parts")
+    for i in range(len(parts)):
+        var s = parts[i].shape()
+        assert_true(s[0] == 4, "non-split dim preserved")
+        assert_true(s[1] == 3, "split dim should be 6/2=3")
+    print("PASS: test_split_axis1")
+
+
+fn test_split_into_single() raises:
+    """split with num_splits=1 returns the whole tensor."""
+    var t: AnyTensor = zeros([4, 3], DType.float32)
+    var parts = split(t, 1, axis=0)
+    assert_true(len(parts) == 1, "should produce 1 part")
+    var s = parts[0].shape()
+    assert_true(s[0] == 4, "full dim 0")
+    assert_true(s[1] == 3, "full dim 1")
+    print("PASS: test_split_into_single")
+
+
+fn main() raises:
+    test_concatenate_axis0()
+    test_concatenate_axis1()
+    test_concatenate_single_tensor()
+    test_stack_axis0()
+    test_stack_1d_tensors()
+    test_split_equal_parts()
+    test_split_axis1()
+    test_split_into_single()
+    print("\n8 collection ops AnyTensor tests passed\n")

--- a/tests/shared/tensor/test_gradient_types_anytensor.mojo
+++ b/tests/shared/tensor/test_gradient_types_anytensor.mojo
@@ -1,0 +1,151 @@
+"""Tests for gradient container types with AnyTensor.
+
+# ADR-009: This file is intentionally limited to <=10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Tests verify that gradient container types (GradientPair, GradientTriple,
+GradientQuad) store AnyTensor fields correctly. Since ExTensor is now an
+alias for AnyTensor, these tests confirm the migration preserves correct
+storage and retrieval of gradient tensors.
+
+Tests cover:
+- GradientPair: Stores two AnyTensor gradients (grad_a, grad_b)
+- GradientTriple: Stores three AnyTensor gradients (grad_input, grad_weights, grad_bias)
+- GradientQuad: Stores four AnyTensor gradients
+- Field values preserved after construction
+"""
+
+from testing import assert_true, assert_almost_equal
+from shared.core.extensor import AnyTensor, zeros, ones
+from shared.core.gradient_types import GradientPair, GradientTriple, GradientQuad
+
+
+fn test_gradient_pair_stores_anytensor() raises:
+    """GradientPair stores two AnyTensor gradient fields."""
+    var g_a: AnyTensor = zeros([4, 3], DType.float32)
+    var g_b: AnyTensor = ones([4, 3], DType.float32)
+    var pair = GradientPair(g_a, g_b)
+    assert_true(pair.grad_a.numel() == 12, "grad_a has 12 elements")
+    assert_true(pair.grad_b.numel() == 12, "grad_b has 12 elements")
+    assert_true(pair.grad_a.dtype() == DType.float32, "grad_a dtype preserved")
+    assert_true(pair.grad_b.dtype() == DType.float32, "grad_b dtype preserved")
+    print("PASS: test_gradient_pair_stores_anytensor")
+
+
+fn test_gradient_pair_preserves_values() raises:
+    """GradientPair preserves tensor values through construction."""
+    var g_a: AnyTensor = zeros([2], DType.float32)
+    g_a._set_float64(0, 0.5)
+    g_a._set_float64(1, 1.0)
+    var g_b: AnyTensor = zeros([2], DType.float32)
+    g_b._set_float64(0, 1.5)
+    g_b._set_float64(1, -0.5)
+    var pair = GradientPair(g_a, g_b)
+    assert_almost_equal(
+        Float64(pair.grad_a._get_float64(0)), 0.5, atol=1e-6, msg="grad_a[0]"
+    )
+    assert_almost_equal(
+        Float64(pair.grad_a._get_float64(1)), 1.0, atol=1e-6, msg="grad_a[1]"
+    )
+    assert_almost_equal(
+        Float64(pair.grad_b._get_float64(0)), 1.5, atol=1e-6, msg="grad_b[0]"
+    )
+    assert_almost_equal(
+        Float64(pair.grad_b._get_float64(1)), -0.5, atol=1e-6, msg="grad_b[1]"
+    )
+    print("PASS: test_gradient_pair_preserves_values")
+
+
+fn test_gradient_pair_different_shapes() raises:
+    """GradientPair holds AnyTensors of different shapes."""
+    var g_a: AnyTensor = zeros([3], DType.float32)
+    var g_b: AnyTensor = zeros([2, 4], DType.float32)
+    var pair = GradientPair(g_a, g_b)
+    assert_true(pair.grad_a.numel() == 3, "grad_a has 3 elements")
+    assert_true(pair.grad_b.numel() == 8, "grad_b has 8 elements")
+    var shape_b = pair.grad_b.shape()
+    assert_true(shape_b[0] == 2, "grad_b dim 0")
+    assert_true(shape_b[1] == 4, "grad_b dim 1")
+    print("PASS: test_gradient_pair_different_shapes")
+
+
+fn test_gradient_triple_stores_anytensor() raises:
+    """GradientTriple stores three AnyTensor gradient fields."""
+    var g_input: AnyTensor = zeros([4, 3], DType.float32)
+    var g_weights: AnyTensor = ones([3, 2], DType.float32)
+    var g_bias: AnyTensor = zeros([2], DType.float32)
+    var triple = GradientTriple(g_input, g_weights, g_bias)
+    assert_true(triple.grad_input.numel() == 12, "grad_input has 12 elements")
+    assert_true(triple.grad_weights.numel() == 6, "grad_weights has 6 elements")
+    assert_true(triple.grad_bias.numel() == 2, "grad_bias has 2 elements")
+    print("PASS: test_gradient_triple_stores_anytensor")
+
+
+fn test_gradient_triple_preserves_values() raises:
+    """GradientTriple preserves tensor values through construction."""
+    var g_input: AnyTensor = zeros([2], DType.float32)
+    g_input._set_float64(0, 1.0)
+    var g_weights: AnyTensor = zeros([2], DType.float32)
+    g_weights._set_float64(0, 0.5)
+    var g_bias: AnyTensor = zeros([1], DType.float32)
+    g_bias._set_float64(0, -1.0)
+    var triple = GradientTriple(g_input, g_weights, g_bias)
+    assert_almost_equal(
+        Float64(triple.grad_input._get_float64(0)),
+        1.0,
+        atol=1e-6,
+        msg="grad_input[0]",
+    )
+    assert_almost_equal(
+        Float64(triple.grad_weights._get_float64(0)),
+        0.5,
+        atol=1e-6,
+        msg="grad_weights[0]",
+    )
+    assert_almost_equal(
+        Float64(triple.grad_bias._get_float64(0)),
+        -1.0,
+        atol=1e-6,
+        msg="grad_bias[0]",
+    )
+    print("PASS: test_gradient_triple_preserves_values")
+
+
+fn test_gradient_quad_stores_anytensor() raises:
+    """GradientQuad stores four AnyTensor gradient fields."""
+    var g_a: AnyTensor = zeros([3], DType.float32)
+    var g_b: AnyTensor = zeros([3], DType.float32)
+    var g_c: AnyTensor = zeros([3], DType.float32)
+    var g_d: AnyTensor = zeros([3], DType.float32)
+    var quad = GradientQuad(g_a, g_b, g_c, g_d)
+    assert_true(quad.grad_a.numel() == 3, "grad_a has 3 elements")
+    assert_true(quad.grad_b.numel() == 3, "grad_b has 3 elements")
+    assert_true(quad.grad_c.numel() == 3, "grad_c has 3 elements")
+    assert_true(quad.grad_d.numel() == 3, "grad_d has 3 elements")
+    print("PASS: test_gradient_quad_stores_anytensor")
+
+
+fn test_gradient_quad_preserves_dtype() raises:
+    """GradientQuad preserves dtype of each AnyTensor field."""
+    var g_a: AnyTensor = zeros([2], DType.float32)
+    var g_b: AnyTensor = zeros([2], DType.float32)
+    var g_c: AnyTensor = zeros([2], DType.float32)
+    var g_d: AnyTensor = zeros([2], DType.float32)
+    var quad = GradientQuad(g_a, g_b, g_c, g_d)
+    assert_true(quad.grad_a.dtype() == DType.float32, "grad_a dtype")
+    assert_true(quad.grad_b.dtype() == DType.float32, "grad_b dtype")
+    assert_true(quad.grad_c.dtype() == DType.float32, "grad_c dtype")
+    assert_true(quad.grad_d.dtype() == DType.float32, "grad_d dtype")
+    print("PASS: test_gradient_quad_preserves_dtype")
+
+
+fn main() raises:
+    test_gradient_pair_stores_anytensor()
+    test_gradient_pair_preserves_values()
+    test_gradient_pair_different_shapes()
+    test_gradient_triple_stores_anytensor()
+    test_gradient_triple_preserves_values()
+    test_gradient_quad_stores_anytensor()
+    test_gradient_quad_preserves_dtype()
+    print("\n7 gradient types AnyTensor tests passed\n")

--- a/tests/shared/tensor/test_optimizer_anytensor.mojo
+++ b/tests/shared/tensor/test_optimizer_anytensor.mojo
@@ -1,0 +1,183 @@
+"""Tests for optimizer infrastructure with AnyTensor.
+
+# ADR-009: This file is intentionally limited to <=10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Tests verify that SGD and Adam optimizers work correctly when Variable.data
+is AnyTensor (since ExTensor is now an alias for AnyTensor). The optimizers
+operate on List[Variable] with gradients stored in GradientTape.
+
+Tests cover:
+- SGD step updates parameters via AnyTensor data
+- SGD with momentum uses AnyTensor velocity buffers
+- Adam step updates parameters via AnyTensor data
+- Adam moment buffers use AnyTensor storage
+- Optimizer preserves tensor shape and dtype after step
+"""
+
+from testing import assert_true
+from tests.shared.conftest import assert_almost_equal
+from shared.core.extensor import AnyTensor, zeros
+from shared.autograd import Variable, GradientTape, SGD, Adam
+
+
+fn test_sgd_step_with_anytensor_data() raises:
+    """SGD step updates Variable whose data is AnyTensor."""
+    var shape: List[Int] = [4]
+    var param_data: AnyTensor = zeros(shape, DType.float32)
+    param_data._set_float64(0, 1.0)
+    param_data._set_float64(1, 0.5)
+    param_data._set_float64(2, 1.0)
+    param_data._set_float64(3, 0.5)
+
+    var tape = GradientTape()
+    tape.enable()
+    var param = Variable(param_data, True, tape)
+    var param_id = param.id
+
+    # Set gradient: all 0.5
+    var grad: AnyTensor = zeros(shape, DType.float32)
+    grad._set_float64(0, 0.5)
+    grad._set_float64(1, 0.5)
+    grad._set_float64(2, 0.5)
+    grad._set_float64(3, 0.5)
+    tape.registry.set_grad(param_id, grad)
+
+    var optimizer = SGD(learning_rate=0.1, momentum=0.0)
+    var params: List[Variable] = []
+    params.append(param.copy())
+
+    optimizer.step(params, tape)
+
+    # param[0] = 1.0 - 0.1 * 0.5 = 0.95
+    var actual = Float64(params[0].data._get_float64(0))
+    assert_almost_equal(actual, 0.95, tolerance=1e-6)
+    # param[1] = 0.5 - 0.1 * 0.5 = 0.45
+    var actual1 = Float64(params[0].data._get_float64(1))
+    assert_almost_equal(actual1, 0.45, tolerance=1e-6)
+    print("PASS: test_sgd_step_with_anytensor_data")
+
+
+fn test_sgd_momentum_anytensor_velocities() raises:
+    """SGD with momentum stores velocity buffers as AnyTensor."""
+    var shape: List[Int] = [2]
+    var param_data: AnyTensor = zeros(shape, DType.float32)
+    param_data._set_float64(0, 1.0)
+    param_data._set_float64(1, 1.0)
+
+    var tape = GradientTape()
+    tape.enable()
+    var param = Variable(param_data, True, tape)
+
+    var grad: AnyTensor = zeros(shape, DType.float32)
+    grad._set_float64(0, 1.0)
+    grad._set_float64(1, 1.0)
+    tape.registry.set_grad(param.id, grad)
+
+    var optimizer = SGD(learning_rate=0.01, momentum=0.9)
+    var params: List[Variable] = []
+    params.append(param.copy())
+
+    optimizer.step(params, tape)
+
+    # After first step with momentum:
+    # v = 0 * 0.9 + 1.0 = 1.0
+    # param = 1.0 - 0.01 * 1.0 = 0.99
+    var actual = Float64(params[0].data._get_float64(0))
+    assert_almost_equal(actual, 0.99, tolerance=1e-6)
+    print("PASS: test_sgd_momentum_anytensor_velocities")
+
+
+fn test_adam_step_with_anytensor_data() raises:
+    """Adam step updates Variable whose data is AnyTensor."""
+    var shape: List[Int] = [2]
+    var param_data: AnyTensor = zeros(shape, DType.float32)
+    param_data._set_float64(0, 1.0)
+    param_data._set_float64(1, 1.0)
+
+    var tape = GradientTape()
+    tape.enable()
+    var param = Variable(param_data, True, tape)
+
+    var grad: AnyTensor = zeros(shape, DType.float32)
+    grad._set_float64(0, 0.5)
+    grad._set_float64(1, 0.5)
+    tape.registry.set_grad(param.id, grad)
+
+    var optimizer = Adam(learning_rate=0.001)
+    var params: List[Variable] = []
+    params.append(param.copy())
+
+    optimizer.step(params, tape)
+
+    # After step, parameters should be updated (decreased from 1.0)
+    var actual = Float64(params[0].data._get_float64(0))
+    assert_true(actual < 1.0, "param should decrease after Adam step")
+    assert_true(actual > 0.99, "param should not decrease too much with lr=0.001")
+    print("PASS: test_adam_step_with_anytensor_data")
+
+
+fn test_optimizer_preserves_shape_dtype() raises:
+    """Optimizer step preserves AnyTensor shape and dtype."""
+    var shape: List[Int] = [3, 2]
+    var param_data: AnyTensor = zeros(shape, DType.float32)
+    param_data._set_float64(0, 1.0)
+
+    var tape = GradientTape()
+    tape.enable()
+    var param = Variable(param_data, True, tape)
+
+    var grad: AnyTensor = zeros(shape, DType.float32)
+    grad._set_float64(0, 0.5)
+    tape.registry.set_grad(param.id, grad)
+
+    var optimizer = SGD(learning_rate=0.01)
+    var params: List[Variable] = []
+    params.append(param.copy())
+
+    optimizer.step(params, tape)
+
+    var result_shape = params[0].data.shape()
+    assert_true(result_shape[0] == 3, "dim 0 preserved")
+    assert_true(result_shape[1] == 2, "dim 1 preserved")
+    assert_true(params[0].data.dtype() == DType.float32, "dtype preserved")
+    assert_true(params[0].data.numel() == 6, "numel preserved")
+    print("PASS: test_optimizer_preserves_shape_dtype")
+
+
+fn test_sgd_no_grad_param_skipped() raises:
+    """SGD skips parameters with requires_grad=False."""
+    var shape: List[Int] = [2]
+    var param_data: AnyTensor = zeros(shape, DType.float32)
+    param_data._set_float64(0, 1.0)
+    param_data._set_float64(1, 1.0)
+
+    var tape = GradientTape()
+    tape.enable()
+    var param = Variable(param_data, False, tape)
+
+    var grad: AnyTensor = zeros(shape, DType.float32)
+    grad._set_float64(0, 1.0)
+    grad._set_float64(1, 1.0)
+    tape.registry.set_grad(param.id, grad)
+
+    var optimizer = SGD(learning_rate=0.1)
+    var params: List[Variable] = []
+    params.append(param.copy())
+
+    optimizer.step(params, tape)
+
+    # Parameters should be unchanged since requires_grad=False
+    var actual = Float64(params[0].data._get_float64(0))
+    assert_almost_equal(actual, 1.0, tolerance=1e-6)
+    print("PASS: test_sgd_no_grad_param_skipped")
+
+
+fn main() raises:
+    test_sgd_step_with_anytensor_data()
+    test_sgd_momentum_anytensor_velocities()
+    test_adam_step_with_anytensor_data()
+    test_optimizer_preserves_shape_dtype()
+    test_sgd_no_grad_param_skipped()
+    print("\n5 optimizer AnyTensor tests passed\n")

--- a/tests/shared/tensor/test_training_anytensor.mojo
+++ b/tests/shared/tensor/test_training_anytensor.mojo
@@ -1,0 +1,147 @@
+"""Tests for training infrastructure with AnyTensor.
+
+# ADR-009: This file is intentionally limited to <=10 fn test_ functions.
+# Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
+# high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
+
+Tests verify that Variable wraps AnyTensor correctly and that the autograd
+infrastructure (Variable creation, backward, detach) works with AnyTensor
+as the underlying data type.
+
+Tests cover:
+- Variable.data is AnyTensor
+- Variable preserves shape, numel, dtype through AnyTensor
+- Variable backward with AnyTensor data
+- Variable detach returns AnyTensor
+- Multiple Variables with AnyTensor in same tape
+"""
+
+from testing import assert_true
+from tests.shared.conftest import assert_almost_equal
+from shared.core.extensor import AnyTensor, zeros, ones
+from shared.autograd import Variable, GradientTape
+from shared.autograd.variable import variable_add, variable_sum
+
+
+fn test_variable_data_is_anytensor() raises:
+    """Variable.data stores AnyTensor correctly."""
+    var data: AnyTensor = zeros([4, 3], DType.float32)
+    var tape = GradientTape()
+    tape.enable()
+    var v = Variable(data, True, tape)
+    assert_true(v.data.numel() == 12, "variable data has 12 elements")
+    assert_true(v.data.dtype() == DType.float32, "variable data dtype preserved")
+    print("PASS: test_variable_data_is_anytensor")
+
+
+fn test_variable_shape_from_anytensor() raises:
+    """Variable.shape() returns shape from underlying AnyTensor."""
+    var data: AnyTensor = zeros([2, 3, 4], DType.float32)
+    var tape = GradientTape()
+    tape.enable()
+    var v = Variable(data, True, tape)
+    var s = v.shape()
+    assert_true(len(s) == 3, "3D shape")
+    assert_true(s[0] == 2, "dim 0")
+    assert_true(s[1] == 3, "dim 1")
+    assert_true(s[2] == 4, "dim 2")
+    print("PASS: test_variable_shape_from_anytensor")
+
+
+fn test_variable_detach_returns_anytensor() raises:
+    """Variable.detach() returns the underlying AnyTensor."""
+    var data: AnyTensor = zeros([3], DType.float32)
+    data._set_float64(0, 1.0)
+    data._set_float64(1, 0.5)
+    data._set_float64(2, -0.5)
+    var tape = GradientTape()
+    tape.enable()
+    var v = Variable(data, True, tape)
+    var detached = v.detach()
+    assert_true(detached.numel() == 3, "detached has 3 elements")
+    assert_almost_equal(
+        Float64(detached._get_float64(0)), 1.0, tolerance=1e-6
+    )
+    assert_almost_equal(
+        Float64(detached._get_float64(1)), 0.5, tolerance=1e-6
+    )
+    print("PASS: test_variable_detach_returns_anytensor")
+
+
+fn test_variable_backward_with_anytensor() raises:
+    """Variable backward computes gradients with AnyTensor data."""
+    var tape = GradientTape()
+    tape.enable()
+
+    var x_data: AnyTensor = zeros([2], DType.float32)
+    x_data._set_float64(0, 1.0)
+    x_data._set_float64(1, 0.5)
+    var x = Variable(x_data, True, tape)
+
+    var y_data: AnyTensor = zeros([2], DType.float32)
+    y_data._set_float64(0, 0.5)
+    y_data._set_float64(1, 1.0)
+    var y = Variable(y_data, True, tape)
+
+    # z = x + y, loss = sum(z)
+    var z = variable_add(x, y, tape)
+    var loss = variable_sum(z, tape)
+
+    loss.backward(tape)
+
+    # d(sum(x+y))/dx = [1, 1]
+    var grad_x = tape.registry.get_grad(x.id)
+    assert_true(grad_x.numel() == 2, "grad_x has 2 elements")
+    assert_almost_equal(
+        Float64(grad_x._get_float64(0)), 1.0, tolerance=1e-6
+    )
+    assert_almost_equal(
+        Float64(grad_x._get_float64(1)), 1.0, tolerance=1e-6
+    )
+    print("PASS: test_variable_backward_with_anytensor")
+
+
+fn test_multiple_variables_anytensor() raises:
+    """Multiple Variables with AnyTensor data in same tape."""
+    var tape = GradientTape()
+    tape.enable()
+
+    var a_data: AnyTensor = ones([3], DType.float32)
+    var b_data: AnyTensor = zeros([3], DType.float32)
+    var c_data: AnyTensor = ones([2, 2], DType.float32)
+
+    var a = Variable(a_data, True, tape)
+    var b = Variable(b_data, False, tape)
+    var c = Variable(c_data, True, tape)
+
+    assert_true(a.data.numel() == 3, "a has 3 elements")
+    assert_true(b.data.numel() == 3, "b has 3 elements")
+    assert_true(c.data.numel() == 4, "c has 4 elements")
+    assert_true(a.requires_grad == True, "a requires grad")
+    assert_true(b.requires_grad == False, "b does not require grad")
+    assert_true(c.requires_grad == True, "c requires grad")
+    # Each variable should have a unique ID
+    assert_true(a.id != b.id, "a and b have different ids")
+    assert_true(b.id != c.id, "b and c have different ids")
+    print("PASS: test_multiple_variables_anytensor")
+
+
+fn test_variable_numel_dtype_from_anytensor() raises:
+    """Variable.numel() and Variable.dtype() delegate to AnyTensor."""
+    var data: AnyTensor = zeros([5, 3], DType.float32)
+    var tape = GradientTape()
+    tape.enable()
+    var v = Variable(data, True, tape)
+    assert_true(v.numel() == 15, "numel delegates to AnyTensor")
+    assert_true(v.dtype() == DType.float32, "dtype delegates to AnyTensor")
+    print("PASS: test_variable_numel_dtype_from_anytensor")
+
+
+fn main() raises:
+    test_variable_data_is_anytensor()
+    test_variable_shape_from_anytensor()
+    test_variable_detach_returns_anytensor()
+    test_variable_backward_with_anytensor()
+    test_multiple_variables_anytensor()
+    test_variable_numel_dtype_from_anytensor()
+    print("\n6 training AnyTensor tests passed\n")


### PR DESCRIPTION
## Summary
- Add TDD tests for Phases 5b, 5c, and 6 of the ExTensor -> AnyTensor migration
- Tests verify collection ops (concatenate, stack, split), optimizer infrastructure (SGD, Adam), gradient container types (GradientPair, GradientTriple, GradientQuad), and training infrastructure (Variable) all work correctly with AnyTensor

## Test Files Created
- `tests/shared/tensor/test_collection_ops_anytensor.mojo` (8 tests) - concatenate/stack/split with List[AnyTensor]
- `tests/shared/tensor/test_optimizer_anytensor.mojo` (5 tests) - SGD/Adam step with AnyTensor-backed Variables
- `tests/shared/tensor/test_gradient_types_anytensor.mojo` (7 tests) - GradientPair/Triple/Quad with AnyTensor fields
- `tests/shared/tensor/test_training_anytensor.mojo` (6 tests) - Variable wrapping AnyTensor, backward, detach

## Test Plan
- [ ] All 26 tests compile and pass in CI
- [ ] Each file has <=10 test functions (ADR-009 compliance)
- [ ] Tests use FP-representable values (0.5, 1.0, -0.5, -1.0)
- [ ] Tests validate shape, dtype, numel, and value preservation

Part of #4998

🤖 Generated with [Claude Code](https://claude.com/claude-code)