### PR TITLE
refactor(training): migrate training and data infrastructure to AnyTensor

### DIFF
--- a/shared/autograd/functional.mojo
+++ b/shared/autograd/functional.mojo
@@ -32,7 +32,7 @@ Common Patterns Supported:
 """
 
 from shared.core import (
-    ExTensor,
+    AnyTensor,
     add,
     multiply,
     subtract,
@@ -56,7 +56,7 @@ from shared.core import (
 # ============================================================================
 
 
-fn multiply_scalar(tensor: ExTensor, scalar: Float64) raises -> ExTensor:
+fn multiply_scalar(tensor: AnyTensor, scalar: Float64) raises -> AnyTensor:
     """Multiply tensor by a scalar value.
 
         More efficient than creating a full tensor filled with the scalar value.
@@ -71,14 +71,14 @@ fn multiply_scalar(tensor: ExTensor, scalar: Float64) raises -> ExTensor:
     Raises:
             Error: If operation fails.
     """
-    var result = ExTensor(tensor.shape(), tensor.dtype())
+    var result = AnyTensor(tensor.shape(), tensor.dtype())
     for i in range(tensor.numel()):
         var val = tensor._get_float64(i)
         result._set_float64(i, val * scalar)
     return result
 
 
-fn add_scalar(tensor: ExTensor, scalar: Float64) raises -> ExTensor:
+fn add_scalar(tensor: AnyTensor, scalar: Float64) raises -> AnyTensor:
     """Add a scalar value to all elements of a tensor.
 
     Args:
@@ -91,14 +91,14 @@ fn add_scalar(tensor: ExTensor, scalar: Float64) raises -> ExTensor:
     Raises:
             Error: If operation fails.
     """
-    var result = ExTensor(tensor.shape(), tensor.dtype())
+    var result = AnyTensor(tensor.shape(), tensor.dtype())
     for i in range(tensor.numel()):
         var val = tensor._get_float64(i)
         result._set_float64(i, val + scalar)
     return result
 
 
-fn subtract_scalar(tensor: ExTensor, scalar: Float64) raises -> ExTensor:
+fn subtract_scalar(tensor: AnyTensor, scalar: Float64) raises -> AnyTensor:
     """Subtract a scalar value from all elements of a tensor.
 
     Args:
@@ -111,14 +111,14 @@ fn subtract_scalar(tensor: ExTensor, scalar: Float64) raises -> ExTensor:
     Raises:
             Error: If operation fails.
     """
-    var result = ExTensor(tensor.shape(), tensor.dtype())
+    var result = AnyTensor(tensor.shape(), tensor.dtype())
     for i in range(tensor.numel()):
         var val = tensor._get_float64(i)
         result._set_float64(i, val - scalar)
     return result
 
 
-fn divide_scalar(tensor: ExTensor, scalar: Float64) raises -> ExTensor:
+fn divide_scalar(tensor: AnyTensor, scalar: Float64) raises -> AnyTensor:
     """Divide all elements of a tensor by a scalar value.
 
     Args:
@@ -134,7 +134,7 @@ fn divide_scalar(tensor: ExTensor, scalar: Float64) raises -> ExTensor:
     if scalar == 0.0:
         raise Error("Cannot divide by zero")
 
-    var result = ExTensor(tensor.shape(), tensor.dtype())
+    var result = AnyTensor(tensor.shape(), tensor.dtype())
     for i in range(tensor.numel()):
         var val = tensor._get_float64(i)
         result._set_float64(i, val / scalar)
@@ -147,8 +147,8 @@ fn divide_scalar(tensor: ExTensor, scalar: Float64) raises -> ExTensor:
 
 
 fn apply_gradient(
-    parameter: ExTensor, gradient: ExTensor, learning_rate: Float64
-) raises -> ExTensor:
+    parameter: AnyTensor, gradient: AnyTensor, learning_rate: Float64
+) raises -> AnyTensor:
     """Apply a gradient to a parameter with given learning rate.
 
         Performs: parameter = parameter - learning_rate * gradient.
@@ -173,8 +173,8 @@ fn apply_gradient(
 
 
 fn apply_gradients(
-    mut parameters: List[ExTensor],
-    gradients: List[ExTensor],
+    mut parameters: List[AnyTensor],
+    gradients: List[AnyTensor],
     learning_rate: Float64,
 ) raises:
     """Apply gradients to multiple parameters in-place.
@@ -213,10 +213,10 @@ struct LossAndGrad:
         grad: Gradient tensor (same shape as input).
     """
 
-    var loss: ExTensor
-    var grad: ExTensor
+    var loss: AnyTensor
+    var grad: AnyTensor
 
-    fn __init__(out self, var loss: ExTensor, var grad: ExTensor):
+    fn __init__(out self, var loss: AnyTensor, var grad: AnyTensor):
         """Initialize loss and gradient pair.
 
         Args:
@@ -228,7 +228,7 @@ struct LossAndGrad:
 
 
 fn mse_loss_and_grad(
-    predictions: ExTensor, targets: ExTensor
+    predictions: AnyTensor, targets: AnyTensor
 ) raises -> LossAndGrad:
     """Compute MSE loss and gradient in one pass.
 
@@ -263,7 +263,7 @@ fn mse_loss_and_grad(
 
 
 fn bce_loss_and_grad(
-    predictions: ExTensor, targets: ExTensor, epsilon: Float64 = 1e-7
+    predictions: AnyTensor, targets: AnyTensor, epsilon: Float64 = 1e-7
 ) raises -> LossAndGrad:
     """Compute binary cross-entropy loss and gradient.
 
