### PR TITLE
refactor(core): migrate collections and optimizer to AnyTensor

### DIFF
--- a/shared/autograd/optimizers.mojo
+++ b/shared/autograd/optimizers.mojo
@@ -35,7 +35,7 @@ Usage Pattern:
         current_lr = optimizer.get_lr()
 
 Design Note:
-    This module operates on Variables (from autograd), not raw ExTensors.
+    This module operates on Variables (from autograd), not raw AnyTensors.
     The optimizer updates Variable.data based on Variable.grad.
 
     All optimizers implement the Optimizer trait from optimizer_base.mojo,
@@ -45,7 +45,7 @@ Design Note:
     - Gradient clipping by global norm
 """
 
-from shared.core import ExTensor, subtract, multiply, divide, add, sqrt
+from shared.core import AnyTensor, subtract, multiply, divide, add, sqrt
 from shared.autograd.variable import Variable
 from shared.autograd.tape import GradientTape
 from shared.autograd.functional import (
@@ -97,7 +97,7 @@ struct SGD(Copyable, Movable, Optimizer):
     """Step size for gradient descent updates."""
     var momentum: Float64
     """Momentum coefficient for accelerated gradient descent."""
-    var velocities: List[ExTensor]
+    var velocities: List[AnyTensor]
     """Velocity buffers for each parameter (initialized on first step)."""
     var _initialized: Bool
     """Flag indicating whether velocity buffers have been initialized."""
@@ -118,7 +118,7 @@ struct SGD(Copyable, Movable, Optimizer):
         """
         self.learning_rate = learning_rate
         self.momentum = momentum