@@ -299,7 +299,7 @@ fn bce_loss_and_grad(
 
 
 fn ce_loss_and_grad(
-    logits: ExTensor, targets: ExTensor, epsilon: Float64 = 1e-7
+    logits: AnyTensor, targets: AnyTensor, epsilon: Float64 = 1e-7
 ) raises -> LossAndGrad:
     """Compute cross-entropy loss and gradient.
 
@@ -337,8 +337,8 @@ fn ce_loss_and_grad(
 
 # Helper function for manual gradient computation patterns
 fn compute_gradient(
-    predictions: ExTensor, targets: ExTensor, loss_type: String = "mse"
-) raises -> ExTensor:
+    predictions: AnyTensor, targets: AnyTensor, loss_type: String = "mse"
+) raises -> AnyTensor:
     """Compute gradient for common loss functions.
 
         Convenience function that dispatches to the appropriate loss_and_grad

--- a/shared/data/README.md
+++ b/shared/data/README.md
@@ -182,7 +182,7 @@ struct TransformedDataset[D: Dataset, T](Dataset):
     var dataset: D
     var transform: T
 
-    fn __getitem__(self, index: Int) -> (ExTensor, ExTensor):
+    fn __getitem__(self, index: Int) -> (AnyTensor, AnyTensor):
         var data, labels = self.dataset[index]
         var transformed = self.transform(data)
         return (transformed, labels)
@@ -197,7 +197,7 @@ struct TransformedDataset[D: Dataset, T](Dataset):
 **Example**:
 
 ```mojo
-var dataset = ExTensorDataset(images, labels)
+var dataset = AnyTensorDataset(images, labels)
 var normalize = Normalize(mean=0.5, std=0.5)
 var augmented = TransformedDataset(dataset, normalize)
 # augmented[0] returns (normalized_data, original_labels)
@@ -211,10 +211,10 @@ Caches samples to avoid repeated I/O:
 struct CachedDataset[D: Dataset](Dataset):
     """Caches loaded samples up to max_cache_size."""
     var dataset: D
-    var cache: Dict[Int, Tuple[ExTensor, ExTensor]]
+    var cache: Dict[Int, Tuple[AnyTensor, AnyTensor]]
     var max_cache_size: Int
 
-    fn __getitem__(mut self, index: Int) -> (ExTensor, ExTensor):
+    fn __getitem__(mut self, index: Int) -> (AnyTensor, AnyTensor):
         if index in cache:
             return cache[index]  # Cache hit
         # Load from dataset and cache
@@ -513,12 +513,12 @@ struct RandomRotation(Transform):
 
 ```mojo
 from shared.data import (
-    ExTensorDataset, BatchLoader, RandomSampler, Normalize,
+    AnyTensorDataset, BatchLoader, RandomSampler, Normalize,
     TransformedDataset
 )
 
 # Create base dataset
-var dataset = ExTensorDataset(images, labels)
+var dataset = AnyTensorDataset(images, labels)
 
 # (Optional) Add transforms for augmentation
 var normalize = Normalize(mean=0.5, std=0.5)
@@ -547,12 +547,12 @@ for batch in batches:
 
 ```mojo
 from shared.data import (
-    ExTensorDataset, BatchLoader, RandomSampler, CachedDataset,
+    AnyTensorDataset, BatchLoader, RandomSampler, CachedDataset,
     TransformedDataset, PrefetchDataLoader, Normalize
 )
 
 # Step 1: Create dataset
-var dataset = ExTensorDataset(images, labels)
+var dataset = AnyTensorDataset(images, labels)
 
 # Step 2: Add transforms
 var normalize = Normalize(mean=0.5, std=0.5)
@@ -587,7 +587,7 @@ for epoch in range(num_epochs):
 
 ```mojo
 from shared.data import (
-    ExTensorDataset, TransformedDataset, RandomHorizontalFlip,
+    AnyTensorDataset, TransformedDataset, RandomHorizontalFlip,
     RandomCrop, Normalize, Compose
 )
 
@@ -599,7 +599,7 @@ var transforms = Compose([
 ])
 
 # Create dataset
-var dataset = ExTensorDataset(images, labels)
+var dataset = AnyTensorDataset(images, labels)
 
 # Apply transforms
 var augmented = TransformedDataset(dataset, transforms)

--- a/shared/data/__init__.mojo
+++ b/shared/data/__init__.mojo
@@ -9,7 +9,7 @@ Modules:
 Architecture:
     - `formats` provides low-level file I/O and format parsing
     - `datasets` provides high-level, user-friendly interfaces
-    - All data is returned as ExTensor for consistency with core library
+    - All data is returned as AnyTensor for consistency with core library
 
 Example:
     from shared.data import load_emnist_train, load_emnist_test
@@ -74,7 +74,7 @@ from shared.data.constants import (
 # Dataset classes and loaders
 from shared.data.datasets import (
     Dataset,  # Base dataset interface
-    ExTensorDataset,  # In-memory tensor dataset wrapper
+    AnyTensorDataset,  # In-memory tensor dataset wrapper
     FileDataset,  # File-based lazy-loading dataset
     CIFAR10Dataset,  # CIFAR-10 dataset with train/test splits
     get_cifar10_classes,  # CIFAR-10 class names

--- a/shared/data/_datasets_core.mojo
+++ b/shared/data/_datasets_core.mojo
@@ -5,12 +5,12 @@ for loading and accessing data in ML workflows.
 
 Includes:
     - Dataset trait: Base interface for all datasets
-    - ExTensorDataset: In-memory tensor dataset wrapper
+    - AnyTensorDataset: In-memory tensor dataset wrapper
     - FileDataset: Lazy-loading dataset from files
     - EMNISTDataset: Extended MNIST dataset with multiple splits
 """
 
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.data.formats import load_idx_labels, load_idx_images
 from utils.index import Index
 
@@ -35,7 +35,7 @@ trait Dataset:
         """
         ...
 
-    fn __getitem__(self, index: Int) raises -> Tuple[ExTensor, ExTensor]:
+    fn __getitem__(self, index: Int) raises -> Tuple[AnyTensor, AnyTensor]:
         """Get a sample from the dataset.
 
         Args:
@@ -51,22 +51,22 @@ trait Dataset:
 
 
 # ============================================================================
-# ExTensorDataset Implementation
+# AnyTensorDataset Implementation
 # ============================================================================
 
 
-struct ExTensorDataset(Copyable, Dataset, Movable, Sized):
+struct AnyTensorDataset(Copyable, Dataset, Movable, Sized):
     """Dataset wrapping tensors for in-memory data.
 
     Stores data and labels as tensors and provides indexed access.
     Suitable for small to medium datasets that fit in memory.
     """
 
-    var data: ExTensor
-    var labels: ExTensor
+    var data: AnyTensor
+    var labels: AnyTensor
     var _len: Int
 
-    fn __init__(out self, var data: ExTensor, var labels: ExTensor) raises:
+    fn __init__(out self, var data: AnyTensor, var labels: AnyTensor) raises:
         """Create dataset from tensors.
 
         Args:
@@ -87,7 +87,7 @@ struct ExTensorDataset(Copyable, Dataset, Movable, Sized):
         """Return number of samples."""
         return self._len
 
-    fn __getitem__(self, index: Int) raises -> Tuple[ExTensor, ExTensor]:
+    fn __getitem__(self, index: Int) raises -> Tuple[AnyTensor, AnyTensor]:
         """Get sample at index.
 
         Args:
@@ -135,7 +135,7 @@ struct FileDataset(Copyable, Dataset, Movable):
     var labels: List[Int]
     var _len: Int
     var cache_enabled: Bool
-    var _cache: Dict[Int, Tuple[ExTensor, ExTensor]]
+    var _cache: Dict[Int, Tuple[AnyTensor, AnyTensor]]
 
     fn __init__(
         out self,
@@ -160,13 +160,13 @@ struct FileDataset(Copyable, Dataset, Movable):
         self.labels = labels^
         self._len = len(self.file_paths)
         self.cache_enabled = cache
-        self._cache = Dict[Int, Tuple[ExTensor, ExTensor]]()
+        self._cache = Dict[Int, Tuple[AnyTensor, AnyTensor]]()
 
     fn __len__(self) -> Int:
         """Return number of samples."""
         return self._len
 
-    fn __getitem__(self, index: Int) raises -> Tuple[ExTensor, ExTensor]:
+    fn __getitem__(self, index: Int) raises -> Tuple[AnyTensor, AnyTensor]:
         """Load and return sample at index.
 
         Args:
@@ -211,7 +211,7 @@ struct FileDataset(Copyable, Dataset, Movable):
 
         return result
 
-    fn _load_file(self, path: String) raises -> ExTensor:
+    fn _load_file(self, path: String) raises -> AnyTensor:
         """Load data from file based on file extension.
 
         Supports multiple file formats with format-specific decoders.
@@ -263,7 +263,7 @@ struct FileDataset(Copyable, Dataset, Movable):
                 "Unsupported file format: " + ext + ". Supported: csv, bin, txt"
             )
 
-    fn _load_csv(self, path: String) raises -> ExTensor:
+    fn _load_csv(self, path: String) raises -> AnyTensor:
         """Load CSV file as tensor.
 
         Parses CSV rows and columns into a 2D tensor.
@@ -285,9 +285,9 @@ struct FileDataset(Copyable, Dataset, Movable):
         # Placeholder: 10x5 CSV data
         for _ in range(50):
             data.append(Float32(1.0))
-        return ExTensor(data^)
+        return AnyTensor(data^)
 
-    fn _load_binary(self, path: String) raises -> ExTensor:
+    fn _load_binary(self, path: String) raises -> AnyTensor:
         """Load binary file as tensor.
 
         Reads raw float32 values from binary file.
@@ -309,9 +309,9 @@ struct FileDataset(Copyable, Dataset, Movable):
         # Placeholder: 100 float32 values
         for _ in range(100):
             data.append(Float32(1.0))
-        return ExTensor(data^)
+        return AnyTensor(data^)
 
-    fn _load_text(self, path: String) raises -> ExTensor:
+    fn _load_text(self, path: String) raises -> AnyTensor:
         """Load text file as tensor.
 
         Parses space and newline separated numbers into a tensor.
@@ -333,7 +333,7 @@ struct FileDataset(Copyable, Dataset, Movable):
         # Placeholder: 50 float32 values
         for _ in range(50):
             data.append(Float32(1.0))
-        return ExTensor(data^)
+        return AnyTensor(data^)
 
 
 # ============================================================================
@@ -355,8 +355,8 @@ struct EMNISTDataset(Copyable, Dataset, Movable):
         data_dir: Directory containing the EMNIST data files.
     """
 
-    var data: ExTensor
-    var labels: ExTensor
+    var data: AnyTensor
+    var labels: AnyTensor
     var _len: Int
     var split: String
     var data_dir: String
@@ -446,7 +446,7 @@ struct EMNISTDataset(Copyable, Dataset, Movable):
         """
         return self._len
 
-    fn __getitem__(self, index: Int) raises -> Tuple[ExTensor, ExTensor]:
+    fn __getitem__(self, index: Int) raises -> Tuple[AnyTensor, AnyTensor]:
         """Get a sample from the dataset.
 
         Args:
@@ -454,8 +454,8 @@ struct EMNISTDataset(Copyable, Dataset, Movable):
 
         Returns:
             Tuple of (image, label) tensors where:
-            - image: ExTensor with shape (1, 28, 28) - single grayscale image.
-            - label: ExTensor with shape (1,) - integer label.
+            - image: AnyTensor with shape (1, 28, 28) - single grayscale image.
+            - label: AnyTensor with shape (1,) - integer label.
 
         Raises:
             Error: If index is out of bounds.
@@ -480,31 +480,31 @@ struct EMNISTDataset(Copyable, Dataset, Movable):
             self.labels.slice(idx, idx + 1, axis=0),
         )
 
-    fn get_train_data(self) raises -> ExTensorDataset:
-        """Get training data as ExTensorDataset.
+    fn get_train_data(self) raises -> AnyTensorDataset:
+        """Get training data as AnyTensorDataset.
 
         Returns:
-            ExTensorDataset containing all training data and labels.
+            AnyTensorDataset containing all training data and labels.
 
         Raises:
             Error: If data or labels are invalid.
         """
-        return ExTensorDataset(self.data, self.labels)
+        return AnyTensorDataset(self.data, self.labels)
 
-    fn get_test_data(self) raises -> ExTensorDataset:
-        """Get test data as ExTensorDataset.
+    fn get_test_data(self) raises -> AnyTensorDataset:
+        """Get test data as AnyTensorDataset.
 
         Note: This method returns the same data as get_train_data since
         EMNISTDataset is initialized with either train or test split via __init__.
         Use __init__ with train=False to load test data.
 
         Returns:
-            ExTensorDataset containing all data and labels.
+            AnyTensorDataset containing all data and labels.
 
         Raises:
             Error: If data or labels are invalid.
         """
-        return ExTensorDataset(self.data, self.labels)
+        return AnyTensorDataset(self.data, self.labels)
 
     fn shape(self) -> List[Int]:
         """Return the shape of individual samples.
@@ -554,7 +554,7 @@ struct EMNISTDataset(Copyable, Dataset, Movable):
 fn load_emnist_train(
     data_dir: String,
     split: String = "balanced",
-) raises -> Tuple[ExTensor, ExTensor]:
+) raises -> Tuple[AnyTensor, AnyTensor]:
     """Load EMNIST training dataset.
 
     Args:
@@ -574,7 +574,7 @@ fn load_emnist_train(
 fn load_emnist_test(
     data_dir: String,
     split: String = "balanced",
-) raises -> Tuple[ExTensor, ExTensor]:
+) raises -> Tuple[AnyTensor, AnyTensor]:
     """Load EMNIST test dataset.
 
     Args:
@@ -597,4 +597,4 @@ fn load_emnist_test(
 
 
 # Type comptime for backwards compatibility
-comptime TensorDataset = ExTensorDataset
+comptime TensorDataset = AnyTensorDataset

--- a/shared/data/batch_utils.mojo
+++ b/shared/data/batch_utils.mojo
@@ -4,16 +4,16 @@ This module provides utilities for extracting mini-batches from datasets
 for training and evaluation.
 """
 
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 
 
 fn extract_batch(
-    data: ExTensor, start_idx: Int, batch_size: Int
-) raises -> ExTensor:
+    data: AnyTensor, start_idx: Int, batch_size: Int
+) raises -> AnyTensor:
     """Extract a mini-batch from a dataset tensor using zero-copy slicing.
 
     Extracts a contiguous slice of samples from the dataset starting at
-    start_idx and containing up to batch_size samples. Uses ExTensor's
+    start_idx and containing up to batch_size samples. Uses AnyTensor's
     slice() method for efficient memory views instead of copying data.
 
     Args:
@@ -73,12 +73,12 @@ fn extract_batch(
 
 
 fn extract_batch_pair(
-    data: ExTensor, labels: ExTensor, start_idx: Int, batch_size: Int
-) raises -> Tuple[ExTensor, ExTensor]:
+    data: AnyTensor, labels: AnyTensor, start_idx: Int, batch_size: Int
+) raises -> Tuple[AnyTensor, AnyTensor]:
     """Extract matching mini-batches of data and labels using zero-copy slicing.
 
     Convenience function that extracts matching slices from both data and
-    label tensors with a single call. Uses ExTensor's slice() method for
+    label tensors with a single call. Uses AnyTensor's slice() method for
     efficient memory views.
 
     Args:

--- a/shared/data/cache.mojo
+++ b/shared/data/cache.mojo
@@ -22,7 +22,7 @@ Example:
     var img, label = cached[0]  # Returns from cache if available
 """
 
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.data._datasets_core import Dataset
 
 
@@ -58,7 +58,7 @@ struct CachedDataset[D: Dataset & Copyable & Movable](
 
     var dataset: Self.D
     """Base dataset to wrap."""
-    var cache: Dict[Int, Tuple[ExTensor, ExTensor]]
+    var cache: Dict[Int, Tuple[AnyTensor, AnyTensor]]
     """Cache of loaded samples (index -> (data, label))."""
     var cache_enabled: Bool
     """Whether caching is enabled."""
@@ -83,7 +83,7 @@ struct CachedDataset[D: Dataset & Copyable & Movable](
             cache_enabled: Whether to enable caching (default True).
         """
         self.dataset = dataset^
-        self.cache = Dict[Int, Tuple[ExTensor, ExTensor]]()
+        self.cache = Dict[Int, Tuple[AnyTensor, AnyTensor]]()
         self.cache_enabled = cache_enabled
         self.max_cache_size = max_cache_size
         self.cache_hits = 0
@@ -97,7 +97,7 @@ struct CachedDataset[D: Dataset & Copyable & Movable](
         """
         return self.dataset.__len__()
 
-    fn __getitem__(self, index: Int) raises -> Tuple[ExTensor, ExTensor]:
+    fn __getitem__(self, index: Int) raises -> Tuple[AnyTensor, AnyTensor]:
         """Get a sample, using cache if available.
 
         Attempts to retrieve from cache first. If not cached, loads from
@@ -120,7 +120,7 @@ struct CachedDataset[D: Dataset & Copyable & Movable](
         # Cache miss - load from base dataset
         return self.dataset.__getitem__(index)
 
-    fn _get_and_cache(mut self, index: Int) raises -> Tuple[ExTensor, ExTensor]:
+    fn _get_and_cache(mut self, index: Int) raises -> Tuple[AnyTensor, AnyTensor]:
         """Get a sample with mutable access, enabling cache updates.
 
         Unlike __getitem__, this method can update cache and statistics.
@@ -181,7 +181,7 @@ struct CachedDataset[D: Dataset & Copyable & Movable](
 
     fn clear_cache(mut self):
         """Clear all cached samples."""
-        self.cache = Dict[Int, Tuple[ExTensor, ExTensor]]()
+        self.cache = Dict[Int, Tuple[AnyTensor, AnyTensor]]()
         self.cache_hits = 0
         self.cache_misses = 0
 

--- a/shared/data/dataset_with_transform.mojo
+++ b/shared/data/dataset_with_transform.mojo
@@ -5,16 +5,16 @@ a transform pipeline. Transforms are applied to data but not labels,
 enabling data augmentation during training.
 
 Example:
-    from shared.data import ExTensorDataset, TransformedDataset
+    from shared.data import AnyTensorDataset, TransformedDataset
     from shared.data.transforms import Normalize
 
-    var dataset = ExTensorDataset(images, labels)
+    var dataset = AnyTensorDataset(images, labels)
     var normalize = Normalize(mean=0.5, std=0.5)
     var transformed = TransformedDataset(dataset, normalize)
     var img, label = transformed[0]  # Returns normalized image
 """
 
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.data._datasets_core import Dataset
 from shared.data.transforms import Transform
 
@@ -29,11 +29,11 @@ struct TransformedDataset[
 
     Parameters:
         D: Dataset type that conforms to the Dataset trait.
-        T: Transform type with __call__(ExTensor) -> ExTensor method.
+        T: Transform type with __call__(AnyTensor) -> AnyTensor method.
 
     Examples:
         ```mojo
-        var dataset = ExTensorDataset(images, labels)
+        var dataset = AnyTensorDataset(images, labels)
         var normalize = Normalize(mean=0.5, std=0.5)
         var transformed = TransformedDataset(dataset, normalize)
 
@@ -65,7 +65,7 @@ struct TransformedDataset[
         """
         return self.dataset.__len__()
 
-    fn __getitem__(self, index: Int) raises -> Tuple[ExTensor, ExTensor]:
+    fn __getitem__(self, index: Int) raises -> Tuple[AnyTensor, AnyTensor]:
         """Get a sample with transform applied.
 
         The transform is applied to the data but not the labels.
@@ -82,7 +82,7 @@ struct TransformedDataset[
         var data, labels = self.dataset.__getitem__(index)
 
         # Apply transform to data only, not labels
-        # The transform must have __call__(ExTensor) -> ExTensor method
+        # The transform must have __call__(AnyTensor) -> AnyTensor method
         var transformed_data = self.transform(data)
 
         return (transformed_data, labels)

--- a/shared/data/datasets/__init__.mojo
+++ b/shared/data/datasets/__init__.mojo
@@ -7,8 +7,8 @@ Modules:
 
 Classes:
     Dataset: Base trait for all datasets
-    ExTensorDataset: In-memory tensor dataset
-    TensorDataset: Alias for ExTensorDataset
+    AnyTensorDataset: In-memory tensor dataset
+    TensorDataset: Alias for AnyTensorDataset
     FileDataset: Lazy-loading file-based dataset
     CIFAR10Dataset: High-level interface for CIFAR-10 data access
 
@@ -25,7 +25,7 @@ Example:
 # Core dataset types from _datasets_core.mojo
 from shared.data._datasets_core import (
     Dataset,
-    ExTensorDataset,
+    AnyTensorDataset,
     TensorDataset,
     FileDataset,
 )

--- a/shared/data/datasets/cifar10.mojo
+++ b/shared/data/datasets/cifar10.mojo
@@ -27,7 +27,7 @@ References:
     - Array API: https://data-apis.org/array-api/latest/
 """
 
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.core import concatenate
 from shared.data.formats import load_cifar10_batch
 from collections import List
@@ -95,10 +95,10 @@ struct CIFAR10Dataset(Copyable, Movable):
     """
 
     var data_dir: String
-    var _train_data: ExTensor
-    var _train_labels: ExTensor
-    var _test_data: ExTensor
-    var _test_labels: ExTensor
+    var _train_data: AnyTensor
+    var _train_labels: AnyTensor
+    var _test_data: AnyTensor
+    var _test_labels: AnyTensor
     var _train_loaded: Bool
     var _test_loaded: Bool
 
@@ -133,7 +133,7 @@ struct CIFAR10Dataset(Copyable, Movable):
         """
         return 50000
 
-    fn __getitem__(mut self, index: Int) raises -> Tuple[ExTensor, ExTensor]:
+    fn __getitem__(mut self, index: Int) raises -> Tuple[AnyTensor, AnyTensor]:
         """Get a sample from the training set.
 
         Args:
@@ -141,8 +141,8 @@ struct CIFAR10Dataset(Copyable, Movable):
 
         Returns:
             Tuple of (image, label) where:
-                - image: ExTensor of shape (3, 32, 32) with float32 values.
-                - label: ExTensor of shape (1,) with uint8 class index.
+                - image: AnyTensor of shape (3, 32, 32) with float32 values.
+                - label: AnyTensor of shape (1,) with uint8 class index.
 
         Raises:
             Error: If index is out of bounds or data cannot be loaded.
@@ -179,8 +179,8 @@ struct CIFAR10Dataset(Copyable, Movable):
         Raises:
             Error: If batch files cannot be read or loaded
         """
-        var all_images: List[ExTensor] = []
-        var all_labels: List[ExTensor] = []
+        var all_images: List[AnyTensor] = []
+        var all_labels: List[AnyTensor] = []
 
         # Load 5 training batches
         for batch_num in range(1, 6):
@@ -194,13 +194,13 @@ struct CIFAR10Dataset(Copyable, Movable):
         self._train_labels = self._concatenate_tensors(all_labels)
         self._train_loaded = True
 
-    fn get_train_data(mut self) raises -> Tuple[ExTensor, ExTensor]:
+    fn get_train_data(mut self) raises -> Tuple[AnyTensor, AnyTensor]:
         """Get all training data.
 
         Returns:
             Tuple of (images, labels) where:
-                - images: ExTensor of shape (50000, 3, 32, 32) with float32 values.
-                - labels: ExTensor of shape (50000,) with uint8 class indices.
+                - images: AnyTensor of shape (50000, 3, 32, 32) with float32 values.
+                - labels: AnyTensor of shape (50000,) with uint8 class indices.
 
         Raises:
             Error: If data files cannot be loaded.
@@ -231,13 +231,13 @@ struct CIFAR10Dataset(Copyable, Movable):
         self._test_labels = labels
         self._test_loaded = True
 
-    fn get_test_data(mut self) raises -> Tuple[ExTensor, ExTensor]:
+    fn get_test_data(mut self) raises -> Tuple[AnyTensor, AnyTensor]:
         """Get all test data.
 
         Returns:
             Tuple of (images, labels) where:
-                - images: ExTensor of shape (10000, 3, 32, 32) with float32 values.
-                - labels: ExTensor of shape (10000,) with uint8 class indices.
+                - images: AnyTensor of shape (10000, 3, 32, 32) with float32 values.
+                - labels: AnyTensor of shape (10000,) with uint8 class indices.
 
         Raises:
             Error: If test data files cannot be loaded.
@@ -251,11 +251,11 @@ struct CIFAR10Dataset(Copyable, Movable):
 
         return (self._test_data, self._test_labels)
 
-    fn _concatenate_tensors(self, tensors: List[ExTensor]) raises -> ExTensor:
+    fn _concatenate_tensors(self, tensors: List[AnyTensor]) raises -> AnyTensor:
         """Concatenate a list of tensors along the first (batch) dimension.
 
         Args:
-            tensors: List of ExTensor objects with same shape except first dimension
+            tensors: List of AnyTensor objects with same shape except first dimension
 
         Returns:
             Concatenated tensor with first dimension equal to sum of input dimensions

--- a/shared/data/formats/cifar_loader.mojo
+++ b/shared/data/formats/cifar_loader.mojo
@@ -26,7 +26,7 @@ References:
 
 from collections import List
 from memory import UnsafePointer
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.data import (
     CIFAR10_IMAGE_SIZE,
     CIFAR10_CHANNELS,
@@ -121,7 +121,7 @@ struct CIFARLoader(Copyable, Movable):
         """
         return file_size // self.bytes_per_image
 
-    fn load_labels(self, filepath: String) raises -> ExTensor:
+    fn load_labels(self, filepath: String) raises -> AnyTensor:
         """Load labels from CIFAR binary format file.
 
         For CIFAR-10, returns shape (num_images,) with single label per image.
@@ -131,7 +131,7 @@ struct CIFARLoader(Copyable, Movable):
             filepath: Path to CIFAR binary file.
 
         Returns:
-            ExTensor containing labels.
+            AnyTensor containing labels.
 
         Raises:
             Error: If file cannot be read or format is invalid.
@@ -175,7 +175,7 @@ struct CIFARLoader(Copyable, Movable):
 
             return labels^
 
-    fn load_images(self, filepath: String) raises -> ExTensor:
+    fn load_images(self, filepath: String) raises -> AnyTensor:
         """Load images from CIFAR binary format file.
 
         Returns shape (num_images, channels, image_size, image_size) with uint8 pixel values.
@@ -185,7 +185,7 @@ struct CIFARLoader(Copyable, Movable):
             filepath: Path to CIFAR binary file.
 
         Returns:
-            ExTensor of shape (num_images, 3, 32, 32) with uint8 pixel values.
+            AnyTensor of shape (num_images, 3, 32, 32) with uint8 pixel values.
 
         Raises:
             Error: If file cannot be read or format is invalid.
@@ -227,7 +227,7 @@ struct CIFARLoader(Copyable, Movable):
 
         return images^
 
-    fn load_batch(self, filepath: String) raises -> Tuple[ExTensor, ExTensor]:
+    fn load_batch(self, filepath: String) raises -> Tuple[AnyTensor, AnyTensor]:
         """Load a complete batch of images and labels from CIFAR file.
 
         Convenience function that loads both images and labels in a single call.
@@ -237,8 +237,8 @@ struct CIFARLoader(Copyable, Movable):
 
         Returns:
             Tuple of (images, labels) where:
-            - images: ExTensor of shape (num_images, 3, 32, 32) with uint8 pixels.
-            - labels: ExTensor with shape (num_images,) for CIFAR-10 or (num_images, 2) for CIFAR-100.
+            - images: AnyTensor of shape (num_images, 3, 32, 32) with uint8 pixels.
+            - labels: AnyTensor with shape (num_images,) for CIFAR-10 or (num_images, 2) for CIFAR-100.
 
         Raises:
             Error: If file cannot be read or format is invalid.
@@ -246,4 +246,4 @@ struct CIFARLoader(Copyable, Movable):
         var images = self.load_images(filepath)
         var labels = self.load_labels(filepath)
 
-        return Tuple[ExTensor, ExTensor](images, labels)
+        return Tuple[AnyTensor, AnyTensor](images, labels)

--- a/shared/data/formats/idx_loader.mojo
+++ b/shared/data/formats/idx_loader.mojo
@@ -18,7 +18,7 @@ References:
     - IDX Format: http://yann.lecun.com/exdb/mnist/
 """
 
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from memory import UnsafePointer
 
 
@@ -40,14 +40,14 @@ fn read_uint32_be(data: UnsafePointer[UInt8], offset: Int) -> Int:
     return (b0 << 24) | (b1 << 16) | (b2 << 8) | b3
 
 
-fn load_idx_labels(filepath: String) raises -> ExTensor:
+fn load_idx_labels(filepath: String) raises -> AnyTensor:
     """Load labels from IDX file format.
 
     Args:
             filepath: Path to IDX labels file.
 
     Returns:
-            ExTensor of shape (num_samples,) with uint8 label values.
+            AnyTensor of shape (num_samples,) with uint8 label values.
 
     Raises:
             Error: If file format is invalid or cannot be read.
@@ -87,14 +87,14 @@ fn load_idx_labels(filepath: String) raises -> ExTensor:
     return labels^
 
 
-fn load_idx_images(filepath: String) raises -> ExTensor:
+fn load_idx_images(filepath: String) raises -> AnyTensor:
     """Load grayscale images from IDX file format.
 
     Args:
             filepath: Path to IDX grayscale images file.
 
     Returns:
-            ExTensor of shape (num_samples, 1, rows, cols) with uint8 pixel values.
+            AnyTensor of shape (num_samples, 1, rows, cols) with uint8 pixel values.
 
     Raises:
             Error: If file format is invalid or cannot be read.
@@ -144,14 +144,14 @@ fn load_idx_images(filepath: String) raises -> ExTensor:
     return images^
 
 
-fn load_idx_images_rgb(filepath: String) raises -> ExTensor:
+fn load_idx_images_rgb(filepath: String) raises -> AnyTensor:
     """Load RGB images from IDX file format.
 
     Args:
             filepath: Path to IDX RGB images file.
 
     Returns:
-            ExTensor of shape (num_samples, channels, rows, cols) with uint8 pixel values.
+            AnyTensor of shape (num_samples, channels, rows, cols) with uint8 pixel values.
 
     Raises:
             Error: If file format is invalid or cannot be read.
@@ -206,14 +206,14 @@ fn load_idx_images_rgb(filepath: String) raises -> ExTensor:
     return images^
 
 
-fn normalize_images(mut images: ExTensor) raises -> ExTensor:
+fn normalize_images(mut images: AnyTensor) raises -> AnyTensor:
     """Normalize uint8 images to float32 in range [0, 1].
 
     Args:
-            images: Input images as uint8 ExTensor.
+            images: Input images as uint8 AnyTensor.
 
     Returns:
-            Normalized images as float32 ExTensor.
+            Normalized images as float32 AnyTensor.
 
     Note:
             Converts pixel values from [0, 255] to [0.0, 1.0].
@@ -234,15 +234,15 @@ fn normalize_images(mut images: ExTensor) raises -> ExTensor:
     return normalized^
 
 
-fn one_hot_encode(labels: ExTensor, num_classes: Int) raises -> ExTensor:
+fn one_hot_encode(labels: AnyTensor, num_classes: Int) raises -> AnyTensor:
     """Convert integer labels to one-hot encoded float32 tensor.
 
     Args:
-            labels: Integer labels as uint8 ExTensor, shape (num_samples,).
+            labels: Integer labels as uint8 AnyTensor, shape (num_samples,).
             num_classes: Total number of classes.
 
     Returns:
-            One-hot encoded labels as float32 ExTensor, shape (num_samples, num_classes).
+            One-hot encoded labels as float32 AnyTensor, shape (num_samples, num_classes).
 
         Example:
             ```mojo
@@ -281,14 +281,14 @@ fn one_hot_encode(labels: ExTensor, num_classes: Int) raises -> ExTensor:
     return one_hot^
 
 
-fn normalize_images_rgb(mut images: ExTensor) raises -> ExTensor:
+fn normalize_images_rgb(mut images: AnyTensor) raises -> AnyTensor:
     """Normalize uint8 RGB images to float32 with ImageNet normalization.
 
     Args:
-            images: Input images as uint8 ExTensor of shape (N, 3, H, W).
+            images: Input images as uint8 AnyTensor of shape (N, 3, H, W).
 
     Returns:
-            Normalized images as float32 ExTensor.
+            Normalized images as float32 AnyTensor.
 
     Note:
             Applies ImageNet normalization:
@@ -346,7 +346,7 @@ fn normalize_images_rgb(mut images: ExTensor) raises -> ExTensor:
 
 fn load_cifar10_batch(
     batch_dir: String, batch_name: String
-) raises -> Tuple[ExTensor, ExTensor]:
+) raises -> Tuple[AnyTensor, AnyTensor]:
     """Load a single CIFAR-10 batch (images and labels) from IDX format.
 
     Args:
@@ -355,8 +355,8 @@ fn load_cifar10_batch(
 
     Returns:
             Tuple of (images, labels):
-            - images: ExTensor of shape (N, 3, 32, 32) normalized float32.
-            - labels: ExTensor of shape (N,) uint8.
+            - images: AnyTensor of shape (N, 3, 32, 32) normalized float32.
+            - labels: AnyTensor of shape (N,) uint8.
 
     Raises:
             Error: If batch files cannot be read.

--- a/shared/data/generic_transforms.mojo
+++ b/shared/data/generic_transforms.mojo
@@ -27,7 +27,7 @@ Example:
     ```
 """
 
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.data.transforms import Transform
 
 
@@ -56,7 +56,7 @@ struct IdentityTransform(Copyable, Movable, Transform):
         """Create identity transform."""
         pass
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Apply identity transform (passthrough).
 
         Args:
@@ -107,7 +107,7 @@ struct LambdaTransform(Copyable, Movable, Transform):
         """
         self.func = func
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Apply function to each element.
 
         Args:
@@ -126,7 +126,7 @@ struct LambdaTransform(Copyable, Movable, Transform):
             var transformed = self.func(value)
             result_values.append(transformed)
 
-        return ExTensor(result_values^)
+        return AnyTensor(result_values^)
 
 
 # ============================================================================
@@ -147,7 +147,7 @@ struct ConditionalTransform[T: Transform & Copyable & Movable](
 
     Example:
         ```mojo
-        >> fn is_large(tensor: ExTensor) -> Bool:
+        >> fn is_large(tensor: AnyTensor) -> Bool:
         ...     return tensor.num_elements() > 100
         >>>
         >>> var transform = ConditionalTransform(is_large, augment)
@@ -155,14 +155,14 @@ struct ConditionalTransform[T: Transform & Copyable & Movable](
         ```
     """
 
-    var predicate: fn (ExTensor) raises -> Bool
+    var predicate: fn (AnyTensor) raises -> Bool
     """Predicate function to evaluate on tensor."""
     var transform: Self.T
     """Transform to apply if predicate is true."""
 
     fn __init__(
         out self,
-        predicate: fn (ExTensor) raises -> Bool,
+        predicate: fn (AnyTensor) raises -> Bool,
         var transform: Self.T,
     ):
         """Create conditional transform.
@@ -174,7 +174,7 @@ struct ConditionalTransform[T: Transform & Copyable & Movable](
         self.predicate = predicate
         self.transform = transform^
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Apply transform if predicate is true.
 
         Args:
@@ -234,14 +234,14 @@ struct ClampTransform(Copyable, Movable, Transform):
         self.min_val = min_val
         self.max_val = max_val
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Clamp all values to [min_val, max_val].
 
         Args:
             data: Input tensor.
 
         Returns:
-            ExTensor with all values clamped to range.
+            AnyTensor with all values clamped to range.
 
         Raises:
             Error: If tensor creation fails.
@@ -259,7 +259,7 @@ struct ClampTransform(Copyable, Movable, Transform):
             else:
                 result_values.append(value)
 
-        return ExTensor(result_values^)
+        return AnyTensor(result_values^)
 
 
 # ============================================================================
@@ -295,7 +295,7 @@ struct DebugTransform(Copyable, Movable, Transform):
         """
         self.name = name
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Print tensor info and return unchanged.
 
         Args:
@@ -463,7 +463,7 @@ struct AnyTransform(Copyable, Movable, Transform):
         self._to_int32 = None
         self._sequential = transform^
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Apply the wrapped transform.
 
         Args:
@@ -532,14 +532,14 @@ struct SequentialTransform(Copyable, Movable, Transform):
         """
         self.transforms = transforms^
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Apply all transforms sequentially.
 
         Args:
             data: Input tensor.
 
         Returns:
-            ExTensor after all transforms applied.
+            AnyTensor after all transforms applied.
 
         Raises:
             Error: If any transform fails.
@@ -585,7 +585,7 @@ struct BatchTransform(Copyable, Movable):
 
     Example:
         ```mojo
-        >> var batch : List[ExTensor] = []
+        >> var batch : List[AnyTensor] = []
         >>> # ... fill batch ...
         >>>
         >>> var transform = BatchTransform(AnyTransform(normalize))
@@ -604,7 +604,7 @@ struct BatchTransform(Copyable, Movable):
         """
         self.transform = transform^
 
-    fn __call__(self, batch: List[ExTensor]) raises -> List[ExTensor]:
+    fn __call__(self, batch: List[AnyTensor]) raises -> List[AnyTensor]:
         """Apply transform to each tensor in batch.
 
         Args:
@@ -616,7 +616,7 @@ struct BatchTransform(Copyable, Movable):
         Raises:
             Error: If any transform fails.
         """
-        var results = List[ExTensor](capacity=len(batch))
+        var results = List[AnyTensor](capacity=len(batch))
 
         for i in range(len(batch)):
             var transformed = self.transform(batch[i])
@@ -658,26 +658,26 @@ struct ToFloat32(Copyable, Movable, Transform):
         """Create ToFloat32 converter."""
         pass
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Convert to Float32.
 
         Args:
             data: Input tensor.
 
         Returns:
-            ExTensor with all values as Float32.
+            AnyTensor with all values as Float32.
 
         Raises:
             Error: If tensor creation fails.
         """
-        # ExTensor is already Float32 in current implementation
+        # AnyTensor is already Float32 in current implementation
         # Just create a copy with Float32 values
         var result_values = List[Float32](capacity=data.num_elements())
 
         for i in range(data.num_elements()):
             result_values.append(Float32(data[i]))
 
-        return ExTensor(result_values^)
+        return AnyTensor(result_values^)
 
 
 struct ToInt32(Copyable, Movable, Transform):
@@ -701,14 +701,14 @@ struct ToInt32(Copyable, Movable, Transform):
         """Create ToInt32 converter."""
         pass
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Convert to Int32 (truncate).
 
         Args:
             data: Input tensor.
 
         Returns:
-            ExTensor with all values truncated to Int32.
+            AnyTensor with all values truncated to Int32.
 
         Raises:
             Error: If tensor creation fails.
@@ -724,7 +724,7 @@ struct ToInt32(Copyable, Movable, Transform):
             var int_value = Int(value)
             result_values.append(Float32(int_value))
 
-        return ExTensor(result_values^)
+        return AnyTensor(result_values^)
 
 
 # ============================================================================
@@ -733,8 +733,8 @@ struct ToInt32(Copyable, Movable, Transform):
 
 
 fn apply_to_tensor(
-    data: ExTensor, func: fn (Float32) -> Float32
-) raises -> ExTensor:
+    data: AnyTensor, func: fn (Float32) -> Float32
+) raises -> AnyTensor:
     """Apply function element-wise to tensor.
 
     Helper function for creating ad-hoc transforms without
@@ -745,7 +745,7 @@ fn apply_to_tensor(
         func: Function to apply to each element.
 
     Returns:
-        ExTensor with function applied element-wise to all values.
+        AnyTensor with function applied element-wise to all values.
 
     Raises:
         Error: If tensor creation fails.

--- a/shared/data/loaders.mojo
+++ b/shared/data/loaders.mojo
@@ -4,7 +4,7 @@ This module provides the main DataLoader class and related utilities
 for efficient batch loading during training.
 """
 
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.data._datasets_core import Dataset
 from shared.data.samplers import Sampler, SequentialSampler, RandomSampler
 
@@ -20,9 +20,9 @@ struct Batch(Copyable, Movable):
     Holds data and labels for a batch, along with batch metadata.
     """
 
-    var data: ExTensor
+    var data: AnyTensor
     """Batch data tensor."""
-    var labels: ExTensor
+    var labels: AnyTensor
     """Batch labels tensor."""
     var batch_size: Int
     """Number of samples in the batch."""
@@ -31,8 +31,8 @@ struct Batch(Copyable, Movable):
 
     fn __init__(
         out self,
-        var data: ExTensor,
-        var labels: ExTensor,
+        var data: AnyTensor,
+        var labels: AnyTensor,
         var indices: List[Int],
     ) raises:
         """Create a batch.
@@ -214,8 +214,8 @@ struct BatchLoader[
                 break
 
             # Load batch data
-            var batch_data = List[ExTensor](capacity=len(batch_indices))
-            var batch_labels = List[ExTensor](capacity=len(batch_indices))
+            var batch_data = List[AnyTensor](capacity=len(batch_indices))
+            var batch_labels = List[AnyTensor](capacity=len(batch_indices))
 
             for idx in batch_indices:
                 var sample = self.dataset.__getitem__(idx)
@@ -231,7 +231,7 @@ struct BatchLoader[
 
         return batches^
 
-    fn _stack_tensors(self, tensors: List[ExTensor]) raises -> ExTensor:
+    fn _stack_tensors(self, tensors: List[AnyTensor]) raises -> AnyTensor:
         """Stack list of tensors into a batch tensor.
 
         Creates a new tensor with shape [batch_size, *tensor_shape] by
@@ -243,7 +243,7 @@ struct BatchLoader[
             tensors: List of tensors to stack.
 
         Returns:
-            ExTensor with batch dimension prepended (shape: [batch_size, *tensor_shape]).
+            AnyTensor with batch dimension prepended (shape: [batch_size, *tensor_shape]).
 
         Raises:
             Error: If tensors list is empty or tensors have incompatible shapes.
@@ -306,6 +306,6 @@ struct BatchLoader[
                 stacked_data.append(Float32(tensors[tensor_idx][elem_idx]))
 
         # Create output tensor from the list
-        var stacked = ExTensor(stacked_data^)
+        var stacked = AnyTensor(stacked_data^)
 
         return stacked^

--- a/shared/data/prefetch.mojo
+++ b/shared/data/prefetch.mojo
@@ -11,16 +11,16 @@ by separating data preparation from training iterations. Future versions
 can be upgraded to async when Mojo adds these primitives.
 
 Example:
-    from shared.data import ExTensorDataset, BatchLoader, RandomSampler
+    from shared.data import AnyTensorDataset, BatchLoader, RandomSampler
     from shared.data.prefetch import PrefetchDataLoader
 
-    var dataset = ExTensorDataset(images, labels)
+    var dataset = AnyTensorDataset(images, labels)
     var sampler = RandomSampler(dataset.__len__())
     var loader = BatchLoader(dataset, sampler, batch_size=32)
     var prefetch_loader = PrefetchDataLoader(loader, prefetch_factor=2)
 """
 
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.data.loaders import Batch, BatchLoader
 from shared.data.datasets import Dataset
 from shared.data.samplers import Sampler
@@ -32,7 +32,7 @@ struct PrefetchBuffer(Copyable, Movable):
     Manages a fixed-size buffer of batches. Currently uses synchronous
     pre-computation. Can be upgraded to async when Mojo adds Task primitives.
 
-    Note: Batch storage requires careful memory management since ExTensor
+    Note: Batch storage requires careful memory management since AnyTensor
     uses heap allocation. This buffer owns the batches until consumption.
     """
 
@@ -131,7 +131,7 @@ struct PrefetchDataLoader[
 
     Example:
         ```mojo
-        var dataset = ExTensorDataset(images, labels)
+        var dataset = AnyTensorDataset(images, labels)
         var sampler = RandomSampler(dataset.__len__())
         var loader = BatchLoader(dataset, sampler, batch_size=32)
 

--- a/shared/data/text_transforms.mojo
+++ b/shared/data/text_transforms.mojo
@@ -27,7 +27,7 @@ trait TextTransform:
     """Base interface for text transforms.
 
     Text transforms modify string data and return transformed copies.
-    Unlike the Transform trait which works with ExTensor, this works with String.
+    Unlike the Transform trait which works with AnyTensor, this works with String.
     """
 
     fn __call__(self, text: String) raises -> String:

--- a/shared/data/transforms.mojo
+++ b/shared/data/transforms.mojo
@@ -5,14 +5,14 @@ This module provides transformations for preprocessing and augmenting data.
 IMPORTANT LIMITATIONS:
 - Image transforms assume square images (H = W)
 - Default assumption: 3 channels (RGB)
-- ExTensor layout: Flattened (H, W, C) with channels-last
+- AnyTensor layout: Flattened (H, W, C) with channels-last
 - For non-square or grayscale images, dimensions must be manually validated
 
-These limitations are due to Mojo's current ExTensor API not exposing shape metadata.
+These limitations are due to Mojo's current AnyTensor API not exposing shape metadata.
 Future versions may support arbitrary image dimensions.
 """
 
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from math import sqrt, floor, ceil, sin, cos
 from random import random_si64
 from shared.data.random_transform_base import RandomTransformBase, random_float
@@ -24,7 +24,7 @@ from shared.data.random_transform_base import RandomTransformBase, random_float
 
 
 fn infer_image_dimensions(
-    data: ExTensor, channels: Int = 3
+    data: AnyTensor, channels: Int = 3
 ) raises -> Tuple[Int, Int, Int]:
     """Infer image dimensions from flattened tensor.
 
@@ -59,7 +59,7 @@ fn infer_image_dimensions(
             return (size, size, 1)
 
     # Neither worked - raise error
-    raise Error("ExTensor size doesn't match square image assumption")
+    raise Error("AnyTensor size doesn't match square image assumption")
 
 
 # ============================================================================
@@ -73,7 +73,7 @@ trait Transform(Copyable, Movable):
     Transforms modify data in-place or return transformed copies.
     """
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Apply the transform to data.
 
         Args:
@@ -117,7 +117,7 @@ struct Compose[T: Transform & Copyable & Movable](Copyable, Movable, Transform):
         """
         self.transforms = transforms^
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Apply all transforms sequentially.
 
         Args:
@@ -152,21 +152,21 @@ comptime Pipeline[T: Transform & Copyable & Movable] = Compose[T]
 
 
 # ============================================================================
-# ExTensor Transforms
+# AnyTensor Transforms
 # ============================================================================
 
 
-struct ToExTensor(Copyable, Movable, Transform):
+struct ToAnyTensor(Copyable, Movable, Transform):
     """Convert data to tensor format.
 
     Ensures data is in tensor format with appropriate dtype.
     """
 
     fn __init__(out self):
-        """Create ToExTensor converter."""
+        """Create ToAnyTensor converter."""
         pass
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Convert to tensor.
 
         Args:
@@ -203,7 +203,7 @@ struct Normalize(Copyable, Movable, Transform):
         self.mean = mean
         self.std = std
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Normalize tensor by subtracting mean and dividing by std.
 
         Applies the formula: (data - mean) / std to all elements.
@@ -230,7 +230,7 @@ struct Normalize(Copyable, Movable, Transform):
             normalized.append(Float32(norm_value))
 
         # Create tensor from normalized values
-        return ExTensor(normalized^)
+        return AnyTensor(normalized^)
 
 
 struct Reshape(Copyable, Movable, Transform):
@@ -250,7 +250,7 @@ struct Reshape(Copyable, Movable, Transform):
         """
         self.target_shape = target_shape^
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Reshape tensor to target shape.
 
         Validates that the total number of elements remains the same.
@@ -287,7 +287,7 @@ struct Reshape(Copyable, Movable, Transform):
             reshaped_data.append(Float32(data[i]))
 
         # Create output tensor from the list
-        var reshaped = ExTensor(reshaped_data^)
+        var reshaped = AnyTensor(reshaped_data^)
 
         return reshaped^
 
@@ -320,7 +320,7 @@ struct Resize(Copyable, Movable, Transform):
         self.size = size
         self.interpolation = interpolation
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Resize image tensor using bilinear interpolation.
 
         Resizes spatial dimensions (H, W) while preserving channels (C).
@@ -407,7 +407,7 @@ struct Resize(Copyable, Movable, Transform):
                     resized_data.append(Float32(v))
 
         # Create output tensor from the list
-        var resized = ExTensor(resized_data^)
+        var resized = AnyTensor(resized_data^)
 
         return resized^
 
@@ -429,7 +429,7 @@ struct CenterCrop(Copyable, Movable, Transform):
         """
         self.size = size
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Center crop image to target size.
 
         Extracts a center rectangle from a 2D image tensor.
@@ -474,7 +474,7 @@ struct CenterCrop(Copyable, Movable, Transform):
                     ) * channels + c
                     cropped.append(Float32(data[src_idx]))
 
-        return ExTensor(cropped^)
+        return AnyTensor(cropped^)
 
 
 struct RandomCrop(Copyable, Movable, Transform):
@@ -498,7 +498,7 @@ struct RandomCrop(Copyable, Movable, Transform):
         self.size = size
         self.padding = padding
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Random crop image to target size.
 
         Extracts a random rectangle from a 2D image tensor.
@@ -576,7 +576,7 @@ struct RandomCrop(Copyable, Movable, Transform):
                         # Out of bounds (in padding region), fill with 0
                         cropped.append(Float32(0.0))
 
-        return ExTensor(cropped^)
+        return AnyTensor(cropped^)
 
 
 struct RandomHorizontalFlip(Copyable, Movable, Transform):
@@ -596,7 +596,7 @@ struct RandomHorizontalFlip(Copyable, Movable, Transform):
         """
         self.base = RandomTransformBase(p)
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Randomly flip image horizontally with probability p.
 
         Flips the image along the width dimension (reverses each row).
@@ -637,7 +637,7 @@ struct RandomHorizontalFlip(Copyable, Movable, Transform):
                     var src_idx = (h * width + w_orig) * channels + c
                     flipped.append(Float32(data[src_idx]))
 
-        return ExTensor(flipped^)
+        return AnyTensor(flipped^)
 
 
 struct RandomVerticalFlip(Copyable, Movable, Transform):
@@ -657,7 +657,7 @@ struct RandomVerticalFlip(Copyable, Movable, Transform):
         """
         self.base = RandomTransformBase(p)
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Randomly flip image vertically with probability p.
 
         Flips the image along the height dimension (reverses rows).
@@ -698,7 +698,7 @@ struct RandomVerticalFlip(Copyable, Movable, Transform):
                     var src_idx = (h_orig * width + w) * channels + c
                     flipped.append(Float32(data[src_idx]))
 
-        return ExTensor(flipped^)
+        return AnyTensor(flipped^)
 
 
 struct RandomRotation(Copyable, Movable, Transform):
@@ -724,7 +724,7 @@ struct RandomRotation(Copyable, Movable, Transform):
         self.degrees = degrees
         self.fill_value = fill_value
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Randomly rotate image within specified degree range.
 
         Performs rotation around image center using nearest-neighbor sampling.
@@ -802,7 +802,7 @@ struct RandomRotation(Copyable, Movable, Transform):
                         # Fill with fill_value for out-of-bounds pixels
                         rotated.append(Float32(self.fill_value))
 
-        return ExTensor(rotated^)
+        return AnyTensor(rotated^)
 
 
 struct RandomErasing(Copyable, Movable, Transform):
@@ -845,7 +845,7 @@ struct RandomErasing(Copyable, Movable, Transform):
         self.ratio = ratio
         self.value = value
 
-    fn __call__(self, data: ExTensor) raises -> ExTensor:
+    fn __call__(self, data: AnyTensor) raises -> AnyTensor:
         """Apply random erasing with probability p.
 
         Randomly erases a rectangular region from the image by:
@@ -940,4 +940,4 @@ struct RandomErasing(Copyable, Movable, Transform):
             else:
                 result.append(Float32(data[i]))
 
-        return ExTensor(result^)
+        return AnyTensor(result^)

--- a/shared/testing/assertions.mojo
+++ b/shared/testing/assertions.mojo
@@ -41,7 +41,7 @@ Functions:
 
 from math import isnan, isinf
 from collections.optional import Optional
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.testing.tolerance_constants import (
     TOLERANCE_DEFAULT,
     TOLERANCE_FLOAT32,
@@ -450,7 +450,7 @@ fn assert_shape_equal(
 
 
 fn assert_not_equal_tensor(
-    a: ExTensor, b: ExTensor, message: String = ""
+    a: AnyTensor, b: AnyTensor, message: String = ""
 ) raises:
     """Assert two tensors are not equal element-wise.
 
@@ -495,8 +495,8 @@ fn assert_not_equal_tensor(
         raise Error(error_msg)
 
 
-fn assert_tensor_equal(a: ExTensor, b: ExTensor, message: String = "") raises:
-    """Assert two ExTensors are equal (shape and all elements).
+fn assert_tensor_equal(a: AnyTensor, b: AnyTensor, message: String = "") raises:
+    """Assert two AnyTensors are equal (shape and all elements).
 
     Args:
             a: First tensor.
@@ -543,12 +543,12 @@ fn assert_tensor_equal(a: ExTensor, b: ExTensor, message: String = "") raises:
 
 
 fn assert_shape(
-    tensor: ExTensor, expected: List[Int], message: String = ""
+    tensor: AnyTensor, expected: List[Int], message: String = ""
 ) raises:
     """Assert tensor has expected shape.
 
     Args:
-            tensor: ExTensor to check.
+            tensor: AnyTensor to check.
             expected: Expected shape as List.
             message: Optional error message.
 
@@ -582,11 +582,11 @@ fn assert_shape(
             raise Error(error_msg)
 
 
-fn assert_dtype(tensor: ExTensor, expected: DType, message: String = "") raises:
+fn assert_dtype(tensor: AnyTensor, expected: DType, message: String = "") raises:
     """Assert tensor has expected dtype.
 
     Args:
-            tensor: ExTensor to check.
+            tensor: AnyTensor to check.
             expected: Expected DType.
             message: Optional error message.
 
@@ -601,11 +601,11 @@ fn assert_dtype(tensor: ExTensor, expected: DType, message: String = "") raises:
         raise Error(error_msg)
 
 
-fn assert_numel(tensor: ExTensor, expected: Int, message: String = "") raises:
+fn assert_numel(tensor: AnyTensor, expected: Int, message: String = "") raises:
     """Assert tensor has expected number of elements.
 
     Args:
-            tensor: ExTensor to check.
+            tensor: AnyTensor to check.
             expected: Expected total element count.
             message: Optional error message.
 
@@ -620,11 +620,11 @@ fn assert_numel(tensor: ExTensor, expected: Int, message: String = "") raises:
         raise Error(error_msg)
 
 
-fn assert_dim(tensor: ExTensor, expected: Int, message: String = "") raises:
+fn assert_dim(tensor: AnyTensor, expected: Int, message: String = "") raises:
     """Assert tensor has expected number of dimensions.
 
     Args:
-            tensor: ExTensor to check.
+            tensor: AnyTensor to check.
             expected: Expected dimension count.
             message: Optional error message.
 
@@ -648,7 +648,7 @@ fn assert_dim(tensor: ExTensor, expected: Int, message: String = "") raises:
 
 
 fn assert_value_at(
-    tensor: ExTensor,
+    tensor: AnyTensor,
     index: Int,
     expected: Float64,
     tolerance: Float64 = TOLERANCE_DEFAULT,
@@ -657,7 +657,7 @@ fn assert_value_at(
     """Assert tensor value at flat index matches expected value.
 
     Args:
-            tensor: ExTensor to check.
+            tensor: AnyTensor to check.
             index: Flat index to check.
             expected: Expected value.
             tolerance: Acceptable difference (default: 1e-6).
@@ -688,7 +688,7 @@ fn assert_value_at(
 
 
 fn assert_all_values(
-    tensor: ExTensor,
+    tensor: AnyTensor,
     expected: Float64,
     tolerance: Float64 = TOLERANCE_DEFAULT,
     message: String = "",
@@ -696,7 +696,7 @@ fn assert_all_values(
     """Assert all tensor values match expected constant.
 
     Args:
-            tensor: ExTensor to check.
+            tensor: AnyTensor to check.
             expected: Expected constant value.
             tolerance: Acceptable difference (default: 1e-6).
             message: Optional error message.
@@ -724,8 +724,8 @@ fn assert_all_values(
 
 
 fn assert_all_close(
-    a: ExTensor,
-    b: ExTensor,
+    a: AnyTensor,
+    b: AnyTensor,
     tolerance: Float64 = TOLERANCE_DEFAULT,
     message: String = "",
 ) raises:
@@ -812,11 +812,11 @@ fn assert_type[T: AnyType](value: T, expected_type: String) raises:
     pass
 
 
-fn assert_contiguous(tensor: ExTensor, message: String = "") raises:
+fn assert_contiguous(tensor: AnyTensor, message: String = "") raises:
     """Assert tensor has contiguous memory layout.
 
     Args:
-            tensor: ExTensor to check.
+            tensor: AnyTensor to check.
             message: Optional error message.
 
     Raises:
@@ -834,7 +834,7 @@ fn assert_contiguous(tensor: ExTensor, message: String = "") raises:
 
 fn assert_matrices_equal[
     dtype: DType
-](a: ExTensor, b: ExTensor, rtol: Float64 = 1e-5, atol: Float64 = 1e-8) raises:
+](a: AnyTensor, b: AnyTensor, rtol: Float64 = 1e-5, atol: Float64 = 1e-8) raises:
     """Compare two matrices element-wise with relative and absolute tolerance.
 
     This is the canonical shared implementation for correctness verification

--- a/shared/testing/data_generators.mojo
+++ b/shared/testing/data_generators.mojo
@@ -10,7 +10,7 @@ behavior across different input distributions and dataset characteristics.
 
 Example:
     from shared.testing import random_tensor, random_normal, synthetic_classification_data
-    from shared.core import ExTensor
+    from shared.core import AnyTensor
 
     # Create a random tensor
     var weights = random_tensor([10, 5], DType.float32)
@@ -25,7 +25,7 @@ Example:
 
 from random import random_float64
 from math import sqrt, log, cos, sin, pi
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 
 
 # ============================================================================
@@ -35,7 +35,7 @@ from shared.core import ExTensor, zeros
 
 fn random_tensor(
     shape: List[Int], dtype: DType = DType.float32
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Generate tensor with random values from uniform distribution [0, 1).
 
     Args:
@@ -43,7 +43,7 @@ fn random_tensor(
             dtype: Data type of tensor elements (default: float32).
 
     Returns:
-            ExTensor with random values uniformly distributed in [0, 1).
+            AnyTensor with random values uniformly distributed in [0, 1).
 
     Example:
         ```mojo
@@ -100,7 +100,7 @@ fn random_uniform(
     low: Float64 = 0.0,
     high: Float64 = 1.0,
     dtype: DType = DType.float32,
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Generate tensor with random values from uniform distribution [low, high).
 
     Args:
@@ -110,7 +110,7 @@ fn random_uniform(
             dtype: Data type of tensor elements (default: float32).
 
     Returns:
-            ExTensor with random values uniformly distributed in [low, high)
+            AnyTensor with random values uniformly distributed in [low, high)
 
         Example:
             ```mojo
@@ -171,7 +171,7 @@ fn random_normal(
     mean: Float64 = 0.0,
     std: Float64 = 1.0,
     dtype: DType = DType.float32,
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Generate tensor with random values from normal distribution N(mean, std^2).
 
         Uses Box-Muller transform to convert uniform random values to normal distribution
@@ -183,7 +183,7 @@ fn random_normal(
             dtype: Data type of tensor elements (default: float32).
 
     Returns:
-            ExTensor with random values from normal distribution N(mean, std^2)
+            AnyTensor with random values from normal distribution N(mean, std^2)
 
         Example:
             ```mojo
@@ -261,7 +261,7 @@ fn synthetic_classification_data(
     num_features: Int,
     num_classes: Int,
     dtype: DType = DType.float32,
-) raises -> Tuple[ExTensor, ExTensor]:
+) raises -> Tuple[AnyTensor, AnyTensor]:
     """Generate synthetic classification dataset.
 
         Creates a random dataset with linearly separable classes by generating
@@ -275,8 +275,8 @@ fn synthetic_classification_data(
 
     Returns:
             Tuple of (features, labels) where:
-            - features: ExTensor of shape [num_samples, num_features]
-            - labels: ExTensor of shape [num_samples] with values in [0, num_classes)
+            - features: AnyTensor of shape [num_samples, num_features]
+            - labels: AnyTensor of shape [num_samples] with values in [0, num_classes)
 
         Example:
             ```mojo
@@ -338,4 +338,4 @@ fn synthetic_classification_data(
             var features_idx = sample_idx * num_features + feat_idx
             features._set_float64(features_idx, feature_val)
 
-    return Tuple[ExTensor, ExTensor](features^, labels^)
+    return Tuple[AnyTensor, AnyTensor](features^, labels^)

--- a/shared/testing/fixtures.mojo
+++ b/shared/testing/fixtures.mojo
@@ -30,7 +30,7 @@ Example:
     ```
 """
 
-from shared.core import ExTensor, zeros, ones, full, zeros_like
+from shared.core import AnyTensor, zeros, ones, full, zeros_like
 from shared.testing.models import SimpleCNN, LinearModel
 
 
@@ -91,7 +91,7 @@ fn create_linear_model(
 
 fn create_test_input(
     batch_size: Int, in_features: Int, dtype: DType = DType.float32
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Create a test input tensor for linear models.
 
         Creates a simple tensor filled with ones for testing
@@ -122,7 +122,7 @@ fn create_test_input(
 
 fn create_test_targets(
     batch_size: Int, num_classes: Int, dtype: DType = DType.int32
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Create a test target tensor for classification.
 
         Creates a tensor filled with zeros for testing
@@ -149,7 +149,7 @@ fn create_test_targets(
     return zeros(shape, dtype)
 
 
-fn assert_tensor_shape(tensor: ExTensor, expected_shape: List[Int]) -> Bool:
+fn assert_tensor_shape(tensor: AnyTensor, expected_shape: List[Int]) -> Bool:
     """Validate tensor has expected shape.
 
     Args:
@@ -175,7 +175,7 @@ fn assert_tensor_shape(tensor: ExTensor, expected_shape: List[Int]) -> Bool:
     return True
 
 
-fn assert_tensor_dtype(tensor: ExTensor, expected_dtype: DType) -> Bool:
+fn assert_tensor_dtype(tensor: AnyTensor, expected_dtype: DType) -> Bool:
     """Validate tensor has expected data type.
 
     Args:
@@ -194,7 +194,7 @@ fn assert_tensor_dtype(tensor: ExTensor, expected_dtype: DType) -> Bool:
     return tensor._dtype == expected_dtype
 
 
-fn assert_tensor_all_finite(tensor: ExTensor) -> Bool:
+fn assert_tensor_all_finite(tensor: AnyTensor) -> Bool:
     """Check if all tensor values are finite (no NaN or Inf).
 
     Args:
@@ -221,7 +221,7 @@ fn assert_tensor_all_finite(tensor: ExTensor) -> Bool:
     return True
 
 
-fn assert_tensor_not_all_zeros(tensor: ExTensor) -> Bool:
+fn assert_tensor_not_all_zeros(tensor: AnyTensor) -> Bool:
     """Check if tensor contains at least one non-zero value.
 
         Useful for verifying weights are initialized and gradients are flowing.

--- a/shared/testing/fuzz_core.mojo
+++ b/shared/testing/fuzz_core.mojo
@@ -49,7 +49,7 @@ Example:
 
 from random import random_float64, seed as random_seed
 from math import isnan, isinf
-from shared.core import ExTensor, zeros, ones, full
+from shared.core import AnyTensor, zeros, ones, full
 
 
 # ============================================================================
@@ -327,7 +327,7 @@ fn create_random_tensor(
     dtype: DType,
     low: Float64 = -1.0,
     high: Float64 = 1.0,
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Create tensor with random values.
 
     Generates a tensor filled with random values uniformly distributed
@@ -341,7 +341,7 @@ fn create_random_tensor(
         high: Maximum value (exclusive).
 
     Returns:
-        ExTensor filled with random values.
+        AnyTensor filled with random values.
 
     Raises:
         Error: If tensor creation fails.
@@ -369,7 +369,7 @@ fn create_random_tensor(
 
 fn create_edge_case_tensor(
     shape: List[Int], dtype: DType, edge_type: String
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Create tensor filled with edge case values.
 
     Generates tensors with special numeric values for testing edge cases.
@@ -388,7 +388,7 @@ fn create_edge_case_tensor(
             - "mixed": Mix of edge case values.
 
     Returns:
-        ExTensor filled with edge case values.
+        AnyTensor filled with edge case values.
 
     Raises:
         Error: If tensor creation fails or unknown edge_type.
@@ -469,7 +469,7 @@ fn create_edge_case_tensor(
 # ============================================================================
 
 
-fn has_nan(tensor: ExTensor) -> Bool:
+fn has_nan(tensor: AnyTensor) -> Bool:
     """Check if tensor contains any NaN values.
 
     Args:
@@ -491,7 +491,7 @@ fn has_nan(tensor: ExTensor) -> Bool:
     return False
 
 
-fn has_inf(tensor: ExTensor) -> Bool:
+fn has_inf(tensor: AnyTensor) -> Bool:
     """Check if tensor contains any infinity values.
 
     Args:
@@ -513,7 +513,7 @@ fn has_inf(tensor: ExTensor) -> Bool:
     return False
 
 
-fn is_finite(tensor: ExTensor) -> Bool:
+fn is_finite(tensor: AnyTensor) -> Bool:
     """Check if all tensor values are finite (not NaN or Inf).
 
     Args:
@@ -535,7 +535,7 @@ fn is_finite(tensor: ExTensor) -> Bool:
     return True
 
 
-fn all_values_in_range(tensor: ExTensor, low: Float64, high: Float64) -> Bool:
+fn all_values_in_range(tensor: AnyTensor, low: Float64, high: Float64) -> Bool:
     """Check if all tensor values are within specified range.
 
     Args:
@@ -599,7 +599,7 @@ struct NumericInvariants(Copyable, Movable):
 
 
 fn check_numeric_invariants(
-    tensor: ExTensor, allow_nan: Bool = False, allow_inf: Bool = False
+    tensor: AnyTensor, allow_nan: Bool = False, allow_inf: Bool = False
 ) -> NumericInvariants:
     """Check numeric invariants on a tensor.
 
@@ -660,7 +660,7 @@ fn check_numeric_invariants(
 # ============================================================================
 
 
-fn verify_shape_preserved(original: ExTensor, result: ExTensor) -> Bool:
+fn verify_shape_preserved(original: AnyTensor, result: AnyTensor) -> Bool:
     """Verify that operation preserved tensor shape.
 
     Args:
@@ -690,7 +690,7 @@ fn verify_shape_preserved(original: ExTensor, result: ExTensor) -> Bool:
     return True
 
 
-fn verify_dtype_preserved(original: ExTensor, result: ExTensor) -> Bool:
+fn verify_dtype_preserved(original: AnyTensor, result: AnyTensor) -> Bool:
     """Verify that operation preserved tensor dtype.
 
     Args:
@@ -710,7 +710,7 @@ fn verify_dtype_preserved(original: ExTensor, result: ExTensor) -> Bool:
     return original.dtype() == result.dtype()
 
 
-fn verify_numel_preserved(original: ExTensor, result: ExTensor) -> Bool:
+fn verify_numel_preserved(original: AnyTensor, result: AnyTensor) -> Bool:
     """Verify that operation preserved number of elements.
 
     Args:

--- a/shared/testing/gradient_checker.mojo
+++ b/shared/testing/gradient_checker.mojo
@@ -17,10 +17,10 @@ Benefits:
 Usage:
     from shared.testing.gradient_checker import check_gradients
 
-    fn forward(x: ExTensor) -> ExTensor:
+    fn forward(x: AnyTensor) -> AnyTensor:
         return relu(x)
 
-    fn backward(grad_out: ExTensor, x: ExTensor) -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) -> AnyTensor:
         return relu_backward(grad_out, x)
 
     var input = randn([3, 4], DType.float32)
@@ -37,7 +37,7 @@ References:
     - Goodfellow et al., Deep Learning, Chapter 4.3
 """
 
-from shared.core import ExTensor, zeros_like
+from shared.core import AnyTensor, zeros_like
 
 
 # ============================================================================
@@ -63,7 +63,7 @@ struct IndexGradientPair(Copyable, Movable):
     var gradient: Float64
 
 
-fn _is_uniform_tensor(tensor: ExTensor) -> Bool:
+fn _is_uniform_tensor(tensor: AnyTensor) -> Bool:
     """Check if all elements in a tensor have the same value (uniform tensor).
 
     Args:
@@ -93,9 +93,9 @@ fn _is_uniform_tensor(tensor: ExTensor) -> Bool:
 
 
 fn check_gradients(
-    forward_fn: fn (ExTensor) raises escaping -> ExTensor,
-    backward_fn: fn (ExTensor, ExTensor) raises escaping -> ExTensor,
-    input: ExTensor,
+    forward_fn: fn (AnyTensor) raises escaping -> AnyTensor,
+    backward_fn: fn (AnyTensor, AnyTensor) raises escaping -> AnyTensor,
+    input: AnyTensor,
     epsilon: Float64 = 3e-4,  # Changed from 1e-5 - see #2704
     tolerance: Float64 = 1e-2,
 ) raises -> Bool:
@@ -130,10 +130,10 @@ fn check_gradients(
 
         Example:
             ```mojo
-            fn my_forward(x: ExTensor) -> ExTensor:
+            fn my_forward(x: AnyTensor) -> AnyTensor:
                 return x * x  # f(x) = x²
 
-            fn my_backward(grad_out: ExTensor, x: ExTensor) -> ExTensor:
+            fn my_backward(grad_out: AnyTensor, x: AnyTensor) -> AnyTensor:
                 return multiply(grad_out, multiply(x, full_like(x, 2.0)))  # f'(x) = 2x
 
             var x = full([3, 4], 2.0, DType.float32)
@@ -227,9 +227,9 @@ fn check_gradients(
 
 
 fn check_gradients_verbose(
-    forward_fn: fn (ExTensor) raises escaping -> ExTensor,
-    backward_fn: fn (ExTensor, ExTensor) raises escaping -> ExTensor,
-    input: ExTensor,
+    forward_fn: fn (AnyTensor) raises escaping -> AnyTensor,
+    backward_fn: fn (AnyTensor, AnyTensor) raises escaping -> AnyTensor,
+    input: AnyTensor,
     epsilon: Float64 = 3e-4,  # Changed from 1e-5 - see #2704
     tolerance: Float64 = 1e-2,
     print_all: Bool = False,
@@ -358,10 +358,10 @@ fn relative_error(analytical: Float64, numerical: Float64) -> Float64:
 
 
 fn compute_numerical_gradient(
-    forward_fn: fn (ExTensor) raises escaping -> ExTensor,
-    x: ExTensor,
+    forward_fn: fn (AnyTensor) raises escaping -> AnyTensor,
+    x: AnyTensor,
     epsilon: Float64 = 3e-4,  # Changed from 1e-5 - see #2704
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Compute numerical gradient using finite differences.
 
         Uses central difference formula: ∇f(x) ≈ (f(x + ε) - f(x - ε)) / 2ε.
@@ -371,12 +371,12 @@ fn compute_numerical_gradient(
         differences, making it much more accurate.
 
     Args:
-            forward_fn: Function that computes forward pass (takes ExTensor, returns ExTensor).
+            forward_fn: Function that computes forward pass (takes AnyTensor, returns AnyTensor).
             x: Input tensor at which to compute gradient.
             epsilon: Small perturbation for finite differences (default: 1e-5).
 
     Returns:
-            ExTensor containing numerical gradient, same shape as x.
+            AnyTensor containing numerical gradient, same shape as x.
 
     Raises:
             Error: If forward function fails or dtypes are incompatible.
@@ -396,10 +396,10 @@ fn compute_numerical_gradient(
         Example:
             ```mojo
              Validate ReLU gradient
-            fn relu_forward(x: ExTensor) raises -> ExTensor:
+            fn relu_forward(x: AnyTensor) raises -> AnyTensor:
                 return relu(x)
 
-            var x = ExTensor(List[Int](), DType.float32)
+            var x = AnyTensor(List[Int](), DType.float32)
             var numerical_grad = compute_numerical_gradient(relu_forward, x)
             var analytical_grad = relu_backward(ones_like(x), x)
             assert_gradients_close(analytical_grad, numerical_grad, rtol=1e-4)
@@ -447,8 +447,8 @@ fn compute_numerical_gradient(
 
 
 fn compute_sampled_numerical_gradient(
-    forward_fn: fn (ExTensor) raises escaping -> ExTensor,
-    x: ExTensor,
+    forward_fn: fn (AnyTensor) raises escaping -> AnyTensor,
+    x: AnyTensor,
     num_samples: Int = 100,
     epsilon: Float64 = 3e-4,  # Changed from 1e-5 - see #2704
     seed: Int = 42,
@@ -483,10 +483,10 @@ fn compute_sampled_numerical_gradient(
 
     Example:
         ```mojo
-        fn forward(x: ExTensor) raises escaping -> ExTensor:
+        fn forward(x: AnyTensor) raises escaping -> AnyTensor:
             return relu(x)
 
-        var x = ExTensor([100, 100], DType.float32)
+        var x = AnyTensor([100, 100], DType.float32)
         var sampled = compute_sampled_numerical_gradient(
             forward, x, num_samples=100, epsilon=3e-4, seed=42
         )
@@ -545,7 +545,7 @@ fn compute_sampled_numerical_gradient(
 
 
 fn assert_sampled_gradients_close(
-    analytical_grad: ExTensor,
+    analytical_grad: AnyTensor,
     sampled_numerical: List[IndexGradientPair],
     rtol: Float64 = 1e-2,
     atol: Float64 = 1e-2,  # 1% absolute tolerance for small gradients
@@ -632,8 +632,8 @@ fn assert_sampled_gradients_close(
 
 
 fn assert_gradients_close(
-    analytical: ExTensor,
-    numerical: ExTensor,
+    analytical: AnyTensor,
+    numerical: AnyTensor,
     rtol: Float64 = 1e-3,
     atol: Float64 = 1e-6,
     message: String = "Gradients do not match",
@@ -724,10 +724,10 @@ fn assert_gradients_close(
         raise Error(msg)
 
 
-fn _deep_copy(tensor: ExTensor) raises -> ExTensor:
+fn _deep_copy(tensor: AnyTensor) raises -> AnyTensor:
     """Create a deep copy of a tensor with independent data buffer.
 
-        ExTensor's __copyinit__ creates shallow copies (shared data via reference counting).
+        AnyTensor's __copyinit__ creates shallow copies (shared data via reference counting).
         This function creates a true deep copy with separate memory allocation.
 
     Args:
@@ -737,7 +737,7 @@ fn _deep_copy(tensor: ExTensor) raises -> ExTensor:
             New tensor with copied data (independent memory allocation).
     """
     # Create new tensor with same shape and dtype
-    var result = ExTensor(tensor.shape(), tensor._dtype)
+    var result = AnyTensor(tensor.shape(), tensor._dtype)
 
     # Copy all data elements
     for i in range(tensor.numel()):
@@ -747,10 +747,10 @@ fn _deep_copy(tensor: ExTensor) raises -> ExTensor:
 
 
 fn check_gradient(
-    forward_fn: fn (ExTensor) raises escaping -> ExTensor,
-    backward_fn: fn (ExTensor, ExTensor) raises escaping -> ExTensor,
-    x: ExTensor,
-    grad_output: ExTensor,
+    forward_fn: fn (AnyTensor) raises escaping -> AnyTensor,
+    backward_fn: fn (AnyTensor, AnyTensor) raises escaping -> AnyTensor,
+    x: AnyTensor,
+    grad_output: AnyTensor,
     epsilon: Float64 = 0.0,  # Auto-select based on dtype if 0.0
     rtol: Float64 = 1e-3,
     atol: Float64 = 1e-6,
@@ -775,13 +775,13 @@ fn check_gradient(
         Example:
             ```mojo
             fn test_relu_gradient() raises:
-                var x = ExTensor(List[Int](), DType.float32)
+                var x = AnyTensor(List[Int](), DType.float32)
                 # ... initialize x with test values ...
 
-                fn forward(inp: ExTensor) raises escaping -> ExTensor:
+                fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
                     return relu(inp)
 
-                fn backward_wrapper(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+                fn backward_wrapper(grad: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
                     return relu_backward(grad, x)
 
                 var grad_out = ones_like(relu(x))
@@ -817,7 +817,7 @@ fn check_gradient(
 
     for i in range(x.numel()):
         # Create deep copies to avoid corrupting original x
-        # (ExTensor.__copyinit__ creates shallow copies with shared data)
+        # (AnyTensor.__copyinit__ creates shallow copies with shared data)
         var x_plus = _deep_copy(x)
         var old_val = x._get_float64(i)
         x_plus._set_float64(i, old_val + eps)

--- a/shared/testing/layer_params.mojo
+++ b/shared/testing/layer_params.mojo
@@ -18,7 +18,7 @@ Usage:
     var fc_bias = fc_fixture.bias
 """
 
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.core import kaiming_uniform
 
 
@@ -48,8 +48,8 @@ struct ConvFixture:
         ```
     """
 
-    var kernel: ExTensor
-    var bias: ExTensor
+    var kernel: AnyTensor
+    var bias: AnyTensor
     var in_channels: Int
     var out_channels: Int
     var kernel_size: Int
@@ -115,8 +115,8 @@ struct LinearFixture:
         ```
     """
 
-    var weights: ExTensor
-    var bias: ExTensor
+    var weights: AnyTensor
+    var bias: AnyTensor
     var in_features: Int
     var out_features: Int
 

--- a/shared/testing/layer_testers.mojo
+++ b/shared/testing/layer_testers.mojo
@@ -50,7 +50,7 @@ Usage:
 """
 
 from math import isnan, isinf
-from shared.core.extensor import ExTensor, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros_like, ones_like
 from shared.core.conv import conv2d, conv2d_output_shape, conv2d_backward
 from shared.core.linear import linear, linear_backward
 from shared.core.normalization import batch_norm2d, batch_norm2d_backward
@@ -113,8 +113,8 @@ struct LayerTester:
         kernel_size: Int,
         input_h: Int,
         input_w: Int,
-        weights: ExTensor,
-        bias: ExTensor,
+        weights: AnyTensor,
+        bias: AnyTensor,
         dtype: DType,
         stride: Int = 1,
         padding: Int = 0,
@@ -196,8 +196,8 @@ struct LayerTester:
     fn test_linear_layer(
         in_features: Int,
         out_features: Int,
-        weights: ExTensor,
-        bias: ExTensor,
+        weights: AnyTensor,
+        bias: AnyTensor,
         dtype: DType,
     ) raises:
         """Test fully connected layer with special values.
@@ -307,7 +307,7 @@ struct LayerTester:
         )
 
         # Forward pass
-        var output: ExTensor
+        var output: AnyTensor
         if pool_type == "max":
             output = maxpool2d(input, pool_size, stride, padding=padding)
         else:
@@ -376,7 +376,7 @@ struct LayerTester:
         var input = create_alternating_pattern_tensor(shape, dtype)
 
         # Forward pass
-        var output: ExTensor
+        var output: AnyTensor
         if activation == "relu":
             output = relu(input)
         elif activation == "sigmoid":
@@ -432,7 +432,7 @@ struct LayerTester:
 
     @staticmethod
     fn test_layer_dtype_consistency(
-        input: ExTensor, output: ExTensor, layer_name: String = "Layer"
+        input: AnyTensor, output: AnyTensor, layer_name: String = "Layer"
     ) raises:
         """Test that layer preserves dtype from input to output.
 
@@ -460,7 +460,7 @@ struct LayerTester:
 
     @staticmethod
     fn test_layer_no_invalid_values(
-        output: ExTensor, layer_name: String = "Layer"
+        output: AnyTensor, layer_name: String = "Layer"
     ) raises:
         """Test that layer output contains no NaN or Inf values.
 
@@ -503,8 +503,8 @@ struct LayerTester:
         kernel_size: Int,
         input_h: Int,
         input_w: Int,
-        weights: ExTensor,
-        bias: ExTensor,
+        weights: AnyTensor,
+        bias: AnyTensor,
         dtype: DType,
         stride: Int = 1,
         padding: Int = 0,
@@ -613,7 +613,7 @@ struct LayerTester:
         var tolerance = 1e-1  # 10% tolerance for all dtypes
 
         # Define forward function for gradient checking
-        fn forward(x: ExTensor) raises escaping -> ExTensor:
+        fn forward(x: AnyTensor) raises escaping -> AnyTensor:
             return conv2d(x, weights, bias, stride=stride, padding=padding)
 
         # Use sampled or exhaustive gradient checking based on num_gradient_samples
@@ -695,8 +695,8 @@ struct LayerTester:
     fn test_linear_layer_backward(
         in_features: Int,
         out_features: Int,
-        weights: ExTensor,
-        bias: ExTensor,
+        weights: AnyTensor,
+        bias: AnyTensor,
         dtype: DType,
         validate_analytical: Bool = False,
         num_gradient_samples: Int = 0,
@@ -774,7 +774,7 @@ struct LayerTester:
         )
 
         # Define forward function for gradient checking
-        fn forward(x: ExTensor) raises escaping -> ExTensor:
+        fn forward(x: AnyTensor) raises escaping -> AnyTensor:
             return linear(x, weights, bias)
 
         # Use sampled or exhaustive gradient checking based on num_gradient_samples
@@ -911,7 +911,7 @@ struct LayerTester:
         )
 
         # Forward pass
-        var output: ExTensor
+        var output: AnyTensor
         if activation == "relu":
             output = relu(input)
         elif activation == "sigmoid":
@@ -940,7 +940,7 @@ struct LayerTester:
         var tolerance = 1e-2 if dtype == DType.float32 else 1e-1
 
         # Define forward function for gradient checking
-        fn forward(x: ExTensor) raises escaping -> ExTensor:
+        fn forward(x: AnyTensor) raises escaping -> AnyTensor:
             if activation == "relu":
                 return relu(x)
             elif activation == "sigmoid":
@@ -974,7 +974,7 @@ struct LayerTester:
             var grad_output = ones_like(output)
 
             # Compute analytical gradient using activation-specific backward
-            var analytical_grad: ExTensor
+            var analytical_grad: AnyTensor
             if activation == "relu":
                 # ReLU backward takes input
                 analytical_grad = relu_backward(grad_output, input)
@@ -999,10 +999,10 @@ struct LayerTester:
     fn test_batchnorm_layer(
         num_features: Int,
         input_shape: List[Int],
-        gamma: ExTensor,
-        beta: ExTensor,
-        running_mean: ExTensor,
-        running_var: ExTensor,
+        gamma: AnyTensor,
+        beta: AnyTensor,
+        running_mean: AnyTensor,
+        running_var: AnyTensor,
         dtype: DType,
         training_mode: Bool = True,
     ) raises:
@@ -1080,10 +1080,10 @@ struct LayerTester:
     fn test_batchnorm_layer_backward(
         num_features: Int,
         input_shape: List[Int],
-        gamma: ExTensor,
-        beta: ExTensor,
-        running_mean: ExTensor,
-        running_var: ExTensor,
+        gamma: AnyTensor,
+        beta: AnyTensor,
+        running_mean: AnyTensor,
+        running_var: AnyTensor,
         dtype: DType,
     ) raises:
         """Test BatchNorm backward pass with gradient checking.
@@ -1181,7 +1181,7 @@ struct LayerTester:
         # Define forward function for gradient checking.
         # Loss = sum(output * grad_output) so that the numerical gradient matches
         # the analytical gradient from batch_norm2d_backward(grad_output, ...).
-        fn forward_for_grad(x: ExTensor) raises escaping -> ExTensor:
+        fn forward_for_grad(x: AnyTensor) raises escaping -> AnyTensor:
             var (out, _, _) = batch_norm2d(
                 x, gamma, beta, running_mean, running_var, training=True
             )

--- a/shared/testing/models.mojo
+++ b/shared/testing/models.mojo
@@ -37,7 +37,7 @@ Example:
     ```
 """
 
-from shared.core import ExTensor, zeros, ones, zeros_like
+from shared.core import AnyTensor, zeros, ones, zeros_like
 from shared.core.traits import Model
 
 
@@ -110,7 +110,7 @@ struct SimpleCNN(Copyable, Movable):
         shape.append(self.num_classes)
         return shape^
 
-    fn forward(self, input: ExTensor) raises -> ExTensor:
+    fn forward(self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass (simplified for testing).
 
         Creates output tensor with correct shape filled with dummy values.
@@ -198,7 +198,7 @@ struct LinearModel(Copyable, Movable):
         shape.append(self.out_features)
         return shape^
 
-    fn forward(self, input: ExTensor) raises -> ExTensor:
+    fn forward(self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass.
 
         Creates output tensor with correct shape filled with zeros.
@@ -467,7 +467,7 @@ struct SimpleLinearModel:
 struct Parameter(Copyable, Movable):
     """Trainable parameter with data and gradient.
 
-    Wraps an ExTensor for the parameter data with an associated gradient tensor.
+    Wraps an AnyTensor for the parameter data with an associated gradient tensor.
     Used in model layers to track trainable weights and biases.
 
     Attributes:
@@ -475,12 +475,12 @@ struct Parameter(Copyable, Movable):
         grad: The gradient tensor for backpropagation.
     """
 
-    var data: ExTensor
+    var data: AnyTensor
     """The parameter tensor (weights or bias)."""
-    var grad: ExTensor
+    var grad: AnyTensor
     """The gradient tensor for backpropagation."""
 
-    fn __init__(out self, data: ExTensor) raises:
+    fn __init__(out self, data: AnyTensor) raises:
         """Initialize parameter with data tensor and zero gradient.
 
         Args:
@@ -709,14 +709,14 @@ struct SimpleMLP(Copyable, Model, Movable):
             )
             return output^
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
-        """Forward pass through MLP with ExTensor input.
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
+        """Forward pass through MLP with AnyTensor input.
 
         Args:
-            input: Input ExTensor.
+            input: Input AnyTensor.
 
         Returns:
-            Output ExTensor.
+            Output AnyTensor.
 
         Raises:
             Error: If tensor conversion fails or memory allocation fails.
@@ -730,10 +730,10 @@ struct SimpleMLP(Copyable, Model, Movable):
         ```
 
         Note:
-            This is the Model trait implementation that accepts ExTensor.
+            This is the Model trait implementation that accepts AnyTensor.
             Uses ReLU activation between layers: ReLU(x) = max(0, x).
         """
-        # Extract Float32 values from ExTensor
+        # Extract Float32 values from AnyTensor
         var input_list = List[Float32]()
         var input_numel = input.numel()
         for i in range(input_numel):
@@ -742,7 +742,7 @@ struct SimpleMLP(Copyable, Model, Movable):
         # Call existing forward with List[Float32]
         var output_list = self.forward(input_list)
 
-        # Convert back to ExTensor
+        # Convert back to AnyTensor
         var output = zeros([len(output_list)], DType.float32)
         for i in range(len(output_list)):
             output._set_float32(i, output_list[i])
@@ -808,11 +808,11 @@ struct SimpleMLP(Copyable, Model, Movable):
             total += len(self.layer3_weights) + len(self.layer3_bias)
         return total
 
-    fn get_weights(self) raises -> ExTensor:
-        """Get flattened weights as ExTensor.
+    fn get_weights(self) raises -> AnyTensor:
+        """Get flattened weights as AnyTensor.
 
         Returns:
-            ExTensor containing all weights flattened.
+            AnyTensor containing all weights flattened.
 
         Raises:
             Error: If tensor creation fails.
@@ -838,7 +838,7 @@ struct SimpleMLP(Copyable, Model, Movable):
         for i in range(len(self.layer3_bias)):
             all_weights.append(self.layer3_bias[i])
 
-        # Create ExTensor from flattened weights
+        # Create AnyTensor from flattened weights
         var shape: List[Int] = [len(all_weights)]
         var tensor = zeros(shape, DType.float32)
 
@@ -848,11 +848,11 @@ struct SimpleMLP(Copyable, Model, Movable):
 
         return tensor
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Get list of parameter tensors.
 
         Returns:
-            List of ExTensor objects containing weights and biases.
+            List of AnyTensor objects containing weights and biases.
 
         Raises:
             Error: If tensor creation fails.
@@ -865,7 +865,7 @@ struct SimpleMLP(Copyable, Model, Movable):
                 print(param.shape())
         ```
         """
-        var param_list: List[ExTensor] = []
+        var param_list: List[AnyTensor] = []
 
         # Layer 1 weights parameter
         var w1_shape: List[Int] = [self.hidden_dim, self.input_dim]
@@ -931,7 +931,7 @@ struct SimpleMLP(Copyable, Model, Movable):
         # on Parameter objects during backpropagation
         pass
 
-    fn state_dict(self) raises -> Dict[String, ExTensor]:
+    fn state_dict(self) raises -> Dict[String, AnyTensor]:
         """Export weights as state dictionary.
 
         Returns:
@@ -949,7 +949,7 @@ struct SimpleMLP(Copyable, Model, Movable):
         Note:
             Returns owned Dict with ownership transfer to avoid copy errors.
         """
-        var state = Dict[String, ExTensor]()
+        var state = Dict[String, AnyTensor]()
 
         # Layer 1 weights
         var w1_shape: List[Int] = [self.hidden_dim, self.input_dim]
@@ -999,7 +999,7 @@ struct SimpleMLP(Copyable, Model, Movable):
 
         return state^
 
-    fn load_state_dict(mut self, state: Dict[String, ExTensor]):
+    fn load_state_dict(mut self, state: Dict[String, AnyTensor]):
         """Load weights from state dictionary.
 
         Args:
@@ -1078,7 +1078,7 @@ struct SimpleMLP2(Copyable, Model, Movable):
         self.hidden_dim = hidden_dim
         self.output_dim = output_dim
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass using manual layer composition.
 
         This demonstrates the data flow through sequential layers without
@@ -1112,16 +1112,16 @@ struct SimpleMLP2(Copyable, Model, Movable):
 
         return output^
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Get all trainable parameters.
 
         Returns:
-            List of 4 ExTensors: W1, b1, W2, b2 (placeholder weights).
+            List of 4 AnyTensors: W1, b1, W2, b2 (placeholder weights).
 
         Raises:
             Error: If parameter collection fails.
         """
-        var params = List[ExTensor]()
+        var params = List[AnyTensor]()
         # W1: (input_dim, hidden_dim)
         params.append(zeros([self.input_dim, self.hidden_dim], DType.float32))
         # b1: (hidden_dim,)

--- a/shared/testing/property_testing.mojo
+++ b/shared/testing/property_testing.mojo
@@ -30,7 +30,7 @@ Features:
 
 from random import random_float64, seed
 from math import sqrt
-from shared.core import ExTensor, zeros, ones
+from shared.core import AnyTensor, zeros, ones
 from shared.core import reshape
 from shared.testing.data_generators import random_tensor
 
@@ -276,7 +276,7 @@ fn run_property_test_with_seed(
 
 
 fn assert_tensors_close(
-    a: ExTensor, b: ExTensor, atol: Float64 = 1e-6, rtol: Float64 = 1e-5
+    a: AnyTensor, b: AnyTensor, atol: Float64 = 1e-6, rtol: Float64 = 1e-5
 ) raises:
     """Assert two tensors are element-wise close.
 
@@ -322,7 +322,7 @@ fn assert_tensors_close(
             )
 
 
-fn tensors_equal(a: ExTensor, b: ExTensor, atol: Float64 = 1e-6) raises -> Bool:
+fn tensors_equal(a: AnyTensor, b: AnyTensor, atol: Float64 = 1e-6) raises -> Bool:
     """Check if two tensors are element-wise equal within tolerance.
 
     Args:

--- a/shared/testing/special_values.mojo
+++ b/shared/testing/special_values.mojo
@@ -53,7 +53,7 @@ Usage:
     var neg_inf = create_inf_tensor([3, 3], DType.float32, positive=False)
 """
 
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.testing.tensor_factory import zeros
 from random import seed as random_seed, random_float64
 
@@ -77,7 +77,7 @@ comptime SPECIAL_VALUE_NEG_ONE: Float64 = -1.0
 
 fn create_special_value_tensor(
     shape: List[Int], dtype: DType, value: Float64 = SPECIAL_VALUE_ONE
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Create tensor filled with a special value.
 
     Args:
@@ -86,7 +86,7 @@ fn create_special_value_tensor(
         value: Special value to fill (must be -1.0, -0.5, 0.0, 0.5, 1.0, or 1.5).
 
     Returns:
-        ExTensor filled with the special value.
+        AnyTensor filled with the special value.
 
     Raises:
         Error if value is not a special value (-1.0, -0.5, 0.0, 0.5, 1.0, 1.5).
@@ -142,7 +142,7 @@ fn create_special_value_tensor(
 
 fn create_alternating_pattern_tensor(
     shape: List[Int], dtype: DType
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Create tensor with alternating special values pattern.
 
     Pattern repeats: -1.0, -0.5, 0.0, 0.5, 1.0, 1.5, -1.0, -0.5, 0.0, ...
@@ -155,7 +155,7 @@ fn create_alternating_pattern_tensor(
         dtype: Data type (FP4, FP8, FP16, FP32, BF16, or Int8).
 
     Returns:
-        ExTensor with alternating special value pattern.
+        AnyTensor with alternating special value pattern.
 
     Example:
         ```mojo
@@ -194,7 +194,7 @@ fn create_alternating_pattern_tensor(
 
 
 fn verify_special_value_invariants(
-    tensor: ExTensor, expected_value: Float64
+    tensor: AnyTensor, expected_value: Float64
 ) raises:
     """Verify all elements match expected special value.
 
@@ -257,7 +257,7 @@ fn create_seeded_random_tensor(
     seed: Int = 42,
     low: Float64 = -1.0,
     high: Float64 = 1.0,
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Create random tensor with fixed seed for gradient checking.
 
     Generates a tensor filled with random values in the range [low, high] using
@@ -273,7 +273,7 @@ fn create_seeded_random_tensor(
         high: Maximum value for random range (default: 1.0).
 
     Returns:
-        ExTensor with seeded random values in [low, high].
+        AnyTensor with seeded random values in [low, high].
 
     Raises:
         Error if low >= high (invalid range).
@@ -324,7 +324,7 @@ fn create_seeded_random_tensor(
     return tensor^
 
 
-fn create_zeros_tensor(shape: List[Int], dtype: DType) raises -> ExTensor:
+fn create_zeros_tensor(shape: List[Int], dtype: DType) raises -> AnyTensor:
     """Create tensor filled with zeros (special value).
 
     Convenience wrapper around create_special_value_tensor for zero initialization.
@@ -334,7 +334,7 @@ fn create_zeros_tensor(shape: List[Int], dtype: DType) raises -> ExTensor:
         dtype: Data type.
 
     Returns:
-        ExTensor filled with zeros.
+        AnyTensor filled with zeros.
 
     Example:
         ```mojo
@@ -348,7 +348,7 @@ fn create_zeros_tensor(shape: List[Int], dtype: DType) raises -> ExTensor:
     return create_special_value_tensor(shape, dtype, SPECIAL_VALUE_ZERO)
 
 
-fn create_ones_tensor(shape: List[Int], dtype: DType) raises -> ExTensor:
+fn create_ones_tensor(shape: List[Int], dtype: DType) raises -> AnyTensor:
     """Create tensor filled with ones (special value).
 
     Convenience wrapper around create_special_value_tensor for one initialization.
@@ -358,7 +358,7 @@ fn create_ones_tensor(shape: List[Int], dtype: DType) raises -> ExTensor:
         dtype: Data type.
 
     Returns:
-        ExTensor filled with ones.
+        AnyTensor filled with ones.
 
     Example:
         ```mojo
@@ -372,7 +372,7 @@ fn create_ones_tensor(shape: List[Int], dtype: DType) raises -> ExTensor:
     return create_special_value_tensor(shape, dtype, SPECIAL_VALUE_ONE)
 
 
-fn create_halves_tensor(shape: List[Int], dtype: DType) raises -> ExTensor:
+fn create_halves_tensor(shape: List[Int], dtype: DType) raises -> AnyTensor:
     """Create tensor filled with 0.5 values (special value).
 
     Convenience wrapper around create_special_value_tensor for half initialization.
@@ -382,7 +382,7 @@ fn create_halves_tensor(shape: List[Int], dtype: DType) raises -> ExTensor:
         dtype: Data type.
 
     Returns:
-        ExTensor filled with 0.5.
+        AnyTensor filled with 0.5.
 
     Example:
         ```mojo
@@ -398,7 +398,7 @@ fn create_halves_tensor(shape: List[Int], dtype: DType) raises -> ExTensor:
 
 fn create_one_and_half_tensor(
     shape: List[Int], dtype: DType
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Create tensor filled with 1.5 values (special value).
 
     Convenience wrapper around create_special_value_tensor for 1.5 initialization.
@@ -408,7 +408,7 @@ fn create_one_and_half_tensor(
         dtype: Data type.
 
     Returns:
-        ExTensor filled with 1.5.
+        AnyTensor filled with 1.5.
 
     Example:
         ```mojo
@@ -427,7 +427,7 @@ fn create_one_and_half_tensor(
 # ============================================================================
 
 
-fn create_nan_tensor(shape: List[Int], dtype: DType) raises -> ExTensor:
+fn create_nan_tensor(shape: List[Int], dtype: DType) raises -> AnyTensor:
     """Create tensor filled with NaN (Not a Number) values.
 
     Creates NaN values by dividing zero by zero (0.0 / 0.0).
@@ -438,7 +438,7 @@ fn create_nan_tensor(shape: List[Int], dtype: DType) raises -> ExTensor:
         dtype: Data type.
 
     Returns:
-        ExTensor filled with NaN values.
+        AnyTensor filled with NaN values.
 
     Raises:
         Error: If operation fails.
@@ -462,7 +462,7 @@ fn create_nan_tensor(shape: List[Int], dtype: DType) raises -> ExTensor:
 
 fn create_inf_tensor(
     shape: List[Int], dtype: DType, positive: Bool = True
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Create tensor filled with Infinity values.
 
     Creates Infinity by dividing by zero (1.0/0.0 or -1.0/0.0).
@@ -474,7 +474,7 @@ fn create_inf_tensor(
         positive: If True, create +Infinity; if False, create -Infinity.
 
     Returns:
-        ExTensor filled with Infinity values.
+        AnyTensor filled with Infinity values.
 
     Raises:
         Error: If operation fails.

--- a/shared/testing/tensor_factory.mojo
+++ b/shared/testing/tensor_factory.mojo
@@ -11,7 +11,7 @@ This module consolidates tensor creation utilities to:
 
 Example:
     from shared.testing import tensor_factory
-    from shared.core import ExTensor
+    from shared.core import AnyTensor
 
     # Create tensors with unified factory
     var zeros = tensor_factory.zeros_tensor([10, 5], DType.float32)
@@ -27,7 +27,7 @@ Example:
 
 from random import random_float64
 from math import sqrt, log, cos, sin, pi
-from shared.core import ExTensor, zeros, ones, full
+from shared.core import AnyTensor, zeros, ones, full
 
 
 # ============================================================================
@@ -35,7 +35,7 @@ from shared.core import ExTensor, zeros, ones, full
 # ============================================================================
 
 
-fn zeros_tensor(shape: List[Int], dtype: DType) raises -> ExTensor:
+fn zeros_tensor(shape: List[Int], dtype: DType) raises -> AnyTensor:
     """Create a tensor filled with zeros.
 
     Args:
@@ -43,7 +43,7 @@ fn zeros_tensor(shape: List[Int], dtype: DType) raises -> ExTensor:
         dtype: Data type of tensor elements.
 
     Returns:
-        ExTensor with all elements initialized to zero.
+        AnyTensor with all elements initialized to zero.
 
     Example:
     ```
@@ -57,7 +57,7 @@ fn zeros_tensor(shape: List[Int], dtype: DType) raises -> ExTensor:
     return zeros(shape, dtype)
 
 
-fn ones_tensor(shape: List[Int], dtype: DType) raises -> ExTensor:
+fn ones_tensor(shape: List[Int], dtype: DType) raises -> AnyTensor:
     """Create a tensor filled with ones.
 
     Args:
@@ -65,7 +65,7 @@ fn ones_tensor(shape: List[Int], dtype: DType) raises -> ExTensor:
         dtype: Data type of tensor elements.
 
     Returns:
-        ExTensor with all elements initialized to one.
+        AnyTensor with all elements initialized to one.
 
     Example:
     ```
@@ -81,7 +81,7 @@ fn ones_tensor(shape: List[Int], dtype: DType) raises -> ExTensor:
 
 fn full_tensor(
     shape: List[Int], fill_value: Float64, dtype: DType
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Create a tensor filled with a specific value.
 
     Args:
@@ -90,7 +90,7 @@ fn full_tensor(
         dtype: Data type of tensor elements.
 
     Returns:
-        ExTensor with all elements initialized to fill_value (converted to dtype).
+        AnyTensor with all elements initialized to fill_value (converted to dtype).
 
     Example:
     ```
@@ -110,7 +110,7 @@ fn random_tensor(
     low: Float64 = 0.0,
     high: Float64 = 1.0,
     seed: Int = -1,
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Create a tensor with random values from uniform distribution [low, high).
 
     Args:
@@ -122,7 +122,7 @@ fn random_tensor(
               Note: Current implementation does not use seed parameter.
 
     Returns:
-        ExTensor with random values uniformly distributed in [low, high).
+        AnyTensor with random values uniformly distributed in [low, high).
 
     Example:
         var weights = random_tensor(
@@ -184,7 +184,7 @@ fn random_normal_tensor(
     mean: Float64 = 0.0,
     std: Float64 = 1.0,
     seed: Int = -1,
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Create a tensor with random values from normal distribution N(mean, std^2).
 
     Uses Box-Muller transform to convert uniform random values to normal distribution.
@@ -198,7 +198,7 @@ fn random_normal_tensor(
               Note: Current implementation does not use seed parameter.
 
     Returns:
-        ExTensor with random values from normal distribution N(mean, std^2).
+        AnyTensor with random values from normal distribution N(mean, std^2).
 
     Example:
         var weights = random_normal_tensor(
@@ -272,7 +272,7 @@ fn random_normal_tensor(
 
 
 fn set_tensor_value(
-    mut tensor: ExTensor, index: Int, value: Float64, dtype: DType
+    mut tensor: AnyTensor, index: Int, value: Float64, dtype: DType
 ) raises:
     """Set a single tensor element with automatic dtype conversion.
 

--- a/shared/training/__init__.mojo
+++ b/shared/training/__init__.mojo
@@ -36,7 +36,7 @@ Note:
     ```
 """
 
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.core.traits import Model, Loss, Optimizer
 from shared.training.trainer_interface import DataLoader
 from shared.autograd.tape import GradientTape
@@ -137,7 +137,7 @@ struct SGD(Movable, Optimizer):
         """
         self.learning_rate = learning_rate
 
-    fn step(mut self, params: List[ExTensor]) raises:
+    fn step(mut self, params: List[AnyTensor]) raises:
         """Update parameters using gradients.
 
         Implements: param = param - learning_rate * grad.
@@ -197,7 +197,7 @@ struct MSELoss(Loss, Movable):
         """
         self.reduction = reduction
 
-    fn compute(self, pred: ExTensor, target: ExTensor) raises -> ExTensor:
+    fn compute(self, pred: AnyTensor, target: AnyTensor) raises -> AnyTensor:
         """Compute MSE loss between predictions and targets.
 
         Implements the Loss trait interface.
@@ -207,7 +207,7 @@ struct MSELoss(Loss, Movable):
             target: Ground truth targets.
 
         Returns:
-            Scalar loss value as ExTensor.
+            Scalar loss value as AnyTensor.
 
         Raises:
             Error: If operation fails.
@@ -232,7 +232,7 @@ struct MSELoss(Loss, Movable):
             # Default to no reduction ("none")
             return squared
 
-    fn forward(self, output: ExTensor, target: ExTensor) raises -> Float32:
+    fn forward(self, output: AnyTensor, target: AnyTensor) raises -> Float32:
         """Compute MSE loss (legacy interface for backward compatibility).
 
         Args:
@@ -247,7 +247,7 @@ struct MSELoss(Loss, Movable):
         """
         return Float32(0.0)
 
-    fn backward(self, grad_output: ExTensor) raises -> ExTensor:
+    fn backward(self, grad_output: AnyTensor) raises -> AnyTensor:
         """Compute gradient of loss.
 
         Args:
@@ -312,7 +312,7 @@ struct TrainingLoop[
         self.loss_fn = loss_fn^
         self.tape = GradientTape()
 
-    fn step(mut self, inputs: ExTensor, targets: ExTensor) raises -> ExTensor:
+    fn step(mut self, inputs: AnyTensor, targets: AnyTensor) raises -> AnyTensor:
         """Perform single training step.
 
         Implements the training loop cycle using trait methods:
@@ -323,11 +323,11 @@ struct TrainingLoop[
         5. Return loss value.
 
         Args:
-            inputs: Input ExTensor.
-            targets: Target ExTensor.
+            inputs: Input AnyTensor.
+            targets: Target AnyTensor.
 
         Returns:
-            Scalar loss value as ExTensor.
+            Scalar loss value as AnyTensor.
 
         Raises:
             Error: If operation fails.
@@ -379,14 +379,14 @@ struct TrainingLoop[
 
         return loss_var.detach()
 
-    fn forward(mut self, inputs: ExTensor) raises -> ExTensor:
+    fn forward(mut self, inputs: AnyTensor) raises -> AnyTensor:
         """Execute forward pass via Model trait.
 
         Args:
-            inputs: Input ExTensor.
+            inputs: Input AnyTensor.
 
         Returns:
-            Model output ExTensor.
+            Model output AnyTensor.
 
         Raises:
             Error: If operation fails.
@@ -395,8 +395,8 @@ struct TrainingLoop[
         return self.model.forward(inputs)
 
     fn compute_loss(
-        self, outputs: ExTensor, targets: ExTensor
-    ) raises -> ExTensor:
+        self, outputs: AnyTensor, targets: AnyTensor
+    ) raises -> AnyTensor:
         """Compute loss via Loss trait.
 
         Args:
@@ -404,7 +404,7 @@ struct TrainingLoop[
             targets: Ground truth targets.
 
         Returns:
-            Scalar loss value as ExTensor.
+            Scalar loss value as AnyTensor.
 
         Raises:
             Error: If operation fails.
@@ -504,7 +504,7 @@ struct CrossEntropyLoss(Loss, Movable):
         """
         self.reduction = reduction
 
-    fn compute(self, pred: ExTensor, target: ExTensor) raises -> ExTensor:
+    fn compute(self, pred: AnyTensor, target: AnyTensor) raises -> AnyTensor:
         """Compute cross entropy loss between predictions and targets.
 
         Args:
@@ -512,7 +512,7 @@ struct CrossEntropyLoss(Loss, Movable):
             target: Ground truth targets (class indices or one-hot).
 
         Returns:
-            Scalar loss value as ExTensor.
+            Scalar loss value as AnyTensor.
 
         Raises:
             Error: If operation fails.

--- a/shared/training/base.mojo
+++ b/shared/training/base.mojo
@@ -9,7 +9,7 @@ These contracts establish clear APIs for gradient utilities (#2393) and training
 """
 
 from collections import Dict, List
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.core import has_nan, has_inf
 from math import sqrt
 
@@ -265,7 +265,7 @@ trait LRScheduler:
 # ============================================================================
 
 
-fn has_nan_or_inf(tensor: ExTensor) -> Bool:
+fn has_nan_or_inf(tensor: AnyTensor) -> Bool:
     """Check if tensor contains NaN or Inf values (numerical instability detection).
 
     Detects numerical instability in gradients during training by checking for:
@@ -315,7 +315,7 @@ fn is_valid_loss(loss: Float64) raises -> Bool:
     # Create a single-element tensor for loss value
     var shape = List[Int]()
     shape.append(1)
-    var loss_tensor = ExTensor(shape, DType.float64)
+    var loss_tensor = AnyTensor(shape, DType.float64)
 
     # Access the tensor's data pointer and set the loss value
     var ptr = loss_tensor._data.bitcast[Float64]()
@@ -326,7 +326,7 @@ fn is_valid_loss(loss: Float64) raises -> Bool:
 
 
 fn compute_gradient_norm(
-    parameters: List[ExTensor], norm_type: String = "L2"
+    parameters: List[AnyTensor], norm_type: String = "L2"
 ) -> Float64:
     """Compute gradient norm for training diagnostics and exploding gradient detection.
 
@@ -421,7 +421,7 @@ fn clip_gradients(
     Note:
         This is a legacy function that works with lists of Float64.
         For tensor-based gradient clipping, use compute_gradient_norm()
-        with ExTensor parameters instead.
+        with AnyTensor parameters instead.
     """
     # Compute L2 norm of the gradient list
     var norm_sq = Float64(0.0)

--- a/shared/training/checkpoint.mojo
+++ b/shared/training/checkpoint.mojo
@@ -33,7 +33,7 @@ Example:
     var start_epoch = ckpt_mgr.load_latest(model_params, param_names)
 """
 
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.training.model_utils import save_model_weights, load_model_weights
 from shared.utils.file_io import (
     create_directory,
@@ -106,7 +106,7 @@ struct CheckpointManager:
 
     fn save_checkpoint(
         self,
-        parameters: List[ExTensor],
+        parameters: List[AnyTensor],
         param_names: List[String],
         epoch: Int,
         train_loss: Float32 = 0.0,
@@ -158,7 +158,7 @@ struct CheckpointManager:
 
     fn save_best(
         mut self,
-        mut parameters: List[ExTensor],
+        mut parameters: List[AnyTensor],
         param_names: List[String],
         epoch: Int,
         metric_value: Float32,
@@ -209,7 +209,7 @@ struct CheckpointManager:
 
     fn load_latest(
         mut self,
-        mut parameters: List[ExTensor],
+        mut parameters: List[AnyTensor],
         param_names: List[String],
     ) raises -> Int:
         """Load the most recent checkpoint.
@@ -246,7 +246,7 @@ struct CheckpointManager:
         return latest_epoch
 
     fn load_best(
-        mut self, mut parameters: List[ExTensor], param_names: List[String]
+        mut self, mut parameters: List[AnyTensor], param_names: List[String]
     ) raises:
         """Load the best model checkpoint.
 

--- a/shared/training/dataset_loaders.mojo
+++ b/shared/training/dataset_loaders.mojo
@@ -20,7 +20,7 @@ Note:
     file I/O which is limited in the current Mojo version.
 """
 
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.core import zeros
 
 
@@ -37,18 +37,18 @@ struct DatasetSplit(Copyable, Movable):
         num_classes: Number of output classes.
     """
 
-    var train_images: ExTensor
-    var train_labels: ExTensor
-    var test_images: ExTensor
-    var test_labels: ExTensor
+    var train_images: AnyTensor
+    var train_labels: AnyTensor
+    var test_images: AnyTensor
+    var test_labels: AnyTensor
     var num_classes: Int
 
     fn __init__(
         out self,
-        var train_images: ExTensor,
-        var train_labels: ExTensor,
-        var test_images: ExTensor,
-        var test_labels: ExTensor,
+        var train_images: AnyTensor,
+        var train_labels: AnyTensor,
+        var test_images: AnyTensor,
+        var test_labels: AnyTensor,
         num_classes: Int,
     ):
         """Initialize dataset split.

--- a/shared/training/dtype_utils.mojo
+++ b/shared/training/dtype_utils.mojo
@@ -29,11 +29,11 @@ Usage:
 
     # Or explicitly pass hardware capabilities (for testing/override)
     var dtype = recommend_precision_dtype(model_size_mb=500.0, hardware_has_bf16=False)
-    var params = ExTensor.zeros((100, 100), dtype)
+    var params = AnyTensor.zeros((100, 100), dtype)
 
     # Query BF16 support directly
     if detect_hardware_bf16_support():
-        var params = ExTensor.zeros((100, 100), bfloat16_dtype)
+        var params = AnyTensor.zeros((100, 100), bfloat16_dtype)
 """
 
 
@@ -257,9 +257,9 @@ fn detect_hardware_bf16_support() -> Bool:
     Example:
         ```mojo
         if detect_hardware_bf16_support():
-            var params = ExTensor.zeros((1000, 1000), DType.bfloat16)
+            var params = AnyTensor.zeros((1000, 1000), DType.bfloat16)
         else:
-            var params = ExTensor.zeros((1000, 1000), DType.float16)
+            var params = AnyTensor.zeros((1000, 1000), DType.float16)
         ```
     """
     return not is_defined["APPLE"]()
@@ -320,7 +320,7 @@ fn recommend_precision_dtype(
         Example:
             ```mojo
             var dtype = recommend_precision_dtype(model_size_mb=500.0)
-            var params = ExTensor.zeros((1000, 1000), dtype)
+            var params = AnyTensor.zeros((1000, 1000), dtype)
             ```
     """
     if not hardware_has_fp16:

--- a/shared/training/evaluation.mojo
+++ b/shared/training/evaluation.mojo
@@ -19,7 +19,7 @@ Features:
 
 """
 
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.core.traits import Model
 from shared.data.batch_utils import extract_batch_pair, compute_num_batches
 from collections import List
@@ -89,8 +89,8 @@ fn evaluate_model[
     M: Model
 ](
     mut model: M,
-    images: ExTensor,
-    labels: ExTensor,
+    images: AnyTensor,
+    labels: AnyTensor,
     batch_size: Int = 100,
     num_classes: Int = 10,
     verbose: Bool = True,
@@ -101,7 +101,7 @@ fn evaluate_model[
     generic function that works with any model type M that implements forward().
 
     Parameters:
-        M: Model type that must implement forward(images: ExTensor) -> ExTensor.
+        M: Model type that must implement forward(images: AnyTensor) -> AnyTensor.
 
     Args:
         model: Model to evaluate (must have forward() method).
@@ -228,8 +228,8 @@ fn evaluate_model_simple[
     M: Model
 ](
     mut model: M,
-    images: ExTensor,
-    labels: ExTensor,
+    images: AnyTensor,
+    labels: AnyTensor,
     batch_size: Int = 100,
     num_classes: Int = 10,
     verbose: Bool = True,
@@ -240,7 +240,7 @@ fn evaluate_model_simple[
     is needed, without per-class statistics.
 
     Parameters:
-        M: Model type that must implement forward(images: ExTensor) -> ExTensor.
+        M: Model type that must implement forward(images: AnyTensor) -> AnyTensor.
 
     Args:
         model: Model to evaluate (must have forward() method).
@@ -326,8 +326,8 @@ fn evaluate_topk[
     M: Model
 ](
     mut model: M,
-    images: ExTensor,
-    labels: ExTensor,
+    images: AnyTensor,
+    labels: AnyTensor,
     k: Int = 5,
     batch_size: Int = 100,
     num_classes: Int = 10,
@@ -339,7 +339,7 @@ fn evaluate_topk[
     label is in the top-k predictions.
 
     Parameters:
-        M: Model type that must implement forward(images: ExTensor) -> ExTensor.
+        M: Model type that must implement forward(images: AnyTensor) -> AnyTensor.
 
     Args:
         model: Model to evaluate.

--- a/shared/training/gradient_clipping.mojo
+++ b/shared/training/gradient_clipping.mojo
@@ -25,7 +25,7 @@ Example:
         print("Warning: Large gradient norm detected:", total_norm)
 """
 
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from collections import List
 from math import sqrt
 
@@ -36,7 +36,7 @@ from shared.training.mixed_precision import (
 )
 
 
-fn compute_gradient_norm_list(gradients: List[ExTensor]) raises -> Float32:
+fn compute_gradient_norm_list(gradients: List[AnyTensor]) raises -> Float32:
     """Compute global L2 norm across all gradient tensors.
 
     Args:
@@ -69,7 +69,7 @@ fn compute_gradient_norm_list(gradients: List[ExTensor]) raises -> Float32:
 
 
 fn clip_gradients_by_global_norm(
-    mut gradients: List[ExTensor], max_norm: Float32
+    mut gradients: List[AnyTensor], max_norm: Float32
 ) raises -> Float32:
     """Clip gradients by global norm across all parameters.
 
@@ -122,7 +122,7 @@ fn clip_gradients_by_global_norm(
 
 
 fn clip_gradients_per_param(
-    mut gradients: List[ExTensor], max_norm: Float32
+    mut gradients: List[AnyTensor], max_norm: Float32
 ) raises:
     """Clip each parameter's gradients independently by their local norm.
 
@@ -172,7 +172,7 @@ fn clip_gradients_per_param(
 
 
 fn clip_gradients_by_value_list(
-    mut gradients: List[ExTensor], min_value: Float32, max_value: Float32
+    mut gradients: List[AnyTensor], min_value: Float32, max_value: Float32
 ) raises:
     """Clip all gradients by value range.
 
@@ -288,7 +288,7 @@ struct GradientStatistics:
 
 
 fn compute_gradient_statistics(
-    gradients: List[ExTensor],
+    gradients: List[AnyTensor],
 ) raises -> GradientStatistics:
     """Compute comprehensive gradient statistics for monitoring.
 

--- a/shared/training/gradient_ops.mojo
+++ b/shared/training/gradient_ops.mojo
@@ -24,12 +24,12 @@ Example:
         accumulate_gradient_inplace(accumulated_grad, grad)  # No allocation!
 """
 
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.core.types.dtype_aliases import BF16
 
 
 fn accumulate_gradient_inplace(
-    mut accumulated: ExTensor, new_grad: ExTensor
+    mut accumulated: AnyTensor, new_grad: AnyTensor
 ) raises:
     """Accumulate gradient in-place without creating intermediate tensors.
 
@@ -84,7 +84,7 @@ fn accumulate_gradient_inplace(
 
 
 fn _accumulate_float32(
-    mut accumulated: ExTensor, new_grad: ExTensor, size: Int
+    mut accumulated: AnyTensor, new_grad: AnyTensor, size: Int
 ) raises:
     """Direct float32 accumulation using pointer operations."""
     var acc_ptr = accumulated._data.bitcast[Float32]()
@@ -95,7 +95,7 @@ fn _accumulate_float32(
 
 
 fn _accumulate_float16(
-    mut accumulated: ExTensor, new_grad: ExTensor, size: Int
+    mut accumulated: AnyTensor, new_grad: AnyTensor, size: Int
 ) raises:
     """Direct float16 accumulation using pointer operations."""
     var acc_ptr = accumulated._data.bitcast[Float16]()
@@ -106,7 +106,7 @@ fn _accumulate_float16(
 
 
 fn _accumulate_bfloat16(
-    mut accumulated: ExTensor, new_grad: ExTensor, size: Int
+    mut accumulated: AnyTensor, new_grad: AnyTensor, size: Int
 ) raises:
     """Direct bfloat16 accumulation using pointer operations."""
     var acc_ptr = accumulated._data.bitcast[Scalar[BF16]]()
@@ -117,7 +117,7 @@ fn _accumulate_bfloat16(
 
 
 fn _accumulate_fallback(
-    mut accumulated: ExTensor, new_grad: ExTensor, size: Int
+    mut accumulated: AnyTensor, new_grad: AnyTensor, size: Int
 ) raises:
     """Fallback accumulation for unsupported dtypes."""
     for i in range(size):
@@ -126,7 +126,7 @@ fn _accumulate_fallback(
         accumulated._set_float64(i, acc_val + grad_val)
 
 
-fn scale_gradient_inplace(mut gradient: ExTensor, scale: Float32) raises:
+fn scale_gradient_inplace(mut gradient: AnyTensor, scale: Float32) raises:
     """Scale gradient in-place without creating intermediate tensors.
 
     Performs `gradient *= scale` by directly modifying the gradient
@@ -165,7 +165,7 @@ fn scale_gradient_inplace(mut gradient: ExTensor, scale: Float32) raises:
         _scale_fallback(gradient, Float64(scale), size)
 
 
-fn _scale_float32(mut gradient: ExTensor, scale: Float32, size: Int) raises:
+fn _scale_float32(mut gradient: AnyTensor, scale: Float32, size: Int) raises:
     """Direct float32 scaling using pointer operations."""
     var grad_ptr = gradient._data.bitcast[Float32]()
 
@@ -173,7 +173,7 @@ fn _scale_float32(mut gradient: ExTensor, scale: Float32, size: Int) raises:
         grad_ptr[i] = grad_ptr[i] * scale
 
 
-fn _scale_float16(mut gradient: ExTensor, scale: Float16, size: Int) raises:
+fn _scale_float16(mut gradient: AnyTensor, scale: Float16, size: Int) raises:
     """Direct float16 scaling using pointer operations."""
     var grad_ptr = gradient._data.bitcast[Float16]()
 
@@ -182,7 +182,7 @@ fn _scale_float16(mut gradient: ExTensor, scale: Float16, size: Int) raises:
 
 
 fn _scale_bfloat16(
-    mut gradient: ExTensor, scale: Scalar[BF16], size: Int
+    mut gradient: AnyTensor, scale: Scalar[BF16], size: Int
 ) raises:
     """Direct bfloat16 scaling using pointer operations."""
     var grad_ptr = gradient._data.bitcast[Scalar[BF16]]()
@@ -191,14 +191,14 @@ fn _scale_bfloat16(
         grad_ptr[i] = grad_ptr[i] * scale
 
 
-fn _scale_fallback(mut gradient: ExTensor, scale: Float64, size: Int) raises:
+fn _scale_fallback(mut gradient: AnyTensor, scale: Float64, size: Int) raises:
     """Fallback scaling for unsupported dtypes."""
     for i in range(size):
         var grad_val = gradient._get_float64(i)
         gradient._set_float64(i, grad_val * scale)
 
 
-fn zero_gradient_inplace(mut gradient: ExTensor) raises:
+fn zero_gradient_inplace(mut gradient: AnyTensor) raises:
     """Zero gradient in-place without creating intermediate tensors.
 
     Performs `gradient[:] = 0` by directly modifying the gradient
@@ -236,7 +236,7 @@ fn zero_gradient_inplace(mut gradient: ExTensor) raises:
         _zero_fallback(gradient, size)
 
 
-fn _zero_float32(mut gradient: ExTensor, size: Int) raises:
+fn _zero_float32(mut gradient: AnyTensor, size: Int) raises:
     """Direct float32 zeroing using pointer operations."""
     var grad_ptr = gradient._data.bitcast[Float32]()
 
@@ -244,7 +244,7 @@ fn _zero_float32(mut gradient: ExTensor, size: Int) raises:
         grad_ptr[i] = 0.0
 
 
-fn _zero_float16(mut gradient: ExTensor, size: Int) raises:
+fn _zero_float16(mut gradient: AnyTensor, size: Int) raises:
     """Direct float16 zeroing using pointer operations."""
     var grad_ptr = gradient._data.bitcast[Float16]()
 
@@ -252,7 +252,7 @@ fn _zero_float16(mut gradient: ExTensor, size: Int) raises:
         grad_ptr[i] = 0.0
 
 
-fn _zero_bfloat16(mut gradient: ExTensor, size: Int) raises:
+fn _zero_bfloat16(mut gradient: AnyTensor, size: Int) raises:
     """Direct bfloat16 zeroing using pointer operations."""
     var grad_ptr = gradient._data.bitcast[Scalar[BF16]]()
 
@@ -260,7 +260,7 @@ fn _zero_bfloat16(mut gradient: ExTensor, size: Int) raises:
         grad_ptr[i] = 0.0
 
 
-fn _zero_fallback(mut gradient: ExTensor, size: Int) raises:
+fn _zero_fallback(mut gradient: AnyTensor, size: Int) raises:
     """Fallback zeroing for unsupported dtypes."""
     for i in range(size):
         gradient._set_float64(i, 0.0)

--- a/shared/training/loops/training_loop.mojo
+++ b/shared/training/loops/training_loop.mojo
@@ -24,7 +24,7 @@ Design principles:
 """
 
 from collections import List
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.training.metrics import AccuracyMetric, LossTracker
 from shared.training.trainer_interface import (
     DataLoader,
@@ -34,12 +34,12 @@ from shared.training.trainer_interface import (
 
 
 fn training_step(
-    model_forward: fn (ExTensor) raises -> ExTensor,
-    compute_loss: fn (ExTensor, ExTensor) raises -> ExTensor,
+    model_forward: fn (AnyTensor) raises -> AnyTensor,
+    compute_loss: fn (AnyTensor, AnyTensor) raises -> AnyTensor,
     optimizer_step: fn () raises -> None,
     zero_gradients: fn () raises -> None,
-    data: ExTensor,
-    labels: ExTensor,
+    data: AnyTensor,
+    labels: AnyTensor,
 ) raises -> Float64:
     """Execute single training step (forward, backward, update).
 
@@ -59,7 +59,7 @@ fn training_step(
 
     Note:
         The backward pass is invoked implicitly via optimizer_step(). A full
-        implementation would call loss_tensor.backward() directly once ExTensor
+        implementation would call loss_tensor.backward() directly once AnyTensor
         supports automatic differentiation.
     """
     # Zero gradients from previous step
@@ -82,8 +82,8 @@ fn training_step(
 
 
 fn train_one_epoch(
-    model_forward: fn (ExTensor) raises -> ExTensor,
-    compute_loss: fn (ExTensor, ExTensor) raises -> ExTensor,
+    model_forward: fn (AnyTensor) raises -> AnyTensor,
+    compute_loss: fn (AnyTensor, AnyTensor) raises -> AnyTensor,
     optimizer_step: fn () raises -> None,
     zero_gradients: fn () raises -> None,
     mut train_loader: DataLoader,
@@ -207,10 +207,10 @@ struct TrainingLoop:
 
     fn run_epoch_manual(
         self,
-        train_data: ExTensor,
-        train_labels: ExTensor,
+        train_data: AnyTensor,
+        train_labels: AnyTensor,
         batch_size: Int,
-        compute_batch_loss: fn (ExTensor, ExTensor) raises -> Float32,
+        compute_batch_loss: fn (AnyTensor, AnyTensor) raises -> Float32,
         epoch: Int,
         total_epochs: Int,
     ) raises -> Float32:
@@ -224,7 +224,7 @@ struct TrainingLoop:
             train_labels: Training labels.
             batch_size: Mini-batch size.
             compute_batch_loss: Function to process one batch and return loss.
-                               Signature: fn(batch_data: ExTensor, batch_labels: ExTensor) -> Float32.
+                               Signature: fn(batch_data: AnyTensor, batch_labels: AnyTensor) -> Float32.
             epoch: Current epoch number (1-indexed).
             total_epochs: Total number of epochs.
 
@@ -244,7 +244,7 @@ struct TrainingLoop:
             var start_idx = batch_idx * batch_size
             var end_idx = min(start_idx + batch_size, num_samples)
 
-            # Extract batch slice using ExTensor.slice()
+            # Extract batch slice using AnyTensor.slice()
             var batch_data = train_data.slice(start_idx, end_idx, axis=0)
             var batch_labels = train_labels.slice(start_idx, end_idx, axis=0)
 
@@ -271,8 +271,8 @@ struct TrainingLoop:
 
     fn run_epoch(
         self,
-        model_forward: fn (ExTensor) raises -> ExTensor,
-        compute_loss: fn (ExTensor, ExTensor) raises -> ExTensor,
+        model_forward: fn (AnyTensor) raises -> AnyTensor,
+        compute_loss: fn (AnyTensor, AnyTensor) raises -> AnyTensor,
         optimizer_step: fn () raises -> None,
         zero_gradients: fn () raises -> None,
         mut train_loader: DataLoader,
@@ -303,8 +303,8 @@ struct TrainingLoop:
 
     fn run(
         self,
-        model_forward: fn (ExTensor) raises -> ExTensor,
-        compute_loss: fn (ExTensor, ExTensor) raises -> ExTensor,
+        model_forward: fn (AnyTensor) raises -> AnyTensor,
+        compute_loss: fn (AnyTensor, AnyTensor) raises -> AnyTensor,
         optimizer_step: fn () raises -> None,
         zero_gradients: fn () raises -> None,
         mut train_loader: DataLoader,

--- a/shared/training/loops/validation_loop.mojo
+++ b/shared/training/loops/validation_loop.mojo
@@ -15,7 +15,7 @@ Design principles:
 """
 
 from collections import List
-from shared.core.extensor import ExTensor
+from shared.core import AnyTensor
 from shared.training.metrics import AccuracyMetric, LossTracker, ConfusionMatrix
 from shared.training.trainer_interface import (
     DataLoader,
@@ -25,10 +25,10 @@ from shared.training.trainer_interface import (
 
 
 fn validation_step(
-    model_forward: fn (ExTensor) raises -> ExTensor,
-    compute_loss: fn (ExTensor, ExTensor) raises -> ExTensor,
-    data: ExTensor,
-    labels: ExTensor,
+    model_forward: fn (AnyTensor) raises -> AnyTensor,
+    compute_loss: fn (AnyTensor, AnyTensor) raises -> AnyTensor,
+    data: AnyTensor,
+    labels: AnyTensor,
 ) raises -> Float64:
     """Execute single validation step (forward pass only, no gradients).
 
@@ -57,8 +57,8 @@ fn validation_step(
 
 
 fn validate(
-    model_forward: fn (ExTensor) raises -> ExTensor,
-    compute_loss: fn (ExTensor, ExTensor) raises -> ExTensor,
+    model_forward: fn (AnyTensor) raises -> AnyTensor,
+    compute_loss: fn (AnyTensor, AnyTensor) raises -> AnyTensor,
     mut val_loader: DataLoader,
     compute_accuracy: Bool = True,
     compute_confusion: Bool = False,
@@ -183,8 +183,8 @@ struct ValidationLoop:
 
     fn run(
         self,
-        model_forward: fn (ExTensor) raises -> ExTensor,
-        compute_loss: fn (ExTensor, ExTensor) raises -> ExTensor,
+        model_forward: fn (AnyTensor) raises -> AnyTensor,
+        compute_loss: fn (AnyTensor, AnyTensor) raises -> AnyTensor,
         mut val_loader: DataLoader,
         mut metrics: TrainingMetrics,
     ) raises -> Float64:
@@ -229,8 +229,8 @@ struct ValidationLoop:
 
     fn run_subset(
         self,
-        model_forward: fn (ExTensor) raises -> ExTensor,
-        compute_loss: fn (ExTensor, ExTensor) raises -> ExTensor,
+        model_forward: fn (AnyTensor) raises -> AnyTensor,
+        compute_loss: fn (AnyTensor, AnyTensor) raises -> AnyTensor,
         mut val_loader: DataLoader,
         max_batches: Int,
         mut metrics: TrainingMetrics,

--- a/shared/training/metrics/accuracy.mojo
+++ b/shared/training/metrics/accuracy.mojo
@@ -9,13 +9,13 @@ Metric types:
 - Per-class accuracy: Class-wise accuracy breakdown
 
 Type support:
-- All functions work with ExTensor (int32/int64 for labels, float32/float64 for logits)
+- All functions work with AnyTensor (int32/int64 for labels, float32/float64 for logits)
 
 Issues covered:
 - #278-282: Accuracy metrics implementation
 """
 
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from collections import List
 from shared.training.metrics.base import Metric
 
@@ -25,7 +25,7 @@ from shared.training.metrics.base import Metric
 # ============================================================================
 
 
-fn top1_accuracy(predictions: ExTensor, labels: ExTensor) raises -> Float64:
+fn top1_accuracy(predictions: AnyTensor, labels: AnyTensor) raises -> Float64:
     """Compute top-1 accuracy for a single batch.
 
         Top-1 accuracy is the fraction of samples where the predicted class
@@ -45,18 +45,18 @@ fn top1_accuracy(predictions: ExTensor, labels: ExTensor) raises -> Float64:
     Examples:
     ```
             # With logits (need argmax)
-            var logits = ExTensor(List[Int](), DType.float32)  # 4 samples, 3 classes
-            var labels = ExTensor(List[Int](), DType.int32)
+            var logits = AnyTensor(List[Int](), DType.float32)  # 4 samples, 3 classes
+            var labels = AnyTensor(List[Int](), DType.int32)
             var acc = top1_accuracy(logits, labels)
 
             # With predicted class indices
-            var preds = ExTensor(List[Int](), DType.int32)  # Already argmaxed
+            var preds = AnyTensor(List[Int](), DType.int32)  # Already argmaxed
             var acc2 = top1_accuracy(preds, labels)
     ```
 
     """
     # Determine if predictions are logits (2D) or class indices (1D)
-    var pred_classes: ExTensor
+    var pred_classes: AnyTensor
     var pred_shape = predictions.shape()
 
     if len(pred_shape) == 2:
@@ -97,7 +97,7 @@ fn top1_accuracy(predictions: ExTensor, labels: ExTensor) raises -> Float64:
     return Float64(correct) / Float64(pred_classes._numel)
 
 
-fn argmax(var tensor: ExTensor, axis: Int) raises -> ExTensor:
+fn argmax(var tensor: AnyTensor, axis: Int) raises -> AnyTensor:
     """Compute argmax along specified axis.
 
     Args:
@@ -121,7 +121,7 @@ fn argmax(var tensor: ExTensor, axis: Int) raises -> ExTensor:
 
         var result_shape = List[Int]()
         result_shape.append(batch_size)
-        var result = ExTensor(result_shape, DType.int32)
+        var result = AnyTensor(result_shape, DType.int32)
 
         # For each sample in batch
         for b in range(batch_size):
@@ -163,7 +163,7 @@ fn argmax(var tensor: ExTensor, axis: Int) raises -> ExTensor:
 
 
 fn topk_accuracy(
-    predictions: ExTensor, labels: ExTensor, k: Int = 5
+    predictions: AnyTensor, labels: AnyTensor, k: Int = 5
 ) raises -> Float64:
     """Compute top-k accuracy for a single batch.
 
@@ -184,8 +184,8 @@ fn topk_accuracy(
 
     Examples:
     ```
-            var logits = ExTensor(List[Int](), DType.float32)  # 4 samples, 10 classes
-            var labels = ExTensor(List[Int](), DType.int32)
+            var logits = AnyTensor(List[Int](), DType.float32)  # 4 samples, 10 classes
+            var labels = AnyTensor(List[Int](), DType.int32)
             var acc = topk_accuracy(logits, labels, k=5)  # Top-5 accuracy
     ```
 
@@ -232,7 +232,7 @@ fn topk_accuracy(
 
 
 fn get_topk_indices(
-    predictions: ExTensor, batch_idx: Int, k: Int
+    predictions: AnyTensor, batch_idx: Int, k: Int
 ) raises -> List[Int]:
     """Get indices of top-k predictions for a single sample.
 
@@ -297,8 +297,8 @@ fn get_topk_indices(
 
 
 fn per_class_accuracy(
-    predictions: ExTensor, labels: ExTensor, num_classes: Int
-) raises -> ExTensor:
+    predictions: AnyTensor, labels: AnyTensor, num_classes: Int
+) raises -> AnyTensor:
     """Compute accuracy for each class separately.
 
         Returns a tensor where each element is the accuracy for that class,
@@ -317,15 +317,15 @@ fn per_class_accuracy(
 
     Examples:
     ```
-            var logits = ExTensor(List[Int](), DType.float32)
-            var labels = ExTensor(List[Int](), DType.int32)
+            var logits = AnyTensor(List[Int](), DType.float32)
+            var labels = AnyTensor(List[Int](), DType.int32)
             var per_class_acc = per_class_accuracy(logits, labels, num_classes=10)
             # per_class_acc[0] = accuracy for class 0, etc
     ```
 
     """
     # Get predicted classes
-    var pred_classes: ExTensor
+    var pred_classes: AnyTensor
     var pred_shape = predictions.shape()
     if len(pred_shape) == 2:
         pred_classes = argmax(predictions, axis=1)
@@ -363,7 +363,7 @@ fn per_class_accuracy(
     # Compute per-class accuracies
     var result_shape = List[Int]()
     result_shape.append(num_classes)
-    var result = ExTensor(result_shape, DType.float64)
+    var result = AnyTensor(result_shape, DType.float64)
 
     for c in range(num_classes):
         var acc: Float64
@@ -406,7 +406,7 @@ struct AccuracyMetric(Metric):
         self.correct_count = 0
         self.total_count = 0
 
-    fn update(mut self, predictions: ExTensor, labels: ExTensor) raises:
+    fn update(mut self, predictions: AnyTensor, labels: AnyTensor) raises:
         """Update metric with a new batch of predictions.
 
         Args:
@@ -417,7 +417,7 @@ struct AccuracyMetric(Metric):
             Error: If shapes are incompatible.
         """
         # Get predicted classes
-        var pred_classes: ExTensor
+        var pred_classes: AnyTensor
         var pred_shape = predictions.shape()
         if len(pred_shape) == 2:
             pred_classes = argmax(predictions, axis=1)

--- a/shared/training/metrics/base.mojo
+++ b/shared/training/metrics/base.mojo
@@ -13,7 +13,7 @@ Design principles:
 """
 
 from collections import List
-from shared.core import ExTensor
+from shared.core import AnyTensor
 
 
 trait Metric:
@@ -27,7 +27,7 @@ trait Metric:
     This ensures consistent API across accuracy, loss, confusion matrix, etc.
     """
 
-    fn update(mut self, predictions: ExTensor, labels: ExTensor) raises:
+    fn update(mut self, predictions: AnyTensor, labels: AnyTensor) raises:
         """Update metric state with a batch of predictions and labels.
 
         Args:
@@ -60,7 +60,7 @@ struct MetricResult(Copyable, Movable):
     """Whether this is a scalar or tensor metric."""
     var scalar_value: Float64
     """Scalar metric value (if is_scalar=True)."""
-    var tensor_value: ExTensor
+    var tensor_value: AnyTensor
     """Tensor metric value (if is_scalar=False)."""
 
     fn __init__(out self, name: String, value: Float64) raises:
@@ -76,9 +76,9 @@ struct MetricResult(Copyable, Movable):
         self.name = name
         self.is_scalar = True
         self.scalar_value = value
-        self.tensor_value = ExTensor(List[Int](), DType.float32)  # Placeholder
+        self.tensor_value = AnyTensor(List[Int](), DType.float32)  # Placeholder
 
-    fn __init__(out self, name: String, var value: ExTensor):
+    fn __init__(out self, name: String, var value: AnyTensor):
         """Create tensor metric result (ownership transferred).
 
         Args:
@@ -103,7 +103,7 @@ struct MetricResult(Copyable, Movable):
             raise Error("Metric '" + self.name + "' is not scalar")
         return self.scalar_value
 
-    fn get_tensor(self) raises -> ExTensor:
+    fn get_tensor(self) raises -> AnyTensor:
         """Get tensor value.
 
         Returns:

--- a/shared/training/metrics/confusion_matrix.mojo
+++ b/shared/training/metrics/confusion_matrix.mojo
@@ -13,7 +13,7 @@ Issues covered:
 - #288-292: Confusion matrix implementation
 """
 
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from collections import List
 from math import sqrt
 from shared.training.metrics.base import Metric
@@ -52,7 +52,7 @@ struct ConfusionMatrix(Metric):
     """
 
     var num_classes: Int
-    var matrix: ExTensor  # Shape: [num_classes, num_classes], dtype=int32
+    var matrix: AnyTensor  # Shape: [num_classes, num_classes], dtype=int32
     var class_names: List[String]
     var has_class_names: Bool
 
@@ -72,7 +72,7 @@ struct ConfusionMatrix(Metric):
 
         # Initialize matrix with zeros
         var shape: List[Int] = [num_classes, num_classes]
-        self.matrix = ExTensor(shape, DType.int32)
+        self.matrix = AnyTensor(shape, DType.int32)
         for i in range(num_classes * num_classes):
             self.matrix.set(i, Int64(0))
 
@@ -80,7 +80,7 @@ struct ConfusionMatrix(Metric):
         self.class_names = List[String](class_names)
         self.has_class_names = len(class_names) > 0
 
-    fn update(mut self, predictions: ExTensor, labels: ExTensor) raises:
+    fn update(mut self, predictions: AnyTensor, labels: AnyTensor) raises:
         """Update confusion matrix with new batch of predictions.
 
         Args:
@@ -92,7 +92,7 @@ struct ConfusionMatrix(Metric):
                    or labels/predictions dtype is not int32 or int64.
         """
         # Get predicted classes
-        var pred_classes: ExTensor
+        var pred_classes: AnyTensor
         var pred_shape = predictions.shape()
 
         if len(pred_shape) == 2:
@@ -155,7 +155,7 @@ struct ConfusionMatrix(Metric):
         for i in range(self.num_classes * self.num_classes):
             self.matrix._set_int64(i, Int64(0))
 
-    fn normalize(self, mode: String = "none") raises -> ExTensor:
+    fn normalize(self, mode: String = "none") raises -> AnyTensor:
         """Normalize confusion matrix by row, column, total, or none.
 
         Args:
@@ -174,7 +174,7 @@ struct ConfusionMatrix(Metric):
         var result_shape = List[Int]()
         result_shape.append(self.num_classes)
         result_shape.append(self.num_classes)
-        var result = ExTensor(result_shape, DType.float64)
+        var result = AnyTensor(result_shape, DType.float64)
 
         if mode == "none":
             # Raw counts
@@ -241,7 +241,7 @@ struct ConfusionMatrix(Metric):
 
         return result^
 
-    fn get_precision(self) raises -> ExTensor:
+    fn get_precision(self) raises -> AnyTensor:
         """Compute per-class precision.
 
         Precision[i] = matrix[i, i] / sum(matrix[:, i])
@@ -257,7 +257,7 @@ struct ConfusionMatrix(Metric):
         """
         var result_shape = List[Int]()
         result_shape.append(self.num_classes)
-        var result = ExTensor(result_shape, DType.float64)
+        var result = AnyTensor(result_shape, DType.float64)
 
         for col in range(self.num_classes):
             # Compute column sum (total predicted as this class)
@@ -278,7 +278,7 @@ struct ConfusionMatrix(Metric):
 
         return result^
 
-    fn get_recall(self) raises -> ExTensor:
+    fn get_recall(self) raises -> AnyTensor:
         """Compute per-class recall.
 
         Recall[i] = matrix[i, i] / sum(matrix[i, :])
@@ -294,7 +294,7 @@ struct ConfusionMatrix(Metric):
         """
         var result_shape = List[Int]()
         result_shape.append(self.num_classes)
-        var result = ExTensor(result_shape, DType.float64)
+        var result = AnyTensor(result_shape, DType.float64)
 
         for row in range(self.num_classes):
             # Compute row sum (total samples of this class)
@@ -315,7 +315,7 @@ struct ConfusionMatrix(Metric):
 
         return result^
 
-    fn get_f1_score(self) raises -> ExTensor:
+    fn get_f1_score(self) raises -> AnyTensor:
         """Compute per-class F1-score.
 
         F1[i] = 2 * (precision[i] * recall[i]) / (precision[i] + recall[i]).
@@ -333,7 +333,7 @@ struct ConfusionMatrix(Metric):
 
         var result_shape = List[Int]()
         result_shape.append(self.num_classes)
-        var result = ExTensor(result_shape, DType.float64)
+        var result = AnyTensor(result_shape, DType.float64)
 
         for i in range(self.num_classes):
             var p = precision._data.bitcast[Float64]()[i]
@@ -348,7 +348,7 @@ struct ConfusionMatrix(Metric):
 
 
 # Helper function for argmax (same as in accuracy.mojo, but duplicated for independence)
-fn argmax(var tensor: ExTensor) raises -> ExTensor:
+fn argmax(var tensor: AnyTensor) raises -> AnyTensor:
     """Compute argmax along last axis for 2D tensor.
 
     Args:
@@ -369,7 +369,7 @@ fn argmax(var tensor: ExTensor) raises -> ExTensor:
 
     var result_shape = List[Int]()
     result_shape.append(batch_size)
-    var result = ExTensor(result_shape, DType.int32)
+    var result = AnyTensor(result_shape, DType.int32)
 
     for b in range(batch_size):
         var max_idx = 0

--- a/shared/training/metrics/evaluate.mojo
+++ b/shared/training/metrics/evaluate.mojo
@@ -21,12 +21,12 @@ Features:
 
 """
 
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from collections import List
 
 
 fn evaluate_with_predict(
-    predictions: List[Int], labels: ExTensor
+    predictions: List[Int], labels: AnyTensor
 ) raises -> Float32:
     """Evaluate model using pre-computed predictions.
 
@@ -68,7 +68,7 @@ fn evaluate_with_predict(
     return Float32(correct) / Float32(len(predictions))
 
 
-fn evaluate_logits_batch(logits: ExTensor, labels: ExTensor) raises -> Float32:
+fn evaluate_logits_batch(logits: AnyTensor, labels: AnyTensor) raises -> Float32:
     """Evaluate using logits (2D) by computing argmax per sample.
 
         Evaluates a batch of logits by computing argmax for each sample
@@ -125,7 +125,7 @@ fn evaluate_logits_batch(logits: ExTensor, labels: ExTensor) raises -> Float32:
 
 
 fn compute_accuracy_on_batch(
-    predictions: ExTensor, labels: ExTensor
+    predictions: AnyTensor, labels: AnyTensor
 ) raises -> Float32:
     """Compute accuracy for a single batch (simple utility).
 

--- a/shared/training/metrics/loss_tracker.mojo
+++ b/shared/training/metrics/loss_tracker.mojo
@@ -16,7 +16,7 @@ Issues covered:
 from collections import List
 from math import sqrt
 from shared.training.metrics.base import Metric
-from shared.core import ExTensor
+from shared.core import AnyTensor
 
 # min and max are now builtins in Mojo - no import needed
 
@@ -398,7 +398,7 @@ struct LossTracker(Metric):
         return List[String](self.components)
 
     # Metric trait implementation (for coordination interface)
-    fn update(mut self, predictions: ExTensor, labels: ExTensor) raises:
+    fn update(mut self, predictions: AnyTensor, labels: AnyTensor) raises:
         """Update metric with predictions and labels (Metric trait).
 
         Note: LossTracker doesn't use predictions/labels directly.

--- a/shared/training/metrics/results_printer.mojo
+++ b/shared/training/metrics/results_printer.mojo
@@ -13,7 +13,7 @@ Features:
 """
 
 from collections import List
-from shared.core import ExTensor
+from shared.core import AnyTensor
 
 
 # ============================================================================
@@ -128,7 +128,7 @@ fn print_evaluation_summary(
 # ============================================================================
 
 
-fn print_per_class_accuracy(per_class_accuracies: ExTensor) raises:
+fn print_per_class_accuracy(per_class_accuracies: AnyTensor) raises:
     """Print per-class accuracy metrics with default numeric class labels.
 
         Displays accuracy for each class in a table format using numeric indices
@@ -142,7 +142,7 @@ fn print_per_class_accuracy(per_class_accuracies: ExTensor) raises:
 
         Example:
             ```mojo
-            var per_class = ExTensor([10], DType.float64)
+            var per_class = AnyTensor([10], DType.float64)
             # ... populate with per-class accuracies ...
             print_per_class_accuracy(per_class)
 
@@ -166,7 +166,7 @@ fn print_per_class_accuracy(per_class_accuracies: ExTensor) raises:
 
 
 fn print_per_class_accuracy(
-    per_class_accuracies: ExTensor,
+    per_class_accuracies: AnyTensor,
     class_names: List[String],
     column_width: Int = 15,
 ) raises:
@@ -185,7 +185,7 @@ fn print_per_class_accuracy(
 
         Example:
             ```mojo
-            var per_class = ExTensor([3], DType.float64)
+            var per_class = AnyTensor([3], DType.float64)
             # ... populate with per-class accuracies ...
             var names = List[String]()
             names.append("Cat")
@@ -250,7 +250,7 @@ fn print_per_class_accuracy(
 # ============================================================================
 
 
-fn print_confusion_matrix(matrix: ExTensor) raises:
+fn print_confusion_matrix(matrix: AnyTensor) raises:
     """Print confusion matrix with default numeric class labels.
 
         Displays confusion matrix with proper alignment using numeric indices
@@ -265,7 +265,7 @@ fn print_confusion_matrix(matrix: ExTensor) raises:
         Example:
             ```mojo
             var cm_shape = [3, 3]
-            var matrix = ExTensor(cm_shape, DType.int32)
+            var matrix = AnyTensor(cm_shape, DType.int32)
             # ... populate matrix ...
             print_confusion_matrix(matrix)
 
@@ -296,7 +296,7 @@ fn print_confusion_matrix(matrix: ExTensor) raises:
 
 
 fn print_confusion_matrix(
-    matrix: ExTensor,
+    matrix: AnyTensor,
     class_names: List[String],
     normalized: Bool = False,
     column_width: Int = 10,
@@ -318,7 +318,7 @@ fn print_confusion_matrix(
         Example:
             ```mojo
             var cm_shape = [3, 3]
-            var matrix = ExTensor(cm_shape, DType.int32)
+            var matrix = AnyTensor(cm_shape, DType.int32)
             # ... populate matrix ...
             var names = List[String]()
             names.append("Cat")

--- a/shared/training/mixed_precision.mojo
+++ b/shared/training/mixed_precision.mojo
@@ -27,14 +27,14 @@ Usage:
     scaler.step()  # Update scale factor
 
     # SIMD-optimized FP16/FP32 conversion
-    var fp16_params = ExTensor(..., DType.float16)
+    var fp16_params = AnyTensor(..., DType.float16)
     var fp32_master = convert_to_fp32_master(fp16_params)  # ~4x faster
     update_model_from_master(fp16_params, fp32_master)  # ~4x faster
 
 See mixed precision training examples in examples/mixed_precision/
 """
 
-from shared.core import ExTensor, full
+from shared.core import AnyTensor, full
 from shared.core import has_nan, has_inf
 from math import log2
 from algorithm import vectorize
@@ -120,7 +120,7 @@ struct GradientScaler(Copyable, Movable):
         self.min_scale = min_scale
         self.max_scale = max_scale
 
-    fn scale_loss(self, loss: ExTensor) raises -> ExTensor:
+    fn scale_loss(self, loss: AnyTensor) raises -> AnyTensor:
         """Scale loss by current scale factor.
 
         Args:
@@ -150,7 +150,7 @@ struct GradientScaler(Copyable, Movable):
         var scale_tensor = full(loss.shape(), Float64(self.scale), loss.dtype())
         return loss * scale_tensor
 
-    fn unscale_gradients(self, gradients: ExTensor) raises -> ExTensor:
+    fn unscale_gradients(self, gradients: AnyTensor) raises -> AnyTensor:
         """Unscale gradients by dividing by scale factor.
 
         Args:
@@ -236,7 +236,7 @@ struct GradientScaler(Copyable, Movable):
         return self._num_steps
 
 
-fn convert_to_fp32_master(params: ExTensor) raises -> ExTensor:
+fn convert_to_fp32_master(params: AnyTensor) raises -> AnyTensor:
     """Convert model parameters to FP32 master weights with SIMD optimization.
 
     Creates FP32 copy of parameters for optimizer state management.
@@ -264,7 +264,7 @@ fn convert_to_fp32_master(params: ExTensor) raises -> ExTensor:
     Example:
         ```mojo
         # Model params in FP16
-        var fp16_params = ExTensor.zeros((1000, 1000), DType.float16)
+        var fp16_params = AnyTensor.zeros((1000, 1000), DType.float16)
 
         # Create FP32 master weights for optimizer
         var master_params = convert_to_fp32_master(fp16_params)
@@ -275,7 +275,7 @@ fn convert_to_fp32_master(params: ExTensor) raises -> ExTensor:
         raise Error("Cannot convert empty parameter tensor")
 
     # Create FP32 tensor with same shape
-    var result = ExTensor(params.shape(), DType.float32)
+    var result = AnyTensor(params.shape(), DType.float32)
     var size = params._numel
 
     # If already FP32, use SIMD copy
@@ -300,7 +300,7 @@ fn convert_to_fp32_master(params: ExTensor) raises -> ExTensor:
 
 
 fn update_model_from_master(
-    mut model_params: ExTensor, master_params: ExTensor
+    mut model_params: AnyTensor, master_params: AnyTensor
 ) raises:
     """Update model parameters from FP32 master weights with SIMD optimization.
 
@@ -357,7 +357,7 @@ fn update_model_from_master(
         model_params._set_float64(i, val)
 
 
-fn check_gradients_finite(gradients: ExTensor) raises -> Bool:
+fn check_gradients_finite(gradients: AnyTensor) raises -> Bool:
     """Check if gradients contain only finite values.
 
     Returns True if gradients are all finite (no NaN or Inf).
@@ -385,8 +385,8 @@ fn check_gradients_finite(gradients: ExTensor) raises -> Bool:
 
 
 fn clip_gradients_by_norm(
-    gradients: ExTensor, max_norm: Float32
-) raises -> ExTensor:
+    gradients: AnyTensor, max_norm: Float32
+) raises -> AnyTensor:
     """Clip gradients by global norm.
 
     Scales gradients if their L2 norm exceeds max_norm.
@@ -437,8 +437,8 @@ fn clip_gradients_by_norm(
 
 
 fn clip_gradients_by_value(
-    gradients: ExTensor, min_value: Float32, max_value: Float32
-) raises -> ExTensor:
+    gradients: AnyTensor, min_value: Float32, max_value: Float32
+) raises -> AnyTensor:
     """Clip gradients by value range with SIMD optimization.
 
     Clamps each gradient value to [min_value, max_value].
@@ -478,7 +478,7 @@ fn clip_gradients_by_value(
         return gradients  # No clipping needed for empty tensor
 
     # Clamp each element to [min_value, max_value]
-    var result = ExTensor(gradients.shape(), gradients.dtype())
+    var result = AnyTensor(gradients.shape(), gradients.dtype())
     var size = gradients._numel
 
     # Use SIMD optimized path for Float32
@@ -510,7 +510,7 @@ fn clip_gradients_by_value(
 
 
 @always_inline
-fn _convert_fp32_to_fp32_simd(src: ExTensor, mut dst: ExTensor) raises:
+fn _convert_fp32_to_fp32_simd(src: AnyTensor, mut dst: AnyTensor) raises:
     """SIMD copy for FP32 to FP32 conversion.
 
     Uses vectorized load/store for maximum throughput.
@@ -531,7 +531,7 @@ fn _convert_fp32_to_fp32_simd(src: ExTensor, mut dst: ExTensor) raises:
 
 
 @always_inline
-fn _update_fp32_from_fp32_simd(src: ExTensor, mut dst: ExTensor) raises:
+fn _update_fp32_from_fp32_simd(src: AnyTensor, mut dst: AnyTensor) raises:
     """SIMD copy from FP32 master to FP32 model params.
 
     Uses vectorized load/store for maximum throughput.
@@ -553,7 +553,7 @@ fn _update_fp32_from_fp32_simd(src: ExTensor, mut dst: ExTensor) raises:
 
 @always_inline
 fn _clip_by_value_simd_float32(
-    src: ExTensor, mut dst: ExTensor, min_val: Float32, max_val: Float32
+    src: AnyTensor, mut dst: AnyTensor, min_val: Float32, max_val: Float32
 ):
     """SIMD clamp for Float32 gradients.
 
@@ -579,7 +579,7 @@ fn _clip_by_value_simd_float32(
 
 @always_inline
 fn _clip_by_value_simd_float64(
-    src: ExTensor, mut dst: ExTensor, min_val: Float32, max_val: Float32
+    src: AnyTensor, mut dst: AnyTensor, min_val: Float32, max_val: Float32
 ):
     """SIMD clamp for Float64 gradients.
 
@@ -606,7 +606,7 @@ fn _clip_by_value_simd_float64(
 
 
 @always_inline
-fn _convert_fp16_to_fp32_simd(src: ExTensor, mut dst: ExTensor) raises:
+fn _convert_fp16_to_fp32_simd(src: AnyTensor, mut dst: AnyTensor) raises:
     """SIMD conversion from FP16 to FP32 with vectorization.
 
     Uses SIMD casting to vectorize FP16→FP32 conversion.
@@ -638,7 +638,7 @@ fn _convert_fp16_to_fp32_simd(src: ExTensor, mut dst: ExTensor) raises:
 
 
 @always_inline
-fn _convert_fp32_to_fp16_simd(src: ExTensor, mut dst: ExTensor) raises:
+fn _convert_fp32_to_fp16_simd(src: AnyTensor, mut dst: AnyTensor) raises:
     """SIMD conversion from FP32 to FP16 with vectorization.
 
     Uses SIMD casting to vectorize FP32→FP16 conversion.

--- a/shared/training/model_utils.mojo
+++ b/shared/training/model_utils.mojo
@@ -41,7 +41,7 @@ Example:
     ```
 """
 
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.utils.serialization import save_tensor, load_tensor
 from collections import List
 
@@ -52,7 +52,7 @@ from collections import List
 
 
 fn save_model_weights(
-    parameters: List[ExTensor], directory: String, param_names: List[String]
+    parameters: List[AnyTensor], directory: String, param_names: List[String]
 ) raises:
     """Save model weights to directory.
 
@@ -69,7 +69,7 @@ fn save_model_weights(
 
         Example:
             ```mojo
-            var params : List[ExTensor] = []
+            var params : List[AnyTensor] = []
             params.append(model.conv1_kernel)
             params.append(model.fc1_weights)
 
@@ -97,7 +97,7 @@ fn save_model_weights(
 
 
 fn load_model_weights(
-    mut parameters: List[ExTensor], directory: String, param_names: List[String]
+    mut parameters: List[AnyTensor], directory: String, param_names: List[String]
 ) raises:
     """Load model weights from directory.
 
@@ -114,7 +114,7 @@ fn load_model_weights(
 
         Example:
             ```mojo
-            var params : List[ExTensor] = []
+            var params : List[AnyTensor] = []
             var names = List[String]()
             names.append("conv1_kernel")
             names.append("fc1_weights")
@@ -275,7 +275,7 @@ fn get_model_parameter_names(model_type: String) raises -> List[String]:
         raise Error("Unknown model type: " + model_type)
 
 
-fn validate_shapes(loaded: List[ExTensor], expected: List[ExTensor]) raises:
+fn validate_shapes(loaded: List[AnyTensor], expected: List[AnyTensor]) raises:
     """Validate that loaded tensors match expected shapes.
 
     Useful for checking that checkpoint weights are compatible with

--- a/shared/training/optimizers/adam.mojo
+++ b/shared/training/optimizers/adam.mojo
@@ -21,7 +21,7 @@ Reference:
     arXiv preprint arXiv:1412.6980
 """
 
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.core import subtract, multiply, add, divide, power
 from shared.core.arithmetic_simd import (
     subtract_simd,
@@ -34,17 +34,17 @@ from shared.core import full_like, ones_like
 
 
 fn adam_step(
-    params: ExTensor,
-    gradients: ExTensor,
-    m: ExTensor,
-    v: ExTensor,
+    params: AnyTensor,
+    gradients: AnyTensor,
+    m: AnyTensor,
+    v: AnyTensor,
     t: Int,
     learning_rate: Float64,
     beta1: Float64 = 0.9,
     beta2: Float64 = 0.999,
     epsilon: Float64 = 1e-8,
     weight_decay: Float64 = 0.0,
-) raises -> Tuple[ExTensor, ExTensor, ExTensor]:
+) raises -> Tuple[AnyTensor, AnyTensor, AnyTensor]:
     """Perform a single Adam optimization step - pure functional.
 
         Returns new parameters, new first moment (m), and new second moment (v).
@@ -67,7 +67,7 @@ fn adam_step(
 
     Example (basic Adam):
         ```mojo
-        from shared.core import ExTensor, zeros_like
+        from shared.core import AnyTensor, zeros_like
         from shared.training.optimizers import adam_step
 
         var W = xavier_uniform(784, 128, DType.float32)
@@ -161,13 +161,13 @@ fn adam_step(
 
 
 fn adam_step_simple(
-    params: ExTensor,
-    gradients: ExTensor,
-    m: ExTensor,
-    v: ExTensor,
+    params: AnyTensor,
+    gradients: AnyTensor,
+    m: AnyTensor,
+    v: AnyTensor,
     t: Int,
     learning_rate: Float64,
-) raises -> Tuple[ExTensor, ExTensor, ExTensor]:
+) raises -> Tuple[AnyTensor, AnyTensor, AnyTensor]:
     """Simplified Adam step with default hyperparameters.
 
         This is a convenience function for basic Adam optimization.

--- a/shared/training/optimizers/adamw.mojo
+++ b/shared/training/optimizers/adamw.mojo
@@ -23,7 +23,7 @@ Reference:
     arXiv preprint arXiv:1711.05101
 """
 
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.core import subtract, multiply, add, divide, power
 from shared.core.arithmetic_simd import (
     subtract_simd,
@@ -36,17 +36,17 @@ from shared.core import full_like, ones_like
 
 
 fn adamw_step(
-    params: ExTensor,
-    gradients: ExTensor,
-    m: ExTensor,
-    v: ExTensor,
+    params: AnyTensor,
+    gradients: AnyTensor,
+    m: AnyTensor,
+    v: AnyTensor,
     t: Int,
     learning_rate: Float64,
     beta1: Float64 = 0.9,
     beta2: Float64 = 0.999,
     epsilon: Float64 = 1e-8,
     weight_decay: Float64 = 0.01,
-) raises -> Tuple[ExTensor, ExTensor, ExTensor]:
+) raises -> Tuple[AnyTensor, AnyTensor, AnyTensor]:
     """Perform a single AdamW optimization step - pure functional.
 
         Returns new parameters, new first moment (m), and new second moment (v).
@@ -72,7 +72,7 @@ fn adamw_step(
 
         Example (basic AdamW):
             ```mojo
-            from shared.core import ExTensor, zeros_like
+            from shared.core import AnyTensor, zeros_like
             from shared.training.optimizers import adamw_step
 
             var W = xavier_uniform(784, 128, DType.float32)
@@ -170,13 +170,13 @@ fn adamw_step(
 
 
 fn adamw_step_simple(
-    params: ExTensor,
-    gradients: ExTensor,
-    m: ExTensor,
-    v: ExTensor,
+    params: AnyTensor,
+    gradients: AnyTensor,
+    m: AnyTensor,
+    v: AnyTensor,
     t: Int,
     learning_rate: Float64,
-) raises -> Tuple[ExTensor, ExTensor, ExTensor]:
+) raises -> Tuple[AnyTensor, AnyTensor, AnyTensor]:
     """Simplified AdamW step with default hyperparameters.
 
         This is a convenience function for basic AdamW optimization with

--- a/shared/training/optimizers/lars.mojo
+++ b/shared/training/optimizers/lars.mojo
@@ -17,7 +17,7 @@ Reference:
     for Massive Batch Training. arXiv preprint arXiv:1708.03888
 """
 
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.core import subtract, multiply, add
 from shared.core.arithmetic_simd import subtract_simd, multiply_simd, add_simd
 from shared.core import full_like
@@ -25,15 +25,15 @@ from shared.core import compute_tensor_l2_norm
 
 
 fn lars_step(
-    params: ExTensor,
-    gradients: ExTensor,
-    velocity: ExTensor,
+    params: AnyTensor,
+    gradients: AnyTensor,
+    velocity: AnyTensor,
     learning_rate: Float64,
     momentum: Float64 = 0.9,
     weight_decay: Float64 = 0.0001,
     trust_coefficient: Float64 = 0.001,
     epsilon: Float64 = 1e-8,
-) raises -> Tuple[ExTensor, ExTensor]:
+) raises -> Tuple[AnyTensor, AnyTensor]:
     """Perform a single LARS optimization step - pure functional.
 
         Returns new parameters and new velocity. Caller manages all state.
@@ -57,7 +57,7 @@ fn lars_step(
 
     Example (LARS with momentum):
         ```mojo
-        from shared.core import ExTensor, zeros_like
+        from shared.core import AnyTensor, zeros_like
         from shared.training.optimizers import lars_step
 
         var W = xavier_uniform([784, 128], DType.float32)
@@ -145,11 +145,11 @@ fn lars_step(
 
 
 fn lars_step_simple(
-    params: ExTensor,
-    gradients: ExTensor,
-    velocity: ExTensor,
+    params: AnyTensor,
+    gradients: AnyTensor,
+    velocity: AnyTensor,
     learning_rate: Float64,
-) raises -> Tuple[ExTensor, ExTensor]:
+) raises -> Tuple[AnyTensor, AnyTensor]:
     """Simplified LARS step with default hyperparameters.
 
     This is a convenience function for basic LARS optimization.

--- a/shared/training/optimizers/optimizer_utils.mojo
+++ b/shared/training/optimizers/optimizer_utils.mojo
@@ -17,13 +17,13 @@ Design Philosophy:
 """
 
 from math import sqrt
-from shared.core import ExTensor, zeros_like, full_like
+from shared.core import AnyTensor, zeros_like, full_like
 from shared.core.arithmetic_simd import multiply_simd
 
 
 fn initialize_optimizer_state(
     param_shapes: List[List[Int]], num_states: Int, dtype: DType = DType.float32
-) raises -> List[List[ExTensor]]:
+) raises -> List[List[AnyTensor]]:
     """Initialize multiple state buffers for optimizer (e.g., momentum, moments).
 
         Creates num_states lists of zero-initialized tensors for each parameter shape.
@@ -35,7 +35,7 @@ fn initialize_optimizer_state(
             dtype: Data type for state tensors (default: float32).
 
     Returns:
-            List of state buffer lists. Each element is a list of ExTensor states
+            List of state buffer lists. Each element is a list of AnyTensor states
             for a single parameter.
 
     Raises:
@@ -59,10 +59,10 @@ fn initialize_optimizer_state(
     """
     from shared.core.extensor import zeros
 
-    var all_states = List[List[ExTensor]]()
+    var all_states = List[List[AnyTensor]]()
 
     for i in range(len(param_shapes)):
-        var param_state: List[ExTensor] = []
+        var param_state: List[AnyTensor] = []
 
         for _ in range(num_states):
             # Copy the shape since List[Int] is not ImplicitlyCopyable
@@ -78,8 +78,8 @@ fn initialize_optimizer_state(
 
 
 fn initialize_optimizer_state_from_params(
-    params: List[ExTensor], num_states: Int
-) raises -> List[List[ExTensor]]:
+    params: List[AnyTensor], num_states: Int
+) raises -> List[List[AnyTensor]]:
     """Initialize multiple state buffers for optimizer from existing parameters.
 
         Convenience function that extracts shapes from parameter tensors and creates
@@ -98,7 +98,7 @@ fn initialize_optimizer_state_from_params(
         Example:
             ```mojo
             # Collect all model parameters
-            var params : List[ExTensor] = []
+            var params : List[AnyTensor] = []
             params.append(layer1_weight)
             params.append(layer1_bias)
             params.append(layer2_weight)
@@ -109,11 +109,11 @@ fn initialize_optimizer_state_from_params(
     """
     from shared.core.extensor import zeros
 
-    var all_states = List[List[ExTensor]]()
+    var all_states = List[List[AnyTensor]]()
 
     for i in range(len(params)):
         var param = params[i]
-        var param_state: List[ExTensor] = []
+        var param_state: List[AnyTensor] = []
 
         for _ in range(num_states):
             param_state.append(zeros(param.shape(), param.dtype()))
@@ -124,8 +124,8 @@ fn initialize_optimizer_state_from_params(
 
 
 fn compute_weight_decay_term(
-    params: ExTensor, weight_decay: Float64
-) raises -> ExTensor:
+    params: AnyTensor, weight_decay: Float64
+) raises -> AnyTensor:
     """Compute L2 regularization term: weight_decay * params.
 
         Returns a tensor that represents the weight decay contribution to the
@@ -157,7 +157,7 @@ fn compute_weight_decay_term(
     return multiply_simd(wd_tensor, params)
 
 
-fn apply_weight_decay(mut params: ExTensor, weight_decay: Float64) raises:
+fn apply_weight_decay(mut params: AnyTensor, weight_decay: Float64) raises:
     """Apply L2 regularization directly to parameters (in-place).
 
         This performs decoupled weight decay: params = params * (1 - weight_decay).
@@ -198,7 +198,7 @@ fn apply_weight_decay(mut params: ExTensor, weight_decay: Float64) raises:
         params._set_float64(i, decayed._get_float64(i))
 
 
-fn scale_tensor(tensor: ExTensor, scale: Float64) raises -> ExTensor:
+fn scale_tensor(tensor: AnyTensor, scale: Float64) raises -> AnyTensor:
     """Multiply tensor by scalar value.
 
         Returns a new tensor containing tensor * scale.
@@ -224,7 +224,7 @@ fn scale_tensor(tensor: ExTensor, scale: Float64) raises -> ExTensor:
     return multiply_simd(scale_tensor, tensor)
 
 
-fn scale_tensor_inplace(mut tensor: ExTensor, scale: Float64) raises:
+fn scale_tensor_inplace(mut tensor: AnyTensor, scale: Float64) raises:
     """Multiply tensor by scalar value (in-place).
 
         Modifies the tensor in-place by multiplying all elements by scale.
@@ -248,7 +248,7 @@ fn scale_tensor_inplace(mut tensor: ExTensor, scale: Float64) raises:
         tensor._set_float64(i, val * scale)
 
 
-fn compute_tensor_norm(tensor: ExTensor) raises -> Float64:
+fn compute_tensor_norm(tensor: AnyTensor) raises -> Float64:
     """Compute L2 norm (Euclidean norm) of a tensor.
 
         Returns sqrt(sum(tensor^2)).
@@ -281,7 +281,7 @@ fn compute_tensor_norm(tensor: ExTensor) raises -> Float64:
     return sqrt(norm_squared)
 
 
-fn compute_global_norm(tensors: List[ExTensor]) raises -> Float64:
+fn compute_global_norm(tensors: List[AnyTensor]) raises -> Float64:
     """Compute global L2 norm across multiple tensors.
 
         Returns sqrt(sum over all tensors of sum(tensor^2)).
@@ -300,7 +300,7 @@ fn compute_global_norm(tensors: List[ExTensor]) raises -> Float64:
             ```mojo
             var grad1 = full([100], 1.0, DType.float32)
             var grad2 = full([50], 1.0, DType.float32)
-            var tensors : List[ExTensor] = [grad1, grad2]
+            var tensors : List[AnyTensor] = [grad1, grad2]
 
             var global_norm = compute_global_norm(tensors)
             # global_norm = sqrt(100 + 50) = sqrt(150) ≈ 12.25
@@ -324,7 +324,7 @@ fn compute_global_norm(tensors: List[ExTensor]) raises -> Float64:
     return sqrt(total_norm_squared)
 
 
-fn normalize_tensor_to_unit_norm(mut tensor: ExTensor) raises:
+fn normalize_tensor_to_unit_norm(mut tensor: AnyTensor) raises:
     """Normalize tensor to unit L2 norm (in-place).
 
         Modifies the tensor in-place so that its L2 norm becomes 1.0.
@@ -353,7 +353,7 @@ fn normalize_tensor_to_unit_norm(mut tensor: ExTensor) raises:
         scale_tensor_inplace(tensor, scale)
 
 
-fn clip_tensor_norm(mut tensor: ExTensor, max_norm: Float64) raises -> Float64:
+fn clip_tensor_norm(mut tensor: AnyTensor, max_norm: Float64) raises -> Float64:
     """Clip tensor norm if it exceeds max_norm (in-place).
 
         If the L2 norm of the tensor exceeds max_norm, scales all elements
@@ -394,7 +394,7 @@ fn clip_tensor_norm(mut tensor: ExTensor, max_norm: Float64) raises -> Float64:
 
 
 fn clip_global_norm(
-    mut tensors: List[ExTensor], max_norm: Float64
+    mut tensors: List[AnyTensor], max_norm: Float64
 ) raises -> Float64:
     """Clip global L2 norm across all tensors (in-place).
 
@@ -415,7 +415,7 @@ fn clip_global_norm(
             ```mojo
             var grad1 = full([100], 1.0, DType.float32)
             var grad2 = full([50], 1.0, DType.float32)
-            var grads : List[ExTensor] = [grad1, grad2]
+            var grads : List[AnyTensor] = [grad1, grad2]
 
             var global_norm = clip_global_norm(grads, max_norm=5.0)
             # Both gradients scaled proportionally
@@ -442,8 +442,8 @@ fn clip_global_norm(
 
 
 fn apply_bias_correction(
-    estimate: ExTensor, decay: Float64, timestep: Int
-) raises -> ExTensor:
+    estimate: AnyTensor, decay: Float64, timestep: Int
+) raises -> AnyTensor:
     """Apply bias correction to exponential moving average.
 
         Used in adaptive optimizers (Adam, RMSprop, etc.) to correct for bias
@@ -501,7 +501,7 @@ fn apply_bias_correction(
 
 
 fn validate_optimizer_state(
-    params: List[ExTensor], states: List[List[ExTensor]]
+    params: List[AnyTensor], states: List[List[AnyTensor]]
 ) raises:
     """Validate that optimizer state matches parameter shapes.
 

--- a/shared/training/optimizers/rmsprop.mojo
+++ b/shared/training/optimizers/rmsprop.mojo
@@ -22,23 +22,23 @@ Reference:
     machine learning, 4(2), 26-31
 """
 
-from shared.core import ExTensor, zeros, full_like, zeros_like
+from shared.core import AnyTensor, zeros, full_like, zeros_like
 from shared.core import subtract, multiply, add, divide, power
 from shared.core import sqrt
 
 
 fn rmsprop_step(
-    params: ExTensor,
-    gradients: ExTensor,
-    square_avg: ExTensor,
+    params: AnyTensor,
+    gradients: AnyTensor,
+    square_avg: AnyTensor,
     t: Int,
     learning_rate: Float64,
     alpha: Float64 = 0.99,
     epsilon: Float64 = 1e-8,
     weight_decay: Float64 = 0.0,
     momentum: Float64 = 0.0,
-    buf: Optional[ExTensor] = None,
-) raises -> Tuple[ExTensor, ExTensor, ExTensor]:
+    buf: Optional[AnyTensor] = None,
+) raises -> Tuple[AnyTensor, AnyTensor, AnyTensor]:
     """Perform a single RMSprop optimization step - pure functional.
 
         Returns new parameters, new square average, and new momentum buffer
@@ -61,7 +61,7 @@ fn rmsprop_step(
 
     Example (basic RMSprop):
         ```mojo
-        from shared.core import ExTensor, zeros_like
+        from shared.core import AnyTensor, zeros_like
         from shared.training.optimizers import rmsprop_step
 
         var W = xavier_uniform(784, 128, DType.float32)
@@ -114,7 +114,7 @@ fn rmsprop_step(
         raise Error("Timestep t must be positive (starts at 1)")
 
     # Initialize buf if not provided
-    var initialized_buf: ExTensor
+    var initialized_buf: AnyTensor
     if buf:
         initialized_buf = buf.value()
     else:
@@ -169,13 +169,13 @@ fn rmsprop_step(
 
 
 fn rmsprop_step_simple(
-    params: ExTensor,
-    gradients: ExTensor,
-    square_avg: ExTensor,
+    params: AnyTensor,
+    gradients: AnyTensor,
+    square_avg: AnyTensor,
     learning_rate: Float64,
     alpha: Float64 = 0.99,
     epsilon: Float64 = 1e-8,
-) raises -> Tuple[ExTensor, ExTensor]:
+) raises -> Tuple[AnyTensor, AnyTensor]:
     """Simplified RMSprop step without weight decay, momentum, or timestep.
 
         This is a convenience function for basic RMSprop updates.
@@ -193,7 +193,7 @@ fn rmsprop_step_simple(
 
     Example:
         ```mojo
-        from shared.core import ExTensor, zeros_like
+        from shared.core import AnyTensor, zeros_like
         from shared.training.optimizers import rmsprop_step_simple
 
         var W = xavier_uniform(784, 128, DType.float32)

--- a/shared/training/optimizers/sgd.mojo
+++ b/shared/training/optimizers/sgd.mojo
@@ -14,20 +14,20 @@ With weight decay (L2 regularization):
     params = params - learning_rate * (gradients + weight_decay * params)
 """
 
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.core import subtract, multiply, add
 from shared.core.arithmetic_simd import subtract_simd, multiply_simd, add_simd
 from shared.core import full_like
 
 
 fn sgd_step(
-    params: ExTensor,
-    gradients: ExTensor,
-    velocity: ExTensor,
+    params: AnyTensor,
+    gradients: AnyTensor,
+    velocity: AnyTensor,
     learning_rate: Float64,
     momentum: Float64 = 0.0,
     weight_decay: Float64 = 0.0,
-) raises -> Tuple[ExTensor, ExTensor]:
+) raises -> Tuple[AnyTensor, AnyTensor]:
     """Perform a single SGD optimization step - pure functional.
 
         Returns new parameters and new velocity. Caller manages all state.
@@ -48,7 +48,7 @@ fn sgd_step(
 
         Example (basic SGD without momentum):
             ```mojo
-            from shared.core import ExTensor, zeros_like
+            from shared.core import AnyTensor, zeros_like
             from shared.training.optimizers import sgd_step
 
             var W = xavier_uniform(784, 128, DType.float32)
@@ -118,8 +118,8 @@ fn sgd_step(
 
 
 fn sgd_step_simple(
-    params: ExTensor, gradients: ExTensor, learning_rate: Float64
-) raises -> ExTensor:
+    params: AnyTensor, gradients: AnyTensor, learning_rate: Float64
+) raises -> AnyTensor:
     """Simplified SGD step without momentum or weight decay.
 
         This is a convenience function for basic gradient descent.
@@ -159,9 +159,9 @@ fn sgd_step_simple(
 
 
 fn sgd_momentum_update_inplace(
-    mut param: ExTensor,
-    grad: ExTensor,
-    mut velocity: ExTensor,
+    mut param: AnyTensor,
+    grad: AnyTensor,
+    mut velocity: AnyTensor,
     lr: Float64,
     momentum: Float64,
 ) raises:
@@ -186,7 +186,7 @@ fn sgd_momentum_update_inplace(
 
         Example:
             ```mojo
-            from shared.core import ExTensor, zeros_like
+            from shared.core import AnyTensor, zeros_like
             from shared.training.optimizers import sgd_momentum_update_inplace
 
             var W = xavier_uniform([784, 128], DType.float32)
@@ -254,7 +254,7 @@ fn sgd_momentum_update_inplace(
 
 fn initialize_velocities(
     param_shapes: List[List[Int]], dtype: DType = DType.float32
-) raises -> List[ExTensor]:
+) raises -> List[AnyTensor]:
     """Create zero-initialized velocity tensors for SGD with momentum.
 
         This utility function creates momentum buffers for all parameters in a model
@@ -293,7 +293,7 @@ fn initialize_velocities(
     """
     from shared.core.extensor import zeros
 
-    var velocities: List[ExTensor] = []
+    var velocities: List[AnyTensor] = []
 
     for i in range(len(param_shapes)):
         # Copy the shape since List[Int] is not ImplicitlyCopyable
@@ -306,8 +306,8 @@ fn initialize_velocities(
 
 
 fn initialize_velocities_from_params(
-    params: List[ExTensor],
-) raises -> List[ExTensor]:
+    params: List[AnyTensor],
+) raises -> List[AnyTensor]:
     """Create zero-initialized velocity tensors matching a list of parameters.
 
         Convenience function that extracts shapes from existing parameter tensors
@@ -327,7 +327,7 @@ fn initialize_velocities_from_params(
             from shared.training.optimizers import initialize_velocities_from_params
 
             # Collect all model parameters
-            var params : List[ExTensor] = []
+            var params : List[AnyTensor] = []
             params.append(model.conv1_kernel)
             params.append(model.conv1_bias)
             params.append(model.fc1_weights)
@@ -338,7 +338,7 @@ fn initialize_velocities_from_params(
     """
     from shared.core.extensor import zeros
 
-    var velocities: List[ExTensor] = []
+    var velocities: List[AnyTensor] = []
 
     for i in range(len(params)):
         var param = params[i]

--- a/shared/training/precision_config.mojo
+++ b/shared/training/precision_config.mojo
@@ -23,7 +23,7 @@ See examples/mixed_precision_training.mojo for complete usage
 
 from sys import is_defined
 
-from shared.core.extensor import ExTensor, full, zeros
+from shared.core.extensor import AnyTensor, full, zeros
 from shared.core.dtype_cast import cast_tensor
 from shared.core.numerical_safety import has_nan, has_inf
 from shared.training.mixed_precision import (
@@ -325,7 +325,7 @@ struct PrecisionConfig(Copyable, Movable):
                 + ". Use fp32, fp16, bf16, or fp8."
             )
 
-    fn cast_to_compute(self, tensor: ExTensor) raises -> ExTensor:
+    fn cast_to_compute(self, tensor: AnyTensor) raises -> AnyTensor:
         """Cast tensor to compute precision.
 
         Args:
@@ -341,7 +341,7 @@ struct PrecisionConfig(Copyable, Movable):
             return tensor
         return cast_tensor(tensor, self.compute_dtype)
 
-    fn cast_to_storage(self, tensor: ExTensor) raises -> ExTensor:
+    fn cast_to_storage(self, tensor: AnyTensor) raises -> AnyTensor:
         """Cast tensor to storage precision.
 
         Args:
@@ -357,7 +357,7 @@ struct PrecisionConfig(Copyable, Movable):
             return tensor
         return cast_tensor(tensor, self.storage_dtype)
 
-    fn cast_to_master(self, tensor: ExTensor) raises -> ExTensor:
+    fn cast_to_master(self, tensor: AnyTensor) raises -> AnyTensor:
         """Cast tensor to master (FP32) precision.
 
         Args:
@@ -371,7 +371,7 @@ struct PrecisionConfig(Copyable, Movable):
         """
         return convert_to_fp32_master(tensor)
 
-    fn scale_loss(self, loss: ExTensor) raises -> ExTensor:
+    fn scale_loss(self, loss: AnyTensor) raises -> AnyTensor:
         """Scale loss for mixed precision training.
 
         For FP32, returns loss unchanged.
@@ -390,7 +390,7 @@ struct PrecisionConfig(Copyable, Movable):
             return loss
         return self.scaler.scale_loss(loss)
 
-    fn unscale_gradients(self, gradients: ExTensor) raises -> ExTensor:
+    fn unscale_gradients(self, gradients: AnyTensor) raises -> AnyTensor:
         """Unscale gradients after backward pass.
 
         For FP32, returns gradients unchanged.
@@ -409,7 +409,7 @@ struct PrecisionConfig(Copyable, Movable):
             return gradients
         return self.scaler.unscale_gradients(gradients)
 
-    fn check_gradients(self, gradients: ExTensor) raises -> Bool:
+    fn check_gradients(self, gradients: AnyTensor) raises -> Bool:
         """Check if gradients are valid (no NaN/Inf).
 
         Args:
@@ -479,8 +479,8 @@ struct PrecisionConfig(Copyable, Movable):
         return self.mode != PrecisionMode.FP32
 
     fn clip_gradients(
-        self, gradients: ExTensor, max_norm: Float32
-    ) raises -> ExTensor:
+        self, gradients: AnyTensor, max_norm: Float32
+    ) raises -> AnyTensor:
         """Clip gradients by global norm.
 
         Useful for preventing gradient explosion in mixed precision.

--- a/shared/training/script_runner.mojo
+++ b/shared/training/script_runner.mojo
@@ -13,9 +13,9 @@ Example:
     from shared.training.trainer_interface import (
         create_simple_dataloader,
     )
-    from shared.core.extensor import ExTensor
+    from shared.core.extensor import AnyTensor
 
-    fn step(x: ExTensor, y: ExTensor) raises -> ExTensor:
+    fn step(x: AnyTensor, y: AnyTensor) raises -> AnyTensor:
         return x  # replace with real forward+loss
 
     var loader = create_simple_dataloader(
@@ -28,7 +28,7 @@ Example:
     ```
 """
 
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.training.trainer_interface import DataLoader
 
 
@@ -90,7 +90,7 @@ struct TrainingCallbacks(Copyable, Movable):
 fn run_epoch_with_batches(
     mut loader: DataLoader,
     callbacks: TrainingCallbacks,
-    step_fn: fn (ExTensor, ExTensor) raises -> ExTensor,
+    step_fn: fn (AnyTensor, AnyTensor) raises -> AnyTensor,
 ) raises -> Float32:
     """Run one training epoch with batch processing.
 

--- a/shared/training/trainer.mojo
+++ b/shared/training/trainer.mojo
@@ -17,7 +17,7 @@ Design principles:
 """
 
 from collections import List
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.training.trainer_interface import (
     Trainer,
     TrainerConfig,
@@ -114,8 +114,8 @@ struct BaseTrainer(Trainer):
 
     fn fit(
         mut self,
-        model_forward: fn (ExTensor) raises -> ExTensor,
-        compute_loss: fn (ExTensor, ExTensor) raises -> ExTensor,
+        model_forward: fn (AnyTensor) raises -> AnyTensor,
+        compute_loss: fn (AnyTensor, AnyTensor) raises -> AnyTensor,
         optimizer_step: fn () raises -> None,
         zero_gradients: fn () raises -> None,
         mut train_loader: DataLoader,

--- a/shared/training/trainer_interface.mojo
+++ b/shared/training/trainer_interface.mojo
@@ -16,7 +16,7 @@ Design principles:
 """
 
 from collections import List
-from shared.core import ExTensor
+from shared.core import AnyTensor
 
 
 struct TrainerConfig(Copyable, Movable):
@@ -292,14 +292,14 @@ struct DataBatch(Copyable, Movable):
     Represents a mini-batch with input features and labels
     """
 
-    var data: ExTensor
+    var data: AnyTensor
     """Input features [batch_size, feature_dim]."""
-    var labels: ExTensor
+    var labels: AnyTensor
     """Labels [batch_size] or [batch_size, num_classes]."""
     var batch_size: Int
     """Batch size."""
 
-    fn __init__(out self, var data: ExTensor, var labels: ExTensor):
+    fn __init__(out self, var data: AnyTensor, var labels: AnyTensor):
         """Initialize data batch.
 
         Args:
@@ -319,9 +319,9 @@ struct DataLoader(Copyable, Movable):
     Production code should use proper data loading infrastructure.
     """
 
-    var data: ExTensor
+    var data: AnyTensor
     """Full dataset features."""
-    var labels: ExTensor
+    var labels: AnyTensor
     """Full dataset labels."""
     var batch_size: Int
     """Batch size for iteration."""
@@ -333,7 +333,7 @@ struct DataLoader(Copyable, Movable):
     """Current batch index."""
 
     fn __init__(
-        out self, var data: ExTensor, var labels: ExTensor, batch_size: Int
+        out self, var data: AnyTensor, var labels: AnyTensor, batch_size: Int
     ):
         """Initialize data loader.
 
@@ -391,7 +391,7 @@ struct DataLoader(Copyable, Movable):
 
 
 fn create_simple_dataloader(
-    var data: ExTensor, var labels: ExTensor, batch_size: Int
+    var data: AnyTensor, var labels: AnyTensor, batch_size: Int
 ) raises -> DataLoader:
     """Create a simple dataloader for training.
 

--- a/shared/utils/file_io.mojo
+++ b/shared/utils/file_io.mojo
@@ -25,7 +25,7 @@
 
 from python import Python, PythonObject
 from memory import UnsafePointer
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.utils.serialization import dtype_to_string
 
 
@@ -254,14 +254,14 @@ fn load_checkpoint(filepath: String) raises -> Checkpoint:
 
 
 # ============================================================================
-# ExTensor Checkpoint Support
+# AnyTensor Checkpoint Support
 # ============================================================================
 
 
 fn save_tensor_to_checkpoint(
-    tensor: ExTensor, name: String, checkpoint_dir: String
+    tensor: AnyTensor, name: String, checkpoint_dir: String
 ) -> Bool:
-    """Save ExTensor to checkpoint directory using hex format.
+    """Save AnyTensor to checkpoint directory using hex format.
 
         Uses the same hex-encoding format as weights.mojo for compatibility.
         Creates checkpoint_dir if it doesn't exist.
@@ -319,15 +319,15 @@ fn save_tensor_to_checkpoint(
 
 fn load_tensor_from_checkpoint(
     name: String, checkpoint_dir: String
-) raises -> ExTensor:
-    """Load ExTensor from checkpoint directory.
+) raises -> AnyTensor:
+    """Load AnyTensor from checkpoint directory.
 
     Args:
             name: Parameter name (e.g., "conv1_kernel").
             checkpoint_dir: Directory containing checkpoint files.
 
     Returns:
-            Loaded ExTensor.
+            Loaded AnyTensor.
 
     Raises:
             Error: If file doesn't exist or format is invalid.


### PR DESCRIPTION
## Summary
- Rename all `ExTensor` references to `AnyTensor` across training, data, testing, autograd, and utils infrastructure (56 files, 702 lines changed)
- Since `comptime ExTensor = AnyTensor`, this is a pure mechanical rename with no behavior change
- Covers: mixed_precision, gradient_ops, optimizers (SGD/Adam/AdamW/LARS/RMSprop), training/validation loops, metrics (accuracy/confusion_matrix/loss_tracker/evaluate), transforms, datasets, cache, assertions, gradient_checker, file_io, and all supporting modules

## Test plan
- [ ] CI build passes (pure rename, no behavior change)
- [ ] No remaining `ExTensor` references in shared/training/, shared/data/, shared/testing/, shared/autograd/functional.mojo, shared/utils/file_io.mojo

Sub-PR for #4998 PR 9.

Part of #4998