-        self.velocities = List[ExTensor]()
+        self.velocities = List[AnyTensor]()
         self._initialized = False
 
     fn step(
@@ -156,11 +156,11 @@ struct SGD(Copyable, Movable, Optimizer):
         """
         # Initialize velocity buffers on first call if using momentum
         if self.momentum > 0.0 and not self._initialized:
-            self.velocities = List[ExTensor]()
+            self.velocities = List[AnyTensor]()
             for i in range(len(parameters)):
                 # Create zero-initialized velocity tensor matching parameter shape
                 var vel_shape = parameters[i].data.shape()
-                var vel = ExTensor(vel_shape, parameters[i].data.dtype())
+                var vel = AnyTensor(vel_shape, parameters[i].data.dtype())
                 vel._fill_zero()
                 self.velocities.append(vel^)
             self._initialized = True
@@ -305,9 +305,9 @@ struct Adam(Copyable, Movable, Optimizer):
     """L2 regularization coefficient."""
     var t: Int
     """Current step counter."""
-    var m_buffers: List[ExTensor]
+    var m_buffers: List[AnyTensor]
     """First moment buffers for each parameter ID."""
-    var v_buffers: List[ExTensor]
+    var v_buffers: List[AnyTensor]
     """Second moment buffers for each parameter ID."""
     var has_buffer: List[Bool]
     """Flags indicating whether moment buffers exist for each parameter ID."""
@@ -345,8 +345,8 @@ struct Adam(Copyable, Movable, Optimizer):
         self.epsilon = epsilon
         self.weight_decay = weight_decay
         self.t = 0
-        self.m_buffers = List[ExTensor]()
-        self.v_buffers = List[ExTensor]()
+        self.m_buffers = List[AnyTensor]()
+        self.v_buffers = List[AnyTensor]()
         self.has_buffer = List[Bool]()
 
     fn step(
@@ -413,23 +413,23 @@ struct Adam(Copyable, Movable, Optimizer):
                 var placeholder_shape = List[Int]()
                 placeholder_shape.append(1)
                 self.m_buffers.append(
-                    ExTensor(placeholder_shape, DType.float32)
+                    AnyTensor(placeholder_shape, DType.float32)
                 )
                 self.v_buffers.append(
-                    ExTensor(placeholder_shape, DType.float32)
+                    AnyTensor(placeholder_shape, DType.float32)
                 )
                 self.has_buffer.append(False)
 
             # Initialize moment buffers if they don't exist
             if not self.has_buffer[param_id]:
                 # m_t = zeros like grad
-                var m = ExTensor(grad.shape(), grad.dtype())
+                var m = AnyTensor(grad.shape(), grad.dtype())
                 for j in range(m.numel()):
                     m._set_float64(j, 0.0)
                 self.m_buffers[param_id] = m^
 
                 # v_t = zeros like grad
-                var v = ExTensor(grad.shape(), grad.dtype())
+                var v = AnyTensor(grad.shape(), grad.dtype())
                 for j in range(v.numel()):
                     v._set_float64(j, 0.0)
                 self.v_buffers[param_id] = v^
@@ -441,7 +441,7 @@ struct Adam(Copyable, Movable, Optimizer):
             var v = self.v_buffers[param_id]
 
             # Update biased first moment estimate: m_t = β₁ * m_{t-1} + (1 - β₁) * g_t
-            var m_new = ExTensor(grad.shape(), grad.dtype())
+            var m_new = AnyTensor(grad.shape(), grad.dtype())
             for j in range(grad.numel()):
                 var m_prev = m._get_float64(j)
                 var grad_val = grad._get_float64(j)
@@ -450,7 +450,7 @@ struct Adam(Copyable, Movable, Optimizer):
             self.m_buffers[param_id] = m_new^
 
             # Update biased second moment estimate: v_t = β₂ * v_{t-1} + (1 - β₂) * g_t²
-            var v_new = ExTensor(grad.shape(), grad.dtype())
+            var v_new = AnyTensor(grad.shape(), grad.dtype())
             for j in range(grad.numel()):
                 var v_prev = v._get_float64(j)
                 var grad_val = grad._get_float64(j)
@@ -471,7 +471,7 @@ struct Adam(Copyable, Movable, Optimizer):
 
             # Compute update: α * m̂_t / (√v̂_t + ε)
             # First: √v̂_t
-            var v_hat_sqrt = ExTensor(v_hat.shape(), v_hat.dtype())
+            var v_hat_sqrt = AnyTensor(v_hat.shape(), v_hat.dtype())
             for j in range(v_hat.numel()):
                 var v_val = v_hat._get_float64(j)
                 var sqrt_v = v_val**0.5
@@ -492,7 +492,7 @@ struct Adam(Copyable, Movable, Optimizer):
                 var weight_decay_update = multiply_scalar(
                     parameters[i].data, self.learning_rate * self.weight_decay
                 )
-                param_update = ExTensor(
+                param_update = AnyTensor(
                     scaled_grad.shape(), scaled_grad.dtype()
                 )
                 for j in range(scaled_grad.numel()):
@@ -614,9 +614,9 @@ struct AdamW(Copyable, Movable, Optimizer):
     """Decoupled weight decay coefficient."""
     var t: Int
     """Current step counter."""
-    var m_buffers: List[ExTensor]
+    var m_buffers: List[AnyTensor]
     """First moment buffers for each parameter ID."""
-    var v_buffers: List[ExTensor]
+    var v_buffers: List[AnyTensor]
     """Second moment buffers for each parameter ID."""
     var has_buffer: List[Bool]
     """Flags indicating whether moment buffers exist for each parameter ID."""
@@ -654,8 +654,8 @@ struct AdamW(Copyable, Movable, Optimizer):
         self.epsilon = epsilon
         self.weight_decay = weight_decay
         self.t = 0
-        self.m_buffers = List[ExTensor]()
-        self.v_buffers = List[ExTensor]()
+        self.m_buffers = List[AnyTensor]()
+        self.v_buffers = List[AnyTensor]()
         self.has_buffer = List[Bool]()
 
     fn step(
@@ -721,21 +721,21 @@ struct AdamW(Copyable, Movable, Optimizer):
                 var placeholder_shape = List[Int]()
                 placeholder_shape.append(1)
                 self.m_buffers.append(
-                    ExTensor(placeholder_shape, DType.float32)
+                    AnyTensor(placeholder_shape, DType.float32)
                 )
                 self.v_buffers.append(
-                    ExTensor(placeholder_shape, DType.float32)
+                    AnyTensor(placeholder_shape, DType.float32)
                 )
                 self.has_buffer.append(False)
 
             # Initialize moment buffers if they don't exist
             if not self.has_buffer[param_id]:
-                var m = ExTensor(grad.shape(), grad.dtype())
+                var m = AnyTensor(grad.shape(), grad.dtype())
                 for j in range(m.numel()):
                     m._set_float64(j, 0.0)
                 self.m_buffers[param_id] = m^
 
-                var v = ExTensor(grad.shape(), grad.dtype())
+                var v = AnyTensor(grad.shape(), grad.dtype())
                 for j in range(v.numel()):
                     v._set_float64(j, 0.0)
                 self.v_buffers[param_id] = v^
@@ -747,7 +747,7 @@ struct AdamW(Copyable, Movable, Optimizer):
             var v = self.v_buffers[param_id]
 
             # Update biased first moment estimate: m_t = β₁ * m_{t-1} + (1 - β₁) * g_t
-            var m_new = ExTensor(grad.shape(), grad.dtype())
+            var m_new = AnyTensor(grad.shape(), grad.dtype())
             for j in range(grad.numel()):
                 var m_prev = m._get_float64(j)
                 var grad_val = grad._get_float64(j)
@@ -756,7 +756,7 @@ struct AdamW(Copyable, Movable, Optimizer):
             self.m_buffers[param_id] = m_new^
 
             # Update biased second moment estimate: v_t = β₂ * v_{t-1} + (1 - β₂) * g_t²
-            var v_new = ExTensor(grad.shape(), grad.dtype())
+            var v_new = AnyTensor(grad.shape(), grad.dtype())
             for j in range(grad.numel()):
                 var v_prev = v._get_float64(j)
                 var grad_val = grad._get_float64(j)
@@ -776,7 +776,7 @@ struct AdamW(Copyable, Movable, Optimizer):
             var v_hat = multiply_scalar(v_updated, 1.0 / bias_correction2)
 
             # Compute √v̂_t
-            var v_hat_sqrt = ExTensor(v_hat.shape(), v_hat.dtype())
+            var v_hat_sqrt = AnyTensor(v_hat.shape(), v_hat.dtype())
             for j in range(v_hat.numel()):
                 var v_val = v_hat._get_float64(j)
                 var sqrt_v = v_val**0.5
@@ -793,7 +793,7 @@ struct AdamW(Copyable, Movable, Optimizer):
 
             # Apply decoupled weight decay: α * λ * θ_{t-1}
             # θ_t = θ_{t-1} - α * m̂_t / (√v̂_t + ε) - α * λ * θ_{t-1}
-            var new_data = ExTensor(
+            var new_data = AnyTensor(
                 parameters[i].data.shape(), parameters[i].data.dtype()
             )
             for j in range(parameters[i].data.numel()):
@@ -892,7 +892,7 @@ struct AdaGrad(Copyable, Movable, Optimizer):
     """Small constant for numerical stability."""
     var weight_decay: Float64
     """L2 regularization coefficient."""
-    var G_buffers: Dict[Int, ExTensor]
+    var G_buffers: Dict[Int, AnyTensor]
     """Accumulated squared gradients for each parameter ID."""
 
     fn __init__(
@@ -923,7 +923,7 @@ struct AdaGrad(Copyable, Movable, Optimizer):
         self.learning_rate = learning_rate
         self.epsilon = epsilon
         self.weight_decay = weight_decay
-        self.G_buffers = Dict[Int, ExTensor]()
+        self.G_buffers = Dict[Int, AnyTensor]()
 
     fn step(
         mut self, mut parameters: List[Variable], mut tape: GradientTape
@@ -970,7 +970,7 @@ struct AdaGrad(Copyable, Movable, Optimizer):
             var grad = tape.registry.get_grad(param_id)
 
             # Initialize or retrieve accumulated gradient buffer
-            var G = ExTensor(
+            var G = AnyTensor(
                 parameters[i].data.shape(), parameters[i].data.dtype()
             )
             if i in self.G_buffers:
@@ -1121,9 +1121,9 @@ struct RMSprop(Copyable, Movable, Optimizer):
     """L2 regularization coefficient."""
     var momentum: Float64
     """Momentum factor for accelerated updates."""
-    var v_buffers: List[ExTensor]
+    var v_buffers: List[AnyTensor]
     """Running average of squared gradients per parameter ID."""
-    var m_buffers: List[ExTensor]
+    var m_buffers: List[AnyTensor]
     """Momentum buffers per parameter ID (if momentum > 0)."""
     var has_buffer: List[Bool]
     """Flags indicating initialized buffers for each parameter ID."""
@@ -1157,8 +1157,8 @@ struct RMSprop(Copyable, Movable, Optimizer):
         self.epsilon = epsilon
         self.weight_decay = weight_decay
         self.momentum = momentum
-        self.v_buffers = List[ExTensor]()
-        self.m_buffers = List[ExTensor]()
+        self.v_buffers = List[AnyTensor]()
+        self.m_buffers = List[AnyTensor]()
         self.has_buffer = List[Bool]()
 
     fn step(
@@ -1198,23 +1198,23 @@ struct RMSprop(Copyable, Movable, Optimizer):
                 var placeholder_shape = List[Int]()
                 placeholder_shape.append(1)
                 self.v_buffers.append(
-                    ExTensor(placeholder_shape, DType.float32)
+                    AnyTensor(placeholder_shape, DType.float32)
                 )
                 self.m_buffers.append(
-                    ExTensor(placeholder_shape, DType.float32)
+                    AnyTensor(placeholder_shape, DType.float32)
                 )
                 self.has_buffer.append(False)
 
             # Initialize buffers if they don't exist for this parameter
             if not self.has_buffer[param_id]:
                 # v_t = zeros like grad
-                var v = ExTensor(grad.shape(), grad.dtype())
+                var v = AnyTensor(grad.shape(), grad.dtype())
                 for j in range(v.numel()):
                     v._set_float64(j, 0.0)
                 self.v_buffers[param_id] = v^
 
                 # m_t = zeros like grad (for momentum)
-                var m = ExTensor(grad.shape(), grad.dtype())
+                var m = AnyTensor(grad.shape(), grad.dtype())
                 for j in range(m.numel()):
                     m._set_float64(j, 0.0)
                 self.m_buffers[param_id] = m^
@@ -1231,7 +1231,7 @@ struct RMSprop(Copyable, Movable, Optimizer):
 
             # Update running average of squared gradients
             var v = self.v_buffers[param_id]
-            var v_new = ExTensor(grad.shape(), grad.dtype())
+            var v_new = AnyTensor(grad.shape(), grad.dtype())
             for j in range(grad.numel()):
                 var v_prev = v._get_float64(j)
                 var grad_val = working_grad._get_float64(j)
@@ -1246,7 +1246,7 @@ struct RMSprop(Copyable, Movable, Optimizer):
             var v_updated = self.v_buffers[param_id]
 
             # Compute adaptive learning rate
-            var adaptive_grad = ExTensor(
+            var adaptive_grad = AnyTensor(
                 working_grad.shape(), working_grad.dtype()
             )
             for j in range(working_grad.numel()):
@@ -1261,7 +1261,7 @@ struct RMSprop(Copyable, Movable, Optimizer):
             # Apply momentum if specified
             if self.momentum > 0.0:
                 var m = self.m_buffers[param_id]
-                var m_new = ExTensor(update.shape(), update.dtype())
+                var m_new = AnyTensor(update.shape(), update.dtype())
                 for j in range(update.numel()):
                     var m_prev = m._get_float64(j)
                     var upd_val = update._get_float64(j)

--- a/shared/autograd/tape_types.mojo
+++ b/shared/autograd/tape_types.mojo
@@ -11,7 +11,7 @@ Design Note:
     - tape.mojo: Imports types from tape_types, imports functions from backward_ops
 """
 
-from shared.core import ExTensor, zeros_like
+from shared.core import AnyTensor, zeros_like
 
 
 struct SavedTensors(Copyable, Movable):
@@ -23,7 +23,7 @@ struct SavedTensors(Copyable, Movable):
     - Reductions (sum, mean): Need input tensor for gradient computation.
     """
 
-    var tensors: List[ExTensor]
+    var tensors: List[AnyTensor]
     """Saved tensors for backward computation."""
     var shapes: List[List[Int]]
     """Saved shapes for tensor reconstruction."""
@@ -32,18 +32,18 @@ struct SavedTensors(Copyable, Movable):
 
     fn __init__(out self):
         """Initialize empty saved tensors."""
-        self.tensors: List[ExTensor] = []
+        self.tensors: List[AnyTensor] = []
         self.shapes = List[List[Int]]()
         self.scalars: List[Float64] = []
 
     fn __copyinit__(out self, existing: Self):
         """Copy constructor - explicitly copy lists."""
         # Initialize empty lists
-        self.tensors: List[ExTensor] = []
+        self.tensors: List[AnyTensor] = []
         self.shapes = List[List[Int]]()
         self.scalars: List[Float64] = []
 
-        # Copy tensors (ExTensor is Copyable)
+        # Copy tensors (AnyTensor is Copyable)
         for i in range(len(existing.tensors)):
             self.tensors.append(existing.tensors[i])
 
@@ -64,7 +64,7 @@ struct SavedTensors(Copyable, Movable):
         self.shapes = existing.shapes^
         self.scalars = existing.scalars^
 
-    fn add_tensor(mut self, tensor: ExTensor) raises:
+    fn add_tensor(mut self, tensor: AnyTensor) raises:
         """Save a tensor for backward pass.
 
         Modifies self in-place by appending tensor to internal storage.
@@ -191,7 +191,7 @@ struct VariableRegistry:
     for variables by their ID.
     """
 
-    var grads: List[ExTensor]
+    var grads: List[AnyTensor]
     """Gradient tensors indexed by variable ID."""
     var has_grad: List[Bool]
     """Flag indicating whether gradient has been computed for each variable."""
@@ -202,7 +202,7 @@ struct VariableRegistry:
 
     fn __init__(out self):
         """Initialize empty registry."""
-        self.grads: List[ExTensor] = []
+        self.grads: List[AnyTensor] = []
         self.has_grad: List[Bool] = []
         self.requires_grad: List[Bool] = []
         self.next_id = 0
@@ -226,14 +226,14 @@ struct VariableRegistry:
         # Create a placeholder tensor (will be replaced when gradient is computed)
         var placeholder_shape = List[Int]()
         placeholder_shape.append(1)
-        var placeholder = ExTensor(placeholder_shape, DType.float32)
+        var placeholder = AnyTensor(placeholder_shape, DType.float32)
         self.grads.append(placeholder^)
         self.has_grad.append(False)
         self.requires_grad.append(requires_grad)
 
         return id
 
-    fn set_grad(mut self, id: Int, grad: ExTensor) raises:
+    fn set_grad(mut self, id: Int, grad: AnyTensor) raises:
         """Set or accumulate gradient for a variable.
 
         Args:
@@ -263,7 +263,7 @@ struct VariableRegistry:
             self.grads[id] = grad_copy^
             self.has_grad[id] = True
 
-    fn get_grad(self, id: Int) raises -> ExTensor:
+    fn get_grad(self, id: Int) raises -> AnyTensor:
         """Get gradient for a variable.
 
         Args:
@@ -280,7 +280,7 @@ struct VariableRegistry:
         # Return empty placeholder
         var placeholder_shape = List[Int]()
         placeholder_shape.append(1)
-        return ExTensor(placeholder_shape, DType.float32)
+        return AnyTensor(placeholder_shape, DType.float32)
 
     fn has_gradient(self, id: Int) -> Bool:
         """Check if a variable has a computed gradient.

--- a/shared/autograd/variable.mojo
+++ b/shared/autograd/variable.mojo
@@ -1,6 +1,6 @@
 """Variable - Autograd-enabled tensor wrapper.
 
-Provides automatic differentiation capabilities by wrapping ExTensor with
+Provides automatic differentiation capabilities by wrapping AnyTensor with
 gradient tracking and computation graph recording.
 
 This module implements a tape-based autograd system similar to PyTorch's eager
@@ -8,7 +8,7 @@ mode execution, where operations are recorded during the forward pass and
 replayed in reverse during backward propagation.
 
 Key Concepts:
-- Variable wraps an ExTensor and adds requires_grad flag and grad storage
+- Variable wraps an AnyTensor and adds requires_grad flag and grad storage
 - Operations on Variables are recorded in a gradient tape
 - Calling .backward(tape) triggers automatic gradient computation via chain rule
 - Gradients accumulate across multiple backward passes (call tape.clear() to reset)
@@ -36,7 +36,7 @@ Examples:
     print(tape.get_grad(y.id))  # dLoss/dy
 """
 
-from shared.core import ExTensor, ones_like, zeros_like
+from shared.core import AnyTensor, ones_like, zeros_like
 from shared.core import add, subtract, multiply, divide
 from shared.core import relu, sigmoid, tanh
 from shared.core import sum, mean
@@ -64,9 +64,9 @@ from shared.autograd.tape import (
 struct Variable(Copyable, Movable):
     """Tensor wrapper with automatic differentiation support.
 
-        Variable extends ExTensor with gradient tracking capabilities. Each Variable
+        Variable extends AnyTensor with gradient tracking capabilities. Each Variable
         maintains:
-        - data: The actual tensor values (ExTensor)
+        - data: The actual tensor values (AnyTensor)
         - id: Unique identifier for tape tracking
         - requires_grad: Whether to track operations for this variable
 
@@ -74,7 +74,7 @@ struct Variable(Copyable, Movable):
         itself. This allows for gradient accumulation and cleanup via the tape.
 
         Attributes:
-            data: The underlying ExTensor containing values.
+            data: The underlying AnyTensor containing values.
             id: Unique identifier for gradient tracking.
             requires_grad: Flag indicating whether this Variable participates in autograd.
 
@@ -84,13 +84,13 @@ struct Variable(Copyable, Movable):
             gradient computation.
     """
 
-    var data: ExTensor
+    var data: AnyTensor
     var id: Int
     var requires_grad: Bool
 
     fn __init__(
         out self,
-        var data: ExTensor,
+        var data: AnyTensor,
         requires_grad: Bool,
         mut tape: GradientTape,
     ) raises:
@@ -126,7 +126,7 @@ struct Variable(Copyable, Movable):
 
     fn __init__(
         out self,
-        var data: ExTensor,
+        var data: AnyTensor,
         requires_grad: Bool,
         id: Int,
     ):
@@ -174,18 +174,18 @@ struct Variable(Copyable, Movable):
         var grad = ones_like(self.data)
         tape.backward(self.id, grad^)
 
-    fn detach(self) -> ExTensor:
+    fn detach(self) -> AnyTensor:
         """Get the underlying tensor without gradient tracking.
 
         Useful for breaking the computation graph when you want to use values
         without tracking gradients.
 
         Returns:
-            The underlying ExTensor (copy).
+            The underlying AnyTensor (copy).
 
         Examples:
             var x = Variable(data, True, tape).
-            var y = x.detach()  # y is just an ExTensor, no gradient tracking.
+            var y = x.detach()  # y is just an AnyTensor, no gradient tracking.
         """
         return self.data
 

--- a/shared/core/gradient_types.mojo
+++ b/shared/core/gradient_types.mojo
@@ -57,7 +57,7 @@ Guidelines for Implementation:
     5. Add docstrings with concrete examples showing usage.
 """
 
-from .extensor import ExTensor
+from .extensor import AnyTensor
 
 
 struct GradientPair(Copyable, Movable):
@@ -78,12 +78,12 @@ struct GradientPair(Copyable, Movable):
         ```
     """
 
-    var grad_a: ExTensor
+    var grad_a: AnyTensor
     """Gradient with respect to first input."""
-    var grad_b: ExTensor
+    var grad_b: AnyTensor
     """Gradient with respect to second input."""
 
-    fn __init__(out self, var grad_a: ExTensor, var grad_b: ExTensor):
+    fn __init__(out self, var grad_a: AnyTensor, var grad_b: AnyTensor):
         """Initialize gradient pair.
 
         Args:
@@ -114,18 +114,18 @@ struct GradientTriple(Copyable, Movable):
         ```
     """
 
-    var grad_input: ExTensor
+    var grad_input: AnyTensor
     """Gradient with respect to input activation."""
-    var grad_weights: ExTensor
+    var grad_weights: AnyTensor
     """Gradient with respect to weights."""
-    var grad_bias: ExTensor
+    var grad_bias: AnyTensor
     """Gradient with respect to bias."""
 
     fn __init__(
         out self,
-        var grad_input: ExTensor,
-        var grad_weights: ExTensor,
-        var grad_bias: ExTensor,
+        var grad_input: AnyTensor,
+        var grad_weights: AnyTensor,
+        var grad_bias: AnyTensor,
     ):
         """Initialize gradient triple.
 
@@ -161,21 +161,21 @@ struct GradientQuad(Copyable, Movable):
         ```
     """
 
-    var grad_a: ExTensor
+    var grad_a: AnyTensor
     """Gradient with respect to first input."""
-    var grad_b: ExTensor
+    var grad_b: AnyTensor
     """Gradient with respect to second input."""
-    var grad_c: ExTensor
+    var grad_c: AnyTensor
     """Gradient with respect to third input."""
-    var grad_d: ExTensor
+    var grad_d: AnyTensor
     """Gradient with respect to fourth input."""
 
     fn __init__(
         out self,
-        var grad_a: ExTensor,
-        var grad_b: ExTensor,
-        var grad_c: ExTensor,
-        var grad_d: ExTensor,
+        var grad_a: AnyTensor,
+        var grad_b: AnyTensor,
+        var grad_c: AnyTensor,
+        var grad_d: AnyTensor,
     ):
         """Initialize gradient quad.
 
@@ -209,12 +209,12 @@ struct Conv2dNoBiasGradient(Copyable, Movable):
         ```
     """
 
-    var grad_input: ExTensor
+    var grad_input: AnyTensor
     """Gradient with respect to input activation."""
-    var grad_weights: ExTensor
+    var grad_weights: AnyTensor
     """Gradient with respect to convolution kernel."""
 
-    fn __init__(out self, var grad_input: ExTensor, var grad_weights: ExTensor):
+    fn __init__(out self, var grad_input: AnyTensor, var grad_weights: AnyTensor):
         """Initialize conv2d no-bias gradient.
 
         Args:
@@ -243,12 +243,12 @@ struct DepthwiseConv2dNoBiasGradient(Copyable, Movable):
         ```
     """
 
-    var grad_input: ExTensor
+    var grad_input: AnyTensor
     """Gradient with respect to input activation."""
-    var grad_weights: ExTensor
+    var grad_weights: AnyTensor
     """Gradient with respect to depthwise convolution kernel."""
 
-    fn __init__(out self, var grad_input: ExTensor, var grad_weights: ExTensor):
+    fn __init__(out self, var grad_input: AnyTensor, var grad_weights: AnyTensor):
         """Initialize depthwise conv2d no-bias gradient.
 
         Args:
@@ -284,21 +284,21 @@ struct DepthwiseSeparableConv2dGradient(Copyable, Movable):
         ```
     """
 
-    var grad_input: ExTensor
+    var grad_input: AnyTensor
     """Gradient with respect to input activation."""
-    var grad_depthwise_kernel: ExTensor
+    var grad_depthwise_kernel: AnyTensor
     """Gradient with respect to depthwise convolution kernel."""
-    var grad_pointwise_kernel: ExTensor
+    var grad_pointwise_kernel: AnyTensor
     """Gradient with respect to pointwise convolution kernel."""
-    var grad_bias: ExTensor
+    var grad_bias: AnyTensor
     """Gradient with respect to bias."""
 
     fn __init__(
         out self,
-        var grad_input: ExTensor,
-        var grad_depthwise_kernel: ExTensor,
-        var grad_pointwise_kernel: ExTensor,
-        var grad_bias: ExTensor,
+        var grad_input: AnyTensor,
+        var grad_depthwise_kernel: AnyTensor,
+        var grad_pointwise_kernel: AnyTensor,
+        var grad_bias: AnyTensor,
     ):
         """Initialize depthwise separable conv2d gradient.
 

--- a/shared/core/lazy_eval.mojo
+++ b/shared/core/lazy_eval.mojo
@@ -12,7 +12,7 @@ Architecture:
 """
 
 from collections import List
-from .extensor import ExTensor, full
+from .extensor import AnyTensor, full
 from .lazy_expression import (
     TensorExpr,
     ExprNode,
@@ -142,7 +142,7 @@ fn _evaluate_at_index[
 ](
     expr: TensorExpr,
     nodes: List[ExprNode],
-    tensors: List[ExTensor],
+    tensors: List[AnyTensor],
     scalars: List[Float64],
     result_shape: List[Int],
     node_idx: Int,
@@ -271,7 +271,7 @@ fn _evaluate_at_index[
 # ============================================================================
 
 
-fn _dispatch_evaluate(expr: TensorExpr) raises -> ExTensor:
+fn _dispatch_evaluate(expr: TensorExpr) raises -> AnyTensor:
     """Runtime dispatch to compile-time specialized evaluation.
 
     Performs dtype dispatch and calls specialized kernel.
@@ -318,7 +318,7 @@ fn _dispatch_evaluate(expr: TensorExpr) raises -> ExTensor:
 # ============================================================================
 
 
-fn _evaluate_typed[dtype: DType](expr: TensorExpr) raises -> ExTensor:
+fn _evaluate_typed[dtype: DType](expr: TensorExpr) raises -> AnyTensor:
     """Compile-time specialized evaluation kernel.
 
     Args:
@@ -358,7 +358,7 @@ fn _evaluate_typed[dtype: DType](expr: TensorExpr) raises -> ExTensor:
 # ============================================================================
 
 
-fn evaluate(expr: TensorExpr) raises -> ExTensor:
+fn evaluate(expr: TensorExpr) raises -> AnyTensor:
     """Evaluate lazy expression to produce result tensor.
 
     Performs fused evaluation of the entire expression tree, producing a

--- a/shared/core/lazy_expression.mojo
+++ b/shared/core/lazy_expression.mojo
@@ -22,7 +22,7 @@ Example:
 """
 
 from collections import List
-from .extensor import ExTensor
+from .extensor import AnyTensor
 from .broadcasting import broadcast_shapes, compute_broadcast_strides
 
 
@@ -108,12 +108,12 @@ struct TensorExpr(Movable):
 
     var _nodes: List[ExprNode]
     var _root_idx: Int
-    var _tensors: List[ExTensor]
+    var _tensors: List[AnyTensor]
     var _scalars: List[Float64]
     var _result_shape: List[Int]
     var _dtype: DType
 
-    fn __init__(out self, tensor: ExTensor) raises:
+    fn __init__(out self, tensor: AnyTensor) raises:
         """Create expression from a single tensor (entry point).
 
         Args:
@@ -123,7 +123,7 @@ struct TensorExpr(Movable):
             Error: If tensor is invalid.
         """
         self._nodes = List[ExprNode]()
-        self._tensors = List[ExTensor]()
+        self._tensors = List[AnyTensor]()
         self._scalars = List[Float64]()
 
         # Create leaf node for tensor
@@ -184,7 +184,7 @@ struct TensorExpr(Movable):
                 count += 1
         return count
 
-    fn _add_leaf_node(mut self, tensor: ExTensor) raises -> Int:
+    fn _add_leaf_node(mut self, tensor: AnyTensor) raises -> Int:
         """Internal: Add a leaf node for a tensor.
 
         Args:
@@ -449,7 +449,7 @@ struct TensorExpr(Movable):
 # ============================================================================
 
 
-fn expr(tensor: ExTensor) raises -> TensorExpr:
+fn expr(tensor: AnyTensor) raises -> TensorExpr:
     """Create a lazy expression from a tensor (entry point).
 
     This is the main entry point for building lazy expressions. It wraps

--- a/shared/core/shape.mojo
+++ b/shared/core/shape.mojo
@@ -1,4 +1,4 @@
-"""Shape manipulation operations for ExTensor.
+"""Shape manipulation operations for AnyTensor.
 
 Implements shape operations like reshape, squeeze, unsqueeze, flatten, concatenate, stack, split
 Following the Python Array API Standard 2023.12.
@@ -11,7 +11,7 @@ Optimizations:
 
 from collections import List
 from memory import memcpy, UnsafePointer
-from .extensor import ExTensor
+from .extensor import AnyTensor
 from shared.tensor.tensor import Tensor
 
 
@@ -20,7 +20,7 @@ from shared.tensor.tensor import Tensor
 # ============================================================================
 
 
-fn is_contiguous(tensor: ExTensor) -> Bool:
+fn is_contiguous(tensor: AnyTensor) -> Bool:
     """Check if tensor data is contiguous in memory (row-major C order).
 
         A tensor is contiguous if elements are laid out sequentially in memory
@@ -36,12 +36,12 @@ fn is_contiguous(tensor: ExTensor) -> Bool:
             Contiguous tensors can be efficiently copied with memcpy instead of
             element-by-element copying.
     """
-    # Delegate to ExTensor.is_contiguous() method to avoid code duplication
+    # Delegate to AnyTensor.is_contiguous() method to avoid code duplication
     # (Issue #3844: consolidated implementations)
     return tensor.is_contiguous()
 
 
-fn as_contiguous(tensor: ExTensor) raises -> ExTensor:
+fn as_contiguous(tensor: AnyTensor) raises -> AnyTensor:
     """Convert tensor to contiguous memory layout if needed.
 
         If the tensor is already contiguous, returns a copy. If it's a view with
@@ -63,7 +63,7 @@ fn as_contiguous(tensor: ExTensor) raises -> ExTensor:
     if is_contiguous(tensor):
         # Already contiguous - just copy
         var shape = tensor.shape()
-        var result = ExTensor(shape, tensor.dtype())
+        var result = AnyTensor(shape, tensor.dtype())
         var numel = tensor.numel()
 
         # Use memcpy for efficient bulk copy
@@ -76,7 +76,7 @@ fn as_contiguous(tensor: ExTensor) raises -> ExTensor:
         # Non-contiguous - use stride-based indexing to read source elements
         var shape = tensor.shape()
         var ndim = len(shape)
-        var result = ExTensor(shape, tensor.dtype())
+        var result = AnyTensor(shape, tensor.dtype())
         var numel = tensor.numel()
         var dtype_size = tensor._get_dtype_size()
         var src_ptr = tensor._data
@@ -100,7 +100,7 @@ fn as_contiguous(tensor: ExTensor) raises -> ExTensor:
         return result^
 
 
-fn view(tensor: ExTensor, new_shape: List[Int]) raises -> ExTensor:
+fn view(tensor: AnyTensor, new_shape: List[Int]) raises -> AnyTensor:
     """Create a zero-copy view of tensor with new shape (if compatible).
 
         Attempts to create a view with different shape while preserving the
@@ -115,7 +115,7 @@ fn view(tensor: ExTensor, new_shape: List[Int]) raises -> ExTensor:
             new_shape: Target shape.
 
     Returns:
-            A new ExTensor sharing the same data with different shape/strides.
+            A new AnyTensor sharing the same data with different shape/strides.
 
     Raises:
             Error: If reshape cannot be done as a view (would require data movement).
@@ -145,12 +145,12 @@ fn view(tensor: ExTensor, new_shape: List[Int]) raises -> ExTensor:
     if new_numel != old_numel:
         raise Error("view: new shape must have same number of elements")
 
-    # Use ExTensor's built-in reshape which creates views via __copyinit__
+    # Use AnyTensor's built-in reshape which creates views via __copyinit__
     # This leverages reference counting for safe shared ownership
     return tensor.reshape(new_shape)
 
 
-fn reshape(tensor: ExTensor, new_shape: List[Int]) raises -> ExTensor:
+fn reshape(tensor: AnyTensor, new_shape: List[Int]) raises -> AnyTensor:
     """Reshape tensor to new shape.
 
     Args:
@@ -219,7 +219,7 @@ fn reshape(tensor: ExTensor, new_shape: List[Int]) raises -> ExTensor:
         raise Error("reshape: new shape must have same number of elements")
 
     # Create new tensor with new shape (data copy)
-    var result = ExTensor(final_shape, tensor.dtype())
+    var result = AnyTensor(final_shape, tensor.dtype())
 
     # Copy data respecting tensor strides (handles non-contiguous inputs)
     if is_contiguous(tensor):
@@ -250,7 +250,7 @@ fn reshape(tensor: ExTensor, new_shape: List[Int]) raises -> ExTensor:
     return result^
 
 
-fn squeeze(tensor: ExTensor, axis: Int = -999) raises -> ExTensor:
+fn squeeze(tensor: AnyTensor, axis: Int = -999) raises -> AnyTensor:
     """Remove size-1 dimensions.
 
     Args:
@@ -313,7 +313,7 @@ fn squeeze(tensor: ExTensor, axis: Int = -999) raises -> ExTensor:
         return reshape(tensor, new_shape)
 
 
-fn unsqueeze(tensor: ExTensor, axis: Int) raises -> ExTensor:
+fn unsqueeze(tensor: AnyTensor, axis: Int) raises -> AnyTensor:
     """Add a size-1 dimension at specified position.
 
     Args:
@@ -357,7 +357,7 @@ fn unsqueeze(tensor: ExTensor, axis: Int) raises -> ExTensor:
 
 
 @always_inline
-fn expand_dims(tensor: ExTensor, axis: Int) raises -> ExTensor:
+fn expand_dims(tensor: AnyTensor, axis: Int) raises -> AnyTensor:
     """Alias for unsqueeze(). Add a size-1 dimension at specified position.
 
     Args:
@@ -373,7 +373,7 @@ fn expand_dims(tensor: ExTensor, axis: Int) raises -> ExTensor:
     return unsqueeze(tensor, axis)
 
 
-fn flatten(tensor: ExTensor) raises -> ExTensor:
+fn flatten(tensor: AnyTensor) raises -> AnyTensor:
     """Flatten tensor to 1D.
 
     Args:
@@ -399,7 +399,7 @@ fn flatten(tensor: ExTensor) raises -> ExTensor:
 
 
 @always_inline
-fn ravel(tensor: ExTensor) raises -> ExTensor:
+fn ravel(tensor: AnyTensor) raises -> AnyTensor:
     """Flatten tensor to 1D (comptime for flatten).
 
         Note: Our implementation now uses zero-copy views for contiguous tensors.
@@ -430,7 +430,7 @@ fn ravel(tensor: ExTensor) raises -> ExTensor:
         return flatten(tensor)
 
 
-fn concatenate(tensors: List[ExTensor], axis: Int = 0) raises -> ExTensor:
+fn concatenate(tensors: List[AnyTensor], axis: Int = 0) raises -> AnyTensor:
     """Concatenate tensors along an existing axis.
 
     Args:
@@ -447,7 +447,7 @@ fn concatenate(tensors: List[ExTensor], axis: Int = 0) raises -> ExTensor:
     ```
             var a = ones([2, 3], DType.float32)  # 2x3
             var b = ones([3, 3], DType.float32)  # 3x3
-            var tensors : List[ExTensor] = []
+            var tensors : List[AnyTensor] = []
             tensors.append(a)
             tensors.append(b)
             var c = concatenate(tensors, axis=0)  # Shape (5, 3)
@@ -499,7 +499,7 @@ fn concatenate(tensors: List[ExTensor], axis: Int = 0) raises -> ExTensor:
             result_shape.append(ref_shape[i])
 
     # Create result tensor
-    var result = ExTensor(result_shape, dtype)
+    var result = AnyTensor(result_shape, dtype)
 
     # Copy data from each tensor into the result
     var dtype_size = result._get_dtype_size()
@@ -583,7 +583,7 @@ fn concatenate(tensors: List[ExTensor], axis: Int = 0) raises -> ExTensor:
     return result^
 
 
-fn stack(tensors: List[ExTensor], axis: Int = 0) raises -> ExTensor:
+fn stack(tensors: List[AnyTensor], axis: Int = 0) raises -> AnyTensor:
     """Stack tensors along a new axis.
 
     Args:
@@ -600,7 +600,7 @@ fn stack(tensors: List[ExTensor], axis: Int = 0) raises -> ExTensor:
     ```
             var a = ones([2, 3], DType.float32)  # 2x3
             var b = ones([2, 3], DType.float32)  # 2x3
-            var tensors : List[ExTensor] = []
+            var tensors : List[AnyTensor] = []
             tensors.append(a)
             tensors.append(b)
             var c = stack(tensors, axis=0)  # Shape (2, 2, 3)
@@ -638,7 +638,7 @@ fn stack(tensors: List[ExTensor], axis: Int = 0) raises -> ExTensor:
         raise Error("stack: axis out of range")
 
     # Unsqueeze each tensor and concatenate
-    var unsqueezed: List[ExTensor] = []
+    var unsqueezed: List[AnyTensor] = []
     for i in range(num_tensors):
         unsqueezed.append(unsqueeze(tensors[i], actual_axis))
 
@@ -651,8 +651,8 @@ fn stack(tensors: List[ExTensor], axis: Int = 0) raises -> ExTensor:
 
 
 fn split(
-    tensor: ExTensor, num_splits: Int, axis: Int = 0
-) raises -> List[ExTensor]:
+    tensor: AnyTensor, num_splits: Int, axis: Int = 0
+) raises -> List[AnyTensor]:
     """Split tensor into equal parts along an axis.
 
     Divides tensor into num_splits equal parts along the specified axis.
@@ -664,7 +664,7 @@ fn split(
         axis: Axis along which to split (default: 0).
 
     Returns:
-        List of ExTensor objects, each with same shape except along split axis.
+        List of AnyTensor objects, each with same shape except along split axis.
 
     Raises:
         Error: If axis is invalid, num_splits <= 0, or tensor size not divisible.
@@ -704,7 +704,7 @@ fn split(
     var chunk_size = split_size // num_splits
 
     # Create slices for each split
-    var results: List[ExTensor] = []
+    var results: List[AnyTensor] = []
 
     for i in range(num_splits):
         var start_idx = i * chunk_size
@@ -718,8 +718,8 @@ fn split(
 
 
 fn split_with_indices(
-    tensor: ExTensor, split_indices: List[Int], axis: Int = 0
-) raises -> List[ExTensor]:
+    tensor: AnyTensor, split_indices: List[Int], axis: Int = 0
+) raises -> List[AnyTensor]:
     """Split tensor at specified indices along an axis.
 
     Divides tensor at specified indices along the given axis.
@@ -731,7 +731,7 @@ fn split_with_indices(
         axis: Axis along which to split (default: 0).
 
     Returns:
-        List of ExTensor objects resulting from splits.
+        List of AnyTensor objects resulting from splits.
 
     Raises:
         Error: If axis is invalid or indices are out of bounds/unordered.
@@ -781,7 +781,7 @@ fn split_with_indices(
             )
 
     # Create slices based on indices
-    var results: List[ExTensor] = []
+    var results: List[AnyTensor] = []
     var prev_idx = 0
 
     for i in range(num_indices):
@@ -919,7 +919,7 @@ fn flatten_size(height: Int, width: Int, channels: Int) -> Int:
     return height * width * channels
 
 
-fn flatten_to_2d(tensor: ExTensor) raises -> ExTensor:
+fn flatten_to_2d(tensor: AnyTensor) raises -> AnyTensor:
     """Flatten a 4D tensor to 2D, preserving the batch dimension.
 
         Commonly used before fully connected layers in CNNs to reshape
@@ -1067,7 +1067,7 @@ fn linear_output_shape(batch_size: Int, out_features: Int) -> Tuple[Int, Int]:
     return Tuple[Int, Int](batch_size, out_features)
 
 
-fn tile(tensor: ExTensor, reps: List[Int]) raises -> ExTensor:
+fn tile(tensor: AnyTensor, reps: List[Int]) raises -> AnyTensor:
     """Tile tensor by repeating along each dimension.
 
     Args:
@@ -1120,7 +1120,7 @@ fn tile(tensor: ExTensor, reps: List[Int]) raises -> ExTensor:
         result_shape.append(padded_shape[i] * padded_reps[i])
 
     # Create result tensor
-    var result = ExTensor(result_shape, tensor.dtype())
+    var result = AnyTensor(result_shape, tensor.dtype())
     var result_numel = result.numel()
 
     # Fill result by repeating input
@@ -1166,7 +1166,7 @@ fn tile(tensor: ExTensor, reps: List[Int]) raises -> ExTensor:
     return result^
 
 
-fn repeat(tensor: ExTensor, n: Int, axis: Int = -1) raises -> ExTensor:
+fn repeat(tensor: AnyTensor, n: Int, axis: Int = -1) raises -> AnyTensor:
     """Repeat each element n times along axis.
 
     Args:
@@ -1195,7 +1195,7 @@ fn repeat(tensor: ExTensor, n: Int, axis: Int = -1) raises -> ExTensor:
         var numel = flat.numel()
         var result_shape = List[Int]()
         result_shape.append(numel * n)
-        var result = ExTensor(result_shape, tensor.dtype())
+        var result = AnyTensor(result_shape, tensor.dtype())
 
         for i in range(numel):
             var val = flat._get_float64(i)
@@ -1222,7 +1222,7 @@ fn repeat(tensor: ExTensor, n: Int, axis: Int = -1) raises -> ExTensor:
                 result_shape.append(shape[i])
 
         # Create result tensor
-        var result = ExTensor(result_shape, tensor.dtype())
+        var result = AnyTensor(result_shape, tensor.dtype())
         var result_numel = result.numel()
 
         # Fill result by repeating elements
@@ -1261,7 +1261,7 @@ fn repeat(tensor: ExTensor, n: Int, axis: Int = -1) raises -> ExTensor:
         return result^
 
 
-fn broadcast_to(tensor: ExTensor, target_shape: List[Int]) raises -> ExTensor:
+fn broadcast_to(tensor: AnyTensor, target_shape: List[Int]) raises -> AnyTensor:
     """Broadcast tensor to target shape.
 
     Args:
@@ -1307,7 +1307,7 @@ fn broadcast_to(tensor: ExTensor, target_shape: List[Int]) raises -> ExTensor:
     var broadcast_strides = compute_broadcast_strides(shape, target_shape)
 
     # Create result tensor
-    var result = ExTensor(target_shape, tensor.dtype())
+    var result = AnyTensor(target_shape, tensor.dtype())
     var result_numel = result.numel()
 
     # Fill result using broadcast strides
@@ -1335,7 +1335,7 @@ fn broadcast_to(tensor: ExTensor, target_shape: List[Int]) raises -> ExTensor:
     return result^
 
 
-fn permute(tensor: ExTensor, dims: List[Int]) raises -> ExTensor:
+fn permute(tensor: AnyTensor, dims: List[Int]) raises -> AnyTensor:
     """Permute tensor dimensions (generalized transpose).
 
     Args:
@@ -1397,7 +1397,7 @@ fn permute(tensor: ExTensor, dims: List[Int]) raises -> ExTensor:
         new_shape.append(shape[dims[i]])
 
     # Create result tensor
-    var result = ExTensor(new_shape, tensor.dtype())
+    var result = AnyTensor(new_shape, tensor.dtype())
     var result_numel = result.numel()
 
     # Fill result by permuting coordinates

--- a/shared/testing/models.mojo
+++ b/shared/testing/models.mojo
@@ -37,7 +37,7 @@ Example:
     ```
 """
 
-from shared.core import ExTensor, zeros, ones, zeros_like
+from shared.core import AnyTensor, zeros, ones, zeros_like
 from shared.core.traits import Model
 
 
@@ -110,7 +110,7 @@ struct SimpleCNN(Copyable, Movable):
         shape.append(self.num_classes)
         return shape^
 
-    fn forward(self, input: ExTensor) raises -> ExTensor:
+    fn forward(self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass (simplified for testing).
 
         Creates output tensor with correct shape filled with dummy values.
@@ -198,7 +198,7 @@ struct LinearModel(Copyable, Movable):
         shape.append(self.out_features)
         return shape^
 
-    fn forward(self, input: ExTensor) raises -> ExTensor:
+    fn forward(self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass.
 
         Creates output tensor with correct shape filled with zeros.
@@ -467,7 +467,7 @@ struct SimpleLinearModel:
 struct Parameter(Copyable, Movable):
     """Trainable parameter with data and gradient.
 
-    Wraps an ExTensor for the parameter data with an associated gradient tensor.
+    Wraps an AnyTensor for the parameter data with an associated gradient tensor.
     Used in model layers to track trainable weights and biases.
 
     Attributes:
@@ -475,12 +475,12 @@ struct Parameter(Copyable, Movable):
         grad: The gradient tensor for backpropagation.
     """
 
-    var data: ExTensor
+    var data: AnyTensor
     """The parameter tensor (weights or bias)."""
-    var grad: ExTensor
+    var grad: AnyTensor
     """The gradient tensor for backpropagation."""
 
-    fn __init__(out self, data: ExTensor) raises:
+    fn __init__(out self, data: AnyTensor) raises:
         """Initialize parameter with data tensor and zero gradient.
 
         Args:
@@ -709,14 +709,14 @@ struct SimpleMLP(Copyable, Model, Movable):
             )
             return output^
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
-        """Forward pass through MLP with ExTensor input.
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
+        """Forward pass through MLP with AnyTensor input.
 
         Args:
-            input: Input ExTensor.
+            input: Input AnyTensor.
 
         Returns:
-            Output ExTensor.
+            Output AnyTensor.
 
         Raises:
             Error: If tensor conversion fails or memory allocation fails.
@@ -730,10 +730,10 @@ struct SimpleMLP(Copyable, Model, Movable):
         ```
 
         Note:
-            This is the Model trait implementation that accepts ExTensor.
+            This is the Model trait implementation that accepts AnyTensor.
             Uses ReLU activation between layers: ReLU(x) = max(0, x).
         """
-        # Extract Float32 values from ExTensor
+        # Extract Float32 values from AnyTensor
         var input_list = List[Float32]()
         var input_numel = input.numel()
         for i in range(input_numel):
@@ -742,7 +742,7 @@ struct SimpleMLP(Copyable, Model, Movable):
         # Call existing forward with List[Float32]
         var output_list = self.forward(input_list)
 
-        # Convert back to ExTensor
+        # Convert back to AnyTensor
         var output = zeros([len(output_list)], DType.float32)
         for i in range(len(output_list)):
             output._set_float32(i, output_list[i])
@@ -808,11 +808,11 @@ struct SimpleMLP(Copyable, Model, Movable):
             total += len(self.layer3_weights) + len(self.layer3_bias)
         return total
 
-    fn get_weights(self) raises -> ExTensor:
-        """Get flattened weights as ExTensor.
+    fn get_weights(self) raises -> AnyTensor:
+        """Get flattened weights as AnyTensor.
 
         Returns:
-            ExTensor containing all weights flattened.
+            AnyTensor containing all weights flattened.
 
         Raises:
             Error: If tensor creation fails.
@@ -838,7 +838,7 @@ struct SimpleMLP(Copyable, Model, Movable):
         for i in range(len(self.layer3_bias)):
             all_weights.append(self.layer3_bias[i])
 
-        # Create ExTensor from flattened weights
+        # Create AnyTensor from flattened weights
         var shape: List[Int] = [len(all_weights)]
         var tensor = zeros(shape, DType.float32)
 
@@ -848,11 +848,11 @@ struct SimpleMLP(Copyable, Model, Movable):
 
         return tensor
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Get list of parameter tensors.
 
         Returns:
-            List of ExTensor objects containing weights and biases.
+            List of AnyTensor objects containing weights and biases.
 
         Raises:
             Error: If tensor creation fails.
@@ -865,7 +865,7 @@ struct SimpleMLP(Copyable, Model, Movable):
                 print(param.shape())
         ```
         """
-        var param_list: List[ExTensor] = []
+        var param_list: List[AnyTensor] = []
 
         # Layer 1 weights parameter
         var w1_shape: List[Int] = [self.hidden_dim, self.input_dim]
@@ -931,7 +931,7 @@ struct SimpleMLP(Copyable, Model, Movable):
         # on Parameter objects during backpropagation
         pass
 
-    fn state_dict(self) raises -> Dict[String, ExTensor]:
+    fn state_dict(self) raises -> Dict[String, AnyTensor]:
         """Export weights as state dictionary.
 
         Returns:
@@ -949,7 +949,7 @@ struct SimpleMLP(Copyable, Model, Movable):
         Note:
             Returns owned Dict with ownership transfer to avoid copy errors.
         """
-        var state = Dict[String, ExTensor]()
+        var state = Dict[String, AnyTensor]()
 
         # Layer 1 weights
         var w1_shape: List[Int] = [self.hidden_dim, self.input_dim]
@@ -999,7 +999,7 @@ struct SimpleMLP(Copyable, Model, Movable):
 
         return state^
 
-    fn load_state_dict(mut self, state: Dict[String, ExTensor]):
+    fn load_state_dict(mut self, state: Dict[String, AnyTensor]):
         """Load weights from state dictionary.
 
         Args:
@@ -1078,7 +1078,7 @@ struct SimpleMLP2(Copyable, Model, Movable):
         self.hidden_dim = hidden_dim
         self.output_dim = output_dim
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass using manual layer composition.
 
         This demonstrates the data flow through sequential layers without
@@ -1112,16 +1112,16 @@ struct SimpleMLP2(Copyable, Model, Movable):
 
         return output^
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Get all trainable parameters.
 
         Returns:
-            List of 4 ExTensors: W1, b1, W2, b2 (placeholder weights).
+            List of 4 AnyTensors: W1, b1, W2, b2 (placeholder weights).
 
         Raises:
             Error: If parameter collection fails.
         """
-        var params = List[ExTensor]()
+        var params = List[AnyTensor]()
         # W1: (input_dim, hidden_dim)
         params.append(zeros([self.input_dim, self.hidden_dim], DType.float32))
         # b1: (hidden_dim,)


### PR DESCRIPTION
## Summary
- **Phase 5b**: Migrate collection operations (`concatenate`, `stack`, `split`, `split_with_indices`, `tile`, `repeat`) and lazy evaluation (`lazy_expression.mojo`, `lazy_eval.mojo`) from `ExTensor` to `AnyTensor`
- **Phase 5c**: Migrate optimizer infrastructure (`Variable`, SGD, Adam, AdamW, AdaGrad, RMSprop), `SavedTensors`, `VariableRegistry`, and gradient types (`GradientPair`, `GradientTriple`, `GradientQuad`, etc.) from `ExTensor` to `AnyTensor`
- Update `shared/testing/models.mojo` (`Parameter`, `SimpleMLP`, `SimpleMLP2`, `state_dict`, `load_state_dict`) to `AnyTensor`

## Files Modified
- `shared/core/shape.mojo` -- collection ops signatures
- `shared/core/lazy_expression.mojo` -- `_tensors: List[AnyTensor]`, `expr()` entry point
- `shared/core/lazy_eval.mojo` -- evaluation kernel signatures
- `shared/autograd/variable.mojo` -- `Variable.data: AnyTensor`
- `shared/autograd/optimizers.mojo` -- all optimizer buffer types
- `shared/autograd/tape_types.mojo` -- `SavedTensors`, `VariableRegistry`
- `shared/core/gradient_types.mojo` -- all gradient container fields
- `shared/testing/models.mojo` -- `Parameter`, `state_dict`, `parameters()`

## Test plan
- [ ] CI build validates compilation (since `comptime ExTensor = AnyTensor`, behavior is identical)
- [ ] Existing tests pass without modification (alias ensures backward compatibility)

Part of #4998