### PR TITLE
refactor(tests): migrate remaining tests and examples to AnyTensor

### DIFF
--- a/examples/alexnet-cifar10/inference.mojo
+++ b/examples/alexnet-cifar10/inference.mojo
@@ -18,7 +18,7 @@ References:
 from model import AlexNet
 from shared.data.datasets import CIFAR10Dataset
 from shared.data import DatasetInfo
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.utils.arg_parser import ArgumentParser
 from shared.training.metrics import evaluate_with_predict
 
@@ -42,7 +42,7 @@ fn parse_args() raises -> Tuple[String, String]:
 
 
 fn evaluate_model(
-    mut model: AlexNet, test_images: ExTensor, test_labels: ExTensor
+    mut model: AlexNet, test_images: AnyTensor, test_labels: AnyTensor
 ) raises -> Tuple[Float32, Float32]:
     """Evaluate model on test set with Top-1 and Top-5 accuracy.
 
@@ -123,7 +123,7 @@ fn evaluate_model(
     return (top1_accuracy_fraction, top5_accuracy)
 
 
-fn _argmax(tensor: ExTensor) raises -> Int:
+fn _argmax(tensor: AnyTensor) raises -> Int:
     """Find index of maximum value in 1D tensor.
 
     Args:
@@ -144,7 +144,7 @@ fn _argmax(tensor: ExTensor) raises -> Int:
     return max_idx
 
 
-fn _top_k_indices(tensor: ExTensor, k: Int) raises -> List[Int]:
+fn _top_k_indices(tensor: AnyTensor, k: Int) raises -> List[Int]:
     """Find indices of top-k maximum values in 1D tensor.
 
     Args:

--- a/examples/alexnet-cifar10/model.mojo
+++ b/examples/alexnet-cifar10/model.mojo
@@ -21,7 +21,7 @@ References:
     - CIFAR-10 Dataset: https://www.cs.toronto.edu/~kriz/cifar.html
 """
 
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import maxpool2d, maxpool2d_backward
 from shared.core.linear import linear, linear_backward
@@ -203,24 +203,24 @@ struct AlexNet:
     var dropout_rate: Float32
 
     # Convolutional layer parameters
-    var conv1_kernel: ExTensor
-    var conv1_bias: ExTensor
-    var conv2_kernel: ExTensor
-    var conv2_bias: ExTensor
-    var conv3_kernel: ExTensor
-    var conv3_bias: ExTensor
-    var conv4_kernel: ExTensor
-    var conv4_bias: ExTensor
-    var conv5_kernel: ExTensor
-    var conv5_bias: ExTensor
+    var conv1_kernel: AnyTensor
+    var conv1_bias: AnyTensor
+    var conv2_kernel: AnyTensor
+    var conv2_bias: AnyTensor
+    var conv3_kernel: AnyTensor
+    var conv3_bias: AnyTensor
+    var conv4_kernel: AnyTensor
+    var conv4_bias: AnyTensor
+    var conv5_kernel: AnyTensor
+    var conv5_bias: AnyTensor
 
     # Fully connected layer parameters
-    var fc1_weights: ExTensor
-    var fc1_bias: ExTensor
-    var fc2_weights: ExTensor
-    var fc2_bias: ExTensor
-    var fc3_weights: ExTensor
-    var fc3_bias: ExTensor
+    var fc1_weights: AnyTensor
+    var fc1_bias: AnyTensor
+    var fc2_weights: AnyTensor
+    var fc2_bias: AnyTensor
+    var fc3_weights: AnyTensor
+    var fc3_bias: AnyTensor
 
     fn __init__(
         out self, num_classes: Int = 10, dropout_rate: Float32 = 0.5
@@ -311,8 +311,8 @@ struct AlexNet:
         self.fc3_bias = zeros(fc3_bias_shape, DType.float32)
 
     fn forward(
-        mut self, input: ExTensor, training: Bool = True
-    ) raises -> ExTensor:
+        mut self, input: AnyTensor, training: Bool = True
+    ) raises -> AnyTensor:
         """Forward pass through AlexNet.
 
         Args:
@@ -421,7 +421,7 @@ struct AlexNet:
 
         return output
 
-    fn predict(mut self, input: ExTensor) raises -> Int:
+    fn predict(mut self, input: AnyTensor) raises -> Int:
         """Predict class for a single input.
 
         Args:
@@ -455,7 +455,7 @@ struct AlexNet:
             - conv1_kernel.weights, conv1_bias.weights, etc.
         """
         # Collect all parameters
-        var parameters: List[ExTensor] = []
+        var parameters: List[AnyTensor] = []
         parameters.append(self.conv1_kernel)
         parameters.append(self.conv1_bias)
         parameters.append(self.conv2_kernel)
@@ -492,7 +492,7 @@ struct AlexNet:
         var param_names = get_model_parameter_names("alexnet")
 
         # Create empty list for loaded parameters
-        var loaded_params: List[ExTensor] = []
+        var loaded_params: List[AnyTensor] = []
 
         # Load using shared utility
         load_model_weights(loaded_params, weights_dir, param_names)
@@ -519,38 +519,38 @@ struct AlexNet:
         mut self,
         learning_rate: Float32,
         momentum: Float32,
-        grad_conv1_kernel: ExTensor,
-        grad_conv1_bias: ExTensor,
-        grad_conv2_kernel: ExTensor,
-        grad_conv2_bias: ExTensor,
-        grad_conv3_kernel: ExTensor,
-        grad_conv3_bias: ExTensor,
-        grad_conv4_kernel: ExTensor,
-        grad_conv4_bias: ExTensor,
-        grad_conv5_kernel: ExTensor,
-        grad_conv5_bias: ExTensor,
-        grad_fc1_weights: ExTensor,
-        grad_fc1_bias: ExTensor,
-        grad_fc2_weights: ExTensor,
-        grad_fc2_bias: ExTensor,
-        grad_fc3_weights: ExTensor,
-        grad_fc3_bias: ExTensor,
-        mut velocity_conv1_kernel: ExTensor,
-        mut velocity_conv1_bias: ExTensor,
-        mut velocity_conv2_kernel: ExTensor,
-        mut velocity_conv2_bias: ExTensor,
-        mut velocity_conv3_kernel: ExTensor,
-        mut velocity_conv3_bias: ExTensor,
-        mut velocity_conv4_kernel: ExTensor,
-        mut velocity_conv4_bias: ExTensor,
-        mut velocity_conv5_kernel: ExTensor,
-        mut velocity_conv5_bias: ExTensor,
-        mut velocity_fc1_weights: ExTensor,
-        mut velocity_fc1_bias: ExTensor,
-        mut velocity_fc2_weights: ExTensor,
-        mut velocity_fc2_bias: ExTensor,
-        mut velocity_fc3_weights: ExTensor,
-        mut velocity_fc3_bias: ExTensor,
+        grad_conv1_kernel: AnyTensor,
+        grad_conv1_bias: AnyTensor,
+        grad_conv2_kernel: AnyTensor,
+        grad_conv2_bias: AnyTensor,
+        grad_conv3_kernel: AnyTensor,
+        grad_conv3_bias: AnyTensor,
+        grad_conv4_kernel: AnyTensor,
+        grad_conv4_bias: AnyTensor,
+        grad_conv5_kernel: AnyTensor,
+        grad_conv5_bias: AnyTensor,
+        grad_fc1_weights: AnyTensor,
+        grad_fc1_bias: AnyTensor,
+        grad_fc2_weights: AnyTensor,
+        grad_fc2_bias: AnyTensor,
+        grad_fc3_weights: AnyTensor,
+        grad_fc3_bias: AnyTensor,
+        mut velocity_conv1_kernel: AnyTensor,
+        mut velocity_conv1_bias: AnyTensor,
+        mut velocity_conv2_kernel: AnyTensor,
+        mut velocity_conv2_bias: AnyTensor,
+        mut velocity_conv3_kernel: AnyTensor,
+        mut velocity_conv3_bias: AnyTensor,
+        mut velocity_conv4_kernel: AnyTensor,
+        mut velocity_conv4_bias: AnyTensor,
+        mut velocity_conv5_kernel: AnyTensor,
+        mut velocity_conv5_bias: AnyTensor,
+        mut velocity_fc1_weights: AnyTensor,
+        mut velocity_fc1_bias: AnyTensor,
+        mut velocity_fc2_weights: AnyTensor,
+        mut velocity_fc2_bias: AnyTensor,
+        mut velocity_fc3_weights: AnyTensor,
+        mut velocity_fc3_bias: AnyTensor,
     ) raises:
         """Update parameters using SGD with momentum.
 

--- a/examples/alexnet-cifar10/train.mojo
+++ b/examples/alexnet-cifar10/train.mojo
@@ -18,7 +18,7 @@ References:
 
 from model import AlexNet
 from shared.data.datasets import CIFAR10Dataset
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import maxpool2d, maxpool2d_backward
 from shared.core.linear import linear, linear_backward
@@ -55,11 +55,11 @@ fn parse_args() raises -> Tuple[Int, Int, Float32, Float32, String, String]:
 
 fn compute_gradients(
     mut model: AlexNet,
-    input: ExTensor,
-    labels: ExTensor,
+    input: AnyTensor,
+    labels: AnyTensor,
     learning_rate: Float32,
     momentum: Float32,
-    mut velocities: List[ExTensor],
+    mut velocities: List[AnyTensor],
 ) raises -> Float32:
     """Compute gradients and update parameters for one batch.
 
@@ -341,14 +341,14 @@ fn compute_gradients(
 
 fn train_epoch(
     mut model: AlexNet,
-    train_images: ExTensor,
-    train_labels: ExTensor,
+    train_images: AnyTensor,
+    train_labels: AnyTensor,
     batch_size: Int,
     learning_rate: Float32,
     momentum: Float32,
     epoch: Int,
     total_epochs: Int,
-    mut velocities: List[ExTensor],
+    mut velocities: List[AnyTensor],
 ) raises -> Float32:
     """Train for one epoch with manual batch iteration.
 
@@ -414,7 +414,7 @@ fn train_epoch(
 
 
 fn evaluate(
-    mut model: AlexNet, test_images: ExTensor, test_labels: ExTensor
+    mut model: AlexNet, test_images: AnyTensor, test_labels: AnyTensor
 ) raises -> Float32:
     """Evaluate model on test set.
 
@@ -457,7 +457,7 @@ fn evaluate(
     return accuracy
 
 
-fn initialize_velocities(model: AlexNet) raises -> List[ExTensor]:
+fn initialize_velocities(model: AlexNet) raises -> List[AnyTensor]:
     """Initialize momentum velocities for all parameters (16 tensors).
 
     Args:
@@ -466,7 +466,7 @@ fn initialize_velocities(model: AlexNet) raises -> List[ExTensor]:
     Returns:
         DynamicVector of zero-initialized velocity tensors matching parameter shapes.
     """
-    var velocities: List[ExTensor] = []
+    var velocities: List[AnyTensor] = []
 
     # Initialize velocities for all 16 parameters (conv1-5 + fc1-3, weights + bias)
     velocities.append(zeros(model.conv1_kernel.shape(), DType.float32))

--- a/examples/alexnet-cifar10/train_new.mojo
+++ b/examples/alexnet-cifar10/train_new.mojo
@@ -29,7 +29,7 @@ References:
 
 from model import AlexNet
 from shared.data.datasets import CIFAR10Dataset
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import maxpool2d, maxpool2d_backward
 from shared.core.linear import linear, linear_backward
@@ -69,7 +69,7 @@ fn parse_args() raises -> TrainerConfig:
     )
 
 
-fn initialize_velocities(model: AlexNet) raises -> List[ExTensor]:
+fn initialize_velocities(model: AlexNet) raises -> List[AnyTensor]:
     """Initialize momentum velocities for all parameters (16 tensors).
 
     Args:
@@ -78,7 +78,7 @@ fn initialize_velocities(model: AlexNet) raises -> List[ExTensor]:
     Returns:
         List of zero-initialized velocity tensors matching parameter shapes.
     """
-    var velocities: List[ExTensor] = []
+    var velocities: List[AnyTensor] = []
 
     # Initialize velocities for all 16 parameters (conv1-5 + fc1-3, weights + bias)
     velocities.append(zeros(model.conv1_kernel.shape(), DType.float32))
@@ -103,11 +103,11 @@ fn initialize_velocities(model: AlexNet) raises -> List[ExTensor]:
 
 fn compute_gradients(
     mut model: AlexNet,
-    input: ExTensor,
-    labels: ExTensor,
+    input: AnyTensor,
+    labels: AnyTensor,
     learning_rate: Float32,
     momentum: Float32,
-    mut velocities: List[ExTensor],
+    mut velocities: List[AnyTensor],
 ) raises -> Float32:
     """Compute gradients and update parameters for one batch.
 

--- a/examples/autograd/linear_regression.mojo
+++ b/examples/autograd/linear_regression.mojo
@@ -11,7 +11,7 @@ Training: Learn w and b to fit the data y = 2x + 1
 """
 
 from shared.autograd import mse_loss_and_grad, apply_gradient, multiply_scalar
-from shared.core.extensor import ExTensor, zeros
+from shared.core.extensor import AnyTensor, zeros
 from shared.core.arithmetic import add, multiply
 from shared.core.reduction import sum as tensor_sum
 
@@ -29,10 +29,10 @@ fn linear_regression_functional() raises:
     var num_epochs: Int = 50
 
     # Create parameters: w and b
-    var w = ExTensor(List[Int](), DType.float32)
+    var w = AnyTensor(List[Int](), DType.float32)
     w._set_float64(0, 0.5)  # Initialize w = 0.5
 
-    var b = ExTensor(List[Int](), DType.float32)
+    var b = AnyTensor(List[Int](), DType.float32)
     b._set_float64(0, 0.0)  # Initialize b = 0.0
 
     print("Initial parameters:")
@@ -43,11 +43,11 @@ fn linear_regression_functional() raises:
     # Create training data: y = 2*x + 1
     # X = [1, 2, 3, 4, 5]
     # Y = [3, 5, 7, 9, 11]
-    var X = ExTensor(List[Int](), DType.float32)
+    var X = AnyTensor(List[Int](), DType.float32)
     for i in range(5):
         X._set_float64(i, Float64(i + 1))
 
-    var Y = ExTensor(List[Int](), DType.float32)
+    var Y = AnyTensor(List[Int](), DType.float32)
     for i in range(5):
         Y._set_float64(i, Float64(2 * (i + 1) + 1))
 
@@ -60,7 +60,7 @@ fn linear_regression_functional() raises:
         var w_val = w._get_float64(0)
         var b_val = b._get_float64(0)
 
-        var predictions = ExTensor(List[Int](), DType.float32)
+        var predictions = AnyTensor(List[Int](), DType.float32)
         for i in range(5):
             var pred = w_val * X._get_float64(i) + b_val
             predictions._set_float64(i, pred)

--- a/examples/autograd/simple_example.mojo
+++ b/examples/autograd/simple_example.mojo
@@ -20,7 +20,7 @@ from shared.autograd.variable import (
     variable_subtract,
     variable_mean,
 )
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 
 
 fn simple_linear_regression() raises:
@@ -58,11 +58,11 @@ fn simple_linear_regression() raises:
     # Create simple training data: y = 2*x + 1
     # X = [1, 2, 3, 4, 5]
     # Y = [3, 5, 7, 9, 11]
-    var X = ExTensor(List[Int](), DType.float32)
+    var X = AnyTensor(List[Int](), DType.float32)
     for i in range(5):
         X._set_float64(i, Float64(i + 1))
 
-    var Y = ExTensor(List[Int](), DType.float32)
+    var Y = AnyTensor(List[Int](), DType.float32)
     for i in range(5):
         Y._set_float64(i, Float64(2 * (i + 1) + 1))
 
@@ -80,12 +80,12 @@ fn simple_linear_regression() raises:
 
         # Forward pass: predictions = w * X + b
         # Expand scalar parameters to match X shape for broadcasting
-        var w_expanded_data = ExTensor(List[Int](), DType.float32)
+        var w_expanded_data = AnyTensor(List[Int](), DType.float32)
         for i in range(5):
             w_expanded_data._set_float64(i, w.data._get_float64(0))
         var w_expanded = Variable(w_expanded_data, True, tape)
 
-        var b_expanded_data = ExTensor(List[Int](), DType.float32)
+        var b_expanded_data = AnyTensor(List[Int](), DType.float32)
         for i in range(5):
             b_expanded_data._set_float64(i, b.data._get_float64(0))
         var b_expanded = Variable(b_expanded_data, True, tape)
@@ -111,13 +111,13 @@ fn simple_linear_regression() raises:
         var grad_b_expanded = tape.get_grad(b_expanded.id)
 
         # Sum gradients across batch dimension to get parameter gradients
-        var grad_w_sum_data = ExTensor(List[Int](), DType.float32)
+        var grad_w_sum_data = AnyTensor(List[Int](), DType.float32)
         var grad_w_val = 0.0
         for i in range(5):
             grad_w_val += grad_w_expanded._get_float64(i)
         grad_w_sum_data._set_float64(0, grad_w_val)
 
-        var grad_b_sum_data = ExTensor(List[Int](), DType.float32)
+        var grad_b_sum_data = AnyTensor(List[Int](), DType.float32)
         var grad_b_val = 0.0
         for i in range(5):
             grad_b_val += grad_b_expanded._get_float64(i)

--- a/examples/basic_usage.mojo
+++ b/examples/basic_usage.mojo
@@ -1,14 +1,14 @@
-"""Basic ExTensor usage example.
+"""Basic AnyTensor usage example.
 
 Demonstrates creation operations and basic tensor manipulation.
 """
 
-from shared.core import ExTensor, zeros, ones, full, arange, eye, linspace
+from shared.core import AnyTensor, zeros, ones, full, arange, eye, linspace
 
 
 fn main() raises:
-    """Run basic ExTensor examples."""
-    print("ExTensor Basic Usage Examples")
+    """Run basic AnyTensor examples."""
+    print("AnyTensor Basic Usage Examples")
     print("=" * 50)
 
     # Create tensors with different shapes

--- a/examples/bf8_example.mojo
+++ b/examples/bf8_example.mojo
@@ -8,7 +8,7 @@ This example shows:
 5. Comparing BF8 (E5M2) vs FP8 (E4M3) characteristics
 """
 
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 
 
 fn main() raises:
@@ -18,7 +18,7 @@ fn main() raises:
     )
     print("This example demonstrates the expected API structure.")
     print(
-        "When BF8 conversion methods are available in ExTensor,"
+        "When BF8 conversion methods are available in AnyTensor,"
     )
     print("this example can be fully implemented.")
     print("")

--- a/examples/custom-layers/attention_layer.mojo
+++ b/examples/custom-layers/attention_layer.mojo
@@ -10,7 +10,7 @@ See documentation: docs/advanced/custom-layers.md
 
 from shared.core.module import Module
 from shared.core.layers import Linear
-from shared.core.extensor import ExTensor, randn
+from shared.core.extensor import AnyTensor, randn
 from shared.core.activation import softmax
 from shared.core.matrix import matmul, transpose
 
@@ -47,7 +47,7 @@ struct MultiHeadAttention(Module):
         self.v_proj = Linear(embed_dim, embed_dim)
         self.out_proj = Linear(embed_dim, embed_dim)
 
-    fn forward(mut self, x: ExTensor) raises -> ExTensor:
+    fn forward(mut self, x: AnyTensor) raises -> AnyTensor:
         """Compute multi-head attention.
 
         Args:
@@ -101,8 +101,8 @@ struct MultiHeadAttention(Module):
         # Output projection
         return self.out_proj.forward(attn_output)
 
-    fn parameters(self) raises -> List[ExTensor]:
-        var params = List[ExTensor]()
+    fn parameters(self) raises -> List[AnyTensor]:
+        var params = List[AnyTensor]()
         params.extend(self.q_proj.parameters())
         params.extend(self.k_proj.parameters())
         params.extend(self.v_proj.parameters())

--- a/examples/custom-layers/focal_loss.mojo
+++ b/examples/custom-layers/focal_loss.mojo
@@ -8,7 +8,7 @@ Usage:
 See documentation: docs/advanced/custom-layers.md
 """
 
-from shared.core.extensor import ExTensor, zeros, ones_like, full_like
+from shared.core.extensor import AnyTensor, zeros, ones_like, full_like
 from shared.core.arithmetic import subtract, multiply, add, power
 from shared.core.elementwise import log, clip
 from shared.core.reduction import mean
@@ -31,8 +31,8 @@ struct FocalLoss:
         self.gamma = gamma
 
     fn __call__(
-        self, predictions: ExTensor, targets: ExTensor
-    ) raises -> ExTensor:
+        self, predictions: AnyTensor, targets: AnyTensor
+    ) raises -> AnyTensor:
         """Compute focal loss for binary classification.
 
         Args:

--- a/examples/custom-layers/prelu_activation.mojo
+++ b/examples/custom-layers/prelu_activation.mojo
@@ -11,10 +11,10 @@ Usage:
 See documentation: docs/advanced/custom-layers.md
 """
 
-from shared.core import ExTensor, zeros, clip
+from shared.core import AnyTensor, zeros, clip
 
 
-fn prelu_simple(input: ExTensor, alpha: Float32) raises -> ExTensor:
+fn prelu_simple(input: AnyTensor, alpha: Float32) raises -> AnyTensor:
     """Apply PReLU activation element-wise.
 
     Args:
@@ -54,7 +54,7 @@ fn main() raises:
     input_data.append(0.0)
     input_data.append(1.0)
     input_data.append(2.0)
-    var input = ExTensor(input_data^)
+    var input = AnyTensor(input_data^)
 
     print("Input values:")
     var input_ptr = input._data.bitcast[Float32]()

--- a/examples/data_pipeline_demo.mojo
+++ b/examples/data_pipeline_demo.mojo
@@ -29,7 +29,7 @@ See Also:
 """
 
 from shared.data import (
-    ExTensorDataset,
+    AnyTensorDataset,
     BatchLoader,
     RandomSampler,
     SequentialSampler,
@@ -39,7 +39,7 @@ from shared.data import (
     PrefetchDataLoader,
 )
 from shared.data.transforms import Normalize, Compose
-from shared.core.extensor import ExTensor, ones, zeros
+from shared.core.extensor import AnyTensor, ones, zeros
 from collections import List
 
 
@@ -50,7 +50,7 @@ from collections import List
 
 fn create_demo_dataset(
     num_samples: Int = 32, num_classes: Int = 10
-) raises -> Tuple[ExTensor, ExTensor]:
+) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create synthetic training data for demonstration.
 
     Args:
@@ -96,7 +96,7 @@ fn demo_basic_pipeline() raises:
     var images, labels = create_demo_dataset(num_samples=16, num_classes=10)
 
     # Create dataset
-    var dataset = ExTensorDataset(images^, labels^)
+    var dataset = AnyTensorDataset(images^, labels^)
     print("✓ Created dataset with " + String(dataset.__len__()) + " samples")
 
     # Create sampler (Sequential = no shuffling)
@@ -144,7 +144,7 @@ fn demo_transform_pipeline() raises:
     var images, labels = create_demo_dataset(num_samples=16, num_classes=10)
 
     # Create base dataset
-    var dataset = ExTensorDataset(images^, labels^)
+    var dataset = AnyTensorDataset(images^, labels^)
     print("✓ Created dataset with " + String(dataset.__len__()) + " samples")
 
     # Create and apply transform
@@ -190,7 +190,7 @@ fn demo_shuffling_pipeline() raises:
     var images, labels = create_demo_dataset(num_samples=16, num_classes=10)
 
     # Create dataset
-    var dataset = ExTensorDataset(images^, labels^)
+    var dataset = AnyTensorDataset(images^, labels^)
     print("✓ Created dataset with " + String(dataset.__len__()) + " samples")
 
     # Create sampler with shuffling
@@ -227,7 +227,7 @@ fn demo_complete_pipeline() raises:
     var images, labels = create_demo_dataset(num_samples=32, num_classes=10)
 
     # Step 1: Create dataset
-    var dataset = ExTensorDataset(images^, labels^)
+    var dataset = AnyTensorDataset(images^, labels^)
     print(
         "✓ Step 1: Created dataset (" + String(dataset.__len__()) + " samples)"
     )
@@ -273,7 +273,7 @@ fn demo_performance_comparison() raises:
     # Configuration 1: No caching
     print("\nConfiguration 1: Sequential, no caching, no transforms")
     var images1, labels1 = create_demo_dataset(num_samples=64, num_classes=10)
-    var dataset1 = ExTensorDataset(images1^, labels1^)
+    var dataset1 = AnyTensorDataset(images1^, labels1^)
     var sampler1 = SequentialSampler(dataset1.__len__())
     var loader1 = BatchLoader(dataset1^, sampler1^, batch_size=16)
     var batches1 = loader1.__iter__()
@@ -282,7 +282,7 @@ fn demo_performance_comparison() raises:
     # Configuration 2: With transforms
     print("\nConfiguration 2: Sequential with transforms")
     var images2, labels2 = create_demo_dataset(num_samples=64, num_classes=10)
-    var dataset2 = ExTensorDataset(images2^, labels2^)
+    var dataset2 = AnyTensorDataset(images2^, labels2^)
     var normalize2 = Normalize(mean=0.5, std=0.5)
     var transformed2 = TransformedDataset(dataset2^, normalize2^)
     var sampler2 = SequentialSampler(transformed2.__len__())
@@ -295,7 +295,7 @@ fn demo_performance_comparison() raises:
     # Configuration 3: With shuffling and caching
     print("\nConfiguration 3: Random sampling with caching")
     var images3, labels3 = create_demo_dataset(num_samples=64, num_classes=10)
-    var dataset3 = ExTensorDataset(images3^, labels3^)
+    var dataset3 = AnyTensorDataset(images3^, labels3^)
     var cached3 = CachedDataset(dataset3^, max_cache_size=-1)
     var sampler3 = RandomSampler(cached3.__len__())
     var loader3 = BatchLoader(cached3^, sampler3^, batch_size=16)

--- a/examples/fp8_example.mojo
+++ b/examples/fp8_example.mojo
@@ -7,7 +7,7 @@ This example shows:
 4. Memory savings with FP8 (8-bit vs 32-bit)
 """
 
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 
 
 fn main() raises:
@@ -17,7 +17,7 @@ fn main() raises:
     )
     print("This example demonstrates the expected API structure.")
     print(
-        "When FP8 conversion methods are available in ExTensor,"
+        "When FP8 conversion methods are available in AnyTensor,"
     )
     print("this example can be fully implemented.")
     print("")

--- a/examples/getting-started/benchmark_quickstart.mojo
+++ b/examples/getting-started/benchmark_quickstart.mojo
@@ -20,7 +20,7 @@ from shared.benchmarking import (
     print_benchmark_report,
     BenchmarkResult,
 )
-from shared.core import ExTensor, ones, zeros
+from shared.core import AnyTensor, ones, zeros
 
 
 # ============================================================================
@@ -45,7 +45,7 @@ struct SimpleNN(Copyable, Movable):
     var output_size: Int
 
 
-fn forward_pass(network: SimpleNN, input_data: ExTensor) raises -> ExTensor:
+fn forward_pass(network: SimpleNN, input_data: AnyTensor) raises -> AnyTensor:
     """Perform a forward pass through the network.
 
     Args:
@@ -66,7 +66,7 @@ fn forward_pass(network: SimpleNN, input_data: ExTensor) raises -> ExTensor:
 
 
 fn training_step(
-    network: SimpleNN, input_data: ExTensor, targets: ExTensor
+    network: SimpleNN, input_data: AnyTensor, targets: AnyTensor
 ) raises -> Float32:
     """Perform a training step.
 

--- a/examples/getting-started/mlp_training_example.mojo
+++ b/examples/getting-started/mlp_training_example.mojo
@@ -14,7 +14,7 @@ pipeline is fully functional.
 """
 
 from shared.core import (
-    ExTensor,
+    AnyTensor,
     # Creation
     zeros,
     ones,
@@ -48,7 +48,7 @@ from shared.core.matrix import matmul, matmul_backward
 from shared.training.optimizers import sgd_step_simple
 
 
-fn create_synthetic_data() raises -> Tuple[ExTensor, ExTensor]:
+fn create_synthetic_data() raises -> Tuple[AnyTensor, AnyTensor]:
     """Create synthetic XOR-like binary classification data.
 
     Returns:
@@ -60,8 +60,8 @@ fn create_synthetic_data() raises -> Tuple[ExTensor, ExTensor]:
     var input_shape = [4, 2]
     var target_shape = [4, 1]
 
-    var inputs = ExTensor(input_shape, DType.float32)
-    var targets = ExTensor(target_shape, DType.float32)
+    var inputs = AnyTensor(input_shape, DType.float32)
+    var targets = AnyTensor(target_shape, DType.float32)
 
     # XOR-like pattern:
     # [0, 0] -> 0
@@ -157,7 +157,7 @@ fn train_mlp() raises:
 
         # For simplicity, process first sample
         var x_sample_shape = [input_size]
-        var x_sample = ExTensor(x_sample_shape, DType.float32)
+        var x_sample = AnyTensor(x_sample_shape, DType.float32)
         x_sample._set_float64(0, X._get_float64(0))  # First feature
         x_sample._set_float64(1, X._get_float64(1))  # Second feature
 
@@ -171,7 +171,7 @@ fn train_mlp() raises:
 
         # Get target for this sample
         var y_sample_shape = [output_size]
-        var y_sample = ExTensor(y_sample_shape, DType.float32)
+        var y_sample = AnyTensor(y_sample_shape, DType.float32)
         y_sample._set_float64(0, y_true._get_float64(0))
 
         # Compute loss
@@ -259,7 +259,7 @@ fn train_mlp() raises:
     for i in range(4):
         # Get sample
         var x_test_shape = [input_size]
-        var x_test = ExTensor(x_test_shape, DType.float32)
+        var x_test = AnyTensor(x_test_shape, DType.float32)
         x_test._set_float64(0, X._get_float64(i * 2))
         x_test._set_float64(1, X._get_float64(i * 2 + 1))
 

--- a/examples/googlenet-cifar10/inference.mojo
+++ b/examples/googlenet-cifar10/inference.mojo
@@ -16,7 +16,7 @@ Features:
     - Inference mode (no training, no batch norm running stats updates)
 """
 
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.data import extract_batch_pair, compute_num_batches, DatasetInfo
 from shared.data.datasets import CIFAR10Dataset
 from shared.training.metrics import evaluate_logits_batch
@@ -42,8 +42,8 @@ fn get_class_names() -> List[String]:
 
 fn evaluate_model(
     mut model: GoogLeNet,
-    images: ExTensor,
-    labels: ExTensor,
+    images: AnyTensor,
+    labels: AnyTensor,
     batch_size: Int = 100,
     verbose: Bool = True,
 ) raises -> Tuple[Float32, List[Int], List[Int]]:

--- a/examples/googlenet-cifar10/model.mojo
+++ b/examples/googlenet-cifar10/model.mojo
@@ -20,7 +20,7 @@ References:
 """
 
 from shared.core import (
-    ExTensor,
+    AnyTensor,
     zeros,
     conv2d,
     maxpool2d,
@@ -55,50 +55,50 @@ struct InceptionModule:
     """
 
     # Branch 1: 1×1 convolution
-    var conv1x1_1_weights: ExTensor
-    var conv1x1_1_bias: ExTensor
-    var bn1x1_1_gamma: ExTensor
-    var bn1x1_1_beta: ExTensor
-    var bn1x1_1_running_mean: ExTensor
-    var bn1x1_1_running_var: ExTensor
+    var conv1x1_1_weights: AnyTensor
+    var conv1x1_1_bias: AnyTensor
+    var bn1x1_1_gamma: AnyTensor
+    var bn1x1_1_beta: AnyTensor
+    var bn1x1_1_running_mean: AnyTensor
+    var bn1x1_1_running_var: AnyTensor
 
     # Branch 2: 1×1 reduce → 3×3
-    var conv1x1_2_weights: ExTensor
-    var conv1x1_2_bias: ExTensor
-    var bn1x1_2_gamma: ExTensor
-    var bn1x1_2_beta: ExTensor
-    var bn1x1_2_running_mean: ExTensor
-    var bn1x1_2_running_var: ExTensor
+    var conv1x1_2_weights: AnyTensor
+    var conv1x1_2_bias: AnyTensor
+    var bn1x1_2_gamma: AnyTensor
+    var bn1x1_2_beta: AnyTensor
+    var bn1x1_2_running_mean: AnyTensor
+    var bn1x1_2_running_var: AnyTensor
 
-    var conv3x3_weights: ExTensor
-    var conv3x3_bias: ExTensor
-    var bn3x3_gamma: ExTensor
-    var bn3x3_beta: ExTensor
-    var bn3x3_running_mean: ExTensor
-    var bn3x3_running_var: ExTensor
+    var conv3x3_weights: AnyTensor
+    var conv3x3_bias: AnyTensor
+    var bn3x3_gamma: AnyTensor
+    var bn3x3_beta: AnyTensor
+    var bn3x3_running_mean: AnyTensor
+    var bn3x3_running_var: AnyTensor
 
     # Branch 3: 1×1 reduce → 5×5
-    var conv1x1_3_weights: ExTensor
-    var conv1x1_3_bias: ExTensor
-    var bn1x1_3_gamma: ExTensor
-    var bn1x1_3_beta: ExTensor
-    var bn1x1_3_running_mean: ExTensor
-    var bn1x1_3_running_var: ExTensor
+    var conv1x1_3_weights: AnyTensor
+    var conv1x1_3_bias: AnyTensor
+    var bn1x1_3_gamma: AnyTensor
+    var bn1x1_3_beta: AnyTensor
+    var bn1x1_3_running_mean: AnyTensor
+    var bn1x1_3_running_var: AnyTensor
 
-    var conv5x5_weights: ExTensor
-    var conv5x5_bias: ExTensor
-    var bn5x5_gamma: ExTensor
-    var bn5x5_beta: ExTensor
-    var bn5x5_running_mean: ExTensor
-    var bn5x5_running_var: ExTensor
+    var conv5x5_weights: AnyTensor
+    var conv5x5_bias: AnyTensor
+    var bn5x5_gamma: AnyTensor
+    var bn5x5_beta: AnyTensor
+    var bn5x5_running_mean: AnyTensor
+    var bn5x5_running_var: AnyTensor
 
     # Branch 4: pool → 1×1 projection
-    var conv1x1_4_weights: ExTensor
-    var conv1x1_4_bias: ExTensor
-    var bn1x1_4_gamma: ExTensor
-    var bn1x1_4_beta: ExTensor
-    var bn1x1_4_running_mean: ExTensor
-    var bn1x1_4_running_var: ExTensor
+    var conv1x1_4_weights: AnyTensor
+    var conv1x1_4_bias: AnyTensor
+    var bn1x1_4_gamma: AnyTensor
+    var bn1x1_4_beta: AnyTensor
+    var bn1x1_4_running_mean: AnyTensor
+    var bn1x1_4_running_var: AnyTensor
 
     fn __init__(
         out self,
@@ -197,7 +197,7 @@ struct InceptionModule:
         self.bn1x1_4_running_mean = zeros(conv1x1_4_bias_shape, DType.float32)
         self.bn1x1_4_running_var = constant(conv1x1_4_bias_shape, 1.0)
 
-    fn forward(mut self, x: ExTensor, training: Bool) raises -> ExTensor:
+    fn forward(mut self, x: AnyTensor, training: Bool) raises -> AnyTensor:
         """Forward pass through Inception module.
 
         Args:
@@ -520,8 +520,8 @@ struct InceptionModule:
 
 
 fn concatenate_depthwise(
-    t1: ExTensor, t2: ExTensor, t3: ExTensor, t4: ExTensor
-) raises -> ExTensor:
+    t1: AnyTensor, t2: AnyTensor, t3: AnyTensor, t4: AnyTensor
+) raises -> AnyTensor:
     """Concatenate 4 tensors along the channel dimension (axis=1).
 
     Args:
@@ -603,12 +603,12 @@ struct GoogLeNet:
     """
 
     # Initial convolution block
-    var initial_conv_weights: ExTensor
-    var initial_conv_bias: ExTensor
-    var initial_bn_gamma: ExTensor
-    var initial_bn_beta: ExTensor
-    var initial_bn_running_mean: ExTensor
-    var initial_bn_running_var: ExTensor
+    var initial_conv_weights: AnyTensor
+    var initial_conv_bias: AnyTensor
+    var initial_bn_gamma: AnyTensor
+    var initial_bn_beta: AnyTensor
+    var initial_bn_running_mean: AnyTensor
+    var initial_bn_running_var: AnyTensor
 
     # Inception modules
     var inception_3a: InceptionModule
@@ -622,8 +622,8 @@ struct GoogLeNet:
     var inception_5b: InceptionModule
 
     # Final classifier
-    var fc_weights: ExTensor
-    var fc_bias: ExTensor
+    var fc_weights: AnyTensor
+    var fc_bias: AnyTensor
 
     fn __init__(out self, num_classes: Int = 10) raises:
         """Initialize GoogLeNet model.
@@ -754,7 +754,7 @@ struct GoogLeNet:
         var fc_bias_shape: List[Int] = [num_classes]
         self.fc_bias = zeros(fc_bias_shape, DType.float32)
 
-    fn forward(mut self, x: ExTensor, training: Bool = True) raises -> ExTensor:
+    fn forward(mut self, x: AnyTensor, training: Bool = True) raises -> AnyTensor:
         """Forward pass through GoogLeNet.
 
         Args:

--- a/examples/googlenet-cifar10/test_model.mojo
+++ b/examples/googlenet-cifar10/test_model.mojo
@@ -1,7 +1,7 @@
 """Quick integration test for GoogLeNet model"""
 
 from model import GoogLeNet
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 
 
 fn main() raises:

--- a/examples/googlenet-cifar10/train.mojo
+++ b/examples/googlenet-cifar10/train.mojo
@@ -33,7 +33,7 @@ Training Details:
 """
 
 from shared.core import (
-    ExTensor,
+    AnyTensor,
     zeros,
     conv2d,
     maxpool2d,
@@ -66,8 +66,8 @@ from model import GoogLeNet, InceptionModule
 
 fn train_epoch(
     mut model: GoogLeNet,
-    train_images: ExTensor,
-    train_labels: ExTensor,
+    train_images: AnyTensor,
+    train_labels: AnyTensor,
     batch_size: Int,
     learning_rate: Float32,
     momentum: Float32,
@@ -328,8 +328,8 @@ fn train_epoch(
 
 fn validate(
     mut model: GoogLeNet,
-    val_images: ExTensor,
-    val_labels: ExTensor,
+    val_images: AnyTensor,
+    val_labels: AnyTensor,
     batch_size: Int,
 ) raises -> Float32:
     """Validate model on validation set.

--- a/examples/integer_example.mojo
+++ b/examples/integer_example.mojo
@@ -9,7 +9,7 @@ UInt32, and UInt64 built-in types, including:
 - Handling overflow and type casting
 """
 
-from shared.core.extensor import ExTensor, zeros
+from shared.core.extensor import AnyTensor, zeros
 
 
 fn example_basic_signed_integers() raises:

--- a/examples/lenet-emnist/inference.mojo
+++ b/examples/lenet-emnist/inference.mojo
@@ -18,7 +18,7 @@ References:
 
 from model import LeNet5
 from shared.data import load_idx_labels, load_idx_images, normalize_images
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.utils.arg_parser import ArgumentParser
 from shared.training.metrics import (
     evaluate_with_predict,
@@ -137,7 +137,7 @@ fn parse_args() raises -> InferenceConfig:
     return InferenceConfig(weights_dir, data_dir)
 
 
-fn infer_single(mut model: LeNet5, image: ExTensor) raises -> PredictionResult:
+fn infer_single(mut model: LeNet5, image: AnyTensor) raises -> PredictionResult:
     """Run inference on a single image.
 
     Args:
@@ -172,7 +172,7 @@ fn infer_single(mut model: LeNet5, image: ExTensor) raises -> PredictionResult:
 
 
 fn evaluate_test_set(
-    mut model: LeNet5, images: ExTensor, labels: ExTensor
+    mut model: LeNet5, images: AnyTensor, labels: AnyTensor
 ) raises -> EvaluationResult:
     """Evaluate model on entire test set.
 

--- a/examples/lenet-emnist/model.mojo
+++ b/examples/lenet-emnist/model.mojo
@@ -19,7 +19,7 @@ References:
     - Reference Implementation: https://github.com/mattwang44/LeNet-from-Scratch
 """
 
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import maxpool2d, maxpool2d_backward
 from shared.core.linear import linear, linear_backward
@@ -138,16 +138,16 @@ struct LeNet5(Model, Movable):
     var num_classes: Int
 
     # Layer parameters
-    var conv1_kernel: ExTensor
-    var conv1_bias: ExTensor
-    var conv2_kernel: ExTensor
-    var conv2_bias: ExTensor
-    var fc1_weights: ExTensor
-    var fc1_bias: ExTensor
-    var fc2_weights: ExTensor
-    var fc2_bias: ExTensor
-    var fc3_weights: ExTensor
-    var fc3_bias: ExTensor
+    var conv1_kernel: AnyTensor
+    var conv1_bias: AnyTensor
+    var conv2_kernel: AnyTensor
+    var conv2_bias: AnyTensor
+    var fc1_weights: AnyTensor
+    var fc1_bias: AnyTensor
+    var fc2_weights: AnyTensor
+    var fc2_bias: AnyTensor
+    var fc3_weights: AnyTensor
+    var fc3_bias: AnyTensor
 
     fn __init__(out self, num_classes: Int = 47) raises:
         """Initialize LeNet-5 model with random weights.
@@ -222,7 +222,7 @@ struct LeNet5(Model, Movable):
         var fc3_bias_shape: List[Int] = [num_classes]
         self.fc3_bias = zeros(fc3_bias_shape, DType.float32)
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass through LeNet-5.
 
         Args:
@@ -284,7 +284,7 @@ struct LeNet5(Model, Movable):
 
         return output^
 
-    fn predict(mut self, input: ExTensor) raises -> Int:
+    fn predict(mut self, input: AnyTensor) raises -> Int:
         """Predict class for a single input.
 
         Args:
@@ -320,7 +320,7 @@ struct LeNet5(Model, Movable):
             - etc.
         """
         # Collect all parameters
-        var parameters: List[ExTensor] = []
+        var parameters: List[AnyTensor] = []
         parameters.append(self.conv1_kernel)
         parameters.append(self.conv1_bias)
         parameters.append(self.conv2_kernel)
@@ -351,7 +351,7 @@ struct LeNet5(Model, Movable):
         var param_names = get_model_parameter_names("lenet5")
 
         # Create empty list for loaded parameters
-        var loaded_params: List[ExTensor] = []
+        var loaded_params: List[AnyTensor] = []
 
         # Load using shared utility
         load_model_weights(loaded_params, weights_dir, param_names)
@@ -371,16 +371,16 @@ struct LeNet5(Model, Movable):
     fn update_parameters(
         mut self,
         learning_rate: Float32,
-        grad_conv1_kernel: ExTensor,
-        grad_conv1_bias: ExTensor,
-        grad_conv2_kernel: ExTensor,
-        grad_conv2_bias: ExTensor,
-        grad_fc1_weights: ExTensor,
-        grad_fc1_bias: ExTensor,
-        grad_fc2_weights: ExTensor,
-        grad_fc2_bias: ExTensor,
-        grad_fc3_weights: ExTensor,
-        grad_fc3_bias: ExTensor,
+        grad_conv1_kernel: AnyTensor,
+        grad_conv1_bias: AnyTensor,
+        grad_conv2_kernel: AnyTensor,
+        grad_conv2_bias: AnyTensor,
+        grad_fc1_weights: AnyTensor,
+        grad_fc1_bias: AnyTensor,
+        grad_fc2_weights: AnyTensor,
+        grad_fc2_bias: AnyTensor,
+        grad_fc3_weights: AnyTensor,
+        grad_fc3_bias: AnyTensor,
     ) raises:
         """Update parameters using SGD.
 
@@ -409,7 +409,7 @@ struct LeNet5(Model, Movable):
         _sgd_update(self.fc3_weights, grad_fc3_weights, learning_rate)
         _sgd_update(self.fc3_bias, grad_fc3_bias, learning_rate)
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Return all trainable parameters.
 
         Returns:
@@ -419,7 +419,7 @@ struct LeNet5(Model, Movable):
             This method copies the parameter tensors. For in-place updates,
             use update_parameters() instead.
         """
-        var params: List[ExTensor] = []
+        var params: List[AnyTensor] = []
         params.append(self.conv1_kernel)
         params.append(self.conv1_bias)
         params.append(self.conv2_kernel)
@@ -445,7 +445,7 @@ struct LeNet5(Model, Movable):
         pass
 
 
-fn _sgd_update(mut param: ExTensor, grad: ExTensor, lr: Float32) raises:
+fn _sgd_update(mut param: AnyTensor, grad: AnyTensor, lr: Float32) raises:
     """SGD parameter update: param = param - lr * grad"""
     var numel = param.numel()
     var param_data = param._data.bitcast[Float32]()

--- a/examples/lenet-emnist/run_infer.mojo
+++ b/examples/lenet-emnist/run_infer.mojo
@@ -21,7 +21,7 @@ from shared.data import (
     normalize_images,
     DatasetInfo,
 )
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.utils.arg_parser import ArgumentParser
 from shared.training.metrics import top1_accuracy, AccuracyMetric
 from collections import List
@@ -102,7 +102,7 @@ fn parse_args() raises -> InferConfig:
     return config^
 
 
-fn load_image(filepath: String) raises -> ExTensor:
+fn load_image(filepath: String) raises -> AnyTensor:
     """Load image from file and normalize for model inference.
 
     Currently supports IDX format (.idx3-ubyte for images). PNG support
@@ -164,7 +164,7 @@ fn load_image(filepath: String) raises -> ExTensor:
 
 
 fn get_top_k_predictions(
-    logits: ExTensor, k: Int
+    logits: AnyTensor, k: Int
 ) raises -> List[Tuple[Int, Float32]]:
     """Get top-k predictions from logits.
 
@@ -203,7 +203,7 @@ fn get_top_k_predictions(
 
 
 fn evaluate_test_set(
-    mut model: LeNet5, test_images: ExTensor, test_labels: ExTensor
+    mut model: LeNet5, test_images: AnyTensor, test_labels: AnyTensor
 ) raises -> Float32:
     """Evaluate model on full test set.
 

--- a/examples/lenet-emnist/run_train.mojo
+++ b/examples/lenet-emnist/run_train.mojo
@@ -25,7 +25,7 @@ from shared.data import (
     one_hot_encode,
     DatasetInfo,
 )
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import maxpool2d, maxpool2d_backward
 from shared.core.linear import linear, linear_backward
@@ -90,8 +90,8 @@ fn parse_args() raises -> TrainConfig:
 
 fn compute_gradients(
     mut model: LeNet5,
-    input: ExTensor,
-    labels: ExTensor,
+    input: AnyTensor,
+    labels: AnyTensor,
     learning_rate: Float32,
     mut precision_config: PrecisionConfig,
 ) raises -> Tuple[Float32, Bool]:
@@ -307,8 +307,8 @@ fn compute_gradients(
 
 fn train_epoch(
     mut model: LeNet5,
-    train_images: ExTensor,
-    train_labels: ExTensor,
+    train_images: AnyTensor,
+    train_labels: AnyTensor,
     batch_size: Int,
     learning_rate: Float32,
     epoch: Int,

--- a/examples/lenet-emnist/train.mojo
+++ b/examples/lenet-emnist/train.mojo
@@ -36,7 +36,7 @@ from shared.data import (
     normalize_images,
     one_hot_encode,
 )
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import maxpool2d, maxpool2d_backward
 from shared.core.linear import linear, linear_backward
@@ -107,7 +107,7 @@ fn parse_args() raises -> TrainConfig:
 
 
 fn compute_gradients(
-    mut model: LeNet5, input: ExTensor, labels: ExTensor, learning_rate: Float32
+    mut model: LeNet5, input: AnyTensor, labels: AnyTensor, learning_rate: Float32
 ) raises -> Float32:
     """Compute gradients and update parameters for one batch.
 
@@ -268,8 +268,8 @@ fn compute_gradients(
 
 fn train_epoch(
     mut model: LeNet5,
-    train_images: ExTensor,
-    train_labels: ExTensor,
+    train_images: AnyTensor,
+    train_labels: AnyTensor,
     batch_size: Int,
     learning_rate: Float32,
     epoch: Int,

--- a/examples/mixed_precision_training.mojo
+++ b/examples/mixed_precision_training.mojo
@@ -18,7 +18,7 @@ Usage:
     mojo examples/mixed_precision_training.mojo
 """
 
-from shared.core import ExTensor, full
+from shared.core import AnyTensor, full
 from shared.training.mixed_precision import (
     GradientScaler,
     convert_to_fp32_master,
@@ -29,14 +29,14 @@ from shared.training.mixed_precision import (
 from shared.training.trainer_interface import TrainerConfig
 
 
-fn simulate_forward_pass(params: ExTensor, input: ExTensor) raises -> ExTensor:
+fn simulate_forward_pass(params: AnyTensor, input: AnyTensor) raises -> AnyTensor:
     """Simulate a simple forward pass: output = params * input."""
     return params * input
 
 
 fn simulate_backward_pass(
-    output: ExTensor, target: ExTensor
-) raises -> ExTensor:
+    output: AnyTensor, target: AnyTensor
+) raises -> AnyTensor:
     """Simulate backward pass: compute gradients."""
     # In real training, this would compute actual gradients
     # For demo, just return the error
@@ -44,7 +44,7 @@ fn simulate_backward_pass(
 
 
 fn simple_optimizer_step(
-    mut master_params: ExTensor, gradients: ExTensor, learning_rate: Float64
+    mut master_params: AnyTensor, gradients: AnyTensor, learning_rate: Float64
 ) raises:
     """Simple SGD update: params = params - lr * grads."""
     var lr_tensor = full(

--- a/examples/mnist/model.mojo
+++ b/examples/mnist/model.mojo
@@ -15,7 +15,7 @@ References:
     - LeNet-5 Architecture: http://yann.lecun.com/exdb/lenet/
 """
 
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import maxpool2d, maxpool2d_backward
 from shared.core.linear import linear, linear_backward
@@ -128,14 +128,14 @@ struct SimpleCNN(Model, Movable):
     """
 
     # Layer parameters
-    var conv1_kernel: ExTensor
-    var conv1_bias: ExTensor
-    var conv2_kernel: ExTensor
-    var conv2_bias: ExTensor
-    var fc1_weights: ExTensor
-    var fc1_bias: ExTensor
-    var fc2_weights: ExTensor
-    var fc2_bias: ExTensor
+    var conv1_kernel: AnyTensor
+    var conv1_bias: AnyTensor
+    var conv2_kernel: AnyTensor
+    var conv2_bias: AnyTensor
+    var fc1_weights: AnyTensor
+    var fc1_bias: AnyTensor
+    var fc2_weights: AnyTensor
+    var fc2_bias: AnyTensor
 
     fn __init__(out self) raises:
         """Initialize Simple CNN model with random weights."""
@@ -196,7 +196,7 @@ struct SimpleCNN(Model, Movable):
         var fc2_bias_shape: List[Int] = [10]
         self.fc2_bias = zeros(fc2_bias_shape, DType.float32)
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass through Simple CNN.
 
         Args:
@@ -254,7 +254,7 @@ struct SimpleCNN(Model, Movable):
 
         return output^
 
-    fn predict(mut self, input: ExTensor) raises -> Int:
+    fn predict(mut self, input: AnyTensor) raises -> Int:
         """Predict class for a single input.
 
         Args:
@@ -290,7 +290,7 @@ struct SimpleCNN(Model, Movable):
             - etc.
         """
         # Collect all parameters
-        var parameters: List[ExTensor] = []
+        var parameters: List[AnyTensor] = []
         parameters.append(self.conv1_kernel)
         parameters.append(self.conv1_bias)
         parameters.append(self.conv2_kernel)
@@ -319,7 +319,7 @@ struct SimpleCNN(Model, Movable):
         var param_names = get_model_parameter_names("simplecnn")
 
         # Create empty list for loaded parameters
-        var loaded_params: List[ExTensor] = []
+        var loaded_params: List[AnyTensor] = []
 
         # Load using shared utility
         load_model_weights(loaded_params, weights_dir, param_names)
@@ -337,14 +337,14 @@ struct SimpleCNN(Model, Movable):
     fn update_parameters(
         mut self,
         learning_rate: Float32,
-        grad_conv1_kernel: ExTensor,
-        grad_conv1_bias: ExTensor,
-        grad_conv2_kernel: ExTensor,
-        grad_conv2_bias: ExTensor,
-        grad_fc1_weights: ExTensor,
-        grad_fc1_bias: ExTensor,
-        grad_fc2_weights: ExTensor,
-        grad_fc2_bias: ExTensor,
+        grad_conv1_kernel: AnyTensor,
+        grad_conv1_bias: AnyTensor,
+        grad_conv2_kernel: AnyTensor,
+        grad_conv2_bias: AnyTensor,
+        grad_fc1_weights: AnyTensor,
+        grad_fc1_bias: AnyTensor,
+        grad_fc2_weights: AnyTensor,
+        grad_fc2_bias: AnyTensor,
     ) raises:
         """Update parameters using SGD.
 
@@ -369,7 +369,7 @@ struct SimpleCNN(Model, Movable):
         _sgd_update(self.fc2_weights, grad_fc2_weights, learning_rate)
         _sgd_update(self.fc2_bias, grad_fc2_bias, learning_rate)
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Return all trainable parameters.
 
         Returns:
@@ -379,7 +379,7 @@ struct SimpleCNN(Model, Movable):
             This method copies the parameter tensors. For in-place updates,
             use update_parameters() instead.
         """
-        var params: List[ExTensor] = []
+        var params: List[AnyTensor] = []
         params.append(self.conv1_kernel)
         params.append(self.conv1_bias)
         params.append(self.conv2_kernel)
@@ -403,7 +403,7 @@ struct SimpleCNN(Model, Movable):
         pass
 
 
-fn _sgd_update(mut param: ExTensor, grad: ExTensor, lr: Float32) raises:
+fn _sgd_update(mut param: AnyTensor, grad: AnyTensor, lr: Float32) raises:
     """SGD parameter update: param = param - lr * grad"""
     var numel = param.numel()
     var param_data = param._data.bitcast[Float32]()

--- a/examples/mnist/train.mojo
+++ b/examples/mnist/train.mojo
@@ -35,7 +35,7 @@ from shared.data import (
     normalize_images,
     one_hot_encode,
 )
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import maxpool2d, maxpool2d_backward
 from shared.core.linear import linear, linear_backward
@@ -107,8 +107,8 @@ fn parse_args() raises -> TrainConfig:
 
 fn compute_gradients(
     mut model: SimpleCNN,
-    input: ExTensor,
-    labels: ExTensor,
+    input: AnyTensor,
+    labels: AnyTensor,
     learning_rate: Float32,
 ) raises -> Float32:
     """Compute gradients and update parameters for one batch.
@@ -258,8 +258,8 @@ fn compute_gradients(
 
 fn train_epoch(
     mut model: SimpleCNN,
-    train_images: ExTensor,
-    train_labels: ExTensor,
+    train_images: AnyTensor,
+    train_labels: AnyTensor,
     batch_size: Int,
     learning_rate: Float32,
     epoch: Int,

--- a/examples/mobilenetv1-cifar10/inference.mojo
+++ b/examples/mobilenetv1-cifar10/inference.mojo
@@ -12,7 +12,7 @@ Features:
     - Inference mode (no training, no batch norm running stats updates)
 """
 
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.data import extract_batch_pair, compute_num_batches, DatasetInfo
 from shared.data.datasets import CIFAR10Dataset, get_cifar10_classes
 from shared.training.metrics import evaluate_logits_batch
@@ -21,8 +21,8 @@ from model import MobileNetV1
 
 fn evaluate_model(
     mut model: MobileNetV1,
-    images: ExTensor,
-    labels: ExTensor,
+    images: AnyTensor,
+    labels: AnyTensor,
     batch_size: Int = 100,
     verbose: Bool = True,
 ) raises -> Tuple[Float32, List[Int], List[Int]]:

--- a/examples/mobilenetv1-cifar10/model.mojo
+++ b/examples/mobilenetv1-cifar10/model.mojo
@@ -20,7 +20,7 @@ References:
 """
 
 from shared.core import (
-    ExTensor,
+    AnyTensor,
     zeros,
     conv2d,
     batch_norm2d,
@@ -35,12 +35,12 @@ from shared.core.shape import conv2d_output_shape
 
 
 fn depthwise_conv2d(
-    x: ExTensor,
-    weights: ExTensor,
-    bias: ExTensor,
+    x: AnyTensor,
+    weights: AnyTensor,
+    bias: AnyTensor,
     stride: Int = 1,
     padding: Int = 1,
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Depthwise convolution: Apply one filter per input channel.
 
     Unlike standard convolution that mixes all input channels, depthwise
@@ -147,20 +147,20 @@ struct DepthwiseSeparableBlock:
     """
 
     # Depthwise convolution (3×3, per-channel)
-    var dw_weights: ExTensor  # (in_channels, 1, 3, 3)
-    var dw_bias: ExTensor  # (in_channels,)
-    var dw_bn_gamma: ExTensor
-    var dw_bn_beta: ExTensor
-    var dw_bn_running_mean: ExTensor
-    var dw_bn_running_var: ExTensor
+    var dw_weights: AnyTensor  # (in_channels, 1, 3, 3)
+    var dw_bias: AnyTensor  # (in_channels,)
+    var dw_bn_gamma: AnyTensor
+    var dw_bn_beta: AnyTensor
+    var dw_bn_running_mean: AnyTensor
+    var dw_bn_running_var: AnyTensor
 
     # Pointwise convolution (1×1, channel mixing)
-    var pw_weights: ExTensor  # (out_channels, in_channels, 1, 1)
-    var pw_bias: ExTensor  # (out_channels,)
-    var pw_bn_gamma: ExTensor
-    var pw_bn_beta: ExTensor
-    var pw_bn_running_mean: ExTensor
-    var pw_bn_running_var: ExTensor
+    var pw_weights: AnyTensor  # (out_channels, in_channels, 1, 1)
+    var pw_bias: AnyTensor  # (out_channels,)
+    var pw_bn_gamma: AnyTensor
+    var pw_bn_beta: AnyTensor
+    var pw_bn_running_mean: AnyTensor
+    var pw_bn_running_var: AnyTensor
 
     fn __init__(
         out self, in_channels: Int, out_channels: Int, stride: Int = 1
@@ -199,8 +199,8 @@ struct DepthwiseSeparableBlock:
         self.pw_bn_running_var = constant(pw_bias_shape, 1.0)
 
     fn forward(
-        mut self, x: ExTensor, stride: Int, training: Bool
-    ) raises -> ExTensor:
+        mut self, x: AnyTensor, stride: Int, training: Bool
+    ) raises -> AnyTensor:
         """Forward pass through depthwise separable block.
 
         Args:
@@ -255,12 +255,12 @@ struct MobileNetV1:
     """
 
     # Initial standard convolution
-    var initial_conv_weights: ExTensor
-    var initial_conv_bias: ExTensor
-    var initial_bn_gamma: ExTensor
-    var initial_bn_beta: ExTensor
-    var initial_bn_running_mean: ExTensor
-    var initial_bn_running_var: ExTensor
+    var initial_conv_weights: AnyTensor
+    var initial_conv_bias: AnyTensor
+    var initial_bn_gamma: AnyTensor
+    var initial_bn_beta: AnyTensor
+    var initial_bn_running_mean: AnyTensor
+    var initial_bn_running_var: AnyTensor
 
     # Depthwise separable blocks (13 total)
     var ds_block_1: DepthwiseSeparableBlock  # 32 → 64, stride=1
@@ -278,8 +278,8 @@ struct MobileNetV1:
     var ds_block_13: DepthwiseSeparableBlock  # 1024 → 1024, stride=1
 
     # Final classifier
-    var fc_weights: ExTensor
-    var fc_bias: ExTensor
+    var fc_weights: AnyTensor
+    var fc_bias: AnyTensor
 
     fn __init__(out self, num_classes: Int = 10) raises:
         """Initialize MobileNetV1 model.
@@ -327,7 +327,7 @@ struct MobileNetV1:
         var fc_bias_shape: List[Int] = [num_classes]
         self.fc_bias = zeros(fc_bias_shape, DType.float32)
 
-    fn forward(mut self, x: ExTensor, training: Bool = True) raises -> ExTensor:
+    fn forward(mut self, x: AnyTensor, training: Bool = True) raises -> AnyTensor:
         """Forward pass through MobileNetV1.
 
         Args:
@@ -438,7 +438,7 @@ struct MobileNetV1:
         var param_names = get_model_parameter_names("mobilenetv1")
 
         # Create empty list for loaded parameters
-        var loaded_params: List[ExTensor] = []
+        var loaded_params: List[AnyTensor] = []
 
         # Load using shared utility
         load_model_weights(loaded_params, weights_dir, param_names)
@@ -837,7 +837,7 @@ struct MobileNetV1:
         )
 
         # Collect all parameters in order
-        var parameters: List[ExTensor] = []
+        var parameters: List[AnyTensor] = []
 
         # Initial convolution parameters
         parameters.append(self.initial_conv_weights)

--- a/examples/mobilenetv1-cifar10/test_model.mojo
+++ b/examples/mobilenetv1-cifar10/test_model.mojo
@@ -1,7 +1,7 @@
 """Quick integration test for MobileNetV1 model"""
 
 from model import MobileNetV1
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 
 
 fn main() raises:

--- a/examples/mobilenetv1-cifar10/train.mojo
+++ b/examples/mobilenetv1-cifar10/train.mojo
@@ -27,7 +27,7 @@ Training Details:
 """
 
 from shared.core import (
-    ExTensor,
+    AnyTensor,
     zeros,
     conv2d,
     batch_norm2d,
@@ -52,8 +52,8 @@ from model import MobileNetV1
 
 fn train_epoch(
     mut model: MobileNetV1,
-    train_images: ExTensor,
-    train_labels: ExTensor,
+    train_images: AnyTensor,
+    train_labels: AnyTensor,
     batch_size: Int,
     learning_rate: Float32,
     momentum: Float32,
@@ -130,8 +130,8 @@ fn train_epoch(
 
 fn validate(
     mut model: MobileNetV1,
-    val_images: ExTensor,
-    val_labels: ExTensor,
+    val_images: AnyTensor,
+    val_labels: AnyTensor,
     batch_size: Int,
 ) raises -> Float32:
     """Validate model on validation set."""

--- a/examples/mojo-patterns/ownership_example.mojo
+++ b/examples/mojo-patterns/ownership_example.mojo
@@ -8,11 +8,11 @@ Usage:
 See documentation: docs/core/mojo-patterns.md
 """
 
-from shared.core import ExTensor, ones, sum, mean, multiply, item, full
+from shared.core import AnyTensor, ones, sum, mean, multiply, item, full
 
 
 # Borrowed: read-only access (no ownership transfer)
-fn compute_loss(predictions: ExTensor, targets: ExTensor) raises -> Float64:
+fn compute_loss(predictions: AnyTensor, targets: AnyTensor) raises -> Float64:
     """Compute loss without taking ownership."""
     var diff = predictions - targets
     var squared = multiply(diff, diff)
@@ -21,7 +21,7 @@ fn compute_loss(predictions: ExTensor, targets: ExTensor) raises -> Float64:
 
 
 # Owned: take ownership (move semantics)
-fn consume_tensor(var tensor: ExTensor) raises -> Float64:
+fn consume_tensor(var tensor: AnyTensor) raises -> Float64:
     """Take ownership and consume tensor."""
     var sum_tensor = sum(tensor)
     var result = item(sum_tensor)
@@ -31,7 +31,7 @@ fn consume_tensor(var tensor: ExTensor) raises -> Float64:
 
 # Inout: mutable reference (modify in place)
 fn update_weights(
-    mut weights: ExTensor, gradients: ExTensor, lr: Float64
+    mut weights: AnyTensor, gradients: AnyTensor, lr: Float64
 ) raises:
     """Update weights in place."""
     var lr_tensor = full(gradients.shape(), lr, gradients.dtype())

--- a/examples/mojo-patterns/simd_example.mojo
+++ b/examples/mojo-patterns/simd_example.mojo
@@ -10,10 +10,10 @@ See documentation: docs/core/mojo-patterns.md
 
 from algorithm import vectorize
 from sys.info import simd_width_of
-from shared.core import ExTensor
+from shared.core import AnyTensor
 
 
-fn simple_simd_add(tensor1: ExTensor, tensor2: ExTensor) raises -> ExTensor:
+fn simple_simd_add(tensor1: AnyTensor, tensor2: AnyTensor) raises -> AnyTensor:
     """Demonstrate SIMD addition using vectorize.
 
     Args:
@@ -26,7 +26,7 @@ fn simple_simd_add(tensor1: ExTensor, tensor2: ExTensor) raises -> ExTensor:
     if tensor1.numel() != tensor2.numel():
         raise Error("Tensors must have same number of elements")
 
-    var result = ExTensor(tensor1._shape, tensor1._dtype)
+    var result = AnyTensor(tensor1._shape, tensor1._dtype)
 
     if tensor1._dtype == DType.float32:
         comptime simd_width = simd_width_of[DType.float32]()
@@ -61,14 +61,14 @@ fn main() raises:
     data1.append(2.0)
     data1.append(3.0)
     data1.append(4.0)
-    var tensor1 = ExTensor(data1^)
+    var tensor1 = AnyTensor(data1^)
 
     var data2 = List[Float32]()
     data2.append(10.0)
     data2.append(20.0)
     data2.append(30.0)
     data2.append(40.0)
-    var tensor2 = ExTensor(data2^)
+    var tensor2 = AnyTensor(data2^)
 
     print("Input tensors: 4 elements each")
     print("Using SIMD width for float32:", simd_width_of[DType.float32]())

--- a/examples/performance/benchmark_model_inference.mojo
+++ b/examples/performance/benchmark_model_inference.mojo
@@ -21,7 +21,7 @@ from shared.benchmarking import (
     print_benchmark_summary,
     BenchmarkResult,
 )
-from shared.core import ExTensor, ones
+from shared.core import AnyTensor, ones
 
 
 # ============================================================================
@@ -48,8 +48,8 @@ struct SimpleNetwork(Copyable, Movable):
 
 
 fn simple_forward(
-    mut network: SimpleNetwork, input_data: ExTensor
-) raises -> ExTensor:
+    mut network: SimpleNetwork, input_data: AnyTensor
+) raises -> AnyTensor:
     """Perform a simple forward pass.
 
     Args:

--- a/examples/performance/benchmark_operations.mojo
+++ b/examples/performance/benchmark_operations.mojo
@@ -21,7 +21,7 @@ from shared.benchmarking import (
     print_benchmark_summary,
     BenchmarkResult,
 )
-from shared.core import ExTensor, ones, relu, zeros
+from shared.core import AnyTensor, ones, relu, zeros
 
 
 # ============================================================================

--- a/examples/resnet18-cifar10/inference.mojo
+++ b/examples/resnet18-cifar10/inference.mojo
@@ -3,7 +3,7 @@
 This script loads a trained ResNet-18 model and evaluates it on the CIFAR-10 test set.
 
 Shared Modules Used:
-    - shared.core: Tensor operations and ExTensor type
+    - shared.core: Tensor operations and AnyTensor type
     - shared.data: Batch extraction and data utilities
     - shared.data.datasets: CIFAR-10 test set loading
     - shared.training.metrics: Evaluation and accuracy computation
@@ -24,7 +24,7 @@ Features:
     - Inference mode (no training, no batch norm running stats updates)
 """
 
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.data import extract_batch_pair, compute_num_batches, DatasetInfo
 from shared.data.datasets import CIFAR10Dataset
 from shared.training.metrics import (
@@ -55,8 +55,8 @@ comptime CLASS_NAMES = [
 
 fn evaluate_model(
     mut model: ResNet18,
-    images: ExTensor,
-    labels: ExTensor,
+    images: AnyTensor,
+    labels: AnyTensor,
     batch_size: Int = 100,
     verbose: Bool = True,
 ) raises -> Tuple[Float32, List[Int], List[Int]]:

--- a/examples/resnet18-cifar10/model.mojo
+++ b/examples/resnet18-cifar10/model.mojo
@@ -40,7 +40,7 @@ Key Innovation:
     - Solves vanishing gradient problem in deep networks
 
 Shared Modules Used:
-    - shared.core: Core tensor operations (ExTensor, zeros, ones)
+    - shared.core: Core tensor operations (AnyTensor, zeros, ones)
     - shared.core.conv: Convolution operations (conv2d, conv2d_backward)
     - shared.core.pooling: Pooling operations (avgpool2d, avgpool2d_backward)
     - shared.core.linear: Linear/fully-connected layers (linear, linear_backward)
@@ -58,7 +58,7 @@ References:
     - CIFAR-10 Dataset: https://www.cs.toronto.edu/~kriz/cifar.html
 """
 
-from shared.core import ExTensor, zeros, ones
+from shared.core import AnyTensor, zeros, ones
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import avgpool2d, avgpool2d_backward
 from shared.core.linear import linear, linear_backward
@@ -107,153 +107,153 @@ struct ResNet18(Movable):
     var num_classes: Int
 
     # Initial conv + BN (6 params)
-    var conv1_kernel: ExTensor
-    var conv1_bias: ExTensor
-    var bn1_gamma: ExTensor
-    var bn1_beta: ExTensor
-    var bn1_running_mean: ExTensor
-    var bn1_running_var: ExTensor
+    var conv1_kernel: AnyTensor
+    var conv1_bias: AnyTensor
+    var bn1_gamma: AnyTensor
+    var bn1_beta: AnyTensor
+    var bn1_running_mean: AnyTensor
+    var bn1_running_var: AnyTensor
 
     # ========== Stage 1 (64 channels): 2 blocks, no projection ==========
     # Block 1 (8 params)
-    var s1b1_conv1_kernel: ExTensor
-    var s1b1_conv1_bias: ExTensor
-    var s1b1_bn1_gamma: ExTensor
-    var s1b1_bn1_beta: ExTensor
-    var s1b1_bn1_running_mean: ExTensor
-    var s1b1_bn1_running_var: ExTensor
-    var s1b1_conv2_kernel: ExTensor
-    var s1b1_conv2_bias: ExTensor
-    var s1b1_bn2_gamma: ExTensor
-    var s1b1_bn2_beta: ExTensor
-    var s1b1_bn2_running_mean: ExTensor
-    var s1b1_bn2_running_var: ExTensor
+    var s1b1_conv1_kernel: AnyTensor
+    var s1b1_conv1_bias: AnyTensor
+    var s1b1_bn1_gamma: AnyTensor
+    var s1b1_bn1_beta: AnyTensor
+    var s1b1_bn1_running_mean: AnyTensor
+    var s1b1_bn1_running_var: AnyTensor
+    var s1b1_conv2_kernel: AnyTensor
+    var s1b1_conv2_bias: AnyTensor
+    var s1b1_bn2_gamma: AnyTensor
+    var s1b1_bn2_beta: AnyTensor
+    var s1b1_bn2_running_mean: AnyTensor
+    var s1b1_bn2_running_var: AnyTensor
 
     # Block 2 (8 params)
-    var s1b2_conv1_kernel: ExTensor
-    var s1b2_conv1_bias: ExTensor
-    var s1b2_bn1_gamma: ExTensor
-    var s1b2_bn1_beta: ExTensor
-    var s1b2_bn1_running_mean: ExTensor
-    var s1b2_bn1_running_var: ExTensor
-    var s1b2_conv2_kernel: ExTensor
-    var s1b2_conv2_bias: ExTensor
-    var s1b2_bn2_gamma: ExTensor
-    var s1b2_bn2_beta: ExTensor
-    var s1b2_bn2_running_mean: ExTensor
-    var s1b2_bn2_running_var: ExTensor
+    var s1b2_conv1_kernel: AnyTensor
+    var s1b2_conv1_bias: AnyTensor
+    var s1b2_bn1_gamma: AnyTensor
+    var s1b2_bn1_beta: AnyTensor
+    var s1b2_bn1_running_mean: AnyTensor
+    var s1b2_bn1_running_var: AnyTensor
+    var s1b2_conv2_kernel: AnyTensor
+    var s1b2_conv2_bias: AnyTensor
+    var s1b2_bn2_gamma: AnyTensor
+    var s1b2_bn2_beta: AnyTensor
+    var s1b2_bn2_running_mean: AnyTensor
+    var s1b2_bn2_running_var: AnyTensor
 
     # ========== Stage 2 (128 channels): 2 blocks, block1 has projection ==========
     # Block 1 (12 params: 8 main + 4 projection)
-    var s2b1_conv1_kernel: ExTensor
-    var s2b1_conv1_bias: ExTensor
-    var s2b1_bn1_gamma: ExTensor
-    var s2b1_bn1_beta: ExTensor
-    var s2b1_bn1_running_mean: ExTensor
-    var s2b1_bn1_running_var: ExTensor
-    var s2b1_conv2_kernel: ExTensor
-    var s2b1_conv2_bias: ExTensor
-    var s2b1_bn2_gamma: ExTensor
-    var s2b1_bn2_beta: ExTensor
-    var s2b1_bn2_running_mean: ExTensor
-    var s2b1_bn2_running_var: ExTensor
+    var s2b1_conv1_kernel: AnyTensor
+    var s2b1_conv1_bias: AnyTensor
+    var s2b1_bn1_gamma: AnyTensor
+    var s2b1_bn1_beta: AnyTensor
+    var s2b1_bn1_running_mean: AnyTensor
+    var s2b1_bn1_running_var: AnyTensor
+    var s2b1_conv2_kernel: AnyTensor
+    var s2b1_conv2_bias: AnyTensor
+    var s2b1_bn2_gamma: AnyTensor
+    var s2b1_bn2_beta: AnyTensor
+    var s2b1_bn2_running_mean: AnyTensor
+    var s2b1_bn2_running_var: AnyTensor
     # Projection shortcut (4 params)
-    var s2b1_proj_kernel: ExTensor
-    var s2b1_proj_bias: ExTensor
-    var s2b1_proj_bn_gamma: ExTensor
-    var s2b1_proj_bn_beta: ExTensor
-    var s2b1_proj_bn_running_mean: ExTensor
-    var s2b1_proj_bn_running_var: ExTensor
+    var s2b1_proj_kernel: AnyTensor
+    var s2b1_proj_bias: AnyTensor
+    var s2b1_proj_bn_gamma: AnyTensor
+    var s2b1_proj_bn_beta: AnyTensor
+    var s2b1_proj_bn_running_mean: AnyTensor
+    var s2b1_proj_bn_running_var: AnyTensor
 
     # Block 2 (8 params)
-    var s2b2_conv1_kernel: ExTensor
-    var s2b2_conv1_bias: ExTensor
-    var s2b2_bn1_gamma: ExTensor
-    var s2b2_bn1_beta: ExTensor
-    var s2b2_bn1_running_mean: ExTensor
-    var s2b2_bn1_running_var: ExTensor
-    var s2b2_conv2_kernel: ExTensor
-    var s2b2_conv2_bias: ExTensor
-    var s2b2_bn2_gamma: ExTensor
-    var s2b2_bn2_beta: ExTensor
-    var s2b2_bn2_running_mean: ExTensor
-    var s2b2_bn2_running_var: ExTensor
+    var s2b2_conv1_kernel: AnyTensor
+    var s2b2_conv1_bias: AnyTensor
+    var s2b2_bn1_gamma: AnyTensor
+    var s2b2_bn1_beta: AnyTensor
+    var s2b2_bn1_running_mean: AnyTensor
+    var s2b2_bn1_running_var: AnyTensor
+    var s2b2_conv2_kernel: AnyTensor
+    var s2b2_conv2_bias: AnyTensor
+    var s2b2_bn2_gamma: AnyTensor
+    var s2b2_bn2_beta: AnyTensor
+    var s2b2_bn2_running_mean: AnyTensor
+    var s2b2_bn2_running_var: AnyTensor
 
     # ========== Stage 3 (256 channels): 2 blocks, block1 has projection ==========
     # Block 1 (12 params: 8 main + 4 projection)
-    var s3b1_conv1_kernel: ExTensor
-    var s3b1_conv1_bias: ExTensor
-    var s3b1_bn1_gamma: ExTensor
-    var s3b1_bn1_beta: ExTensor
-    var s3b1_bn1_running_mean: ExTensor
-    var s3b1_bn1_running_var: ExTensor
-    var s3b1_conv2_kernel: ExTensor
-    var s3b1_conv2_bias: ExTensor
-    var s3b1_bn2_gamma: ExTensor
-    var s3b1_bn2_beta: ExTensor
-    var s3b1_bn2_running_mean: ExTensor
-    var s3b1_bn2_running_var: ExTensor
+    var s3b1_conv1_kernel: AnyTensor
+    var s3b1_conv1_bias: AnyTensor
+    var s3b1_bn1_gamma: AnyTensor
+    var s3b1_bn1_beta: AnyTensor
+    var s3b1_bn1_running_mean: AnyTensor
+    var s3b1_bn1_running_var: AnyTensor
+    var s3b1_conv2_kernel: AnyTensor
+    var s3b1_conv2_bias: AnyTensor
+    var s3b1_bn2_gamma: AnyTensor
+    var s3b1_bn2_beta: AnyTensor
+    var s3b1_bn2_running_mean: AnyTensor
+    var s3b1_bn2_running_var: AnyTensor
     # Projection shortcut (4 params)
-    var s3b1_proj_kernel: ExTensor
-    var s3b1_proj_bias: ExTensor
-    var s3b1_proj_bn_gamma: ExTensor
-    var s3b1_proj_bn_beta: ExTensor
-    var s3b1_proj_bn_running_mean: ExTensor
-    var s3b1_proj_bn_running_var: ExTensor
+    var s3b1_proj_kernel: AnyTensor
+    var s3b1_proj_bias: AnyTensor
+    var s3b1_proj_bn_gamma: AnyTensor
+    var s3b1_proj_bn_beta: AnyTensor
+    var s3b1_proj_bn_running_mean: AnyTensor
+    var s3b1_proj_bn_running_var: AnyTensor
 
     # Block 2 (8 params)
-    var s3b2_conv1_kernel: ExTensor
-    var s3b2_conv1_bias: ExTensor
-    var s3b2_bn1_gamma: ExTensor
-    var s3b2_bn1_beta: ExTensor
-    var s3b2_bn1_running_mean: ExTensor
-    var s3b2_bn1_running_var: ExTensor
-    var s3b2_conv2_kernel: ExTensor
-    var s3b2_conv2_bias: ExTensor
-    var s3b2_bn2_gamma: ExTensor
-    var s3b2_bn2_beta: ExTensor
-    var s3b2_bn2_running_mean: ExTensor
-    var s3b2_bn2_running_var: ExTensor
+    var s3b2_conv1_kernel: AnyTensor
+    var s3b2_conv1_bias: AnyTensor
+    var s3b2_bn1_gamma: AnyTensor
+    var s3b2_bn1_beta: AnyTensor
+    var s3b2_bn1_running_mean: AnyTensor
+    var s3b2_bn1_running_var: AnyTensor
+    var s3b2_conv2_kernel: AnyTensor
+    var s3b2_conv2_bias: AnyTensor
+    var s3b2_bn2_gamma: AnyTensor
+    var s3b2_bn2_beta: AnyTensor
+    var s3b2_bn2_running_mean: AnyTensor
+    var s3b2_bn2_running_var: AnyTensor
 
     # ========== Stage 4 (512 channels): 2 blocks, block1 has projection ==========
     # Block 1 (12 params: 8 main + 4 projection)
-    var s4b1_conv1_kernel: ExTensor
-    var s4b1_conv1_bias: ExTensor
-    var s4b1_bn1_gamma: ExTensor
-    var s4b1_bn1_beta: ExTensor
-    var s4b1_bn1_running_mean: ExTensor
-    var s4b1_bn1_running_var: ExTensor
-    var s4b1_conv2_kernel: ExTensor
-    var s4b1_conv2_bias: ExTensor
-    var s4b1_bn2_gamma: ExTensor
-    var s4b1_bn2_beta: ExTensor
-    var s4b1_bn2_running_mean: ExTensor
-    var s4b1_bn2_running_var: ExTensor
+    var s4b1_conv1_kernel: AnyTensor
+    var s4b1_conv1_bias: AnyTensor
+    var s4b1_bn1_gamma: AnyTensor
+    var s4b1_bn1_beta: AnyTensor
+    var s4b1_bn1_running_mean: AnyTensor
+    var s4b1_bn1_running_var: AnyTensor
+    var s4b1_conv2_kernel: AnyTensor
+    var s4b1_conv2_bias: AnyTensor
+    var s4b1_bn2_gamma: AnyTensor
+    var s4b1_bn2_beta: AnyTensor
+    var s4b1_bn2_running_mean: AnyTensor
+    var s4b1_bn2_running_var: AnyTensor
     # Projection shortcut (4 params)
-    var s4b1_proj_kernel: ExTensor
-    var s4b1_proj_bias: ExTensor
-    var s4b1_proj_bn_gamma: ExTensor
-    var s4b1_proj_bn_beta: ExTensor
-    var s4b1_proj_bn_running_mean: ExTensor
-    var s4b1_proj_bn_running_var: ExTensor
+    var s4b1_proj_kernel: AnyTensor
+    var s4b1_proj_bias: AnyTensor
+    var s4b1_proj_bn_gamma: AnyTensor
+    var s4b1_proj_bn_beta: AnyTensor
+    var s4b1_proj_bn_running_mean: AnyTensor
+    var s4b1_proj_bn_running_var: AnyTensor
 
     # Block 2 (8 params)
-    var s4b2_conv1_kernel: ExTensor
-    var s4b2_conv1_bias: ExTensor
-    var s4b2_bn1_gamma: ExTensor
-    var s4b2_bn1_beta: ExTensor
-    var s4b2_bn1_running_mean: ExTensor
-    var s4b2_bn1_running_var: ExTensor
-    var s4b2_conv2_kernel: ExTensor
-    var s4b2_conv2_bias: ExTensor
-    var s4b2_bn2_gamma: ExTensor
-    var s4b2_bn2_beta: ExTensor
-    var s4b2_bn2_running_mean: ExTensor
-    var s4b2_bn2_running_var: ExTensor
+    var s4b2_conv1_kernel: AnyTensor
+    var s4b2_conv1_bias: AnyTensor
+    var s4b2_bn1_gamma: AnyTensor
+    var s4b2_bn1_beta: AnyTensor
+    var s4b2_bn1_running_mean: AnyTensor
+    var s4b2_bn1_running_var: AnyTensor
+    var s4b2_conv2_kernel: AnyTensor
+    var s4b2_conv2_bias: AnyTensor
+    var s4b2_bn2_gamma: AnyTensor
+    var s4b2_bn2_beta: AnyTensor
+    var s4b2_bn2_running_mean: AnyTensor
+    var s4b2_bn2_running_var: AnyTensor
 
     # FC layer (2 params)
-    var fc_weights: ExTensor
-    var fc_bias: ExTensor
+    var fc_weights: AnyTensor
+    var fc_bias: AnyTensor
 
     fn __init__(out self, num_classes: Int = 10) raises:
         """Initialize ResNet-18 model with random weights.
@@ -525,8 +525,8 @@ struct ResNet18(Movable):
         self.fc_bias = zeros(fc_bias_shape, DType.float32)
 
     fn forward(
-        mut self, input: ExTensor, training: Bool = True
-    ) raises -> ExTensor:
+        mut self, input: AnyTensor, training: Bool = True
+    ) raises -> AnyTensor:
         """Forward pass through ResNet-18.
 
         Args:
@@ -984,7 +984,7 @@ struct ResNet18(Movable):
 
         return logits
 
-    fn predict(mut self, input: ExTensor) raises -> Int:
+    fn predict(mut self, input: AnyTensor) raises -> Int:
         """Predict class for a single input.
 
         Args:

--- a/examples/resnet18-cifar10/test_model.mojo
+++ b/examples/resnet18-cifar10/test_model.mojo
@@ -8,7 +8,7 @@ Shared Modules Used:
 """
 
 from model import ResNet18
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.utils.serialization import save_tensor, load_tensor
 from shared.data import DatasetInfo
 from collections import List

--- a/examples/resnet18-cifar10/train.mojo
+++ b/examples/resnet18-cifar10/train.mojo
@@ -29,7 +29,7 @@ Usage:
     mojo run examples/resnet18-cifar10/train.mojo --epochs 200 --batch-size 128 --lr 0.01
 """
 
-from shared.core import ExTensor, zeros, ones
+from shared.core import AnyTensor, zeros, ones
 from shared.core.loss import cross_entropy, cross_entropy_backward
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import avgpool2d, avgpool2d_backward
@@ -48,7 +48,7 @@ from model import ResNet18
 
 
 fn compute_accuracy(
-    mut model: ResNet18, images: ExTensor, labels: ExTensor
+    mut model: ResNet18, images: AnyTensor, labels: AnyTensor
 ) raises -> Float32:
     """Compute classification accuracy on a dataset.
 
@@ -108,8 +108,8 @@ fn compute_accuracy(
 
 fn compute_batch_gradients(
     mut model: ResNet18,
-    batch_images: ExTensor,
-    batch_labels: ExTensor,
+    batch_images: AnyTensor,
+    batch_labels: AnyTensor,
 ) raises -> Float32:
     """Compute gradients and loss for one batch.
 
@@ -155,12 +155,12 @@ fn compute_batch_gradients(
 
 fn train_epoch(
     mut model: ResNet18,
-    train_images: ExTensor,
-    train_labels: ExTensor,
+    train_images: AnyTensor,
+    train_labels: AnyTensor,
     batch_size: Int,
     learning_rate: Float32,
     momentum: Float32,
-    mut velocities: List[ExTensor],
+    mut velocities: List[AnyTensor],
     epoch: Int,
     total_epochs: Int,
 ) raises -> Float32:
@@ -306,7 +306,7 @@ fn main() raises:
 
     # Initialize momentum velocities (one per trainable parameter)
     print("Initializing momentum velocities...")
-    var velocities: List[ExTensor] = []
+    var velocities: List[AnyTensor] = []
 
     # Note: In a complete implementation, initialize 84 velocity tensors
     # matching the shape of each parameter. For this demonstration:

--- a/examples/trait_based_layer.mojo
+++ b/examples/trait_based_layer.mojo
@@ -21,7 +21,7 @@ Usage:
     mojo run examples/trait_based_layer.mojo
 """
 
-from shared.core import ExTensor, zeros, zeros_like
+from shared.core import AnyTensor, zeros, zeros_like
 from shared.core.linear import linear, linear_backward
 from shared.core.traits import (
     Differentiable,
@@ -50,7 +50,7 @@ struct ReLULayer(Differentiable):
         ```
     """
 
-    var last_input: ExTensor  # Cached for backward pass
+    var last_input: AnyTensor  # Cached for backward pass
 
     fn __init__(out self) raises:
         """Initialize ReLU layer."""
@@ -59,7 +59,7 @@ struct ReLULayer(Differentiable):
         shape.append(1)
         self.last_input = zeros(shape, DType.float32)
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass: ReLU(x) = max(0, x).
 
         Args:
@@ -82,7 +82,7 @@ struct ReLULayer(Differentiable):
 
         return output^
 
-    fn backward(self, grad_output: ExTensor) raises -> ExTensor:
+    fn backward(self, grad_output: AnyTensor) raises -> AnyTensor:
         """Backward pass: ∂ReLU/∂x = 1 if x > 0 else 0.
 
         Args:
@@ -130,14 +130,14 @@ struct FullyConnectedLayer(Differentiable, Parameterized):
         ```
     """
 
-    var weights: ExTensor
-    var bias: ExTensor
-    var grad_weights: ExTensor
-    var grad_bias: ExTensor
+    var weights: AnyTensor
+    var bias: AnyTensor
+    var grad_weights: AnyTensor
+    var grad_bias: AnyTensor
 
     # Cached for backward pass
-    var last_input: ExTensor
-    var last_output: ExTensor
+    var last_input: AnyTensor
+    var last_output: AnyTensor
 
     fn __init__(out self, in_features: Int, out_features: Int) raises:
         """Initialize fully connected layer.
@@ -179,7 +179,7 @@ struct FullyConnectedLayer(Differentiable, Parameterized):
         self.bias._fill_value_float(0.0)
 
     # Differentiable trait implementation
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass: y = xW^T + b.
 
         Args:
@@ -193,7 +193,7 @@ struct FullyConnectedLayer(Differentiable, Parameterized):
         self.last_output = linear(input, self.weights, self.bias)
         return self.last_output
 
-    fn backward(self, grad_output: ExTensor) raises -> ExTensor:
+    fn backward(self, grad_output: AnyTensor) raises -> AnyTensor:
         """Backward pass: Compute gradients w.r.t. input and parameters.
 
         Args:
@@ -219,24 +219,24 @@ struct FullyConnectedLayer(Differentiable, Parameterized):
         return result.grad_input
 
     # Parameterized trait implementation
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Get all learnable parameters.
 
         Returns:
             List of [weights, bias].
         """
-        var params: List[ExTensor] = []
+        var params: List[AnyTensor] = []
         params.append(self.weights)
         params.append(self.bias)
         return params^
 
-    fn gradients(self) raises -> List[ExTensor]:
+    fn gradients(self) raises -> List[AnyTensor]:
         """Get gradients for all parameters.
 
         Returns:
             List of [grad_weights, grad_bias].
         """
-        var grads: List[ExTensor] = []
+        var grads: List[AnyTensor] = []
         grads.append(self.grad_weights)
         grads.append(self.grad_bias)
         return grads^
@@ -278,20 +278,20 @@ struct BatchNormLayer(Differentiable, Parameterized, Serializable, Trainable):
     """
 
     # Learnable parameters
-    var gamma: ExTensor  # Scale
-    var beta: ExTensor  # Shift
+    var gamma: AnyTensor  # Scale
+    var beta: AnyTensor  # Shift
 
     # Running statistics (non-trainable)
-    var running_mean: ExTensor
-    var running_var: ExTensor
+    var running_mean: AnyTensor
+    var running_var: AnyTensor
 
     # Gradients
-    var grad_gamma: ExTensor
-    var grad_beta: ExTensor
+    var grad_gamma: AnyTensor
+    var grad_beta: AnyTensor
 
     # Cached for backward
-    var last_input: ExTensor
-    var last_normalized: ExTensor
+    var last_input: AnyTensor
+    var last_normalized: AnyTensor
 
     # Training state
     var training_mode: Bool
@@ -333,7 +333,7 @@ struct BatchNormLayer(Differentiable, Parameterized, Serializable, Trainable):
         self.epsilon = 1e-5
 
     # Differentiable trait
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass: Normalize, scale, and shift.
 
         Note:
@@ -346,7 +346,7 @@ struct BatchNormLayer(Differentiable, Parameterized, Serializable, Trainable):
         # Placeholder: Use shared/core/normalization.batch_norm2d() for production
         return input
 
-    fn backward(self, grad_output: ExTensor) raises -> ExTensor:
+    fn backward(self, grad_output: AnyTensor) raises -> AnyTensor:
         """Backward pass: Compute gradients.
 
         Note:
@@ -357,16 +357,16 @@ struct BatchNormLayer(Differentiable, Parameterized, Serializable, Trainable):
         return grad_output
 
     # Parameterized trait
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Get learnable parameters (gamma, beta)."""
-        var params: List[ExTensor] = []
+        var params: List[AnyTensor] = []
         params.append(self.gamma)
         params.append(self.beta)
         return params^
 
-    fn gradients(self) raises -> List[ExTensor]:
+    fn gradients(self) raises -> List[AnyTensor]:
         """Get parameter gradients."""
-        var grads: List[ExTensor] = []
+        var grads: List[AnyTensor] = []
         grads.append(self.grad_gamma)
         grads.append(self.grad_beta)
         return grads^
@@ -524,16 +524,16 @@ fn main() raises:
 # BEFORE (No traits):
 # ===================
 # struct MyLayer:
-#     var weights: ExTensor
-#     var bias: ExTensor
+#     var weights: AnyTensor
+#     var bias: AnyTensor
 #
-#     fn forward(mut self, input: ExTensor) -> ExTensor:
+#     fn forward(mut self, input: AnyTensor) -> AnyTensor:
 #         # ... implementation
 #
-#     fn backward(self, grad: ExTensor) -> ExTensor:
+#     fn backward(self, grad: AnyTensor) -> AnyTensor:
 #         # ... implementation
 #
-#     fn get_parameters(self) -> List[ExTensor]:
+#     fn get_parameters(self) -> List[AnyTensor]:
 #         # ... implementation
 #
 # Issues:
@@ -545,19 +545,19 @@ fn main() raises:
 # AFTER (With traits):
 # ====================
 # struct MyLayer(Differentiable, Parameterized):
-#     var weights: ExTensor
-#     var bias: ExTensor
+#     var weights: AnyTensor
+#     var bias: AnyTensor
 #
-#     fn forward(mut self, input: ExTensor) -> ExTensor:
+#     fn forward(mut self, input: AnyTensor) -> AnyTensor:
 #         # ... same implementation
 #
-#     fn backward(self, grad: ExTensor) -> ExTensor:
+#     fn backward(self, grad: AnyTensor) -> AnyTensor:
 #         # ... same implementation
 #
-#     fn parameters(self) -> List[ExTensor]:
+#     fn parameters(self) -> List[AnyTensor]:
 #         # ... same implementation (renamed)
 #
-#     fn gradients(self) -> List[ExTensor]:
+#     fn gradients(self) -> List[AnyTensor]:
 #         # ... new method
 #
 #     fn zero_grad(mut self):

--- a/examples/vgg16-cifar10/inference.mojo
+++ b/examples/vgg16-cifar10/inference.mojo
@@ -6,7 +6,7 @@ Usage:
     mojo run examples/vgg16-cifar10/inference.mojo --weights-dir vgg16_weights --data-dir datasets/cifar10
 """
 
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.data.formats import load_cifar10_batch
 from shared.data.datasets import CIFAR10Dataset
 from shared.data import extract_batch_pair, DatasetInfo
@@ -35,7 +35,7 @@ fn parse_args() raises -> Tuple[String, String]:
 
 
 fn compute_test_accuracy(
-    mut model: VGG16, test_images: ExTensor, test_labels: ExTensor
+    mut model: VGG16, test_images: AnyTensor, test_labels: AnyTensor
 ) raises -> Float32:
     """Compute accuracy on test set using shared metrics utilities.
 

--- a/examples/vgg16-cifar10/model.mojo
+++ b/examples/vgg16-cifar10/model.mojo
@@ -54,7 +54,7 @@ References:
     - CIFAR-10 Dataset: https://www.cs.toronto.edu/~kriz/cifar.html
 """
 
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import maxpool2d, maxpool2d_backward
 from shared.core.linear import linear, linear_backward
@@ -184,48 +184,48 @@ struct VGG16:
     var dropout_rate: Float32
 
     # Block 1 parameters
-    var conv1_1_kernel: ExTensor
-    var conv1_1_bias: ExTensor
-    var conv1_2_kernel: ExTensor
-    var conv1_2_bias: ExTensor
+    var conv1_1_kernel: AnyTensor
+    var conv1_1_bias: AnyTensor
+    var conv1_2_kernel: AnyTensor
+    var conv1_2_bias: AnyTensor
 
     # Block 2 parameters
-    var conv2_1_kernel: ExTensor
-    var conv2_1_bias: ExTensor
-    var conv2_2_kernel: ExTensor
-    var conv2_2_bias: ExTensor
+    var conv2_1_kernel: AnyTensor
+    var conv2_1_bias: AnyTensor
+    var conv2_2_kernel: AnyTensor
+    var conv2_2_bias: AnyTensor
 
     # Block 3 parameters
-    var conv3_1_kernel: ExTensor
-    var conv3_1_bias: ExTensor
-    var conv3_2_kernel: ExTensor
-    var conv3_2_bias: ExTensor
-    var conv3_3_kernel: ExTensor
-    var conv3_3_bias: ExTensor
+    var conv3_1_kernel: AnyTensor
+    var conv3_1_bias: AnyTensor
+    var conv3_2_kernel: AnyTensor
+    var conv3_2_bias: AnyTensor
+    var conv3_3_kernel: AnyTensor
+    var conv3_3_bias: AnyTensor
 
     # Block 4 parameters
-    var conv4_1_kernel: ExTensor
-    var conv4_1_bias: ExTensor
-    var conv4_2_kernel: ExTensor
-    var conv4_2_bias: ExTensor
-    var conv4_3_kernel: ExTensor
-    var conv4_3_bias: ExTensor
+    var conv4_1_kernel: AnyTensor
+    var conv4_1_bias: AnyTensor
+    var conv4_2_kernel: AnyTensor
+    var conv4_2_bias: AnyTensor
+    var conv4_3_kernel: AnyTensor
+    var conv4_3_bias: AnyTensor
 
     # Block 5 parameters
-    var conv5_1_kernel: ExTensor
-    var conv5_1_bias: ExTensor
-    var conv5_2_kernel: ExTensor
-    var conv5_2_bias: ExTensor
-    var conv5_3_kernel: ExTensor
-    var conv5_3_bias: ExTensor
+    var conv5_1_kernel: AnyTensor
+    var conv5_1_bias: AnyTensor
+    var conv5_2_kernel: AnyTensor
+    var conv5_2_bias: AnyTensor
+    var conv5_3_kernel: AnyTensor
+    var conv5_3_bias: AnyTensor
 
     # Fully connected layer parameters
-    var fc1_weights: ExTensor
-    var fc1_bias: ExTensor
-    var fc2_weights: ExTensor
-    var fc2_bias: ExTensor
-    var fc3_weights: ExTensor
-    var fc3_bias: ExTensor
+    var fc1_weights: AnyTensor
+    var fc1_bias: AnyTensor
+    var fc2_weights: AnyTensor
+    var fc2_bias: AnyTensor
+    var fc3_weights: AnyTensor
+    var fc3_bias: AnyTensor
 
     fn __init__(
         out self, num_classes: Int = 10, dropout_rate: Float32 = 0.5
@@ -401,8 +401,8 @@ struct VGG16:
         self.fc3_bias = zeros([num_classes], DType.float32)
 
     fn forward(
-        mut self, input: ExTensor, training: Bool = True
-    ) raises -> ExTensor:
+        mut self, input: AnyTensor, training: Bool = True
+    ) raises -> AnyTensor:
         """Forward pass through VGG-16.
 
         Args:
@@ -587,7 +587,7 @@ struct VGG16:
 
         return output
 
-    fn predict(mut self, input: ExTensor) raises -> Int:
+    fn predict(mut self, input: AnyTensor) raises -> Int:
         """Predict class for a single input.
 
         Args:
@@ -621,7 +621,7 @@ struct VGG16:
             - conv1_1_kernel.weights, conv1_1_bias.weights, etc.
         """
         # Collect all parameters in order
-        var parameters: List[ExTensor] = []
+        var parameters: List[AnyTensor] = []
         parameters.append(self.conv1_1_kernel)
         parameters.append(self.conv1_1_bias)
         parameters.append(self.conv1_2_kernel)
@@ -674,7 +674,7 @@ struct VGG16:
         var param_names = get_model_parameter_names("vgg16")
 
         # Create empty list for loaded parameters
-        var loaded_params: List[ExTensor] = []
+        var loaded_params: List[AnyTensor] = []
 
         # Load using shared utility
         load_model_weights(loaded_params, weights_dir, param_names)

--- a/examples/vgg16-cifar10/train.mojo
+++ b/examples/vgg16-cifar10/train.mojo
@@ -19,7 +19,7 @@ References:
 
 from model import VGG16
 from shared.data.datasets import CIFAR10Dataset
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import maxpool2d, maxpool2d_backward
 from shared.core.linear import linear, linear_backward
@@ -39,11 +39,11 @@ from shared.training.metrics.evaluate import evaluate_with_predict
 
 fn compute_gradients(
     mut model: VGG16,
-    input: ExTensor,
-    labels: ExTensor,
+    input: AnyTensor,
+    labels: AnyTensor,
     learning_rate: Float32,
     momentum: Float32,
-    mut velocities: List[ExTensor],
+    mut velocities: List[AnyTensor],
 ) raises -> Float32:
     """Compute gradients and update parameters for one batch.
 
@@ -685,7 +685,7 @@ fn compute_gradients(
 
 
 fn evaluate(
-    mut model: VGG16, test_images: ExTensor, test_labels: ExTensor
+    mut model: VGG16, test_images: AnyTensor, test_labels: AnyTensor
 ) raises -> Float32:
     """Evaluate model on test set using shared metrics utilities.
 
@@ -734,7 +734,7 @@ fn evaluate(
     return accuracy
 
 
-fn initialize_velocities(model: VGG16) raises -> List[ExTensor]:
+fn initialize_velocities(model: VGG16) raises -> List[AnyTensor]:
     """Initialize momentum velocities for all parameters (32 tensors).
 
     Args:
@@ -743,7 +743,7 @@ fn initialize_velocities(model: VGG16) raises -> List[ExTensor]:
     Returns:
         DynamicVector of zero-initialized velocity tensors matching parameter shapes.
     """
-    var velocities: List[ExTensor] = []
+    var velocities: List[AnyTensor] = []
 
     # Initialize velocities for all 32 parameters (conv1-5 blocks + fc1-3)
     # Block 1 (4 params)

--- a/examples/vgg16-cifar10/train_new.mojo
+++ b/examples/vgg16-cifar10/train_new.mojo
@@ -29,7 +29,7 @@ References:
 
 from model import VGG16
 from shared.data.datasets import CIFAR10Dataset
-from shared.core import ExTensor, zeros
+from shared.core import AnyTensor, zeros
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import maxpool2d, maxpool2d_backward
 from shared.core.linear import linear, linear_backward
@@ -105,7 +105,7 @@ fn parse_args() raises -> TrainingArgs:
     )
 
 
-fn initialize_velocities(model: VGG16) raises -> List[ExTensor]:
+fn initialize_velocities(model: VGG16) raises -> List[AnyTensor]:
     """Initialize momentum velocities for all parameters (32 tensors).
 
     Args:
@@ -114,7 +114,7 @@ fn initialize_velocities(model: VGG16) raises -> List[ExTensor]:
     Returns:
         List of zero-initialized velocity tensors matching parameter shapes.
     """
-    var velocities: List[ExTensor] = []
+    var velocities: List[AnyTensor] = []
 
     # Initialize velocities for all 32 parameters (conv1-5 blocks + fc1-3)
     # Block 1 (4 params)
@@ -166,11 +166,11 @@ fn initialize_velocities(model: VGG16) raises -> List[ExTensor]:
 
 fn compute_gradients(
     mut model: VGG16,
-    input: ExTensor,
-    labels: ExTensor,
+    input: AnyTensor,
+    labels: AnyTensor,
     learning_rate: Float32,
     momentum: Float32,
-    mut velocities: List[ExTensor],
+    mut velocities: List[AnyTensor],
 ) raises -> Float32:
     """Compute gradients and update parameters for one batch.
 
@@ -803,7 +803,7 @@ fn compute_gradients(
 
 
 fn evaluate(
-    mut model: VGG16, test_images: ExTensor, test_labels: ExTensor
+    mut model: VGG16, test_images: AnyTensor, test_labels: AnyTensor
 ) raises -> Float32:
     """Evaluate model on test set.
 

--- a/tests/conftest.mojo
+++ b/tests/conftest.mojo
@@ -1,9 +1,9 @@
-"""Test configuration for ExTensor test suite.
+"""Test configuration for AnyTensor test suite.
 
 This file contains shared configuration and setup for all tests.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 
 
 # ============================================================================
@@ -168,11 +168,11 @@ struct TestFixtures:
         ```
     """
 
-    fn small_tensor(self) raises -> ExTensor:
+    fn small_tensor(self) raises -> AnyTensor:
         """Create a small 3x3 tensor with known values.
 
         Returns:
-            ExTensor with shape [3, 3] and deterministic values.
+            AnyTensor with shape [3, 3] and deterministic values.
 
         Example:
             ```mojo
@@ -186,7 +186,7 @@ struct TestFixtures:
             tensor._set_float64(i, Float64(i + 1))
         return tensor
 
-    fn random_tensor(self, rows: Int, cols: Int) raises -> ExTensor:
+    fn random_tensor(self, rows: Int, cols: Int) raises -> AnyTensor:
         """Create a random tensor with deterministic seed.
 
         Args:
@@ -194,7 +194,7 @@ struct TestFixtures:
             cols: Number of columns.
 
         Returns:
-            ExTensor with shape [rows, cols] containing random values.
+            AnyTensor with shape [rows, cols] containing random values.
 
         Note:
             Uses seed=42 for reproducibility.

--- a/tests/examples/test_trait_based_serialization.mojo
+++ b/tests/examples/test_trait_based_serialization.mojo
@@ -8,7 +8,7 @@ Tests serialization of layers implementing the Serializable trait:
 Runs as: pixi run mojo ./tests/examples/test_trait_based_serialization.mojo
 """
 
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.utils.serialization import (
     save_named_tensors,
     load_named_tensors,

--- a/tests/helpers/__init__.mojo
+++ b/tests/helpers/__init__.mojo
@@ -1,7 +1,7 @@
-"""Test helpers for ExTensor test suite.
+"""Test helpers for AnyTensor test suite.
 
 Provides utility functions, fixtures, and helpers for comprehensive testing
-of ExTensor and related components.
+of AnyTensor and related components.
 
 Exports:
 - print_tensor: Pretty-print tensors for debugging

--- a/tests/helpers/fixtures.mojo
+++ b/tests/helpers/fixtures.mojo
@@ -1,4 +1,4 @@
-"""Test fixtures for ExTensor testing.
+"""Test fixtures for AnyTensor testing.
 
 Provides common tensor creation utilities for tests, including
 random tensors, sequential tensors, and special value tensors.
@@ -7,7 +7,7 @@ These fixtures wrap the comprehensive infrastructure in shared.testing
 with convenient test-specific APIs.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.core.extensor import nan_tensor as shared_nan_tensor
 from shared.core.extensor import inf_tensor as shared_inf_tensor
 from shared.testing.data_generators import random_tensor as shared_random_tensor
@@ -16,7 +16,7 @@ from shared.testing.data_generators import random_uniform
 
 fn random_tensor(
     shape: List[Int], dtype: DType = DType.float32
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Create a tensor with random values from uniform distribution [0, 1).
 
     Args:
@@ -24,7 +24,7 @@ fn random_tensor(
         dtype: Data type of tensor elements (default: float32).
 
     Returns:
-        ExTensor with random values uniformly distributed in [0, 1).
+        AnyTensor with random values uniformly distributed in [0, 1).
 
     Example:
         ```mojo
@@ -40,7 +40,7 @@ fn random_tensor(
 
 fn sequential_tensor(
     shape: List[Int], dtype: DType = DType.float32
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Create tensor with sequential values 0, 1, 2, 3, ...
 
     Tensor is filled with sequential values in row-major order, then reshaped
@@ -51,7 +51,7 @@ fn sequential_tensor(
         dtype: Data type of tensor elements (default: float32).
 
     Returns:
-        ExTensor with values 0, 1, 2, ... in flattened order.
+        AnyTensor with values 0, 1, 2, ... in flattened order.
 
     Example:
         ```mojo
@@ -76,14 +76,14 @@ fn sequential_tensor(
     return tensor
 
 
-fn nan_tensor(shape: List[Int]) raises -> ExTensor:
+fn nan_tensor(shape: List[Int]) raises -> AnyTensor:
     """Create tensor filled with NaN values.
 
     Args:
         shape: Shape of the output tensor as a list of dimensions.
 
     Returns:
-        ExTensor with all elements set to NaN.
+        AnyTensor with all elements set to NaN.
 
     Example:
         ```mojo
@@ -102,14 +102,14 @@ fn nan_tensor(shape: List[Int]) raises -> ExTensor:
     return shared_nan_tensor(shape, DType.float32)
 
 
-fn inf_tensor(shape: List[Int]) raises -> ExTensor:
+fn inf_tensor(shape: List[Int]) raises -> AnyTensor:
     """Create tensor filled with infinity values.
 
     Args:
         shape: Shape of the output tensor as a list of dimensions.
 
     Returns:
-        ExTensor with all elements set to positive infinity.
+        AnyTensor with all elements set to positive infinity.
 
     Example:
         ```mojo
@@ -128,14 +128,14 @@ fn inf_tensor(shape: List[Int]) raises -> ExTensor:
     return shared_inf_tensor(shape, DType.float32)
 
 
-fn ones_like(tensor: ExTensor) raises -> ExTensor:
+fn ones_like(tensor: AnyTensor) raises -> AnyTensor:
     """Create tensor of ones matching input shape and dtype.
 
     Args:
         tensor: Template tensor to match shape and dtype from.
 
     Returns:
-        ExTensor of ones with same shape and dtype as input.
+        AnyTensor of ones with same shape and dtype as input.
 
     Example:
         ```mojo
@@ -150,14 +150,14 @@ fn ones_like(tensor: ExTensor) raises -> ExTensor:
     return ones(tensor.shape(), tensor.dtype())
 
 
-fn zeros_like(tensor: ExTensor) raises -> ExTensor:
+fn zeros_like(tensor: AnyTensor) raises -> AnyTensor:
     """Create tensor of zeros matching input shape and dtype.
 
     Args:
         tensor: Template tensor to match shape and dtype from.
 
     Returns:
-        ExTensor of zeros with same shape and dtype as input.
+        AnyTensor of zeros with same shape and dtype as input.
 
     Example:
         ```mojo

--- a/tests/helpers/utils.mojo
+++ b/tests/helpers/utils.mojo
@@ -1,16 +1,16 @@
-"""Test utilities for ExTensor testing.
+"""Test utilities for AnyTensor testing.
 
 Provides utility functions for test setup, debugging, and validation.
 """
 
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 
 
-fn print_tensor(tensor: ExTensor) -> String:
+fn print_tensor(tensor: AnyTensor) -> String:
     """Pretty-print tensor with shape, dtype, and values.
 
     Args:
-        tensor: The ExTensor to print.
+        tensor: The AnyTensor to print.
 
     Returns:
         String representation of the tensor with shape, dtype, and values.
@@ -63,11 +63,11 @@ fn print_tensor(tensor: ExTensor) -> String:
     return result
 
 
-fn tensor_summary(tensor: ExTensor) -> String:
+fn tensor_summary(tensor: AnyTensor) -> String:
     """Print tensor statistics: shape, dtype, min, max, mean, std.
 
     Args:
-        tensor: The ExTensor to summarize.
+        tensor: The AnyTensor to summarize.
 
     Returns:
         String with shape, dtype, numel, and statistical summary.
@@ -126,7 +126,7 @@ fn tensor_summary(tensor: ExTensor) -> String:
     return result
 
 
-fn compare_tensors(a: ExTensor, b: ExTensor) -> String:
+fn compare_tensors(a: AnyTensor, b: AnyTensor) -> String:
     """Detailed comparison of two tensors for debugging test failures.
 
     Args:

--- a/tests/integration/test_all_architectures.mojo
+++ b/tests/integration/test_all_architectures.mojo
@@ -17,13 +17,13 @@ Usage:
     mojo run tests/integration/test_all_architectures.mojo
 """
 
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 import sys
 
 
 fn test_model_forward(
     model_name: String,
-    forward_fn: fn (ExTensor, Bool) raises -> ExTensor,
+    forward_fn: fn (AnyTensor, Bool) raises -> AnyTensor,
     batch_size: Int = 4,
 ) raises -> Bool:
     """Test a model's forward pass with dummy data.

--- a/tests/models/test_alexnet_e2e.mojo
+++ b/tests/models/test_alexnet_e2e.mojo
@@ -10,7 +10,7 @@ This test uses functional layer composition (no AlexNet model class required).
 Tests the same forward-backward pipeline that a full model would use.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import maxpool2d
 from shared.core.linear import linear, linear_backward
@@ -39,22 +39,22 @@ from math import isnan, isinf
 fn create_alexnet_parameters(
     dtype: DType,
 ) raises -> Tuple[
-    ExTensor,
-    ExTensor,
-    ExTensor,
-    ExTensor,
-    ExTensor,
-    ExTensor,
-    ExTensor,
-    ExTensor,
-    ExTensor,
-    ExTensor,
-    ExTensor,
-    ExTensor,
-    ExTensor,
-    ExTensor,
-    ExTensor,
-    ExTensor,
+    AnyTensor,
+    AnyTensor,
+    AnyTensor,
+    AnyTensor,
+    AnyTensor,
+    AnyTensor,
+    AnyTensor,
+    AnyTensor,
+    AnyTensor,
+    AnyTensor,
+    AnyTensor,
+    AnyTensor,
+    AnyTensor,
+    AnyTensor,
+    AnyTensor,
+    AnyTensor,
 ]:
     """Create all AlexNet parameters (conv kernels, biases, FC weights, biases).
     """
@@ -121,24 +121,24 @@ fn create_alexnet_parameters(
 
 
 fn alexnet_forward(
-    x: ExTensor,
-    c1_k: ExTensor,
-    c1_b: ExTensor,
-    c2_k: ExTensor,
-    c2_b: ExTensor,
-    c3_k: ExTensor,
-    c3_b: ExTensor,
-    c4_k: ExTensor,
-    c4_b: ExTensor,
-    c5_k: ExTensor,
-    c5_b: ExTensor,
-    fc1_w: ExTensor,
-    fc1_b: ExTensor,
-    fc2_w: ExTensor,
-    fc2_b: ExTensor,
-    fc3_w: ExTensor,
-    fc3_b: ExTensor,
-) raises -> ExTensor:
+    x: AnyTensor,
+    c1_k: AnyTensor,
+    c1_b: AnyTensor,
+    c2_k: AnyTensor,
+    c2_b: AnyTensor,
+    c3_k: AnyTensor,
+    c3_b: AnyTensor,
+    c4_k: AnyTensor,
+    c4_b: AnyTensor,
+    c5_k: AnyTensor,
+    c5_b: AnyTensor,
+    fc1_w: AnyTensor,
+    fc1_b: AnyTensor,
+    fc2_w: AnyTensor,
+    fc2_b: AnyTensor,
+    fc3_w: AnyTensor,
+    fc3_b: AnyTensor,
+) raises -> AnyTensor:
     """Forward pass through AlexNet."""
     # Conv1 + ReLU + MaxPool
     var c1 = conv2d(x, c1_k, c1_b, stride=4, padding=2)

--- a/tests/models/test_alexnet_layers_part1.mojo
+++ b/tests/models/test_alexnet_layers_part1.mojo
@@ -22,7 +22,7 @@ These are expected, fundamental limitations of Float16 arithmetic (not bugs).
 See issue #3009 for detailed analysis.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.conv import conv2d
 from shared.core.pooling import maxpool2d
 from shared.core.linear import linear
@@ -51,7 +51,7 @@ from math import isnan, isinf
 # ============================================================================
 
 
-fn create_conv1_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_conv1_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create Conv1 layer parameters (3→64, 11x11 kernel)."""
     var in_channels = 3
     var out_channels = 64
@@ -74,7 +74,7 @@ fn create_conv1_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
     return kernel, bias
 
 
-fn create_conv2_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_conv2_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create Conv2 layer parameters (64→192, 5x5 kernel)."""
     var in_channels = 64
     var out_channels = 192

--- a/tests/models/test_alexnet_layers_part2.mojo
+++ b/tests/models/test_alexnet_layers_part2.mojo
@@ -16,7 +16,7 @@ These are expected, fundamental limitations of Float16 arithmetic (not bugs).
 See issue #3009 for detailed analysis.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.conv import conv2d
 from shared.core.pooling import maxpool2d
 from shared.core.linear import linear
@@ -45,7 +45,7 @@ from math import isnan, isinf
 # ============================================================================
 
 
-fn create_conv3_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_conv3_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create Conv3 layer parameters (192→384, 3x3 kernel)."""
     var in_channels = 192
     var out_channels = 384
@@ -68,7 +68,7 @@ fn create_conv3_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
     return kernel, bias
 
 
-fn create_conv4_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_conv4_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create Conv4 layer parameters (384→384, 3x3 kernel)."""
     var in_channels = 384
     var out_channels = 384
@@ -91,7 +91,7 @@ fn create_conv4_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
     return kernel, bias
 
 
-fn create_conv5_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_conv5_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create Conv5 layer parameters (384→256, 3x3 kernel)."""
     var in_channels = 384
     var out_channels = 256

--- a/tests/models/test_alexnet_layers_part3.mojo
+++ b/tests/models/test_alexnet_layers_part3.mojo
@@ -8,7 +8,7 @@ layers independently with special FP-representable values.
 # high test load. Split from test_alexnet_layers.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.conv import conv2d
 from shared.core.pooling import maxpool2d
 from shared.core.linear import linear

--- a/tests/models/test_alexnet_layers_part4.mojo
+++ b/tests/models/test_alexnet_layers_part4.mojo
@@ -8,7 +8,7 @@ independently with special FP-representable values.
 # high test load. Split from test_alexnet_layers.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.conv import conv2d
 from shared.core.pooling import maxpool2d
 from shared.core.linear import linear
@@ -37,7 +37,7 @@ from math import isnan, isinf
 # ============================================================================
 
 
-fn create_fc1_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_fc1_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create FC1 layer parameters (9216→4096)."""
     var in_features = 9216  # 256 * 6 * 6
     var out_features = 4096
@@ -54,7 +54,7 @@ fn create_fc1_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
     return weights, bias
 
 
-fn create_fc2_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_fc2_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create FC2 layer parameters (4096→4096)."""
     var in_features = 4096
     var out_features = 4096

--- a/tests/models/test_alexnet_layers_part5.mojo
+++ b/tests/models/test_alexnet_layers_part5.mojo
@@ -8,7 +8,7 @@ Flatten operation, and full forward pass sequence through all AlexNet layers.
 # high test load. Split from test_alexnet_layers.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.conv import conv2d
 from shared.core.pooling import maxpool2d
 from shared.core.linear import linear
@@ -37,7 +37,7 @@ from math import isnan, isinf
 # ============================================================================
 
 
-fn create_conv1_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_conv1_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create Conv1 layer parameters (3→64, 11x11 kernel)."""
     var in_channels = 3
     var out_channels = 64
@@ -57,7 +57,7 @@ fn create_conv1_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
     return kernel, bias
 
 
-fn create_conv2_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_conv2_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create Conv2 layer parameters (64→192, 5x5 kernel)."""
     var in_channels = 64
     var out_channels = 192
@@ -77,7 +77,7 @@ fn create_conv2_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
     return kernel, bias
 
 
-fn create_conv3_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_conv3_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create Conv3 layer parameters (192→384, 3x3 kernel)."""
     var in_channels = 192
     var out_channels = 384
@@ -97,7 +97,7 @@ fn create_conv3_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
     return kernel, bias
 
 
-fn create_conv4_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_conv4_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create Conv4 layer parameters (384→384, 3x3 kernel)."""
     var in_channels = 384
     var out_channels = 384
@@ -117,7 +117,7 @@ fn create_conv4_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
     return kernel, bias
 
 
-fn create_conv5_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_conv5_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create Conv5 layer parameters (384→256, 3x3 kernel)."""
     var in_channels = 384
     var out_channels = 256
@@ -137,7 +137,7 @@ fn create_conv5_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
     return kernel, bias
 
 
-fn create_fc1_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_fc1_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create FC1 layer parameters (9216→4096)."""
     var in_features = 9216  # 256 * 6 * 6
     var out_features = 4096
@@ -151,7 +151,7 @@ fn create_fc1_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
     return weights, bias
 
 
-fn create_fc2_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_fc2_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create FC2 layer parameters (4096→4096)."""
     var in_features = 4096
     var out_features = 4096
@@ -165,7 +165,7 @@ fn create_fc2_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
     return weights, bias
 
 
-fn create_fc3_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_fc3_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create FC3 layer parameters (4096→1000)."""
     var in_features = 4096
     var out_features = 1000

--- a/tests/models/test_googlenet_e2e_part1.mojo
+++ b/tests/models/test_googlenet_e2e_part1.mojo
@@ -23,7 +23,7 @@ from tests.shared.conftest import (
     assert_shape,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.activation import relu
 from shared.core.pooling import maxpool2d, global_avgpool2d
 from shared.core.normalization import batch_norm2d
@@ -40,47 +40,47 @@ from shared.core.initializers import kaiming_normal, xavier_normal, constant
 struct InceptionModule:
     """Inception module with 4 parallel branches."""
 
-    var conv1x1_1_weights: ExTensor
-    var conv1x1_1_bias: ExTensor
-    var bn1x1_1_gamma: ExTensor
-    var bn1x1_1_beta: ExTensor
-    var bn1x1_1_running_mean: ExTensor
-    var bn1x1_1_running_var: ExTensor
+    var conv1x1_1_weights: AnyTensor
+    var conv1x1_1_bias: AnyTensor
+    var bn1x1_1_gamma: AnyTensor
+    var bn1x1_1_beta: AnyTensor
+    var bn1x1_1_running_mean: AnyTensor
+    var bn1x1_1_running_var: AnyTensor
 
-    var conv1x1_2_weights: ExTensor
-    var conv1x1_2_bias: ExTensor
-    var bn1x1_2_gamma: ExTensor
-    var bn1x1_2_beta: ExTensor
-    var bn1x1_2_running_mean: ExTensor
-    var bn1x1_2_running_var: ExTensor
+    var conv1x1_2_weights: AnyTensor
+    var conv1x1_2_bias: AnyTensor
+    var bn1x1_2_gamma: AnyTensor
+    var bn1x1_2_beta: AnyTensor
+    var bn1x1_2_running_mean: AnyTensor
+    var bn1x1_2_running_var: AnyTensor
 
-    var conv3x3_weights: ExTensor
-    var conv3x3_bias: ExTensor
-    var bn3x3_gamma: ExTensor
-    var bn3x3_beta: ExTensor
-    var bn3x3_running_mean: ExTensor
-    var bn3x3_running_var: ExTensor
+    var conv3x3_weights: AnyTensor
+    var conv3x3_bias: AnyTensor
+    var bn3x3_gamma: AnyTensor
+    var bn3x3_beta: AnyTensor
+    var bn3x3_running_mean: AnyTensor
+    var bn3x3_running_var: AnyTensor
 
-    var conv1x1_3_weights: ExTensor
-    var conv1x1_3_bias: ExTensor
-    var bn1x1_3_gamma: ExTensor
-    var bn1x1_3_beta: ExTensor
-    var bn1x1_3_running_mean: ExTensor
-    var bn1x1_3_running_var: ExTensor
+    var conv1x1_3_weights: AnyTensor
+    var conv1x1_3_bias: AnyTensor
+    var bn1x1_3_gamma: AnyTensor
+    var bn1x1_3_beta: AnyTensor
+    var bn1x1_3_running_mean: AnyTensor
+    var bn1x1_3_running_var: AnyTensor
 
-    var conv5x5_weights: ExTensor
-    var conv5x5_bias: ExTensor
-    var bn5x5_gamma: ExTensor
-    var bn5x5_beta: ExTensor
-    var bn5x5_running_mean: ExTensor
-    var bn5x5_running_var: ExTensor
+    var conv5x5_weights: AnyTensor
+    var conv5x5_bias: AnyTensor
+    var bn5x5_gamma: AnyTensor
+    var bn5x5_beta: AnyTensor
+    var bn5x5_running_mean: AnyTensor
+    var bn5x5_running_var: AnyTensor
 
-    var conv1x1_4_weights: ExTensor
-    var conv1x1_4_bias: ExTensor
-    var bn1x1_4_gamma: ExTensor
-    var bn1x1_4_beta: ExTensor
-    var bn1x1_4_running_mean: ExTensor
-    var bn1x1_4_running_var: ExTensor
+    var conv1x1_4_weights: AnyTensor
+    var conv1x1_4_bias: AnyTensor
+    var bn1x1_4_gamma: AnyTensor
+    var bn1x1_4_beta: AnyTensor
+    var bn1x1_4_running_mean: AnyTensor
+    var bn1x1_4_running_var: AnyTensor
 
     fn __init__(
         out self,
@@ -153,7 +153,7 @@ struct InceptionModule:
         self.bn1x1_4_running_mean = zeros([pool_proj], DType.float32)
         self.bn1x1_4_running_var = constant([pool_proj], 1.0)
 
-    fn forward(mut self, x: ExTensor, training: Bool) raises -> ExTensor:
+    fn forward(mut self, x: AnyTensor, training: Bool) raises -> AnyTensor:
         """Forward pass through Inception module."""
         # Branch 1: 1x1 conv
         var b1 = conv2d(
@@ -241,8 +241,8 @@ struct InceptionModule:
 
 
 fn concatenate_depthwise(
-    t1: ExTensor, t2: ExTensor, t3: ExTensor, t4: ExTensor
-) raises -> ExTensor:
+    t1: AnyTensor, t2: AnyTensor, t3: AnyTensor, t4: AnyTensor
+) raises -> AnyTensor:
     """Concatenate 4 tensors along channel dimension."""
     var batch_size = t1.shape()[0]
     var c1 = t1.shape()[1]
@@ -297,12 +297,12 @@ struct GoogLeNetSmall:
     """Simplified GoogLeNet for E2E testing with smaller input size."""
 
     # Initial conv
-    var initial_conv_weights: ExTensor
-    var initial_conv_bias: ExTensor
-    var initial_bn_gamma: ExTensor
-    var initial_bn_beta: ExTensor
-    var initial_bn_running_mean: ExTensor
-    var initial_bn_running_var: ExTensor
+    var initial_conv_weights: AnyTensor
+    var initial_conv_bias: AnyTensor
+    var initial_bn_gamma: AnyTensor
+    var initial_bn_beta: AnyTensor
+    var initial_bn_running_mean: AnyTensor
+    var initial_bn_running_var: AnyTensor
 
     # Inception modules (3 instead of 9 for faster testing)
     var inception_1: InceptionModule
@@ -310,8 +310,8 @@ struct GoogLeNetSmall:
     var inception_3: InceptionModule
 
     # FC layer
-    var fc_weights: ExTensor
-    var fc_bias: ExTensor
+    var fc_weights: AnyTensor
+    var fc_bias: AnyTensor
 
     fn __init__(out self, num_classes: Int = 10) raises:
         """Initialize simplified GoogLeNet for testing."""
@@ -360,7 +360,7 @@ struct GoogLeNetSmall:
         self.fc_weights = xavier_normal(96, num_classes, [num_classes, 96])
         self.fc_bias = zeros([num_classes], DType.float32)
 
-    fn forward(mut self, x: ExTensor, training: Bool = True) raises -> ExTensor:
+    fn forward(mut self, x: AnyTensor, training: Bool = True) raises -> AnyTensor:
         """Forward pass through simplified GoogLeNet."""
         # Initial conv
         var out = conv2d(

--- a/tests/models/test_googlenet_e2e_part2.mojo
+++ b/tests/models/test_googlenet_e2e_part2.mojo
@@ -23,7 +23,7 @@ from tests.shared.conftest import (
     assert_shape,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.activation import relu
 from shared.core.pooling import maxpool2d, global_avgpool2d
 from shared.core.normalization import batch_norm2d
@@ -40,47 +40,47 @@ from shared.core.initializers import kaiming_normal, xavier_normal, constant
 struct InceptionModule:
     """Inception module with 4 parallel branches."""
 
-    var conv1x1_1_weights: ExTensor
-    var conv1x1_1_bias: ExTensor
-    var bn1x1_1_gamma: ExTensor
-    var bn1x1_1_beta: ExTensor
-    var bn1x1_1_running_mean: ExTensor
-    var bn1x1_1_running_var: ExTensor
+    var conv1x1_1_weights: AnyTensor
+    var conv1x1_1_bias: AnyTensor
+    var bn1x1_1_gamma: AnyTensor
+    var bn1x1_1_beta: AnyTensor
+    var bn1x1_1_running_mean: AnyTensor
+    var bn1x1_1_running_var: AnyTensor
 
-    var conv1x1_2_weights: ExTensor
-    var conv1x1_2_bias: ExTensor
-    var bn1x1_2_gamma: ExTensor
-    var bn1x1_2_beta: ExTensor
-    var bn1x1_2_running_mean: ExTensor
-    var bn1x1_2_running_var: ExTensor
+    var conv1x1_2_weights: AnyTensor
+    var conv1x1_2_bias: AnyTensor
+    var bn1x1_2_gamma: AnyTensor
+    var bn1x1_2_beta: AnyTensor
+    var bn1x1_2_running_mean: AnyTensor
+    var bn1x1_2_running_var: AnyTensor
 
-    var conv3x3_weights: ExTensor
-    var conv3x3_bias: ExTensor
-    var bn3x3_gamma: ExTensor
-    var bn3x3_beta: ExTensor
-    var bn3x3_running_mean: ExTensor
-    var bn3x3_running_var: ExTensor
+    var conv3x3_weights: AnyTensor
+    var conv3x3_bias: AnyTensor
+    var bn3x3_gamma: AnyTensor
+    var bn3x3_beta: AnyTensor
+    var bn3x3_running_mean: AnyTensor
+    var bn3x3_running_var: AnyTensor
 
-    var conv1x1_3_weights: ExTensor
-    var conv1x1_3_bias: ExTensor
-    var bn1x1_3_gamma: ExTensor
-    var bn1x1_3_beta: ExTensor
-    var bn1x1_3_running_mean: ExTensor
-    var bn1x1_3_running_var: ExTensor
+    var conv1x1_3_weights: AnyTensor
+    var conv1x1_3_bias: AnyTensor
+    var bn1x1_3_gamma: AnyTensor
+    var bn1x1_3_beta: AnyTensor
+    var bn1x1_3_running_mean: AnyTensor
+    var bn1x1_3_running_var: AnyTensor
 
-    var conv5x5_weights: ExTensor
-    var conv5x5_bias: ExTensor
-    var bn5x5_gamma: ExTensor
-    var bn5x5_beta: ExTensor
-    var bn5x5_running_mean: ExTensor
-    var bn5x5_running_var: ExTensor
+    var conv5x5_weights: AnyTensor
+    var conv5x5_bias: AnyTensor
+    var bn5x5_gamma: AnyTensor
+    var bn5x5_beta: AnyTensor
+    var bn5x5_running_mean: AnyTensor
+    var bn5x5_running_var: AnyTensor
 
-    var conv1x1_4_weights: ExTensor
-    var conv1x1_4_bias: ExTensor
-    var bn1x1_4_gamma: ExTensor
-    var bn1x1_4_beta: ExTensor
-    var bn1x1_4_running_mean: ExTensor
-    var bn1x1_4_running_var: ExTensor
+    var conv1x1_4_weights: AnyTensor
+    var conv1x1_4_bias: AnyTensor
+    var bn1x1_4_gamma: AnyTensor
+    var bn1x1_4_beta: AnyTensor
+    var bn1x1_4_running_mean: AnyTensor
+    var bn1x1_4_running_var: AnyTensor
 
     fn __init__(
         out self,
@@ -153,7 +153,7 @@ struct InceptionModule:
         self.bn1x1_4_running_mean = zeros([pool_proj], DType.float32)
         self.bn1x1_4_running_var = constant([pool_proj], 1.0)
 
-    fn forward(mut self, x: ExTensor, training: Bool) raises -> ExTensor:
+    fn forward(mut self, x: AnyTensor, training: Bool) raises -> AnyTensor:
         """Forward pass through Inception module."""
         # Branch 1: 1x1 conv
         var b1 = conv2d(
@@ -241,8 +241,8 @@ struct InceptionModule:
 
 
 fn concatenate_depthwise(
-    t1: ExTensor, t2: ExTensor, t3: ExTensor, t4: ExTensor
-) raises -> ExTensor:
+    t1: AnyTensor, t2: AnyTensor, t3: AnyTensor, t4: AnyTensor
+) raises -> AnyTensor:
     """Concatenate 4 tensors along channel dimension."""
     var batch_size = t1.shape()[0]
     var c1 = t1.shape()[1]
@@ -297,12 +297,12 @@ struct GoogLeNetSmall:
     """Simplified GoogLeNet for E2E testing with smaller input size."""
 
     # Initial conv
-    var initial_conv_weights: ExTensor
-    var initial_conv_bias: ExTensor
-    var initial_bn_gamma: ExTensor
-    var initial_bn_beta: ExTensor
-    var initial_bn_running_mean: ExTensor
-    var initial_bn_running_var: ExTensor
+    var initial_conv_weights: AnyTensor
+    var initial_conv_bias: AnyTensor
+    var initial_bn_gamma: AnyTensor
+    var initial_bn_beta: AnyTensor
+    var initial_bn_running_mean: AnyTensor
+    var initial_bn_running_var: AnyTensor
 
     # Inception modules (3 instead of 9 for faster testing)
     var inception_1: InceptionModule
@@ -310,8 +310,8 @@ struct GoogLeNetSmall:
     var inception_3: InceptionModule
 
     # FC layer
-    var fc_weights: ExTensor
-    var fc_bias: ExTensor
+    var fc_weights: AnyTensor
+    var fc_bias: AnyTensor
 
     fn __init__(out self, num_classes: Int = 10) raises:
         """Initialize simplified GoogLeNet for testing."""
@@ -360,7 +360,7 @@ struct GoogLeNetSmall:
         self.fc_weights = xavier_normal(96, num_classes, [num_classes, 96])
         self.fc_bias = zeros([num_classes], DType.float32)
 
-    fn forward(mut self, x: ExTensor, training: Bool = True) raises -> ExTensor:
+    fn forward(mut self, x: AnyTensor, training: Bool = True) raises -> AnyTensor:
         """Forward pass through simplified GoogLeNet."""
         # Initial conv
         var out = conv2d(

--- a/tests/models/test_googlenet_layers_part1.mojo
+++ b/tests/models/test_googlenet_layers_part1.mojo
@@ -23,7 +23,7 @@ from tests.shared.conftest import (
     assert_shape,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full, randn
+from shared.core.extensor import AnyTensor, zeros, ones, full, randn
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import maxpool2d, global_avgpool2d
 from shared.core.linear import linear
@@ -47,24 +47,24 @@ struct InceptionModule:
     """
 
     # Branch 1: 1×1 convolution
-    var conv1x1_1_weights: ExTensor
-    var conv1x1_1_bias: ExTensor
+    var conv1x1_1_weights: AnyTensor
+    var conv1x1_1_bias: AnyTensor
 
     # Branch 2: 1×1 reduce → 3×3
-    var conv1x1_2_weights: ExTensor
-    var conv1x1_2_bias: ExTensor
-    var conv3x3_weights: ExTensor
-    var conv3x3_bias: ExTensor
+    var conv1x1_2_weights: AnyTensor
+    var conv1x1_2_bias: AnyTensor
+    var conv3x3_weights: AnyTensor
+    var conv3x3_bias: AnyTensor
 
     # Branch 3: 1×1 reduce → 5×5
-    var conv1x1_3_weights: ExTensor
-    var conv1x1_3_bias: ExTensor
-    var conv5x5_weights: ExTensor
-    var conv5x5_bias: ExTensor
+    var conv1x1_3_weights: AnyTensor
+    var conv1x1_3_bias: AnyTensor
+    var conv5x5_weights: AnyTensor
+    var conv5x5_bias: AnyTensor
 
     # Branch 4: pool → 1×1 projection
-    var conv1x1_4_weights: ExTensor
-    var conv1x1_4_bias: ExTensor
+    var conv1x1_4_weights: AnyTensor
+    var conv1x1_4_bias: AnyTensor
 
     fn __init__(
         out self,
@@ -125,7 +125,7 @@ struct InceptionModule:
         )
         self.conv1x1_4_bias = zeros([pool_proj], DType.float32)
 
-    fn forward(self, x: ExTensor) raises -> ExTensor:
+    fn forward(self, x: AnyTensor) raises -> AnyTensor:
         """Forward pass through all 4 branches with concatenation.
 
         Returns:
@@ -169,8 +169,8 @@ struct InceptionModule:
 
 
 fn concatenate_depthwise(
-    t1: ExTensor, t2: ExTensor, t3: ExTensor, t4: ExTensor
-) raises -> ExTensor:
+    t1: AnyTensor, t2: AnyTensor, t3: AnyTensor, t4: AnyTensor
+) raises -> AnyTensor:
     """Concatenate 4 tensors along the channel dimension (axis=1).
 
     Args:

--- a/tests/models/test_googlenet_layers_part2.mojo
+++ b/tests/models/test_googlenet_layers_part2.mojo
@@ -21,7 +21,7 @@ from tests.shared.conftest import (
     assert_shape,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full, randn
+from shared.core.extensor import AnyTensor, zeros, ones, full, randn
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import maxpool2d, global_avgpool2d
 from shared.core.linear import linear
@@ -30,8 +30,8 @@ from shared.core.initializers import kaiming_normal, xavier_normal, constant
 
 
 fn concatenate_depthwise(
-    t1: ExTensor, t2: ExTensor, t3: ExTensor, t4: ExTensor
-) raises -> ExTensor:
+    t1: AnyTensor, t2: AnyTensor, t3: AnyTensor, t4: AnyTensor
+) raises -> AnyTensor:
     """Concatenate 4 tensors along the channel dimension (axis=1).
 
     Args:

--- a/tests/models/test_googlenet_layers_part3.mojo
+++ b/tests/models/test_googlenet_layers_part3.mojo
@@ -22,7 +22,7 @@ from tests.shared.conftest import (
     assert_shape,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full, randn
+from shared.core.extensor import AnyTensor, zeros, ones, full, randn
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import maxpool2d, global_avgpool2d
 from shared.core.linear import linear
@@ -31,8 +31,8 @@ from shared.core.initializers import kaiming_normal, xavier_normal, constant
 
 
 fn concatenate_depthwise(
-    t1: ExTensor, t2: ExTensor, t3: ExTensor, t4: ExTensor
-) raises -> ExTensor:
+    t1: AnyTensor, t2: AnyTensor, t3: AnyTensor, t4: AnyTensor
+) raises -> AnyTensor:
     """Concatenate 4 tensors along the channel dimension (axis=1).
 
     Args:

--- a/tests/models/test_heap_corruption_combined_part1.mojo
+++ b/tests/models/test_heap_corruption_combined_part1.mojo
@@ -7,7 +7,7 @@ Split from test_heap_corruption_combined.mojo (ADR-009).
 Contains 8 fn test_ functions (limit: 10).
 """
 
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.core.conv import conv2d
 from shared.core.activation import relu
 from shared.testing.layer_params import ConvFixture
@@ -23,7 +23,7 @@ from shared.testing.layer_testers import LayerTester
 # ============================================================================
 
 
-fn create_conv1_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_conv1_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create Conv1 layer parameters (1→6, 5x5 kernel)."""
     var fixture = ConvFixture(
         in_channels=1, out_channels=6, kernel_size=5, dtype=dtype
@@ -31,7 +31,7 @@ fn create_conv1_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
     return fixture.kernel, fixture.bias
 
 
-fn create_conv2_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_conv2_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create Conv2 layer parameters (6→16, 5x5 kernel)."""
     var fixture = ConvFixture(
         in_channels=6, out_channels=16, kernel_size=5, dtype=dtype

--- a/tests/models/test_heap_corruption_combined_part2.mojo
+++ b/tests/models/test_heap_corruption_combined_part2.mojo
@@ -7,7 +7,7 @@ Split from test_heap_corruption_combined.mojo (ADR-009).
 Contains 8 fn test_ functions (limit: 10).
 """
 
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.core.pooling import maxpool2d
 from shared.core.linear import linear
 from shared.core.activation import relu
@@ -24,7 +24,7 @@ from shared.testing.layer_testers import LayerTester
 # ============================================================================
 
 
-fn create_fc1_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_fc1_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create FC1 layer parameters (400→120)."""
     var fixture = LinearFixture(in_features=400, out_features=120, dtype=dtype)
     return fixture.weights, fixture.bias

--- a/tests/models/test_heap_corruption_combined_part3.mojo
+++ b/tests/models/test_heap_corruption_combined_part3.mojo
@@ -7,7 +7,7 @@ Split from test_heap_corruption_combined.mojo (ADR-009).
 Contains 8 fn test_ functions (limit: 10).
 """
 
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.core.linear import linear
 from shared.testing.layer_params import LinearFixture
 from shared.testing.assertions import (
@@ -29,13 +29,13 @@ from math import isnan, isinf
 # ============================================================================
 
 
-fn create_fc2_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_fc2_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create FC2 layer parameters (120→84)."""
     var fixture = LinearFixture(in_features=120, out_features=84, dtype=dtype)
     return fixture.weights, fixture.bias
 
 
-fn create_fc3_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_fc3_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create FC3 layer parameters (84→10)."""
     var fixture = LinearFixture(in_features=84, out_features=10, dtype=dtype)
     return fixture.weights, fixture.bias

--- a/tests/models/test_lenet5_conv_layers.mojo
+++ b/tests/models/test_lenet5_conv_layers.mojo
@@ -10,7 +10,7 @@ Tests:
 - Conv2 (6→16 channels, 5x5 kernel): forward float32, float16, backward float32
 """
 
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.testing.layer_params import ConvFixture
 from shared.testing.layer_testers import LayerTester
 
@@ -20,7 +20,7 @@ from shared.testing.layer_testers import LayerTester
 # ============================================================================
 
 
-fn create_conv1_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_conv1_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create Conv1 layer parameters (1→6, 5x5 kernel)."""
     var fixture = ConvFixture(
         in_channels=1, out_channels=6, kernel_size=5, dtype=dtype
@@ -28,7 +28,7 @@ fn create_conv1_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
     return fixture.kernel, fixture.bias
 
 
-fn create_conv2_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_conv2_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create Conv2 layer parameters (6→16, 5x5 kernel)."""
     var fixture = ConvFixture(
         in_channels=6, out_channels=16, kernel_size=5, dtype=dtype

--- a/tests/models/test_lenet5_e2e_part1.mojo
+++ b/tests/models/test_lenet5_e2e_part1.mojo
@@ -24,7 +24,7 @@ Note: Split from monolithic test file due to Mojo 0.26.1 heap corruption
 bug that occurs after ~15 cumulative tests. See Issue #2942.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.core.conv import conv2d
 from shared.core.pooling import maxpool2d
 from shared.core.linear import linear
@@ -62,16 +62,16 @@ struct LeNet5:
     """
 
     var num_classes: Int
-    var conv1_kernel: ExTensor
-    var conv1_bias: ExTensor
-    var conv2_kernel: ExTensor
-    var conv2_bias: ExTensor
-    var fc1_weights: ExTensor
-    var fc1_bias: ExTensor
-    var fc2_weights: ExTensor
-    var fc2_bias: ExTensor
-    var fc3_weights: ExTensor
-    var fc3_bias: ExTensor
+    var conv1_kernel: AnyTensor
+    var conv1_bias: AnyTensor
+    var conv2_kernel: AnyTensor
+    var conv2_bias: AnyTensor
+    var fc1_weights: AnyTensor
+    var fc1_bias: AnyTensor
+    var fc2_weights: AnyTensor
+    var fc2_bias: AnyTensor
+    var fc3_weights: AnyTensor
+    var fc3_bias: AnyTensor
 
     fn __init__(out self, num_classes: Int = 47) raises:
         """Initialize LeNet-5 model with random weights."""
@@ -114,7 +114,7 @@ struct LeNet5:
         )
         self.fc3_bias = zeros([num_classes], DType.float32)
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass through LeNet-5."""
         # Conv1 + ReLU + MaxPool
         var conv1_out = conv2d(
@@ -150,7 +150,7 @@ struct LeNet5:
 
         return output^
 
-    fn predict(mut self, input: ExTensor) raises -> Int:
+    fn predict(mut self, input: AnyTensor) raises -> Int:
         """Predict class for a single input."""
         var logits = self.forward(input)
 
@@ -165,9 +165,9 @@ struct LeNet5:
 
         return max_idx
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Return all trainable parameters."""
-        var params: List[ExTensor] = []
+        var params: List[AnyTensor] = []
         params.append(self.conv1_kernel)
         params.append(self.conv1_bias)
         params.append(self.conv2_kernel)

--- a/tests/models/test_lenet5_e2e_part2.mojo
+++ b/tests/models/test_lenet5_e2e_part2.mojo
@@ -24,7 +24,7 @@ Note: Split from monolithic test file due to Mojo 0.26.1 heap corruption
 bug that occurs after ~15 cumulative tests. See Issue #2942.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.core.conv import conv2d
 from shared.core.pooling import maxpool2d
 from shared.core.linear import linear
@@ -62,16 +62,16 @@ struct LeNet5:
     """
 
     var num_classes: Int
-    var conv1_kernel: ExTensor
-    var conv1_bias: ExTensor
-    var conv2_kernel: ExTensor
-    var conv2_bias: ExTensor
-    var fc1_weights: ExTensor
-    var fc1_bias: ExTensor
-    var fc2_weights: ExTensor
-    var fc2_bias: ExTensor
-    var fc3_weights: ExTensor
-    var fc3_bias: ExTensor
+    var conv1_kernel: AnyTensor
+    var conv1_bias: AnyTensor
+    var conv2_kernel: AnyTensor
+    var conv2_bias: AnyTensor
+    var fc1_weights: AnyTensor
+    var fc1_bias: AnyTensor
+    var fc2_weights: AnyTensor
+    var fc2_bias: AnyTensor
+    var fc3_weights: AnyTensor
+    var fc3_bias: AnyTensor
 
     fn __init__(out self, num_classes: Int = 47) raises:
         """Initialize LeNet-5 model with random weights."""
@@ -114,7 +114,7 @@ struct LeNet5:
         )
         self.fc3_bias = zeros([num_classes], DType.float32)
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass through LeNet-5."""
         # Conv1 + ReLU + MaxPool
         var conv1_out = conv2d(
@@ -150,9 +150,9 @@ struct LeNet5:
 
         return output^
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Return all trainable parameters."""
-        var params: List[ExTensor] = []
+        var params: List[AnyTensor] = []
         params.append(self.conv1_kernel)
         params.append(self.conv1_bias)
         params.append(self.conv2_kernel)
@@ -172,16 +172,16 @@ struct LeNet5:
     fn update_parameters(
         mut self,
         learning_rate: Float32,
-        grad_conv1_kernel: ExTensor,
-        grad_conv1_bias: ExTensor,
-        grad_conv2_kernel: ExTensor,
-        grad_conv2_bias: ExTensor,
-        grad_fc1_weights: ExTensor,
-        grad_fc1_bias: ExTensor,
-        grad_fc2_weights: ExTensor,
-        grad_fc2_bias: ExTensor,
-        grad_fc3_weights: ExTensor,
-        grad_fc3_bias: ExTensor,
+        grad_conv1_kernel: AnyTensor,
+        grad_conv1_bias: AnyTensor,
+        grad_conv2_kernel: AnyTensor,
+        grad_conv2_bias: AnyTensor,
+        grad_fc1_weights: AnyTensor,
+        grad_fc1_bias: AnyTensor,
+        grad_fc2_weights: AnyTensor,
+        grad_fc2_bias: AnyTensor,
+        grad_fc3_weights: AnyTensor,
+        grad_fc3_bias: AnyTensor,
     ) raises:
         """Update parameters using SGD."""
         _sgd_update(self.conv1_kernel, grad_conv1_kernel, learning_rate)
@@ -196,7 +196,7 @@ struct LeNet5:
         _sgd_update(self.fc3_bias, grad_fc3_bias, learning_rate)
 
 
-fn _sgd_update(mut param: ExTensor, grad: ExTensor, lr: Float32) raises:
+fn _sgd_update(mut param: AnyTensor, grad: AnyTensor, lr: Float32) raises:
     """SGD parameter update: param = param - lr * grad"""
     var numel = param.numel()
     var param_data = param._data.bitcast[Float32]()

--- a/tests/models/test_lenet5_fc_layers.mojo
+++ b/tests/models/test_lenet5_fc_layers.mojo
@@ -20,7 +20,7 @@ compared to Float32. This is an expected limitation of Float16 arithmetic
 (not a bug). See issue #3009 for detailed analysis.
 """
 
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.testing.layer_params import LinearFixture
 from shared.testing.layer_testers import LayerTester
 
@@ -30,19 +30,19 @@ from shared.testing.layer_testers import LayerTester
 # ============================================================================
 
 
-fn create_fc1_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_fc1_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create FC1 layer parameters (400→120)."""
     var fixture = LinearFixture(in_features=400, out_features=120, dtype=dtype)
     return fixture.weights, fixture.bias
 
 
-fn create_fc2_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_fc2_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create FC2 layer parameters (120→84)."""
     var fixture = LinearFixture(in_features=120, out_features=84, dtype=dtype)
     return fixture.weights, fixture.bias
 
 
-fn create_fc3_parameters(dtype: DType) raises -> Tuple[ExTensor, ExTensor]:
+fn create_fc3_parameters(dtype: DType) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create FC3 layer parameters (84→10)."""
     var fixture = LinearFixture(in_features=84, out_features=10, dtype=dtype)
     return fixture.weights, fixture.bias

--- a/tests/models/test_lenet5_reshape_layers.mojo
+++ b/tests/models/test_lenet5_reshape_layers.mojo
@@ -9,7 +9,7 @@ Tests:
 - Flatten operation: float32, float16
 """
 
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.testing.assertions import (
     assert_shape,
     assert_dtype,

--- a/tests/models/test_mobilenetv1_e2e_part1.mojo
+++ b/tests/models/test_mobilenetv1_e2e_part1.mojo
@@ -41,7 +41,7 @@ from tests.shared.conftest import (
     assert_true,
     TestFixtures,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full, randn
+from shared.core.extensor import AnyTensor, zeros, ones, full, randn
 from shared.core.conv import (
     conv2d,
     depthwise_conv2d,

--- a/tests/models/test_mobilenetv1_e2e_part2.mojo
+++ b/tests/models/test_mobilenetv1_e2e_part2.mojo
@@ -40,7 +40,7 @@ from tests.shared.conftest import (
     assert_true,
     TestFixtures,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full, randn
+from shared.core.extensor import AnyTensor, zeros, ones, full, randn
 from shared.core.conv import (
     conv2d,
     depthwise_conv2d,

--- a/tests/models/test_mobilenetv1_layers_part1.mojo
+++ b/tests/models/test_mobilenetv1_layers_part1.mojo
@@ -19,7 +19,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     full,

--- a/tests/models/test_mobilenetv1_layers_part2.mojo
+++ b/tests/models/test_mobilenetv1_layers_part2.mojo
@@ -20,7 +20,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     full,

--- a/tests/models/test_mobilenetv1_layers_part3.mojo
+++ b/tests/models/test_mobilenetv1_layers_part3.mojo
@@ -19,7 +19,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     full,

--- a/tests/models/test_resnet18_e2e.mojo
+++ b/tests/models/test_resnet18_e2e.mojo
@@ -33,7 +33,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, full, randn
+from shared.core.extensor import AnyTensor, zeros, ones, full, randn
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.linear import linear, linear_backward
 from shared.core.activation import relu, relu_backward
@@ -49,9 +49,9 @@ from shared.core.loss import cross_entropy
 
 
 fn resnet18_forward_simplified(
-    x: ExTensor,
+    x: AnyTensor,
     training: Bool = True,
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Simplified ResNet-18 forward pass for testing.
 
     Uses small tensor sizes and representative architecture.
@@ -82,9 +82,9 @@ fn resnet18_forward_simplified(
     var running_mean = zeros([64], DType.float32)
     var running_var = ones([64], DType.float32)
 
-    var bn_out: ExTensor
-    var _: ExTensor
-    var __: ExTensor
+    var bn_out: AnyTensor
+    var _: AnyTensor
+    var __: AnyTensor
     (bn_out, _, __) = batch_norm2d(
         x_out,
         gamma,
@@ -210,13 +210,13 @@ fn resnet18_forward_simplified(
 
 
 fn _forward_basic_block(
-    x: ExTensor,
+    x: AnyTensor,
     in_channels: Int,
     out_channels: Int,
     stride: Int,
     use_projection: Bool,
     training: Bool,
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Forward pass for a single basic block.
 
     Args:
@@ -248,9 +248,9 @@ fn _forward_basic_block(
     var running_mean1 = zeros([out_channels], DType.float32)
     var running_var1 = ones([out_channels], DType.float32)
 
-    var bn1_out: ExTensor
-    var _: ExTensor
-    var __: ExTensor
+    var bn1_out: AnyTensor
+    var _: AnyTensor
+    var __: AnyTensor
     (bn1_out, _, __) = batch_norm2d(
         conv1_out,
         gamma1,
@@ -280,7 +280,7 @@ fn _forward_basic_block(
     var running_mean2 = zeros([out_channels], DType.float32)
     var running_var2 = ones([out_channels], DType.float32)
 
-    var bn2_out: ExTensor
+    var bn2_out: AnyTensor
     (bn2_out, _, __) = batch_norm2d(
         conv2_out,
         gamma2,
@@ -291,7 +291,7 @@ fn _forward_basic_block(
     )
 
     # Skip connection
-    var skip: ExTensor
+    var skip: AnyTensor
     if use_projection:
         # Projection shortcut: 1x1 conv + BN
         var proj_weight_shape = List[Int]()
@@ -311,9 +311,9 @@ fn _forward_basic_block(
         var running_mean_proj = zeros([out_channels], DType.float32)
         var running_var_proj = ones([out_channels], DType.float32)
 
-        var bn_proj_out: ExTensor
-        var _bn_proj_rm: ExTensor
-        var _bn_proj_rv: ExTensor
+        var bn_proj_out: AnyTensor
+        var _bn_proj_rm: AnyTensor
+        var _bn_proj_rv: AnyTensor
         (bn_proj_out, _bn_proj_rm, _bn_proj_rv) = batch_norm2d(
             proj_out,
             gamma_proj,

--- a/tests/models/test_resnet18_layers_part1.mojo
+++ b/tests/models/test_resnet18_layers_part1.mojo
@@ -29,7 +29,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, full, randn
+from shared.core.extensor import AnyTensor, zeros, ones, full, randn
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.activation import relu, relu_backward
 from shared.core.normalization import batch_norm2d
@@ -42,21 +42,21 @@ from shared.core.arithmetic import add
 
 
 fn create_basic_block(
-    x: ExTensor,
-    conv1_weight: ExTensor,
-    conv1_bias: ExTensor,
-    bn1_gamma: ExTensor,
-    bn1_beta: ExTensor,
-    bn1_running_mean: ExTensor,
-    bn1_running_var: ExTensor,
-    conv2_weight: ExTensor,
-    conv2_bias: ExTensor,
-    bn2_gamma: ExTensor,
-    bn2_beta: ExTensor,
-    bn2_running_mean: ExTensor,
-    bn2_running_var: ExTensor,
+    x: AnyTensor,
+    conv1_weight: AnyTensor,
+    conv1_bias: AnyTensor,
+    bn1_gamma: AnyTensor,
+    bn1_beta: AnyTensor,
+    bn1_running_mean: AnyTensor,
+    bn1_running_var: AnyTensor,
+    conv2_weight: AnyTensor,
+    conv2_bias: AnyTensor,
+    bn2_gamma: AnyTensor,
+    bn2_beta: AnyTensor,
+    bn2_running_mean: AnyTensor,
+    bn2_running_var: AnyTensor,
     training: Bool = True,
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Forward pass for a basic residual block without projection.
 
     Formula:
@@ -91,9 +91,9 @@ fn create_basic_block(
     """
     # First conv -> BN -> ReLU
     var conv1_out = conv2d(x, conv1_weight, conv1_bias, stride=1, padding=1)
-    var bn1_out: ExTensor
-    var _: ExTensor
-    var __: ExTensor
+    var bn1_out: AnyTensor
+    var _: AnyTensor
+    var __: AnyTensor
     (bn1_out, _, __) = batch_norm2d(
         conv1_out,
         bn1_gamma,
@@ -108,7 +108,7 @@ fn create_basic_block(
     var conv2_out = conv2d(
         relu1_out, conv2_weight, conv2_bias, stride=1, padding=1
     )
-    var bn2_out: ExTensor
+    var bn2_out: AnyTensor
     (bn2_out, _, __) = batch_norm2d(
         conv2_out,
         bn2_gamma,
@@ -422,9 +422,9 @@ fn test_residual_block_128_channels_projection() raises:
         x, conv1_weight, conv1_bias, stride=2, padding=1
     )  # (2, 128, 16, 16)
 
-    var bn1_out: ExTensor
-    var _: ExTensor
-    var __: ExTensor
+    var bn1_out: AnyTensor
+    var _: AnyTensor
+    var __: AnyTensor
     (bn1_out, _, __) = batch_norm2d(
         conv1_out,
         bn1_gamma,
@@ -439,7 +439,7 @@ fn test_residual_block_128_channels_projection() raises:
     var conv2_out = conv2d(
         relu1_out, conv2_weight, conv2_bias, stride=1, padding=1
     )
-    var bn2_out: ExTensor
+    var bn2_out: AnyTensor
     (bn2_out, _, __) = batch_norm2d(
         conv2_out,
         bn2_gamma,
@@ -575,9 +575,9 @@ fn test_batchnorm2d_training_mode() raises:
     var running_var = ones([channels], DType.float32)
 
     # Forward pass in training mode
-    var output: ExTensor
-    var new_running_mean: ExTensor
-    var new_running_var: ExTensor
+    var output: AnyTensor
+    var new_running_mean: AnyTensor
+    var new_running_var: AnyTensor
     (output, new_running_mean, new_running_var) = batch_norm2d(
         x,
         gamma,
@@ -627,9 +627,9 @@ fn test_batchnorm2d_inference_mode() raises:
     var running_var = ones([channels], DType.float32)
 
     # Forward pass in inference mode
-    var output: ExTensor
-    var new_running_mean: ExTensor
-    var new_running_var: ExTensor
+    var output: AnyTensor
+    var new_running_mean: AnyTensor
+    var new_running_var: AnyTensor
     (output, new_running_mean, new_running_var) = batch_norm2d(
         x,
         gamma,

--- a/tests/models/test_resnet18_layers_part2.mojo
+++ b/tests/models/test_resnet18_layers_part2.mojo
@@ -25,7 +25,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, full, randn
+from shared.core.extensor import AnyTensor, zeros, ones, full, randn
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.activation import relu, relu_backward
 from shared.core.normalization import batch_norm2d
@@ -38,21 +38,21 @@ from shared.core.arithmetic import add
 
 
 fn create_basic_block(
-    x: ExTensor,
-    conv1_weight: ExTensor,
-    conv1_bias: ExTensor,
-    bn1_gamma: ExTensor,
-    bn1_beta: ExTensor,
-    bn1_running_mean: ExTensor,
-    bn1_running_var: ExTensor,
-    conv2_weight: ExTensor,
-    conv2_bias: ExTensor,
-    bn2_gamma: ExTensor,
-    bn2_beta: ExTensor,
-    bn2_running_mean: ExTensor,
-    bn2_running_var: ExTensor,
+    x: AnyTensor,
+    conv1_weight: AnyTensor,
+    conv1_bias: AnyTensor,
+    bn1_gamma: AnyTensor,
+    bn1_beta: AnyTensor,
+    bn1_running_mean: AnyTensor,
+    bn1_running_var: AnyTensor,
+    conv2_weight: AnyTensor,
+    conv2_bias: AnyTensor,
+    bn2_gamma: AnyTensor,
+    bn2_beta: AnyTensor,
+    bn2_running_mean: AnyTensor,
+    bn2_running_var: AnyTensor,
     training: Bool = True,
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Forward pass for a basic residual block without projection.
 
     Formula:
@@ -87,9 +87,9 @@ fn create_basic_block(
     """
     # First conv -> BN -> ReLU
     var conv1_out = conv2d(x, conv1_weight, conv1_bias, stride=1, padding=1)
-    var bn1_out: ExTensor
-    var _: ExTensor
-    var __: ExTensor
+    var bn1_out: AnyTensor
+    var _: AnyTensor
+    var __: AnyTensor
     (bn1_out, _, __) = batch_norm2d(
         conv1_out,
         bn1_gamma,
@@ -104,7 +104,7 @@ fn create_basic_block(
     var conv2_out = conv2d(
         relu1_out, conv2_weight, conv2_bias, stride=1, padding=1
     )
-    var bn2_out: ExTensor
+    var bn2_out: AnyTensor
     (bn2_out, _, __) = batch_norm2d(
         conv2_out,
         bn2_gamma,
@@ -154,9 +154,9 @@ fn test_batchnorm2d_gamma_beta_effects() raises:
     var running_var = ones([channels], DType.float32)
 
     # Forward pass
-    var output: ExTensor
-    var _: ExTensor
-    var __: ExTensor
+    var output: AnyTensor
+    var _: AnyTensor
+    var __: AnyTensor
     (output, _, __) = batch_norm2d(
         x, gamma, beta, running_mean, running_var, training=False
     )

--- a/tests/models/test_vgg16_e2e.mojo
+++ b/tests/models/test_vgg16_e2e.mojo
@@ -34,7 +34,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, full, randn
+from shared.core.extensor import AnyTensor, zeros, ones, full, randn
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.linear import linear, linear_backward
 from shared.core.activation import relu, relu_backward
@@ -49,10 +49,10 @@ from shared.core import mean
 
 
 fn conv_block(
-    input_tensor: ExTensor,
+    input_tensor: AnyTensor,
     out_channels: Int,
     num_convs: Int,
-) raises -> ExTensor:
+) raises -> AnyTensor:
     """Apply a VGG conv block: sequential conv layers with ReLU.
 
     Args:
@@ -95,8 +95,8 @@ fn conv_block(
 
 
 fn vgg16_forward(
-    input_tensor: ExTensor,
-) raises -> ExTensor:
+    input_tensor: AnyTensor,
+) raises -> AnyTensor:
     """Forward pass through VGG-16 model.
 
     Args:

--- a/tests/models/test_vgg16_layers_part1.mojo
+++ b/tests/models/test_vgg16_layers_part1.mojo
@@ -38,7 +38,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.conv import (
     conv2d,
     conv2d_no_bias,

--- a/tests/models/test_vgg16_layers_part2.mojo
+++ b/tests/models/test_vgg16_layers_part2.mojo
@@ -25,7 +25,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.conv import (
     conv2d,
     conv2d_no_bias,

--- a/tests/shared/autograd/test_dropout_backward.mojo
+++ b/tests/shared/autograd/test_dropout_backward.mojo
@@ -21,7 +21,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from shared.core.dropout import dropout, dropout2d, dropout_backward, dropout2d_backward
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 
 
 # ============================================================================

--- a/tests/shared/autograd/test_optimizer_base_part1.mojo
+++ b/tests/shared/autograd/test_optimizer_base_part1.mojo
@@ -13,7 +13,7 @@ Split from test_optimizer_base.mojo to comply with ADR-009 (≤10 fn test_ per f
 
 from testing import assert_true
 from tests.shared.conftest import assert_almost_equal
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.autograd import Variable, GradientTape, SGD, Adam, AdaGrad, RMSprop
 from shared.autograd.optimizer_base import validate_learning_rate
 

--- a/tests/shared/autograd/test_optimizer_base_part2.mojo
+++ b/tests/shared/autograd/test_optimizer_base_part2.mojo
@@ -15,7 +15,7 @@ Split from test_optimizer_base.mojo to comply with ADR-009 (≤10 fn test_ per f
 
 from testing import assert_true, assert_equal
 from tests.shared.conftest import assert_almost_equal
-from shared.core.extensor import ExTensor, zeros
+from shared.core.extensor import AnyTensor, zeros
 from shared.autograd import Variable, GradientTape, SGD, Adam, AdaGrad, RMSprop
 from shared.autograd.optimizer_base import (
     zero_grad_impl,
@@ -34,12 +34,12 @@ fn test_zero_grad_implementation() raises:
 
     # Create a variable to register with the tape (gets auto-assigned ID)
     var shape: List[Int] = [1]
-    var data = ExTensor(shape, DType.float32)
+    var data = AnyTensor(shape, DType.float32)
     var param = Variable(data^, True, tape)
     var var_id = param.id
 
     # Add a gradient for this variable
-    var grad = ExTensor(shape, DType.float32)
+    var grad = AnyTensor(shape, DType.float32)
     grad._set_float64(0, 1.0)
     tape.registry.set_grad(var_id, grad^)
 
@@ -64,12 +64,12 @@ fn test_sgd_zero_grad() raises:
 
     # Create a variable to register with tape
     var shape: List[Int] = [1]
-    var data = ExTensor(shape, DType.float32)
+    var data = AnyTensor(shape, DType.float32)
     var param = Variable(data^, True, tape)
     var var_id = param.id
 
     # Add gradient
-    var grad = ExTensor(shape, DType.float32)
+    var grad = AnyTensor(shape, DType.float32)
     tape.registry.set_grad(var_id, grad^)
 
     # Clear gradients
@@ -89,12 +89,12 @@ fn test_adam_zero_grad() raises:
 
     # Create a variable to register with tape
     var shape: List[Int] = [1]
-    var data = ExTensor(shape, DType.float32)
+    var data = AnyTensor(shape, DType.float32)
     var param = Variable(data^, True, tape)
     var var_id = param.id
 
     # Add gradient
-    var grad = ExTensor(shape, DType.float32)
+    var grad = AnyTensor(shape, DType.float32)
     tape.registry.set_grad(var_id, grad^)
 
     # Clear gradients
@@ -115,7 +115,7 @@ fn test_zero_grad_preserves_optimizer_state() raises:
 
     # Create a parameter
     var shape: List[Int] = [2]
-    var data = ExTensor(shape, DType.float32)
+    var data = AnyTensor(shape, DType.float32)
     data._set_float64(0, 1.0)
     data._set_float64(1, 2.0)
 
@@ -125,7 +125,7 @@ fn test_zero_grad_preserves_optimizer_state() raises:
     parameters.append(param.copy())
 
     # Add gradient
-    var grad = ExTensor(shape, DType.float32)
+    var grad = AnyTensor(shape, DType.float32)
     grad._set_float64(0, 0.1)
     grad._set_float64(1, 0.2)
     tape.registry.set_grad(var_id, grad^)
@@ -157,14 +157,14 @@ fn test_clip_gradients_no_clipping_needed() raises:
 
     # Create parameter
     var shape: List[Int] = [3]
-    var data = ExTensor(shape, DType.float32)
+    var data = AnyTensor(shape, DType.float32)
     var param = Variable(data^, True, tape)
     var var_id = param.id
     var parameters: List[Variable] = []
     parameters.append(param.copy())
 
     # Add small gradient (norm < 5.0)
-    var grad = ExTensor(shape, DType.float32)
+    var grad = AnyTensor(shape, DType.float32)
     grad._set_float64(0, 0.1)
     grad._set_float64(1, 0.1)
     grad._set_float64(2, 0.1)
@@ -193,14 +193,14 @@ fn test_clip_gradients_with_clipping() raises:
 
     # Create parameter
     var shape: List[Int] = [3]
-    var data = ExTensor(shape, DType.float32)
+    var data = AnyTensor(shape, DType.float32)
     var param = Variable(data^, True, tape)
     var var_id = param.id
     var parameters: List[Variable] = []
     parameters.append(param.copy())
 
     # Add large gradient (norm > 1.0)
-    var grad = ExTensor(shape, DType.float32)
+    var grad = AnyTensor(shape, DType.float32)
     grad._set_float64(0, 3.0)
     grad._set_float64(1, 4.0)
     grad._set_float64(2, 0.0)

--- a/tests/shared/autograd/test_optimizer_base_part3.mojo
+++ b/tests/shared/autograd/test_optimizer_base_part3.mojo
@@ -16,7 +16,7 @@ Split from test_optimizer_base.mojo to comply with ADR-009 (≤10 fn test_ per f
 
 from testing import assert_true, assert_equal
 from tests.shared.conftest import assert_almost_equal
-from shared.core.extensor import ExTensor, zeros
+from shared.core.extensor import AnyTensor, zeros
 from shared.autograd import Variable, GradientTape, SGD, Adam, AdaGrad, RMSprop
 from shared.autograd.optimizer_base import (
     clip_gradients_by_global_norm,
@@ -36,11 +36,11 @@ fn test_clip_gradients_multiple_parameters() raises:
 
     # Create two parameters
     var shape: List[Int] = [2]
-    var data1 = ExTensor(shape, DType.float32)
+    var data1 = AnyTensor(shape, DType.float32)
     var param1 = Variable(data1^, True, tape)
     var var_id1 = param1.id
 
-    var data2 = ExTensor(shape, DType.float32)
+    var data2 = AnyTensor(shape, DType.float32)
     var param2 = Variable(data2^, True, tape)
     var var_id2 = param2.id
 
@@ -49,12 +49,12 @@ fn test_clip_gradients_multiple_parameters() raises:
     parameters.append(param2.copy())
 
     # Add gradients to both parameters
-    var grad1 = ExTensor(shape, DType.float32)
+    var grad1 = AnyTensor(shape, DType.float32)
     grad1._set_float64(0, 3.0)
     grad1._set_float64(1, 0.0)
     tape.registry.set_grad(var_id1, grad1^)
 
-    var grad2 = ExTensor(shape, DType.float32)
+    var grad2 = AnyTensor(shape, DType.float32)
     grad2._set_float64(0, 0.0)
     grad2._set_float64(1, 4.0)
     tape.registry.set_grad(var_id2, grad2^)
@@ -105,15 +105,15 @@ fn test_count_parameters_with_gradients() raises:
 
     # Create 3 parameters
     var shape: List[Int] = [1]
-    var data1 = ExTensor(shape, DType.float32)
+    var data1 = AnyTensor(shape, DType.float32)
     var param1 = Variable(data1^, True, tape)
     var var_id1 = param1.id
 
-    var data2 = ExTensor(shape, DType.float32)
+    var data2 = AnyTensor(shape, DType.float32)
     var param2 = Variable(data2^, True, tape)
     var var_id2 = param2.id
 
-    var data3 = ExTensor(shape, DType.float32)
+    var data3 = AnyTensor(shape, DType.float32)
     var param3 = Variable(data3^, False, tape)  # Doesn't require grad
 
     var parameters: List[Variable] = []
@@ -122,10 +122,10 @@ fn test_count_parameters_with_gradients() raises:
     parameters.append(param3.copy())
 
     # Add gradients for param1 and param2 only
-    var grad1 = ExTensor(shape, DType.float32)
+    var grad1 = AnyTensor(shape, DType.float32)
     tape.registry.set_grad(var_id1, grad1^)
 
-    var grad2 = ExTensor(shape, DType.float32)
+    var grad2 = AnyTensor(shape, DType.float32)
     tape.registry.set_grad(var_id2, grad2^)
 
     # Count should be 2 (param3 doesn't require grad)
@@ -140,7 +140,7 @@ fn test_count_parameters_with_no_gradients() raises:
 
     # Create parameter without gradient
     var shape: List[Int] = [1]
-    var data = ExTensor(shape, DType.float32)
+    var data = AnyTensor(shape, DType.float32)
     var param = Variable(data^, True, tape)
     var parameters: List[Variable] = []
     parameters.append(param.copy())
@@ -163,7 +163,7 @@ fn test_optimizer_integration_with_gradient_clipping() raises:
 
     # Create parameter
     var shape: List[Int] = [2]
-    var data = ExTensor(shape, DType.float32)
+    var data = AnyTensor(shape, DType.float32)
     data._set_float64(0, 1.0)
     data._set_float64(1, 2.0)
 
@@ -173,7 +173,7 @@ fn test_optimizer_integration_with_gradient_clipping() raises:
     parameters.append(param.copy())
 
     # Add large gradient
-    var grad = ExTensor(shape, DType.float32)
+    var grad = AnyTensor(shape, DType.float32)
     grad._set_float64(0, 10.0)
     grad._set_float64(1, 0.0)
     tape.registry.set_grad(var_id, grad^)

--- a/tests/shared/autograd/test_sgd_momentum.mojo
+++ b/tests/shared/autograd/test_sgd_momentum.mojo
@@ -10,7 +10,7 @@ Verifies:
 
 from testing import assert_true
 from tests.shared.conftest import assert_almost_equal
-from shared.core.extensor import ExTensor, zeros
+from shared.core.extensor import AnyTensor, zeros
 from shared.autograd import Variable, GradientTape, SGD
 
 

--- a/tests/shared/benchmarks/bench_data_loading.mojo
+++ b/tests/shared/benchmarks/bench_data_loading.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     measure_time,
     TestFixtures,
 )
-from shared.core.extensor import ExTensor, zeros, ones, randn
+from shared.core.extensor import AnyTensor, zeros, ones, randn
 from time import perf_counter_ns
 from collections import List
 

--- a/tests/shared/benchmarks/bench_layers.mojo
+++ b/tests/shared/benchmarks/bench_layers.mojo
@@ -20,7 +20,7 @@ from tests.shared.conftest import (
 )
 from shared.core.layers.linear import Linear
 from shared.core.activation import relu, sigmoid, tanh
-from shared.core.extensor import ExTensor, ones, zeros_like
+from shared.core.extensor import AnyTensor, ones, zeros_like
 from time import perf_counter_ns
 from collections import List
 

--- a/tests/shared/benchmarks/bench_optimizers.mojo
+++ b/tests/shared/benchmarks/bench_optimizers.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     measure_time,
     TestFixtures,
 )
-from shared.core.extensor import ExTensor, randn, zeros_like
+from shared.core.extensor import AnyTensor, randn, zeros_like
 from shared.training.optimizers.sgd import sgd_step, sgd_step_simple
 from shared.training.optimizers.adam import adam_step, adam_step_simple
 from time import perf_counter_ns

--- a/tests/shared/conftest.mojo
+++ b/tests/shared/conftest.mojo
@@ -8,7 +8,7 @@ This module provides:
 
 from random import seed
 from time import perf_counter_ns
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.testing import SimpleMLP
 
 # Re-export all assertions from shared.testing.assertions for backward compatibility
@@ -70,11 +70,11 @@ struct TestFixtures:
         seed(Self.deterministic_seed())
 
     @staticmethod
-    fn small_tensor() raises -> ExTensor:
+    fn small_tensor() raises -> AnyTensor:
         """Create small 3x3 tensor for unit tests.
 
         Returns:
-            3x3 ExTensor with deterministic values (0.1).
+            3x3 AnyTensor with deterministic values (0.1).
         """
         from shared.core.extensor import full
 
@@ -84,11 +84,11 @@ struct TestFixtures:
         return full(shape, Float64(0.1), DType.float32)
 
     @staticmethod
-    fn medium_tensor() raises -> ExTensor:
+    fn medium_tensor() raises -> AnyTensor:
         """Create medium 10x10 tensor for unit tests.
 
         Returns:
-            10x10 ExTensor with zeros.
+            10x10 AnyTensor with zeros.
         """
         from shared.core.extensor import zeros
 
@@ -98,11 +98,11 @@ struct TestFixtures:
         return zeros(shape, DType.float32)
 
     @staticmethod
-    fn simple_weights() raises -> ExTensor:
+    fn simple_weights() raises -> AnyTensor:
         """Create simple weight tensor for linear layer tests.
 
         Returns:
-            5x3 ExTensor with deterministic small values.
+            5x3 AnyTensor with deterministic small values.
         """
         from shared.core.extensor import full
 
@@ -112,11 +112,11 @@ struct TestFixtures:
         return full(shape, Float64(0.01), DType.float32)
 
     @staticmethod
-    fn simple_bias() raises -> ExTensor:
+    fn simple_bias() raises -> AnyTensor:
         """Create simple bias tensor for linear layer tests.
 
         Returns:
-            5-element ExTensor with zeros.
+            5-element AnyTensor with zeros.
         """
         from shared.core.extensor import zeros
 
@@ -127,7 +127,7 @@ struct TestFixtures:
     @staticmethod
     fn synthetic_data(
         n_samples: Int = 100, n_features: Int = 10
-    ) raises -> ExTensor:
+    ) raises -> AnyTensor:
         """Create synthetic data tensor for testing.
 
         Args:
@@ -135,7 +135,7 @@ struct TestFixtures:
             n_features: Number of features (columns).
 
         Returns:
-            ExTensor of shape (n_samples, n_features) with random values.
+            AnyTensor of shape (n_samples, n_features) with random values.
         """
         from shared.core.extensor import randn
 
@@ -145,14 +145,14 @@ struct TestFixtures:
         return randn(shape, DType.float32)
 
     @staticmethod
-    fn synthetic_labels(n_samples: Int = 100) raises -> ExTensor:
+    fn synthetic_labels(n_samples: Int = 100) raises -> AnyTensor:
         """Create synthetic label tensor for testing.
 
         Args:
             n_samples: Number of samples.
 
         Returns:
-            ExTensor of shape (n_samples,) with binary labels (0 or 1).
+            AnyTensor of shape (n_samples,) with binary labels (0 or 1).
         """
         from shared.core.extensor import zeros
 

--- a/tests/shared/data/datasets/test_emnist_part1.mojo
+++ b/tests/shared/data/datasets/test_emnist_part1.mojo
@@ -11,8 +11,8 @@ high test load. Split from test_emnist.mojo. See docs/adr/ADR-009-heap-corruptio
 """
 
 from testing import assert_equal, assert_true, assert_false, assert_raises
-from shared.data import EMNISTDataset, ExTensorDataset, Dataset
-from shared.core.extensor import ExTensor
+from shared.data import EMNISTDataset, AnyTensorDataset, Dataset
+from shared.core.extensor import AnyTensor
 
 
 # ============================================================================
@@ -137,7 +137,7 @@ fn test_emnist_getitem_index() raises:
         var sample_data, sample_label = dataset.__getitem__(0)
         _ = sample_label  # Consume unused variable
 
-        # Verify sample is a valid ExTensor
+        # Verify sample is a valid AnyTensor
         var data_shape = sample_data.shape()
         assert_equal(
             len(data_shape), 4, "Image should have 4 dimensions (N, C, H, W)"

--- a/tests/shared/data/datasets/test_emnist_part2.mojo
+++ b/tests/shared/data/datasets/test_emnist_part2.mojo
@@ -3,7 +3,7 @@
 Tests cover:
 - Dataset shape validation
 - Class count validation for each split
-- Integration with ExTensorDataset
+- Integration with AnyTensorDataset
 
 ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
@@ -11,8 +11,8 @@ high test load. Split from test_emnist.mojo. See docs/adr/ADR-009-heap-corruptio
 """
 
 from testing import assert_equal, assert_true, assert_false, assert_raises
-from shared.data import EMNISTDataset, ExTensorDataset, Dataset
-from shared.core.extensor import ExTensor
+from shared.data import EMNISTDataset, AnyTensorDataset, Dataset
+from shared.core.extensor import AnyTensor
 
 
 # ============================================================================
@@ -118,25 +118,25 @@ fn test_emnist_num_classes_mnist() raises:
 
 
 fn test_emnist_get_train_data() raises:
-    """Test get_train_data() returns ExTensorDataset.
+    """Test get_train_data() returns AnyTensorDataset.
 
-    Verifies that the method wraps data in ExTensorDataset correctly.
+    Verifies that the method wraps data in AnyTensorDataset correctly.
     """
     try:
         var dataset = EMNISTDataset("/tmp/emnist", split="balanced", train=True)
         var tensor_dataset = dataset.get_train_data()
 
-        # Verify it's a valid ExTensorDataset
+        # Verify it's a valid AnyTensorDataset
         var length = tensor_dataset.__len__()
-        assert_true(length > 0, "ExTensorDataset should have samples")
+        assert_true(length > 0, "AnyTensorDataset should have samples")
     except e:
         print("Test data not available - skipping get_train_data test")
 
 
 fn test_emnist_get_test_data() raises:
-    """Test get_test_data() returns ExTensorDataset.
+    """Test get_test_data() returns AnyTensorDataset.
 
-    Verifies that the method wraps data in ExTensorDataset correctly.
+    Verifies that the method wraps data in AnyTensorDataset correctly.
     """
     try:
         var dataset = EMNISTDataset(
@@ -144,9 +144,9 @@ fn test_emnist_get_test_data() raises:
         )
         var tensor_dataset = dataset.get_test_data()
 
-        # Verify it's a valid ExTensorDataset
+        # Verify it's a valid AnyTensorDataset
         var length = tensor_dataset.__len__()
-        assert_true(length > 0, "ExTensorDataset should have samples")
+        assert_true(length > 0, "AnyTensorDataset should have samples")
     except e:
         print("Test data not available - skipping get_test_data test")
 

--- a/tests/shared/data/datasets/test_emnist_part3.mojo
+++ b/tests/shared/data/datasets/test_emnist_part3.mojo
@@ -12,8 +12,8 @@ high test load. Split from test_emnist.mojo. See docs/adr/ADR-009-heap-corruptio
 """
 
 from testing import assert_equal, assert_true, assert_false, assert_raises
-from shared.data import EMNISTDataset, ExTensorDataset, Dataset
-from shared.core.extensor import ExTensor
+from shared.data import EMNISTDataset, AnyTensorDataset, Dataset
+from shared.core.extensor import AnyTensor
 
 
 # ============================================================================

--- a/tests/shared/data/datasets/test_tensor_dataset.mojo
+++ b/tests/shared/data/datasets/test_tensor_dataset.mojo
@@ -11,7 +11,7 @@ from tests.shared.conftest import (
     TestFixtures,
 )
 from shared.data.datasets import TensorDataset
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 
 
 # ============================================================================
@@ -157,9 +157,9 @@ fn test_tensor_dataset_negative_indexing() raises:
     dataset[-2] the second-to-last, etc.
     """
     var data_list: List[Float32] = [Float32(1.0), Float32(2.0), Float32(3.0)]
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
     var labels_list: List[Int] = [0, 1, 2]
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
     var dataset = TensorDataset(data^, labels^)
 
     var last_sample = dataset[-1]
@@ -178,9 +178,9 @@ fn test_tensor_dataset_out_of_bounds() raises:
     should raise IndexError to prevent silent failures.
     """
     var data_list: List[Float32] = [Float32(1.0), Float32(2.0), Float32(3.0)]
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
     var labels_list: List[Int] = [0, 1, 2]
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
     var dataset = TensorDataset(data^, labels^)
 
     # Test positive out of bounds
@@ -207,9 +207,9 @@ fn test_tensor_dataset_iteration_consistency() raises:
     ensuring deterministic behavior for debugging and testing.
     """
     var data_list: List[Float32] = [Float32(1.0), Float32(2.0)]
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
     var labels_list: List[Int] = [0, 1]
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
     var dataset = TensorDataset(data^, labels^)
 
     var sample1 = dataset[0]
@@ -234,9 +234,9 @@ fn test_tensor_dataset_no_copy_on_access() raises:
     rather than creating copies, reducing memory overhead.
     """
     var data_list: List[Float32] = [Float32(1.0), Float32(2.0)]
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
     var labels_list: List[Int] = [0, 1]
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
     var dataset = TensorDataset(data^, labels^)
 
     # Access first sample
@@ -266,8 +266,8 @@ fn test_tensor_dataset_memory_efficiency() raises:
         data.append(Float32(i))
         labels.append(i)
 
-    var data_tensor = ExTensor(data^)
-    var labels_tensor = ExTensor(labels^)
+    var data_tensor = AnyTensor(data^)
+    var labels_tensor = AnyTensor(labels^)
     var dataset = TensorDataset(data_tensor^, labels_tensor^)
 
     # Verify dataset was created successfully with all samples

--- a/tests/shared/data/formats/test_cifar_loader_part1.mojo
+++ b/tests/shared/data/formats/test_cifar_loader_part1.mojo
@@ -15,7 +15,7 @@ Run with: mojo test tests/shared/data/formats/test_cifar_loader_part1.mojo
 
 from collections import List
 from memory import UnsafePointer
-from shared.core.extensor import ExTensor, zeros
+from shared.core.extensor import AnyTensor, zeros
 from shared.data.formats import (
     CIFARLoader,
     CIFAR10_BYTES_PER_IMAGE,

--- a/tests/shared/data/loaders/test_batch_loader_part1.mojo
+++ b/tests/shared/data/loaders/test_batch_loader_part1.mojo
@@ -14,7 +14,7 @@ from tests.shared.conftest import (
 from shared.data.datasets import TensorDataset
 from shared.data.loaders import BatchLoader
 from shared.data.samplers import SequentialSampler, RandomSampler
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 
 
 # ============================================================================
@@ -31,11 +31,11 @@ fn test_batch_loader_fixed_batch_size() raises:
     var data_list = List[Float32]()
     for i in range(100):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
     var labels_list = List[Int]()
     for i in range(100):
         labels_list.append(i)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
     var dataset = TensorDataset(data^, labels^)
     var dataset_len = dataset.__len__()
     var sampler = SequentialSampler(dataset_len)
@@ -54,11 +54,11 @@ fn test_batch_loader_perfect_division() raises:
     var data_list = List[Float32]()
     for i in range(96):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
     var labels_list = List[Int]()
     for i in range(96):
         labels_list.append(i)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
     var dataset = TensorDataset(data^, labels^)
     var dataset_len = dataset.__len__()
     var sampler = SequentialSampler(dataset_len)
@@ -78,7 +78,7 @@ fn test_batch_loader_partial_last_batch() raises:
         data_list.append(Float32(i))
     var data_shape = List[Int]()
     data_shape.append(100)
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
 
@@ -87,7 +87,7 @@ fn test_batch_loader_partial_last_batch() raises:
         labels_list.append(i)
     var labels_shape = List[Int]()
     labels_shape.append(100)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     for i in range(len(labels_list)):
         labels._set_int32(i, Int32(labels_list[i]))
 
@@ -107,7 +107,7 @@ fn test_batch_loader_partial_last_batch() raises:
         data_list2.append(Float32(i))
     var data_shape2 = List[Int]()
     data_shape2.append(100)
-    var data2 = ExTensor(data_shape2, DType.float32)
+    var data2 = AnyTensor(data_shape2, DType.float32)
     for i in range(len(data_list2)):
         data2._set_float32(i, data_list2[i])
 
@@ -116,7 +116,7 @@ fn test_batch_loader_partial_last_batch() raises:
         labels_list2.append(i)
     var labels_shape2 = List[Int]()
     labels_shape2.append(100)
-    var labels2 = ExTensor(labels_shape2, DType.int32)
+    var labels2 = AnyTensor(labels_shape2, DType.int32)
     for i in range(len(labels_list2)):
         labels2._set_int32(i, Int32(labels_list2[i]))
 
@@ -140,7 +140,7 @@ fn test_batch_loader_tensor_stacking() raises:
         data_list.append(Float32(i))
     var data_shape = List[Int]()
     data_shape.append(100)
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
 
@@ -149,7 +149,7 @@ fn test_batch_loader_tensor_stacking() raises:
         labels_list.append(i)
     var labels_shape = List[Int]()
     labels_shape.append(100)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     for i in range(len(labels_list)):
         labels._set_int32(i, Int32(labels_list[i]))
 
@@ -178,7 +178,7 @@ fn test_batch_loader_no_shuffle() raises:
         data_list.append(Float32(i))
     var data_shape = List[Int]()
     data_shape.append(100)
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
     var labels_list = List[Int]()
@@ -186,7 +186,7 @@ fn test_batch_loader_no_shuffle() raises:
         labels_list.append(i)
     var labels_shape = List[Int]()
     labels_shape.append(100)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     for i in range(len(labels_list)):
         labels._set_int32(i, Int32(labels_list[i]))
     var dataset = TensorDataset(data^, labels^)
@@ -209,7 +209,7 @@ fn test_batch_loader_shuffle() raises:
         data_list.append(Float32(i))
     var data_shape = List[Int]()
     data_shape.append(100)
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
     var labels_list = List[Int]()
@@ -217,7 +217,7 @@ fn test_batch_loader_shuffle() raises:
         labels_list.append(i)
     var labels_shape = List[Int]()
     labels_shape.append(100)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     for i in range(len(labels_list)):
         labels._set_int32(i, Int32(labels_list[i]))
     var dataset = TensorDataset(data^, labels^)
@@ -240,7 +240,7 @@ fn test_batch_loader_shuffle_deterministic() raises:
         data_list.append(Float32(i))
     var data_shape = List[Int]()
     data_shape.append(100)
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
     var labels_list = List[Int]()
@@ -248,7 +248,7 @@ fn test_batch_loader_shuffle_deterministic() raises:
         labels_list.append(i)
     var labels_shape = List[Int]()
     labels_shape.append(100)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     for i in range(len(labels_list)):
         labels._set_int32(i, Int32(labels_list[i]))
     var dataset = TensorDataset(data^, labels^)
@@ -269,7 +269,7 @@ fn test_batch_loader_shuffle_per_epoch() raises:
         data_list.append(Float32(i))
     var data_shape = List[Int]()
     data_shape.append(100)
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
     var labels_list = List[Int]()
@@ -277,7 +277,7 @@ fn test_batch_loader_shuffle_per_epoch() raises:
         labels_list.append(i)
     var labels_shape = List[Int]()
     labels_shape.append(100)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     for i in range(len(labels_list)):
         labels._set_int32(i, Int32(labels_list[i]))
     var dataset = TensorDataset(data^, labels^)
@@ -304,13 +304,13 @@ fn test_batch_loader_1d_data() raises:
     """
     var data_shape = List[Int]()
     data_shape.append(8)  # 1D tensor with 8 elements
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(8):
         data._set_float32(i, Float32(i))
 
     var labels_shape = List[Int]()
     labels_shape.append(8)  # Labels also 1D: 8 elements
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     for i in range(8):
         labels._set_int32(i, Int32(i * 10))
 

--- a/tests/shared/data/loaders/test_batch_loader_part2.mojo
+++ b/tests/shared/data/loaders/test_batch_loader_part2.mojo
@@ -14,7 +14,7 @@ from tests.shared.conftest import (
 from shared.data.datasets import TensorDataset
 from shared.data.loaders import BatchLoader
 from shared.data.samplers import SequentialSampler, RandomSampler
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 
 
 # ============================================================================
@@ -33,7 +33,7 @@ fn test_batch_loader_all_samples_per_epoch() raises:
         data_list.append(Float32(i))
     var data_shape = List[Int]()
     data_shape.append(100)
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
     var labels_list = List[Int]()
@@ -41,7 +41,7 @@ fn test_batch_loader_all_samples_per_epoch() raises:
         labels_list.append(i)
     var labels_shape = List[Int]()
     labels_shape.append(100)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     for i in range(len(labels_list)):
         labels._set_int32(i, Int32(labels_list[i]))
     var dataset = TensorDataset(data^, labels^)
@@ -70,7 +70,7 @@ fn test_batch_loader_efficient_batching() raises:
         data_list.append(Float32(i))
     var data_shape = List[Int]()
     data_shape.append(1000)
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
     var labels_list = List[Int]()
@@ -78,7 +78,7 @@ fn test_batch_loader_efficient_batching() raises:
         labels_list.append(i)
     var labels_shape = List[Int]()
     labels_shape.append(1000)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     for i in range(len(labels_list)):
         labels._set_int32(i, Int32(labels_list[i]))
     var dataset = TensorDataset(data^, labels^)
@@ -101,7 +101,7 @@ fn test_batch_loader_iteration_speed() raises:
         data_list.append(Float32(i))
     var data_shape = List[Int]()
     data_shape.append(3200)
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
     var labels_list = List[Int]()
@@ -109,7 +109,7 @@ fn test_batch_loader_iteration_speed() raises:
         labels_list.append(i)
     var labels_shape = List[Int]()
     labels_shape.append(3200)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     for i in range(len(labels_list)):
         labels._set_int32(i, Int32(labels_list[i]))
     var dataset = TensorDataset(data^, labels^)

--- a/tests/shared/data/test_cache_part1.mojo
+++ b/tests/shared/data/test_cache_part1.mojo
@@ -11,8 +11,8 @@ from tests.shared.conftest import (
     assert_equal,
     assert_almost_equal,
 )
-from shared.data import ExTensorDataset, CachedDataset
-from shared.core.extensor import ExTensor, ones, zeros
+from shared.data import AnyTensorDataset, CachedDataset
+from shared.core.extensor import AnyTensor, ones, zeros
 from collections import List
 
 
@@ -32,7 +32,7 @@ fn test_cached_dataset_creation() raises:
     var data = ones(data_shape, DType.float32)
     var labels = zeros(label_shape, DType.float32)
 
-    var base_dataset = ExTensorDataset(data^, labels^)
+    var base_dataset = AnyTensorDataset(data^, labels^)
     var cached = CachedDataset(base_dataset^, max_cache_size=-1)
 
     assert_equal(cached.__len__(), 10)
@@ -50,7 +50,7 @@ fn test_cached_dataset_length() raises:
     var data = ones(data_shape, DType.float32)
     var labels = zeros(label_shape, DType.float32)
 
-    var base_dataset = ExTensorDataset(data^, labels^)
+    var base_dataset = AnyTensorDataset(data^, labels^)
     var cached = CachedDataset(base_dataset^, max_cache_size=-1)
 
     assert_equal(cached.__len__(), 42)
@@ -67,7 +67,7 @@ fn test_cached_dataset_stores_samples() raises:
     var data = ones(data_shape, DType.float32)
     var labels = zeros(label_shape, DType.float32)
 
-    var base_dataset = ExTensorDataset(data^, labels^)
+    var base_dataset = AnyTensorDataset(data^, labels^)
     var cached = CachedDataset(base_dataset^, max_cache_size=-1)
 
     # Access a sample via mutable method
@@ -88,7 +88,7 @@ fn test_cached_dataset_cache_hit() raises:
     var data = ones(data_shape, DType.float32)
     var labels = zeros(label_shape, DType.float32)
 
-    var base_dataset = ExTensorDataset(data^, labels^)
+    var base_dataset = AnyTensorDataset(data^, labels^)
     var cached = CachedDataset(base_dataset^, max_cache_size=-1)
 
     # First access - cache miss
@@ -113,7 +113,7 @@ fn test_cached_dataset_max_cache_size() raises:
     var data = ones(data_shape, DType.float32)
     var labels = zeros(label_shape, DType.float32)
 
-    var base_dataset = ExTensorDataset(data^, labels^)
+    var base_dataset = AnyTensorDataset(data^, labels^)
     var cached = CachedDataset(base_dataset^, max_cache_size=3)
 
     # Access 5 samples via mutable method
@@ -135,7 +135,7 @@ fn test_cached_dataset_disabled_cache() raises:
     var data = ones(data_shape, DType.float32)
     var labels = zeros(label_shape, DType.float32)
 
-    var base_dataset = ExTensorDataset(data^, labels^)
+    var base_dataset = AnyTensorDataset(data^, labels^)
     var cached = CachedDataset(
         base_dataset^, max_cache_size=-1, cache_enabled=False
     )
@@ -157,7 +157,7 @@ fn test_cached_dataset_preload_cache() raises:
     var data = ones(data_shape, DType.float32)
     var labels = zeros(label_shape, DType.float32)
 
-    var base_dataset = ExTensorDataset(data^, labels^)
+    var base_dataset = AnyTensorDataset(data^, labels^)
     var cached = CachedDataset(base_dataset^, max_cache_size=-1)
 
     cached._preload_cache()
@@ -177,7 +177,7 @@ fn test_cached_dataset_clear_cache() raises:
     var data = ones(data_shape, DType.float32)
     var labels = zeros(label_shape, DType.float32)
 
-    var base_dataset = ExTensorDataset(data^, labels^)
+    var base_dataset = AnyTensorDataset(data^, labels^)
     var cached = CachedDataset(base_dataset^, max_cache_size=-1)
 
     # Add to cache

--- a/tests/shared/data/test_cache_part2.mojo
+++ b/tests/shared/data/test_cache_part2.mojo
@@ -11,8 +11,8 @@ from tests.shared.conftest import (
     assert_equal,
     assert_almost_equal,
 )
-from shared.data import ExTensorDataset, CachedDataset
-from shared.core.extensor import ExTensor, ones, zeros
+from shared.data import AnyTensorDataset, CachedDataset
+from shared.core.extensor import AnyTensor, ones, zeros
 from collections import List
 
 
@@ -32,7 +32,7 @@ fn test_cached_dataset_enable_disable() raises:
     var data = ones(data_shape, DType.float32)
     var labels = zeros(label_shape, DType.float32)
 
-    var base_dataset = ExTensorDataset(data^, labels^)
+    var base_dataset = AnyTensorDataset(data^, labels^)
     var cached = CachedDataset(base_dataset^, max_cache_size=-1)
 
     # Cache is enabled by default
@@ -58,7 +58,7 @@ fn test_cached_dataset_hit_rate() raises:
     var data = ones(data_shape, DType.float32)
     var labels = zeros(label_shape, DType.float32)
 
-    var base_dataset = ExTensorDataset(data^, labels^)
+    var base_dataset = AnyTensorDataset(data^, labels^)
     var cached = CachedDataset(base_dataset^, max_cache_size=-1)
 
     # No accesses yet - should return 0.0
@@ -83,7 +83,7 @@ fn test_cached_dataset_get_stats() raises:
     var data = ones(data_shape, DType.float32)
     var labels = zeros(label_shape, DType.float32)
 
-    var base_dataset = ExTensorDataset(data^, labels^)
+    var base_dataset = AnyTensorDataset(data^, labels^)
     var cached = CachedDataset(base_dataset^, max_cache_size=-1)
 
     var _d1, _l1 = cached._get_and_cache(0)

--- a/tests/shared/data/test_dataset_with_transform.mojo
+++ b/tests/shared/data/test_dataset_with_transform.mojo
@@ -9,9 +9,9 @@ from tests.shared.conftest import (
     assert_equal,
     TestFixtures,
 )
-from shared.data import ExTensorDataset, TransformedDataset
+from shared.data import AnyTensorDataset, TransformedDataset
 from shared.data.transforms import Normalize
-from shared.core.extensor import ExTensor, ones, zeros
+from shared.core.extensor import AnyTensor, ones, zeros
 from collections import List
 
 
@@ -31,7 +31,7 @@ fn test_transformed_dataset_creation() raises:
     var data = ones(data_shape, DType.float32)
     var labels = zeros(label_shape, DType.float32)
 
-    var base_dataset = ExTensorDataset(data^, labels^)
+    var base_dataset = AnyTensorDataset(data^, labels^)
     var normalize = Normalize(mean=0.5, std=0.5)
     var transformed = TransformedDataset(base_dataset^, normalize^)
 
@@ -49,7 +49,7 @@ fn test_transformed_dataset_length() raises:
     var data = ones(data_shape, DType.float32)
     var labels = zeros(label_shape, DType.float32)
 
-    var base_dataset = ExTensorDataset(data^, labels^)
+    var base_dataset = AnyTensorDataset(data^, labels^)
     var normalize = Normalize(mean=0.5, std=0.5)
     var transformed = TransformedDataset(base_dataset^, normalize^)
 
@@ -67,7 +67,7 @@ fn test_transformed_dataset_applies_transform() raises:
     var data = ones(data_shape, DType.float32)
     var labels = zeros(label_shape, DType.float32)
 
-    var base_dataset = ExTensorDataset(data^, labels^)
+    var base_dataset = AnyTensorDataset(data^, labels^)
     var normalize = Normalize(mean=0.5, std=0.5)
     var transformed = TransformedDataset(base_dataset^, normalize^)
 
@@ -95,7 +95,7 @@ fn test_transformed_dataset_preserves_labels() raises:
     var data = ones(data_shape, DType.float32)
     var labels = zeros(label_shape, DType.float32)
 
-    var base_dataset = ExTensorDataset(data^, labels^)
+    var base_dataset = AnyTensorDataset(data^, labels^)
     var normalize = Normalize(mean=0.5, std=0.5)
     var transformed = TransformedDataset(base_dataset^, normalize^)
 
@@ -119,7 +119,7 @@ fn test_transformed_dataset_all_samples() raises:
     var data = ones(data_shape, DType.float32)
     var labels = zeros(label_shape, DType.float32)
 
-    var base_dataset = ExTensorDataset(data^, labels^)
+    var base_dataset = AnyTensorDataset(data^, labels^)
     var normalize = Normalize(mean=0.5, std=0.5)
     var transformed = TransformedDataset(base_dataset^, normalize^)
 

--- a/tests/shared/data/test_datasets_part1.mojo
+++ b/tests/shared/data/test_datasets_part1.mojo
@@ -20,10 +20,10 @@ from tests.shared.conftest import (
     assert_greater,
     TestFixtures,
 )
-from shared.data.datasets import ExTensorDataset
+from shared.data.datasets import AnyTensorDataset
 from shared.data.loaders import BatchLoader
 from shared.data.samplers import SequentialSampler
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 
 
 # ============================================================================
@@ -32,12 +32,12 @@ from shared.core.extensor import ExTensor
 
 
 fn test_dataset_length_consistency() raises:
-    """Test ExTensorDataset reports correct length.
+    """Test AnyTensorDataset reports correct length.
 
     __len__() should match actual number of samples in first dimension.
 
     Integration Points:
-        - ExTensorDataset initialization
+        - AnyTensorDataset initialization
         - Length metadata accuracy
 
     Success Criteria:
@@ -49,21 +49,21 @@ fn test_dataset_length_consistency() raises:
     var data_list = List[Float32]()
     for i in range(100):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     for i in range(100):
         labels_list.append(i)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
 
     # Check length matches
     assert_equal(dataset.__len__(), 100)
 
 
 fn test_dataset_sequential_access() raises:
-    """Test ExTensorDataset supports sequential __getitem__ access.
+    """Test AnyTensorDataset supports sequential __getitem__ access.
 
     Should be able to retrieve samples by index in order.
 
@@ -82,14 +82,14 @@ fn test_dataset_sequential_access() raises:
     var data_list = List[Float32]()
     for i in range(10):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     for i in range(10):
         labels_list.append(i * 2)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
 
     # Access first sample
     var sample0 = dataset.__getitem__(0)
@@ -103,7 +103,7 @@ fn test_dataset_sequential_access() raises:
 
 
 fn test_dataset_negative_indexing() raises:
-    """Test ExTensorDataset supports negative indexing.
+    """Test AnyTensorDataset supports negative indexing.
 
     Negative indices count from end: -1 is last, -2 is second-to-last, etc.
 
@@ -121,14 +121,14 @@ fn test_dataset_negative_indexing() raises:
     var data_list = List[Float32]()
     for i in range(20):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     for i in range(20):
         labels_list.append(i)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
 
     # Access with negative indices
     var last = dataset.__getitem__(-1)
@@ -139,7 +139,7 @@ fn test_dataset_negative_indexing() raises:
 
 
 fn test_dataset_bounds_checking() raises:
-    """Test ExTensorDataset handles out-of-bounds access properly.
+    """Test AnyTensorDataset handles out-of-bounds access properly.
 
     Accessing index >= len() should raise error.
     Accessing very negative index should raise error.
@@ -157,14 +157,14 @@ fn test_dataset_bounds_checking() raises:
     var data_list = List[Float32]()
     for i in range(10):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     for i in range(10):
         labels_list.append(i)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
 
     # Valid access should work
     var valid = dataset.__getitem__(0)
@@ -174,12 +174,12 @@ fn test_dataset_bounds_checking() raises:
 
 
 fn test_dataset_with_loader() raises:
-    """Test ExTensorDataset works seamlessly with BatchLoader.
+    """Test AnyTensorDataset works seamlessly with BatchLoader.
 
     Dataset should integrate with loader for batching.
 
     Integration Points:
-        - ExTensorDataset + BatchLoader
+        - AnyTensorDataset + BatchLoader
         - Loader batch count calculation
         - Dataset trait conformance
 
@@ -193,14 +193,14 @@ fn test_dataset_with_loader() raises:
     var data_list = List[Float32]()
     for i in range(100):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     for i in range(100):
         labels_list.append(i)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
     var dataset_len = dataset.__len__()
 
     var sampler = SequentialSampler(dataset_len)
@@ -216,7 +216,7 @@ fn test_dataset_with_loader() raises:
 
 
 fn test_tensor_dataset_batching_shapes() raises:
-    """Test ExTensorDataset produces correct shapes when batched.
+    """Test AnyTensorDataset produces correct shapes when batched.
 
     When batches are created from 1D input, batch shape should be [batch_size].
 
@@ -234,21 +234,21 @@ fn test_tensor_dataset_batching_shapes() raises:
     var data_list = List[Float32]()
     for i in range(50):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     for i in range(50):
         labels_list.append(i)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
     var dataset_len = dataset.__len__()
 
     assert_equal(dataset_len, 50)
 
 
 fn test_dataset_random_access() raises:
-    """Test ExTensorDataset supports random access via samplers.
+    """Test AnyTensorDataset supports random access via samplers.
 
     Can access arbitrary indices via __getitem__ in any order.
 
@@ -266,14 +266,14 @@ fn test_dataset_random_access() raises:
     var data_list = List[Float32]()
     for i in range(20):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     for i in range(20):
         labels_list.append(i)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
 
     # Access in non-sequential order
     var s0 = dataset.__getitem__(0)
@@ -291,7 +291,7 @@ fn test_dataset_random_access() raises:
 
 
 fn test_dataset_interface_protocol() raises:
-    """Test ExTensorDataset conforms to Dataset trait protocol.
+    """Test AnyTensorDataset conforms to Dataset trait protocol.
 
     Must implement __len__() and __getitem__() correctly.
 
@@ -310,14 +310,14 @@ fn test_dataset_interface_protocol() raises:
     var data_list = List[Float32]()
     for i in range(30):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     for i in range(30):
         labels_list.append(i)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
 
     # Both methods should be accessible
     var len_val = dataset.__len__()

--- a/tests/shared/data/test_datasets_part2.mojo
+++ b/tests/shared/data/test_datasets_part2.mojo
@@ -1,6 +1,6 @@
 """High-level integration tests for dataset abstractions (Part 2 of 2).
 
-Tests cover edge cases and advanced access patterns for ExTensorDataset.
+Tests cover edge cases and advanced access patterns for AnyTensorDataset.
 Individual unit tests exist in datasets/ subdirectory.
 
 ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
@@ -20,10 +20,10 @@ from tests.shared.conftest import (
     assert_greater,
     TestFixtures,
 )
-from shared.data.datasets import ExTensorDataset
+from shared.data.datasets import AnyTensorDataset
 from shared.data.loaders import BatchLoader
 from shared.data.samplers import SequentialSampler
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 
 
 # ============================================================================
@@ -32,7 +32,7 @@ from shared.core.extensor import ExTensor
 
 
 fn test_dataset_small_size() raises:
-    """Test ExTensorDataset with very small number of samples.
+    """Test AnyTensorDataset with very small number of samples.
 
     Should handle minimal datasets (2-5 samples) correctly.
 
@@ -50,19 +50,19 @@ fn test_dataset_small_size() raises:
     var data_list = List[Float32]()
     data_list.append(1.0)
     data_list.append(2.0)
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     labels_list.append(0)
     labels_list.append(1)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
     assert_equal(dataset.__len__(), 2)
 
 
 fn test_dataset_single_sample() raises:
-    """Test ExTensorDataset with single sample (minimal edge case).
+    """Test AnyTensorDataset with single sample (minimal edge case).
 
     Should handle 1-sample datasets correctly.
 
@@ -80,13 +80,13 @@ fn test_dataset_single_sample() raises:
 
     var data_list = List[Float32]()
     data_list.append(42.0)
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     labels_list.append(99)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
 
     assert_equal(dataset.__len__(), 1)
     var s0 = dataset.__getitem__(0)
@@ -94,7 +94,7 @@ fn test_dataset_single_sample() raises:
 
 
 fn test_dataset_large_size() raises:
-    """Test ExTensorDataset with larger number of samples.
+    """Test AnyTensorDataset with larger number of samples.
 
     Should scale to thousands of samples without issues.
 
@@ -113,19 +113,19 @@ fn test_dataset_large_size() raises:
     var data_list = List[Float32]()
     for i in range(1000):
         data_list.append(Float32(i % 100) / 100.0)
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     for i in range(1000):
         labels_list.append(i % 10)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
     assert_equal(dataset.__len__(), 1000)
 
 
 fn test_dataset_repeated_access() raises:
-    """Test ExTensorDataset handles repeated access to same sample.
+    """Test AnyTensorDataset handles repeated access to same sample.
 
     Accessing the same index multiple times should always return same sample.
 
@@ -143,14 +143,14 @@ fn test_dataset_repeated_access() raises:
     var data_list = List[Float32]()
     for i in range(10):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     for i in range(10):
         labels_list.append(i)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
 
     # Access same sample multiple times
     var s5_a = dataset.__getitem__(5)
@@ -162,7 +162,7 @@ fn test_dataset_repeated_access() raises:
 
 
 fn test_dataset_with_different_batch_sizes() raises:
-    """Test ExTensorDataset works with various batch sizes in loader.
+    """Test AnyTensorDataset works with various batch sizes in loader.
 
     Should integrate with loaders using different batch_size values.
 
@@ -180,14 +180,14 @@ fn test_dataset_with_different_batch_sizes() raises:
     var data_list = List[Float32]()
     for i in range(100):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     for i in range(100):
         labels_list.append(i)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
     var dataset_len = dataset.__len__()
 
     # Verify dataset reports correct length

--- a/tests/shared/data/test_loaders.mojo
+++ b/tests/shared/data/test_loaders.mojo
@@ -17,10 +17,10 @@ from tests.shared.conftest import (
     assert_greater,
     TestFixtures,
 )
-from shared.data.datasets import ExTensorDataset
+from shared.data.datasets import AnyTensorDataset
 from shared.data.loaders import BatchLoader
 from shared.data.samplers import SequentialSampler, RandomSampler
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 
 
 # ============================================================================
@@ -32,7 +32,7 @@ fn test_loader_dataset_sampler_integration() raises:
     """Test BatchLoader works end-to-end with TensorDataset and SequentialSampler.
 
     Integration Points:
-        - ExTensorDataset initialization
+        - AnyTensorDataset initialization
         - SequentialSampler index generation
         - BatchLoader iteration with both components
 
@@ -47,14 +47,14 @@ fn test_loader_dataset_sampler_integration() raises:
     var data_list = List[Float32]()
     for i in range(100):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     for i in range(100):
         labels_list.append(i)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
     var dataset_len = dataset.__len__()
 
     # Create sampler
@@ -87,14 +87,14 @@ fn test_loader_perfect_batch_division() raises:
     var data_list = List[Float32]()
     for i in range(96):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     for i in range(96):
         labels_list.append(i)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
     var dataset_len = dataset.__len__()
     var sampler = SequentialSampler(dataset_len)
     var loader = BatchLoader(dataset^, sampler^, batch_size=32, shuffle=False)
@@ -121,14 +121,14 @@ fn test_loader_drop_last_enabled() raises:
     var data_list = List[Float32]()
     for i in range(100):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     for i in range(100):
         labels_list.append(i)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
     var dataset_len = dataset.__len__()
     var sampler = SequentialSampler(dataset_len)
     var loader = BatchLoader(dataset^, sampler^, batch_size=32, drop_last=True)
@@ -156,14 +156,14 @@ fn test_loader_batch_size_larger_than_dataset() raises:
     var data_list = List[Float32]()
     for i in range(10):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     for i in range(10):
         labels_list.append(i)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
     var dataset_len = dataset.__len__()
     var sampler = SequentialSampler(dataset_len)
 
@@ -191,13 +191,13 @@ fn test_loader_single_sample_dataset() raises:
 
     var data_list = List[Float32]()
     data_list.append(42.0)
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     labels_list.append(0)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
     var dataset_len = dataset.__len__()
     var sampler = SequentialSampler(dataset_len)
     var loader = BatchLoader(dataset^, sampler^, batch_size=32, shuffle=False)
@@ -317,14 +317,14 @@ fn test_loader_small_batch_size() raises:
     var data_list = List[Float32]()
     for i in range(10):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     for i in range(10):
         labels_list.append(i)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
     var dataset_len = dataset.__len__()
     var sampler = SequentialSampler(dataset_len)
     var loader = BatchLoader(dataset^, sampler^, batch_size=1, shuffle=False)
@@ -350,14 +350,14 @@ fn test_loader_large_batch_size() raises:
     var data_list = List[Float32]()
     for i in range(100):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     for i in range(100):
         labels_list.append(i)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
     var dataset_len = dataset.__len__()
     var sampler = SequentialSampler(dataset_len)
     var loader = BatchLoader(dataset^, sampler^, batch_size=128, shuffle=False)

--- a/tests/shared/data/test_prefetch.mojo
+++ b/tests/shared/data/test_prefetch.mojo
@@ -8,14 +8,14 @@ from tests.shared.conftest import (
     assert_equal,
 )
 from shared.data import (
-    ExTensorDataset,
+    AnyTensorDataset,
     BatchLoader,
     RandomSampler,
     TransformedDataset,
 )
 from shared.data.prefetch import PrefetchBuffer, PrefetchDataLoader
 from shared.data.loaders import Batch
-from shared.core.extensor import ExTensor, ones, zeros
+from shared.core.extensor import AnyTensor, ones, zeros
 from collections import List
 
 
@@ -131,7 +131,7 @@ fn test_prefetch_data_loader_creation() raises:
     var data = ones(data_shape, DType.float32)
     var labels = zeros(label_shape, DType.float32)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
     var sampler = RandomSampler(10)
     var loader = BatchLoader(dataset^, sampler^, batch_size=2)
 
@@ -150,7 +150,7 @@ fn test_prefetch_data_loader_invalid_prefetch_factor() raises:
     var data = ones(data_shape, DType.float32)
     var labels = zeros(label_shape, DType.float32)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
     var sampler = RandomSampler(10)
     var loader = BatchLoader(dataset^, sampler^, batch_size=2)
 
@@ -172,7 +172,7 @@ fn test_prefetch_data_loader_iteration() raises:
     var data = ones(data_shape, DType.float32)
     var labels = zeros(label_shape, DType.float32)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
     var sampler = RandomSampler(10)
     var loader = BatchLoader(dataset^, sampler^, batch_size=2)
 

--- a/tests/shared/data/test_transforms_part1.mojo
+++ b/tests/shared/data/test_transforms_part1.mojo
@@ -20,7 +20,7 @@ from tests.shared.conftest import (
     TestFixtures,
 )
 from shared.data.transforms import Compose, Normalize, Reshape
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 
 
 # ============================================================================
@@ -47,7 +47,7 @@ fn test_compose_empty_pipeline() raises:
     var data_list = List[Float32]()
     for i in range(10):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     # Create empty Compose pipeline
     var pipeline = Compose[Normalize]()
@@ -77,7 +77,7 @@ fn test_compose_single_transform() raises:
     var data_list = List[Float32]()
     for i in range(20):
         data_list.append(Float32(i) / 10.0)
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     # Create single-transform pipeline
     var transforms_list = List[Normalize]()
@@ -111,7 +111,7 @@ fn test_compose_multiple_transforms() raises:
     var data_list = List[Float32]()
     for i in range(20):
         data_list.append(Float32(i) / 10.0)
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     # Create pipeline with normalize transform
     var transforms_list = List[Normalize]()
@@ -144,7 +144,7 @@ fn test_compose_determinism() raises:
     var data_list = List[Float32]()
     for i in range(15):
         data_list.append(Float32(i) * 0.5)
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var transforms_list = List[Normalize]()
     transforms_list.append(Normalize())
@@ -184,7 +184,7 @@ fn test_normalize_transform() raises:
     var data_list = List[Float32]()
     for i in range(10):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var normalize = Normalize()
     var result = normalize(data)
@@ -213,7 +213,7 @@ fn test_reshape_transform() raises:
     var data_list = List[Float32]()
     for i in range(10):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     # Create reshape to (2, 5)
     var new_shape = List[Int]()
@@ -251,7 +251,7 @@ fn test_transform_stateless() raises:
     var data_list = List[Float32]()
     for i in range(10):
         data_list.append(Float32(i) * 0.1)
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var normalize = Normalize()
 
@@ -284,7 +284,7 @@ fn test_transform_no_mutation() raises:
     var data_list = List[Float32]()
     for i in range(10):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var original_shape = data.shape()
 

--- a/tests/shared/data/test_transforms_part2.mojo
+++ b/tests/shared/data/test_transforms_part2.mojo
@@ -21,7 +21,7 @@ from tests.shared.conftest import (
     TestFixtures,
 )
 from shared.data.transforms import Compose, Normalize, Reshape
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 
 
 # ============================================================================
@@ -46,20 +46,20 @@ fn test_transform_on_dataset_sample() raises:
     """
     TestFixtures.set_seed()
 
-    from shared.data.datasets import ExTensorDataset
+    from shared.data.datasets import AnyTensorDataset
 
     # Create small dataset
     var data_list = List[Float32]()
     for i in range(20):
         data_list.append(Float32(i) * 0.1)
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     for i in range(20):
         labels_list.append(i)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
 
     # Get sample from dataset
     var sample = dataset.__getitem__(0)
@@ -90,20 +90,20 @@ fn test_transform_batch_consistency() raises:
     """
     TestFixtures.set_seed()
 
-    from shared.data.datasets import ExTensorDataset
+    from shared.data.datasets import AnyTensorDataset
 
     # Create dataset
     var data_list = List[Float32]()
     for i in range(20):
         data_list.append(Float32(i) * 0.1)
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var labels_list = List[Int]()
     for i in range(20):
         labels_list.append(i)
-    var labels = ExTensor(labels_list^)
+    var labels = AnyTensor(labels_list^)
 
-    var dataset = ExTensorDataset(data^, labels^)
+    var dataset = AnyTensorDataset(data^, labels^)
 
     var normalize = Normalize()
 
@@ -139,7 +139,7 @@ fn test_transform_on_small_tensor() raises:
 
     var data_list = List[Float32]()
     data_list.append(42.0)
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var normalize = Normalize()
     var result = normalize(data)
@@ -167,7 +167,7 @@ fn test_transform_on_large_tensor() raises:
     var data_list = List[Float32]()
     for i in range(1000):
         data_list.append(Float32(i % 100) * 0.01)
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var normalize = Normalize()
     var result = normalize(data)
@@ -195,7 +195,7 @@ fn test_transform_zero_value_handling() raises:
     var data_list = List[Float32]()
     for _ in range(10):
         data_list.append(0.0)
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var normalize = Normalize()
     # This might result in NaN/Inf, but should not crash
@@ -224,7 +224,7 @@ fn test_transform_negative_values() raises:
     var data_list = List[Float32]()
     for i in range(10):
         data_list.append(Float32(i) - 5.0)  # -5 to 4
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var normalize = Normalize()
     var result = normalize(data)
@@ -252,7 +252,7 @@ fn test_transform_repeated_application() raises:
     var data_list = List[Float32]()
     for i in range(20):
         data_list.append(Float32(i) * 0.1)
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var normalize = Normalize()
 
@@ -282,7 +282,7 @@ fn test_transform_preserves_element_count() raises:
     var data_list = List[Float32]()
     for i in range(30):
         data_list.append(Float32(i) * 0.05)
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var original_count = data.num_elements()
 

--- a/tests/shared/data/test_transforms_part3.mojo
+++ b/tests/shared/data/test_transforms_part3.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     TestFixtures,
 )
 from shared.data.transforms import Compose, Normalize, Reshape
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 
 
 # ============================================================================
@@ -46,7 +46,7 @@ fn test_normalize_output_range() raises:
     var data_list = List[Float32]()
     for i in range(20):
         data_list.append(Float32(i))
-    var data = ExTensor(data_list^)
+    var data = AnyTensor(data_list^)
 
     var normalize = Normalize()
     var result = normalize(data)

--- a/tests/shared/data/transforms/test_augmentations_part1.mojo
+++ b/tests/shared/data/transforms/test_augmentations_part1.mojo
@@ -22,10 +22,10 @@ from shared.data.transforms import (
     CenterCrop,
     RandomErasing,
 )
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 
 # Type comptime for compatibility
-comptime Tensor = ExTensor
+comptime Tensor = AnyTensor
 
 
 # ============================================================================
@@ -45,7 +45,7 @@ fn test_random_augmentation_deterministic() raises:
         data_list.append(1.0)
     var data_shape = List[Int]()
     data_shape.append(len(data_list))
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
 
@@ -75,7 +75,7 @@ fn test_random_augmentation_varies() raises:
         data_list.append(1.0)
     var data_shape = List[Int]()
     data_shape.append(len(data_list))
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
 
@@ -113,7 +113,7 @@ fn test_random_rotation_range() raises:
         data_list.append(1.0)
     var data_shape = List[Int]()
     data_shape.append(len(data_list))
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
 
@@ -136,7 +136,7 @@ fn test_random_rotation_no_change() raises:
         data_list.append(1.0)
     var data_shape = List[Int]()
     data_shape.append(len(data_list))
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
 
@@ -164,7 +164,7 @@ fn test_random_rotation_fill_value() raises:
         data_list.append(1.0)
     var data_shape = List[Int]()
     data_shape.append(len(data_list))
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
 
@@ -192,7 +192,7 @@ fn test_random_crop_varies_location() raises:
         data_list.append(Float32(i))
     var data_shape = List[Int]()
     data_shape.append(len(data_list))
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
 
@@ -219,7 +219,7 @@ fn test_random_crop_with_padding() raises:
         data_list.append(1.0)
     var data_shape = List[Int]()
     data_shape.append(len(data_list))
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
 

--- a/tests/shared/data/transforms/test_augmentations_part2.mojo
+++ b/tests/shared/data/transforms/test_augmentations_part2.mojo
@@ -21,10 +21,10 @@ from shared.data.transforms import (
     CenterCrop,
     RandomErasing,
 )
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 
 # Type comptime for compatibility
-comptime Tensor = ExTensor
+comptime Tensor = AnyTensor
 
 
 # ============================================================================
@@ -48,7 +48,7 @@ fn test_random_horizontal_flip_probability() raises:
         data_list.append(Float32(i + 1))
     var data_shape = List[Int]()
     data_shape.append(len(data_list))
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
 
@@ -79,7 +79,7 @@ fn test_random_flip_always() raises:
         data_list.append(Float32(i + 1))
     var data_shape = List[Int]()
     data_shape.append(len(data_list))
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
 
@@ -104,7 +104,7 @@ fn test_random_flip_never() raises:
         data_list.append(Float32(i + 1))
     var data_shape = List[Int]()
     data_shape.append(len(data_list))
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
 
@@ -133,7 +133,7 @@ fn test_random_erasing_basic() raises:
         data_list.append(1.0)
     var data_shape = List[Int]()
     data_shape.append(len(data_list))
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
 
@@ -162,7 +162,7 @@ fn test_random_erasing_scale() raises:
         data_list.append(1.0)
     var data_shape = List[Int]()
     data_shape.append(len(data_list))
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
 
@@ -199,7 +199,7 @@ fn test_compose_random_augmentations() raises:
         data_list.append(1.0)
     var data_shape = List[Int]()
     data_shape.append(len(data_list))
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
 
@@ -230,7 +230,7 @@ fn test_augmentation_determinism_in_pipeline() raises:
         data_list.append(1.0)
     var data_shape = List[Int]()
     data_shape.append(len(data_list))
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     for i in range(len(data_list)):
         data._set_float32(i, data_list[i])
 

--- a/tests/shared/data/transforms/test_generic_transforms_part1.mojo
+++ b/tests/shared/data/transforms/test_generic_transforms_part1.mojo
@@ -6,7 +6,7 @@
 Tests identity transforms and lambda transforms.
 """
 
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from tests.shared.conftest import (
     assert_true,
     assert_equal,
@@ -31,7 +31,7 @@ from shared.data.generic_transforms import (
 )
 
 # Type comptime for test convenience
-comptime Tensor = ExTensor
+comptime Tensor = AnyTensor
 
 
 # ============================================================================
@@ -45,7 +45,7 @@ fn test_identity_basic() raises:
     values.append(1.0)
     values.append(2.0)
     values.append(3.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
     var identity = IdentityTransform()
 
     var result = identity(data)
@@ -63,7 +63,7 @@ fn test_identity_preserves_values() raises:
     values.append(-1.5)
     values.append(42.0)
     values.append(100.5)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
     var identity = IdentityTransform()
 
     var result = identity(data)
@@ -75,7 +75,7 @@ fn test_identity_preserves_values() raises:
 fn test_identity_empty_tensor() raises:
     """Test identity handles empty tensor."""
     var values = List[Float32]()
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
     var identity = IdentityTransform()
 
     var result = identity(data)
@@ -94,7 +94,7 @@ fn test_lambda_double_values() raises:
     values.append(1.0)
     values.append(2.0)
     values.append(3.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
 
     fn double_fn(value: Float32) -> Float32:
         return value * 2.0
@@ -113,7 +113,7 @@ fn test_lambda_add_constant() raises:
     values.append(1.0)
     values.append(2.0)
     values.append(3.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
 
     fn add_ten(value: Float32) -> Float32:
         return value + 10.0
@@ -132,7 +132,7 @@ fn test_lambda_square_values() raises:
     values.append(2.0)
     values.append(3.0)
     values.append(4.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
 
     fn square(value: Float32) -> Float32:
         return value * value
@@ -151,7 +151,7 @@ fn test_lambda_negative_values() raises:
     values.append(-1.0)
     values.append(-2.0)
     values.append(-3.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
 
     fn abs_value(value: Float32) -> Float32:
         return abs(value)

--- a/tests/shared/data/transforms/test_generic_transforms_part2.mojo
+++ b/tests/shared/data/transforms/test_generic_transforms_part2.mojo
@@ -6,7 +6,7 @@
 Tests conditional transforms and the first half of clamp transforms.
 """
 
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from tests.shared.conftest import (
     assert_true,
     assert_equal,
@@ -31,7 +31,7 @@ from shared.data.generic_transforms import (
 )
 
 # Type comptime for test convenience
-comptime Tensor = ExTensor
+comptime Tensor = AnyTensor
 
 
 # ============================================================================
@@ -45,9 +45,9 @@ fn test_conditional_always_apply() raises:
     values.append(1.0)
     values.append(2.0)
     values.append(3.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
 
-    fn always_true(tensor: ExTensor) raises -> Bool:
+    fn always_true(tensor: AnyTensor) raises -> Bool:
         return True
 
     fn double_fn(value: Float32) -> Float32:
@@ -72,9 +72,9 @@ fn test_conditional_never_apply() raises:
     values.append(1.0)
     values.append(2.0)
     values.append(3.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
 
-    fn always_false(tensor: ExTensor) raises -> Bool:
+    fn always_false(tensor: AnyTensor) raises -> Bool:
         return False
 
     fn double_fn(value: Float32) -> Float32:
@@ -98,15 +98,15 @@ fn test_conditional_based_on_size() raises:
     var small_values = List[Float32]()
     small_values.append(1.0)
     small_values.append(2.0)
-    var small_data = ExTensor(small_values^)
+    var small_data = AnyTensor(small_values^)
     var large_values = List[Float32]()
     large_values.append(1.0)
     large_values.append(2.0)
     large_values.append(3.0)
     large_values.append(4.0)
-    var large_data = ExTensor(large_values^)
+    var large_data = AnyTensor(large_values^)
 
-    fn is_large(tensor: ExTensor) raises -> Bool:
+    fn is_large(tensor: AnyTensor) raises -> Bool:
         return tensor.num_elements() > 3
 
     fn double_fn(value: Float32) -> Float32:
@@ -135,14 +135,14 @@ fn test_conditional_based_on_values() raises:
     positive_values.append(1.0)
     positive_values.append(2.0)
     positive_values.append(3.0)
-    var positive_data = ExTensor(positive_values^)
+    var positive_data = AnyTensor(positive_values^)
     var mixed_values = List[Float32]()
     mixed_values.append(-1.0)
     mixed_values.append(2.0)
     mixed_values.append(3.0)
-    var mixed_data = ExTensor(mixed_values^)
+    var mixed_data = AnyTensor(mixed_values^)
 
-    fn all_positive(tensor: ExTensor) raises -> Bool:
+    fn all_positive(tensor: AnyTensor) raises -> Bool:
         for i in range(tensor.num_elements()):
             if tensor[i] < 0.0:
                 return False
@@ -179,7 +179,7 @@ fn test_clamp_basic() raises:
     values.append(1.0)
     values.append(1.5)
     values.append(2.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
     var clamp = ClampTransform(0.3, 1.2)
 
     var result = clamp(data)
@@ -197,7 +197,7 @@ fn test_clamp_all_below_min() raises:
     values.append(-5.0)
     values.append(-2.0)
     values.append(0.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
     var clamp = ClampTransform(1.0, 10.0)
 
     var result = clamp(data)
@@ -213,7 +213,7 @@ fn test_clamp_all_above_max() raises:
     values.append(15.0)
     values.append(20.0)
     values.append(25.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
     var clamp = ClampTransform(1.0, 10.0)
 
     var result = clamp(data)

--- a/tests/shared/data/transforms/test_generic_transforms_part3.mojo
+++ b/tests/shared/data/transforms/test_generic_transforms_part3.mojo
@@ -6,7 +6,7 @@
 Tests second half of clamp transforms and debug transforms.
 """
 
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from tests.shared.conftest import (
     assert_true,
     assert_equal,
@@ -31,7 +31,7 @@ from shared.data.generic_transforms import (
 )
 
 # Type comptime for test convenience
-comptime Tensor = ExTensor
+comptime Tensor = AnyTensor
 
 
 # ============================================================================
@@ -45,7 +45,7 @@ fn test_clamp_all_in_range() raises:
     values.append(2.0)
     values.append(5.0)
     values.append(8.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
     var clamp = ClampTransform(1.0, 10.0)
 
     var result = clamp(data)
@@ -62,7 +62,7 @@ fn test_clamp_negative_range() raises:
     values.append(-5.0)
     values.append(0.0)
     values.append(5.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
     var clamp = ClampTransform(-8.0, -2.0)
 
     var result = clamp(data)
@@ -81,7 +81,7 @@ fn test_clamp_zero_crossing() raises:
     values.append(0.0)
     values.append(1.0)
     values.append(5.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
     var clamp = ClampTransform(-2.0, 2.0)
 
     var result = clamp(data)
@@ -104,7 +104,7 @@ fn test_debug_passthrough() raises:
     values.append(1.0)
     values.append(2.0)
     values.append(3.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
     var debug = DebugTransform("test")
 
     var result = debug(data)
@@ -119,7 +119,7 @@ fn test_debug_passthrough() raises:
 fn test_debug_with_empty_tensor() raises:
     """Test debug transform with empty tensor."""
     var values = List[Float32]()
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
     var debug = DebugTransform("empty_test")
 
     var result = debug(data)
@@ -133,7 +133,7 @@ fn test_debug_with_large_tensor() raises:
     for i in range(100):
         values.append(Float32(i))
 
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
     var debug = DebugTransform("large_test")
 
     var result = debug(data)

--- a/tests/shared/data/transforms/test_generic_transforms_part4.mojo
+++ b/tests/shared/data/transforms/test_generic_transforms_part4.mojo
@@ -6,7 +6,7 @@
 Tests type conversion transforms and first part of sequential transforms.
 """
 
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from tests.shared.conftest import (
     assert_true,
     assert_equal,
@@ -31,7 +31,7 @@ from shared.data.generic_transforms import (
 )
 
 # Type comptime for test convenience
-comptime Tensor = ExTensor
+comptime Tensor = AnyTensor
 
 
 # ============================================================================
@@ -45,7 +45,7 @@ fn test_to_float32_preserves_values() raises:
     values.append(1.5)
     values.append(2.5)
     values.append(3.5)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
     var converter = ToFloat32()
 
     var result = converter(data)
@@ -61,7 +61,7 @@ fn test_to_int32_truncates() raises:
     values.append(1.9)
     values.append(2.5)
     values.append(3.1)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
     var converter = ToInt32()
 
     var result = converter(data)
@@ -77,7 +77,7 @@ fn test_to_int32_negative() raises:
     values.append(-1.9)
     values.append(-2.5)
     values.append(-3.1)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
     var converter = ToInt32()
 
     var result = converter(data)
@@ -93,7 +93,7 @@ fn test_to_int32_zero() raises:
     values.append(0.0)
     values.append(0.1)
     values.append(-0.1)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
     var converter = ToInt32()
 
     var result = converter(data)
@@ -114,7 +114,7 @@ fn test_sequential_basic() raises:
     values.append(1.0)
     values.append(2.0)
     values.append(3.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
 
     fn double_fn(value: Float32) -> Float32:
         return value * 2.0
@@ -141,7 +141,7 @@ fn test_sequential_single_transform() raises:
     values.append(1.0)
     values.append(2.0)
     values.append(3.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
 
     fn double_fn(value: Float32) -> Float32:
         return value * 2.0
@@ -163,7 +163,7 @@ fn test_sequential_empty() raises:
     values.append(1.0)
     values.append(2.0)
     values.append(3.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
 
     var transforms: List[AnyTransform] = []
     var sequential = SequentialTransform(transforms^)

--- a/tests/shared/data/transforms/test_generic_transforms_part5.mojo
+++ b/tests/shared/data/transforms/test_generic_transforms_part5.mojo
@@ -6,7 +6,7 @@
 Tests second part of sequential transforms and batch transforms.
 """
 
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from tests.shared.conftest import (
     assert_true,
     assert_equal,
@@ -31,7 +31,7 @@ from shared.data.generic_transforms import (
 )
 
 # Type comptime for test convenience
-comptime Tensor = ExTensor
+comptime Tensor = AnyTensor
 
 
 # ============================================================================
@@ -45,7 +45,7 @@ fn test_sequential_with_clamp() raises:
     values.append(0.5)
     values.append(1.5)
     values.append(2.5)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
 
     fn double_fn(value: Float32) -> Float32:
         return value * 2.0
@@ -70,7 +70,7 @@ fn test_sequential_deterministic() raises:
     values.append(1.0)
     values.append(2.0)
     values.append(3.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
 
     fn triple(value: Float32) -> Float32:
         return value * 3.0
@@ -107,9 +107,9 @@ fn test_batch_transform_basic() raises:
     values3.append(6.0)
 
     var tensors: List[Tensor] = []
-    tensors.append(ExTensor(values1^))
-    tensors.append(ExTensor(values2^))
-    tensors.append(ExTensor(values3^))
+    tensors.append(AnyTensor(values1^))
+    tensors.append(AnyTensor(values2^))
+    tensors.append(AnyTensor(values3^))
 
     fn double_fn(value: Float32) -> Float32:
         return value * 2.0
@@ -155,7 +155,7 @@ fn test_batch_transform_single_tensor() raises:
     values.append(3.0)
 
     var tensors: List[Tensor] = []
-    tensors.append(ExTensor(values^))
+    tensors.append(AnyTensor(values^))
 
     fn add_ten(value: Float32) -> Float32:
         return value + 10.0
@@ -184,9 +184,9 @@ fn test_batch_transform_different_sizes() raises:
     values3.append(6.0)
 
     var tensors: List[Tensor] = []
-    tensors.append(ExTensor(values1^))
-    tensors.append(ExTensor(values2^))
-    tensors.append(ExTensor(values3^))
+    tensors.append(AnyTensor(values1^))
+    tensors.append(AnyTensor(values2^))
+    tensors.append(AnyTensor(values3^))
 
     fn double_fn(value: Float32) -> Float32:
         return value * 2.0
@@ -224,8 +224,8 @@ fn test_batch_transform_with_clamp() raises:
     values2.append(25.0)
 
     var tensors: List[Tensor] = []
-    tensors.append(ExTensor(values1^))
-    tensors.append(ExTensor(values2^))
+    tensors.append(AnyTensor(values1^))
+    tensors.append(AnyTensor(values2^))
 
     var base_transform = ClampTransform(2.0, 18.0)
     var batch = BatchTransform(AnyTransform(base_transform^))

--- a/tests/shared/data/transforms/test_generic_transforms_part6.mojo
+++ b/tests/shared/data/transforms/test_generic_transforms_part6.mojo
@@ -6,7 +6,7 @@
 Tests integration scenarios and edge cases.
 """
 
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from tests.shared.conftest import (
     assert_true,
     assert_equal,
@@ -31,7 +31,7 @@ from shared.data.generic_transforms import (
 )
 
 # Type comptime for test convenience
-comptime Tensor = ExTensor
+comptime Tensor = AnyTensor
 
 
 # ============================================================================
@@ -47,7 +47,7 @@ fn test_integration_preprocessing_pipeline() raises:
     values.append(5.0)
     values.append(10.0)
     values.append(15.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
 
     fn normalize(value: Float32) -> Float32:
         # Scale to [0, 1]
@@ -76,13 +76,13 @@ fn test_integration_conditional_augmentation() raises:
     large_values.append(2.0)
     large_values.append(3.0)
     large_values.append(4.0)
-    var large_data = ExTensor(large_values^)
+    var large_data = AnyTensor(large_values^)
     var small_values = List[Float32]()
     small_values.append(1.0)
     small_values.append(2.0)
-    var small_data = ExTensor(small_values^)
+    var small_data = AnyTensor(small_values^)
 
-    fn is_large_enough(tensor: ExTensor) raises -> Bool:
+    fn is_large_enough(tensor: AnyTensor) raises -> Bool:
         return tensor.num_elements() >= 3
 
     fn augment(value: Float32) -> Float32:
@@ -115,8 +115,8 @@ fn test_integration_batch_preprocessing() raises:
     values2.append(400.0)
 
     var batch: List[Tensor] = []
-    batch.append(ExTensor(values1^))
-    batch.append(ExTensor(values2^))
+    batch.append(AnyTensor(values1^))
+    batch.append(AnyTensor(values2^))
 
     fn scale_down(value: Float32) -> Float32:
         return value / 100.0
@@ -145,7 +145,7 @@ fn test_integration_type_conversion_pipeline() raises:
     values.append(1.9)
     values.append(2.5)
     values.append(3.1)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
 
     var transforms: List[AnyTransform] = []
     transforms.append(AnyTransform(ToInt32()))  # Convert to int (truncate)
@@ -172,7 +172,7 @@ fn test_edge_case_very_large_values() raises:
     values.append(1e6)
     values.append(1e7)
     values.append(1e8)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
     var clamp = ClampTransform(0.0, 1e9)
 
     var result = clamp(data)
@@ -188,7 +188,7 @@ fn test_edge_case_very_small_values() raises:
     values.append(1e-6)
     values.append(1e-7)
     values.append(1e-8)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
     var clamp = ClampTransform(1e-9, 1.0)
 
     var result = clamp(data)
@@ -204,7 +204,7 @@ fn test_edge_case_all_zeros() raises:
     values.append(0.0)
     values.append(0.0)
     values.append(0.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
 
     fn add_one(value: Float32) -> Float32:
         return value + 1.0
@@ -221,7 +221,7 @@ fn test_edge_case_single_element() raises:
     """Test transforms with single element."""
     var values = List[Float32]()
     values.append(42.0)
-    var data = ExTensor(values^)
+    var data = AnyTensor(values^)
 
     var transforms: List[AnyTransform] = []
     transforms.append(AnyTransform(ClampTransform(0.0, 100.0)))

--- a/tests/shared/fuzz/test_tensor_fuzz_part1.mojo
+++ b/tests/shared/fuzz/test_tensor_fuzz_part1.mojo
@@ -28,7 +28,7 @@ Note:
 from random import seed as random_seed
 from math import isnan, isinf
 
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.arithmetic import add, subtract, multiply, divide
 
 from shared.testing.fuzz_core import (

--- a/tests/shared/fuzz/test_tensor_fuzz_part2.mojo
+++ b/tests/shared/fuzz/test_tensor_fuzz_part2.mojo
@@ -26,7 +26,7 @@ Note:
 from random import seed as random_seed
 from math import isnan, isinf
 
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.arithmetic import add, subtract, multiply, divide
 
 from shared.testing.fuzz_core import (

--- a/tests/shared/integration/test_end_to_end.mojo
+++ b/tests/shared/integration/test_end_to_end.mojo
@@ -20,7 +20,7 @@ from tests.shared.conftest import (
     TestFixtures,
 )
 from shared.testing import SimpleMLP
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.core.loss import mean_squared_error
 from shared.core.reduction import mean
 from shared.core.activation import softmax
@@ -305,7 +305,7 @@ fn test_model_checkpoint_save_load() raises:
 
     var original_output = model.forward(test_input)
 
-    # Get parameters (List[ExTensor]) for verification
+    # Get parameters (List[AnyTensor]) for verification
     var params = model.parameters()
 
     # Verify we have the expected number of parameters
@@ -478,8 +478,8 @@ fn test_full_pipeline_integration() raises:
 
     # Step 2: Create synthetic dataset
     var n_samples = 10
-    var train_inputs: List[ExTensor] = []
-    var train_targets: List[ExTensor] = []
+    var train_inputs: List[AnyTensor] = []
+    var train_targets: List[AnyTensor] = []
 
     for sample_idx in range(n_samples):
         # Create input

--- a/tests/shared/integration/test_multi_precision_training_part1.mojo
+++ b/tests/shared/integration/test_multi_precision_training_part1.mojo
@@ -23,7 +23,7 @@ from tests.shared.conftest import (
     assert_dtype,
     TestFixtures,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.training.precision_config import PrecisionConfig, PrecisionMode
 from shared.training.mixed_precision import GradientScaler
 from shared.training.dtype_utils import (

--- a/tests/shared/integration/test_multi_precision_training_part2.mojo
+++ b/tests/shared/integration/test_multi_precision_training_part2.mojo
@@ -23,7 +23,7 @@ from tests.shared.conftest import (
     assert_dtype,
     TestFixtures,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.training.precision_config import PrecisionConfig, PrecisionMode
 from shared.training.mixed_precision import GradientScaler
 from shared.training.dtype_utils import (

--- a/tests/shared/integration/test_packaging.mojo
+++ b/tests/shared/integration/test_packaging.mojo
@@ -40,9 +40,9 @@ fn test_subpackage_accessibility() raises:
     from shared import core, training, data, utils
 
     # Verify subpackages are accessible by testing exports
-    from shared.core import ExTensor, zeros
+    from shared.core import AnyTensor, zeros
     from shared.training import SGD, MSELoss
-    from shared.data import Dataset, ExTensorDataset
+    from shared.data import Dataset, AnyTensorDataset
     from shared.utils import Logger, Config
 
     # Test that we can actually call the functions
@@ -68,7 +68,7 @@ fn test_subpackage_accessibility() raises:
 fn test_root_level_imports() raises:
     """Test most commonly used components are available at root level."""
     # Root package doesn't re-export all components directly
-    from shared.core import ExTensor
+    from shared.core import AnyTensor
     from shared.training import SGD
     from shared.utils import Logger
 
@@ -93,8 +93,8 @@ fn test_layer_root_level_imports() raises:
     # Core module trait
     from shared import Module
 
-    # Core tensors and creation functions (ExTensor + Tensor alias)
-    from shared import ExTensor, Tensor, zeros, ones, randn
+    # Core tensors and creation functions (AnyTensor + Tensor alias)
+    from shared import AnyTensor, Tensor, zeros, ones, randn
 
     # Training schedulers
     from shared import StepLR, CosineAnnealingLR
@@ -126,9 +126,9 @@ fn test_layer_root_level_imports() raises:
 
 fn test_module_level_imports() raises:
     """Test importing from specific modules."""
-    from shared.core import ExTensor, relu, linear
+    from shared.core import AnyTensor, relu, linear
     from shared.training import SGD, MSELoss
-    from shared.data import ExTensorDataset, Batch
+    from shared.data import AnyTensorDataset, Batch
 
     print("✓ Module level imports test passed")
 
@@ -149,7 +149,7 @@ fn test_nested_imports() raises:
 
 fn test_core_training_integration() raises:
     """Test integration between core and training modules."""
-    from shared.core import ExTensor, zeros
+    from shared.core import AnyTensor, zeros
     from shared.training import SGD, MSELoss
 
     # Create tensors using core
@@ -174,15 +174,15 @@ fn test_core_training_integration() raises:
 
 fn test_core_data_integration() raises:
     """Test integration between core and data modules."""
-    from shared.core import ExTensor, zeros, ones
-    from shared.data import ExTensorDataset
+    from shared.core import AnyTensor, zeros, ones
+    from shared.data import AnyTensorDataset
 
     # Create tensors using core
     var data = zeros([10, 5], DType.float32)
     var labels = ones([10, 1], DType.float32)
 
     # Create dataset using data
-    var dataset = ExTensorDataset(data, labels)
+    var dataset = AnyTensorDataset(data, labels)
 
     # Verify dataset was created and has correct properties
     var data_shape = data.shape()
@@ -199,13 +199,13 @@ fn test_core_data_integration() raises:
 fn test_training_data_integration() raises:
     """Test integration between training and data modules."""
     from shared.training import SGD
-    from shared.data import ExTensorDataset
+    from shared.data import AnyTensorDataset
     from shared.core import zeros, ones
 
     # Create simple dataset
     var data = zeros([10, 5], DType.float32)
     var labels = ones([10, 1], DType.float32)
-    var dataset = ExTensorDataset(data, labels)
+    var dataset = AnyTensorDataset(data, labels)
 
     # Create optimizer
     var optimizer = SGD(learning_rate=0.01)
@@ -233,7 +233,7 @@ fn test_complete_training_workflow() raises:
     """Test complete training workflow using all modules."""
     from shared.core import zeros, ones, relu
     from shared.training import SGD, MSELoss
-    from shared.data import ExTensorDataset
+    from shared.data import AnyTensorDataset
     from shared.utils import Logger
 
     # 1. Create model parameters (core)
@@ -243,7 +243,7 @@ fn test_complete_training_workflow() raises:
     # 2. Create data (data)
     var data = zeros([10, 10], DType.float32)
     var labels = ones([10, 5], DType.float32)
-    var dataset = ExTensorDataset(data, labels)
+    var dataset = AnyTensorDataset(data, labels)
 
     # 3. Create optimizer and loss (training)
     var optimizer = SGD(learning_rate=0.01)
@@ -275,14 +275,14 @@ fn test_paper_implementation_pattern() raises:
     """Test typical usage pattern from paper implementation."""
     # Simulates how a paper implementation would use the shared library
 
-    from shared.core import ExTensor, zeros, conv2d, flatten, relu
+    from shared.core import AnyTensor, zeros, conv2d, flatten, relu
     from shared.training import (
         SGD,
         CosineAnnealingLR,
         EarlyStopping,
         ModelCheckpoint,
     )
-    from shared.data import ExTensorDataset
+    from shared.data import AnyTensorDataset
 
     # Paper-specific tensors for conv operations
     var input_data = zeros([1, 1, 28, 28], DType.float32)
@@ -298,7 +298,7 @@ fn test_paper_implementation_pattern() raises:
     # Create dataset
     var data = zeros([10, 1, 28, 28], DType.float32)
     var labels = zeros([10, 10], DType.float32)
-    var dataset = ExTensorDataset(data, labels)
+    var dataset = AnyTensorDataset(data, labels)
 
     # Verify all components are properly instantiated
     assert_true(input_data.dim() == 4, "Input data should be 4D tensor")
@@ -394,7 +394,7 @@ fn test_normalize_compose_from_shared_data() raises:
 #     Verifies that:
 #     - Compose can be instantiated
 #     - Normalize can be chained inside a Compose
-#     - The composed transforms can be called on an ExTensor
+#     - The composed transforms can be called on an AnyTensor
 #
 #     Follow-up from #3220 - stronger coverage of the re-exported API.
 #     """
@@ -560,14 +560,14 @@ fn test_cross_module_computation() raises:
     from shared.core import zeros, ones, relu
     from shared.core.matrix import matmul
     from shared.training import SGD, MSELoss
-    from shared.data import ExTensorDataset
+    from shared.data import AnyTensorDataset
 
     # Create realistic tensors
     var data = zeros([32, 64], DType.float32)  # Batch of 32, features of 64
     var labels = zeros([32, 10], DType.float32)  # 32 samples, 10 classes
 
     # Create dataset
-    var _dataset = ExTensorDataset(data, labels)
+    var _dataset = AnyTensorDataset(data, labels)
 
     # Create a simple network forward pass
     var weights1 = zeros([64, 128], DType.float32)  # Input layer
@@ -655,14 +655,14 @@ fn test_error_propagation() raises:
     """Test that errors propagate correctly between modules."""
     from shared.core import zeros
     from shared.training import SGD
-    from shared.data import ExTensorDataset
+    from shared.data import AnyTensorDataset
 
     # Test that incompatible tensor shapes fail appropriately
     var good_data = zeros([10, 5], DType.float32)
     var good_labels = zeros([10, 3], DType.float32)
 
     # This should work
-    var good_dataset = ExTensorDataset(good_data, good_labels)
+    var good_dataset = AnyTensorDataset(good_data, good_labels)
     assert_true(len(good_dataset) > 0, "Valid dataset should be created")
 
     # Test optimizer with edge case learning rates
@@ -686,7 +686,7 @@ fn test_integration_stress() raises:
     from shared.core import zeros, ones, relu
     from shared.core.matrix import matmul
     from shared.training import SGD, MSELoss
-    from shared.data import ExTensorDataset
+    from shared.data import AnyTensorDataset
 
     # Create a realistic batch size
     var batch_size = 128
@@ -699,7 +699,7 @@ fn test_integration_stress() raises:
     var train_labels = zeros([batch_size, output_dim], DType.float32)
 
     # Create dataset
-    var _dataset = ExTensorDataset(train_data, train_labels)
+    var _dataset = AnyTensorDataset(train_data, train_labels)
 
     # Create network parameters
     var w1 = zeros([input_dim, hidden_dim], DType.float32)

--- a/tests/shared/integration/test_packaging_part1.mojo
+++ b/tests/shared/integration/test_packaging_part1.mojo
@@ -44,9 +44,9 @@ fn test_subpackage_accessibility() raises:
     from shared import core, training, data, utils
 
     # Verify subpackages are accessible by testing exports
-    from shared.core import ExTensor, zeros
+    from shared.core import AnyTensor, zeros
     from shared.training import SGD, MSELoss
-    from shared.data import Dataset, ExTensorDataset
+    from shared.data import Dataset, AnyTensorDataset
     from shared.utils import Logger, Config
 
     # Test that we can actually call the functions
@@ -72,7 +72,7 @@ fn test_subpackage_accessibility() raises:
 fn test_root_level_imports() raises:
     """Test most commonly used components are available at root level."""
     # Root package doesn't re-export all components directly
-    from shared.core import ExTensor
+    from shared.core import AnyTensor
     from shared.training import SGD
     from shared.utils import Logger
 
@@ -81,9 +81,9 @@ fn test_root_level_imports() raises:
 
 fn test_module_level_imports() raises:
     """Test importing from specific modules."""
-    from shared.core import ExTensor, relu, linear
+    from shared.core import AnyTensor, relu, linear
     from shared.training import SGD, MSELoss
-    from shared.data import ExTensorDataset, Batch
+    from shared.data import AnyTensorDataset, Batch
 
     print("✓ Module level imports test passed")
 
@@ -99,7 +99,7 @@ fn test_nested_imports() raises:
 
 fn test_core_training_integration() raises:
     """Test integration between core and training modules."""
-    from shared.core import ExTensor, zeros
+    from shared.core import AnyTensor, zeros
     from shared.training import SGD, MSELoss
 
     # Create tensors using core

--- a/tests/shared/integration/test_packaging_part2.mojo
+++ b/tests/shared/integration/test_packaging_part2.mojo
@@ -20,15 +20,15 @@ from testing import assert_true, assert_equal
 
 fn test_core_data_integration() raises:
     """Test integration between core and data modules."""
-    from shared.core import ExTensor, zeros, ones
-    from shared.data import ExTensorDataset
+    from shared.core import AnyTensor, zeros, ones
+    from shared.data import AnyTensorDataset
 
     # Create tensors using core
     var data = zeros([10, 5], DType.float32)
     var labels = ones([10, 1], DType.float32)
 
     # Create dataset using data
-    var dataset = ExTensorDataset(data, labels)
+    var dataset = AnyTensorDataset(data, labels)
 
     # Verify dataset was created and has correct properties
     var data_shape = data.shape()
@@ -45,13 +45,13 @@ fn test_core_data_integration() raises:
 fn test_training_data_integration() raises:
     """Test integration between training and data modules."""
     from shared.training import SGD
-    from shared.data import ExTensorDataset
+    from shared.data import AnyTensorDataset
     from shared.core import zeros, ones
 
     # Create simple dataset
     var data = zeros([10, 5], DType.float32)
     var labels = ones([10, 1], DType.float32)
-    var dataset = ExTensorDataset(data, labels)
+    var dataset = AnyTensorDataset(data, labels)
 
     # Create optimizer
     var optimizer = SGD(learning_rate=0.01)
@@ -77,7 +77,7 @@ fn test_complete_training_workflow() raises:
     """Test complete training workflow using all modules."""
     from shared.core import zeros, ones, relu
     from shared.training import SGD, MSELoss
-    from shared.data import ExTensorDataset
+    from shared.data import AnyTensorDataset
     from shared.utils import Logger
 
     # 1. Create model parameters (core)
@@ -87,7 +87,7 @@ fn test_complete_training_workflow() raises:
     # 2. Create data (data)
     var data = zeros([10, 10], DType.float32)
     var labels = ones([10, 5], DType.float32)
-    var dataset = ExTensorDataset(data, labels)
+    var dataset = AnyTensorDataset(data, labels)
 
     # 3. Create optimizer and loss (training)
     var optimizer = SGD(learning_rate=0.01)
@@ -115,14 +115,14 @@ fn test_paper_implementation_pattern() raises:
     """Test typical usage pattern from paper implementation."""
     # Simulates how a paper implementation would use the shared library
 
-    from shared.core import ExTensor, zeros, conv2d, flatten, relu
+    from shared.core import AnyTensor, zeros, conv2d, flatten, relu
     from shared.training import (
         SGD,
         CosineAnnealingLR,
         EarlyStopping,
         ModelCheckpoint,
     )
-    from shared.data import ExTensorDataset
+    from shared.data import AnyTensorDataset
 
     # Paper-specific tensors for conv operations
     var input_data = zeros([1, 1, 28, 28], DType.float32)
@@ -138,7 +138,7 @@ fn test_paper_implementation_pattern() raises:
     # Create dataset
     var data = zeros([10, 1, 28, 28], DType.float32)
     var labels = zeros([10, 10], DType.float32)
-    var dataset = ExTensorDataset(data, labels)
+    var dataset = AnyTensorDataset(data, labels)
 
     # Verify all components are properly instantiated
     assert_true(input_data.dim() == 4, "Input data should be 4D tensor")

--- a/tests/shared/integration/test_packaging_part3.mojo
+++ b/tests/shared/integration/test_packaging_part3.mojo
@@ -94,14 +94,14 @@ fn test_cross_module_computation() raises:
     from shared.core import zeros, ones, relu
     from shared.core.matrix import matmul
     from shared.training import SGD, MSELoss
-    from shared.data import ExTensorDataset
+    from shared.data import AnyTensorDataset
 
     # Create realistic tensors
     var data = zeros([32, 64], DType.float32)  # Batch of 32, features of 64
     var labels = zeros([32, 10], DType.float32)  # 32 samples, 10 classes
 
     # Create dataset
-    var dataset = ExTensorDataset(data, labels)
+    var dataset = AnyTensorDataset(data, labels)
 
     # Create a simple network forward pass
     var weights1 = zeros([64, 128], DType.float32)  # Input layer
@@ -189,14 +189,14 @@ fn test_error_propagation() raises:
     """Test that errors propagate correctly between modules."""
     from shared.core import zeros
     from shared.training import SGD
-    from shared.data import ExTensorDataset
+    from shared.data import AnyTensorDataset
 
     # Test that incompatible tensor shapes fail appropriately
     var good_data = zeros([10, 5], DType.float32)
     var good_labels = zeros([10, 3], DType.float32)
 
     # This should work
-    var good_dataset = ExTensorDataset(good_data, good_labels)
+    var good_dataset = AnyTensorDataset(good_data, good_labels)
     assert_true(len(good_dataset) > 0, "Valid dataset should be created")
 
     # Test optimizer with edge case learning rates
@@ -220,7 +220,7 @@ fn test_integration_stress() raises:
     from shared.core import zeros, ones, relu
     from shared.core.matrix import matmul
     from shared.training import SGD, MSELoss
-    from shared.data import ExTensorDataset
+    from shared.data import AnyTensorDataset
 
     # Create a realistic batch size
     var batch_size = 128
@@ -233,7 +233,7 @@ fn test_integration_stress() raises:
     var train_labels = zeros([batch_size, output_dim], DType.float32)
 
     # Create dataset
-    var dataset = ExTensorDataset(train_data, train_labels)
+    var dataset = AnyTensorDataset(train_data, train_labels)
 
     # Create network parameters
     var w1 = zeros([input_dim, hidden_dim], DType.float32)

--- a/tests/shared/integration/test_training_e2e.mojo
+++ b/tests/shared/integration/test_training_e2e.mojo
@@ -20,7 +20,7 @@ from tests.shared.conftest import (
     assert_less,
     TestFixtures,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import maxpool2d, maxpool2d_backward
 from shared.core.linear import linear, linear_backward
@@ -41,10 +41,10 @@ struct SimpleMLP:
     Architecture: input(10) -> fc1(10->20) -> relu -> fc2(20->5) -> output.
     """
 
-    var fc1_weights: ExTensor
-    var fc1_bias: ExTensor
-    var fc2_weights: ExTensor
-    var fc2_bias: ExTensor
+    var fc1_weights: AnyTensor
+    var fc1_bias: AnyTensor
+    var fc2_weights: AnyTensor
+    var fc2_bias: AnyTensor
 
     fn __init__(out self) raises:
         """Initialize with small random weights."""
@@ -68,7 +68,7 @@ struct SimpleMLP:
         fc2_b_shape.append(5)
         self.fc2_bias = zeros(fc2_b_shape, DType.float32)
 
-    fn forward(self, input: ExTensor) raises -> ExTensor:
+    fn forward(self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass: fc1 -> relu -> fc2."""
         var fc1_out = linear(input, self.fc1_weights, self.fc1_bias)
         var relu_out = relu(fc1_out)
@@ -76,7 +76,7 @@ struct SimpleMLP:
         return fc2_out^
 
     fn train_step(
-        mut self, input: ExTensor, labels: ExTensor, learning_rate: Float32
+        mut self, input: AnyTensor, labels: AnyTensor, learning_rate: Float32
     ) raises -> Float32:
         """Execute one training step with manual backprop.
 
@@ -117,7 +117,7 @@ struct SimpleMLP:
         return loss
 
 
-fn _sgd_update(mut param: ExTensor, grad: ExTensor, lr: Float32) raises:
+fn _sgd_update(mut param: AnyTensor, grad: AnyTensor, lr: Float32) raises:
     """Update parameter: param = param - lr * grad."""
     var numel = param.numel()
     var param_data = param._data.bitcast[Float32]()
@@ -128,7 +128,7 @@ fn _sgd_update(mut param: ExTensor, grad: ExTensor, lr: Float32) raises:
 
 fn create_dummy_batch(
     batch_size: Int, input_dim: Int, num_classes: Int
-) raises -> Tuple[ExTensor, ExTensor]:
+) raises -> Tuple[AnyTensor, AnyTensor]:
     """Create dummy batch for testing.
 
     Returns:
@@ -150,7 +150,7 @@ fn create_dummy_batch(
     for i in range(batch_size):
         labels_data[i * num_classes] = Float32(1.0)
 
-    return Tuple[ExTensor, ExTensor](input^, labels^)
+    return Tuple[AnyTensor, AnyTensor](input^, labels^)
 
 
 # ============================================================================

--- a/tests/shared/test_imports.mojo
+++ b/tests/shared/test_imports.mojo
@@ -16,7 +16,7 @@ from testing import assert_true
 
 fn test_core_imports() raises:
     """Test core package imports work correctly."""
-    from shared.core import ExTensor, zeros, ones, randn
+    from shared.core import AnyTensor, zeros, ones, randn
     from shared.core import relu, sigmoid, tanh, softmax, gelu
 
     # Test that functions are actually callable and work correctly
@@ -65,7 +65,7 @@ fn test_core_activations_imports() raises:
 
 fn test_core_types_imports() raises:
     """Test core types imports."""
-    from shared.core import ExTensor, FP8, BF8
+    from shared.core import AnyTensor, FP8, BF8
 
     print("✓ Core types imports test passed")
 
@@ -94,10 +94,10 @@ fn test_core_layers_direct_imports() raises:
 fn test_core_types_direct_imports() raises:
     """Test types are importable directly from their shared.core sub-modules.
 
-    Note: ExTensor lives in shared.core.extensor (not shared.core.types which
+    Note: AnyTensor lives in shared.core.extensor (not shared.core.types which
     contains dtype aliases like FP8, BF8, BF16).
     """
-    from shared.core.extensor import ExTensor
+    from shared.core.extensor import AnyTensor
     from shared.core.types import FP8, BF8
 
     print("✓ Core types direct imports test passed")
@@ -290,7 +290,7 @@ fn test_data_imports() raises:
     """Test data package imports work correctly."""
     from shared.data import (
         Dataset,
-        ExTensorDataset,
+        AnyTensorDataset,
         CIFAR10Dataset,
         EMNISTDataset,
     )
@@ -300,7 +300,7 @@ fn test_data_imports() raises:
 
 fn test_data_datasets_imports() raises:
     """Test data datasets imports."""
-    from shared.data import Dataset, ExTensorDataset, FileDataset
+    from shared.data import Dataset, AnyTensorDataset, FileDataset
 
     print("✓ Data datasets imports test passed")
 
@@ -323,7 +323,7 @@ fn test_data_transforms_imports() raises:
 fn test_data_datasets_direct_imports() raises:
     """Test datasets are importable directly from shared.data.datasets sub-module.
     """
-    from shared.data.datasets import Dataset, ExTensorDataset
+    from shared.data.datasets import Dataset, AnyTensorDataset
 
     print("✓ Data datasets direct imports test passed")
 
@@ -387,7 +387,7 @@ fn test_root_imports() raises:
     """Test root package convenience imports work."""
     # Root package doesn't re-export all components
     # Users should import from subpackages
-    from shared.core import ExTensor
+    from shared.core import AnyTensor
     from shared.training import SGD
     from shared.utils import Logger
 

--- a/tests/shared/test_imports_part1.mojo
+++ b/tests/shared/test_imports_part1.mojo
@@ -20,7 +20,7 @@ from testing import assert_true
 
 fn test_core_imports() raises:
     """Test core package imports work correctly."""
-    from shared.core import ExTensor, zeros, ones, randn
+    from shared.core import AnyTensor, zeros, ones, randn
     from shared.core import relu, sigmoid, tanh, softmax, gelu
 
     # Test that functions are actually callable and work correctly
@@ -69,7 +69,7 @@ fn test_core_activations_imports() raises:
 
 fn test_core_types_imports() raises:
     """Test core types imports."""
-    from shared.core import ExTensor, FP8, BF8
+    from shared.core import AnyTensor, FP8, BF8
 
     print("✓ Core types imports test passed")
 

--- a/tests/shared/test_imports_part2.mojo
+++ b/tests/shared/test_imports_part2.mojo
@@ -45,7 +45,7 @@ fn test_data_imports() raises:
     """Test data package imports work correctly."""
     from shared.data import (
         Dataset,
-        ExTensorDataset,
+        AnyTensorDataset,
         CIFAR10Dataset,
         EMNISTDataset,
     )
@@ -55,7 +55,7 @@ fn test_data_imports() raises:
 
 fn test_data_datasets_imports() raises:
     """Test data datasets imports."""
-    from shared.data import Dataset, ExTensorDataset, FileDataset
+    from shared.data import Dataset, AnyTensorDataset, FileDataset
 
     print("✓ Data datasets imports test passed")
 

--- a/tests/shared/test_imports_part3.mojo
+++ b/tests/shared/test_imports_part3.mojo
@@ -43,7 +43,7 @@ fn test_root_imports() raises:
     """Test root package convenience imports work."""
     # Root package doesn't re-export all components
     # Users should import from subpackages
-    from shared.core import ExTensor
+    from shared.core import AnyTensor
     from shared.training import SGD
     from shared.utils import Logger
 

--- a/tests/shared/test_model_utils.mojo
+++ b/tests/shared/test_model_utils.mojo
@@ -8,7 +8,7 @@ Tests the model weight save/load functionality including:
 """
 
 from testing import assert_true, assert_equal
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.training.model_utils import (
     save_model_weights,
     load_model_weights,
@@ -23,7 +23,7 @@ import os
 fn test_save_load_model_weights() raises:
     """Test saving and loading model weights."""
     # Create test parameters
-    var params: List[ExTensor] = []
+    var params: List[AnyTensor] = []
     var shape1: List[Int] = [3, 4]
     var shape2: List[Int] = [4, 2]
 
@@ -49,7 +49,7 @@ fn test_save_load_model_weights() raises:
         assert_true(_file_exists(file2), "fc1_weights.weights not created")
 
         # Load weights
-        var loaded: List[ExTensor] = []
+        var loaded: List[AnyTensor] = []
         load_model_weights(loaded, tmpdir, names)
 
         # Verify number of parameters
@@ -134,8 +134,8 @@ fn test_get_vgg16_parameter_names() raises:
 fn test_validate_shapes_matching() raises:
     """Test shape validation with matching tensors."""
     # Create matching tensors
-    var expected: List[ExTensor] = []
-    var loaded: List[ExTensor] = []
+    var expected: List[AnyTensor] = []
+    var loaded: List[AnyTensor] = []
 
     var shape1: List[Int] = [3, 4]
     var shape2: List[Int] = [4, 5, 6]
@@ -152,8 +152,8 @@ fn test_validate_shapes_matching() raises:
 
 fn test_validate_shapes_rank_mismatch() raises:
     """Test shape validation with rank mismatch."""
-    var expected: List[ExTensor] = []
-    var loaded: List[ExTensor] = []
+    var expected: List[AnyTensor] = []
+    var loaded: List[AnyTensor] = []
 
     var shape1: List[Int] = [3, 4]
     var shape2: List[Int] = [3, 4, 1]  # Different rank
@@ -172,8 +172,8 @@ fn test_validate_shapes_rank_mismatch() raises:
 
 fn test_validate_shapes_dimension_mismatch() raises:
     """Test shape validation with dimension mismatch."""
-    var expected: List[ExTensor] = []
-    var loaded: List[ExTensor] = []
+    var expected: List[AnyTensor] = []
+    var loaded: List[AnyTensor] = []
 
     var shape1: List[Int] = [3, 4]
     var shape2: List[Int] = [3, 5]  # Different second dimension
@@ -192,8 +192,8 @@ fn test_validate_shapes_dimension_mismatch() raises:
 
 fn test_validate_shapes_count_mismatch() raises:
     """Test shape validation with parameter count mismatch."""
-    var expected: List[ExTensor] = []
-    var loaded: List[ExTensor] = []
+    var expected: List[AnyTensor] = []
+    var loaded: List[AnyTensor] = []
 
     var shape1: List[Int] = [3, 4]
 

--- a/tests/shared/test_serialization.mojo
+++ b/tests/shared/test_serialization.mojo
@@ -9,7 +9,7 @@ Tests the complete serialization pipeline including:
 
 from testing import assert_true, assert_equal
 from shared.testing.assertions import assert_almost_equal
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.utils.serialization import (
     NamedTensor,
     save_tensor,

--- a/tests/shared/testing/test_gradient_check.mojo
+++ b/tests/shared/testing/test_gradient_check.mojo
@@ -9,7 +9,7 @@ from shared.testing import (
     assert_gradients_close,
     relative_error,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 
 
 # ============================================================================

--- a/tests/shared/testing/test_gradient_checker_meta_part1.mojo
+++ b/tests/shared/testing/test_gradient_checker_meta_part1.mojo
@@ -36,7 +36,7 @@ from shared.testing import (
     compute_numerical_gradient,
     relative_error,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full, zeros_like
+from shared.core.extensor import AnyTensor, zeros, ones, full, zeros_like
 
 
 # ============================================================================
@@ -44,7 +44,7 @@ from shared.core.extensor import ExTensor, zeros, ones, full, zeros_like
 # ============================================================================
 
 
-fn square_forward(input: ExTensor) raises escaping -> ExTensor:
+fn square_forward(input: AnyTensor) raises escaping -> AnyTensor:
     """Forward pass: f(x) = x^2.
 
     Args:
@@ -61,8 +61,8 @@ fn square_forward(input: ExTensor) raises escaping -> ExTensor:
 
 
 fn square_backward_correct(
-    grad_out: ExTensor, input: ExTensor
-) raises escaping -> ExTensor:
+    grad_out: AnyTensor, input: AnyTensor
+) raises escaping -> AnyTensor:
     """Correct backward pass for f(x) = x^2: df/dx = 2x.
 
     This is the mathematically correct gradient.
@@ -84,8 +84,8 @@ fn square_backward_correct(
 
 
 fn square_backward_wrong_linear(
-    grad_out: ExTensor, input: ExTensor
-) raises escaping -> ExTensor:
+    grad_out: AnyTensor, input: AnyTensor
+) raises escaping -> AnyTensor:
     """Wrong backward pass for f(x) = x^2: Using df/dx = x (incorrect!).
 
     This is intentionally wrong to test that gradient checker catches errors.
@@ -108,8 +108,8 @@ fn square_backward_wrong_linear(
 
 
 fn square_backward_wrong_triple(
-    grad_out: ExTensor, input: ExTensor
-) raises escaping -> ExTensor:
+    grad_out: AnyTensor, input: AnyTensor
+) raises escaping -> AnyTensor:
     """Wrong backward pass for f(x) = x^2: Using df/dx = 3x (incorrect!).
 
     This is intentionally wrong to test gradient checker sensitivity.
@@ -149,10 +149,10 @@ fn test_gradient_checker_accepts_correct_gradient() raises:
 
     var x = full([1], 1.0, DType.float32)
 
-    fn forward(t: ExTensor) raises escaping -> ExTensor:
+    fn forward(t: AnyTensor) raises escaping -> AnyTensor:
         return square_forward(t)
 
-    fn backward(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return square_backward_correct(grad, inp)
 
     var passed = check_gradients(
@@ -185,10 +185,10 @@ fn test_gradient_checker_correct_gradient_multiple_values() raises:
         var test_val = test_values[i]
         var x = full([1], test_val, DType.float32)
 
-        fn forward(t: ExTensor) raises escaping -> ExTensor:
+        fn forward(t: AnyTensor) raises escaping -> AnyTensor:
             return square_forward(t)
 
-        fn backward(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+        fn backward(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
             return square_backward_correct(grad, inp)
 
         var passed = check_gradients(
@@ -214,10 +214,10 @@ fn test_gradient_checker_correct_gradient_multidimensional() raises:
 
     var x = full([2, 3], 1.5, DType.float32)
 
-    fn forward(t: ExTensor) raises escaping -> ExTensor:
+    fn forward(t: AnyTensor) raises escaping -> AnyTensor:
         return square_forward(t)
 
-    fn backward(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return square_backward_correct(grad, inp)
 
     var passed = check_gradients(
@@ -250,10 +250,10 @@ fn test_gradient_checker_rejects_wrong_gradient_linear() raises:
 
     var x = full([1], 1.0, DType.float32)
 
-    fn forward(t: ExTensor) raises escaping -> ExTensor:
+    fn forward(t: AnyTensor) raises escaping -> AnyTensor:
         return square_forward(t)
 
-    fn backward(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return square_backward_wrong_linear(grad, inp)
 
     var passed = check_gradients(
@@ -278,10 +278,10 @@ fn test_gradient_checker_rejects_wrong_gradient_triple() raises:
 
     var x = full([1], 1.0, DType.float32)
 
-    fn forward(t: ExTensor) raises escaping -> ExTensor:
+    fn forward(t: AnyTensor) raises escaping -> AnyTensor:
         return square_forward(t)
 
-    fn backward(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return square_backward_wrong_triple(grad, inp)
 
     var passed = check_gradients(
@@ -313,10 +313,10 @@ fn test_gradient_checker_wrong_gradient_multiple_values() raises:
         var test_val = test_values[i]
         var x = full([1], test_val, DType.float32)
 
-        fn forward(t: ExTensor) raises escaping -> ExTensor:
+        fn forward(t: AnyTensor) raises escaping -> AnyTensor:
             return square_forward(t)
 
-        fn backward(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+        fn backward(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
             return square_backward_wrong_linear(grad, inp)
 
         var passed = check_gradients(
@@ -350,7 +350,7 @@ fn test_compute_numerical_gradient_matches_analytical() raises:
 
     var x = full([1], 2.0, DType.float32)
 
-    fn forward(t: ExTensor) raises escaping -> ExTensor:
+    fn forward(t: AnyTensor) raises escaping -> AnyTensor:
         return square_forward(t)
 
     var numerical_grad = compute_numerical_gradient(forward, x, epsilon=1e-5)

--- a/tests/shared/testing/test_gradient_checker_meta_part2.mojo
+++ b/tests/shared/testing/test_gradient_checker_meta_part2.mojo
@@ -33,7 +33,7 @@ from shared.testing import (
     compute_numerical_gradient,
     relative_error,
 )
-from shared.core import ExTensor, zeros, ones, full, zeros_like
+from shared.core import AnyTensor, zeros, ones, full, zeros_like
 
 
 # ============================================================================
@@ -41,7 +41,7 @@ from shared.core import ExTensor, zeros, ones, full, zeros_like
 # ============================================================================
 
 
-fn square_forward(input: ExTensor) raises escaping -> ExTensor:
+fn square_forward(input: AnyTensor) raises escaping -> AnyTensor:
     """Forward pass: f(x) = x^2.
 
     Args:
@@ -58,8 +58,8 @@ fn square_forward(input: ExTensor) raises escaping -> ExTensor:
 
 
 fn square_backward_correct(
-    grad_out: ExTensor, input: ExTensor
-) raises escaping -> ExTensor:
+    grad_out: AnyTensor, input: AnyTensor
+) raises escaping -> AnyTensor:
     """Correct backward pass for f(x) = x^2: df/dx = 2x.
 
     This is the mathematically correct gradient.
@@ -98,10 +98,10 @@ fn test_gradient_checker_zero_input() raises:
 
     var x = full([1], 0.0, DType.float32)
 
-    fn forward(t: ExTensor) raises escaping -> ExTensor:
+    fn forward(t: AnyTensor) raises escaping -> AnyTensor:
         return square_forward(t)
 
-    fn backward(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return square_backward_correct(grad, inp)
 
     var passed = check_gradients(
@@ -129,10 +129,10 @@ fn test_gradient_checker_negative_input() raises:
 
     var x = full([1], -2.0, DType.float32)
 
-    fn forward(t: ExTensor) raises escaping -> ExTensor:
+    fn forward(t: AnyTensor) raises escaping -> AnyTensor:
         return square_forward(t)
 
-    fn backward(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return square_backward_correct(grad, inp)
 
     var passed = check_gradients(
@@ -161,10 +161,10 @@ fn test_gradient_checker_large_input() raises:
 
     var x = full([1], 5.0, DType.float32)
 
-    fn forward(t: ExTensor) raises escaping -> ExTensor:
+    fn forward(t: AnyTensor) raises escaping -> AnyTensor:
         return square_forward(t)
 
-    fn backward(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return square_backward_correct(grad, inp)
 
     # Moderate inputs still need larger tolerance for float32 precision
@@ -195,10 +195,10 @@ fn test_gradient_checker_small_epsilon() raises:
 
     var x = full([1], 1.0, DType.float32)
 
-    fn forward(t: ExTensor) raises escaping -> ExTensor:
+    fn forward(t: AnyTensor) raises escaping -> AnyTensor:
         return square_forward(t)
 
-    fn backward(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return square_backward_correct(grad, inp)
 
     var passed = check_gradients(
@@ -223,10 +223,10 @@ fn test_gradient_checker_large_epsilon() raises:
 
     var x = full([1], 1.0, DType.float32)
 
-    fn forward(t: ExTensor) raises escaping -> ExTensor:
+    fn forward(t: AnyTensor) raises escaping -> AnyTensor:
         return square_forward(t)
 
-    fn backward(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return square_backward_correct(grad, inp)
 
     var passed = check_gradients(
@@ -264,10 +264,10 @@ fn test_check_gradients_does_not_mutate_input() raises:
     for i in range(x.numel()):
         before.append(x._get_float64(i))
 
-    fn forward(t: ExTensor) raises escaping -> ExTensor:
+    fn forward(t: AnyTensor) raises escaping -> AnyTensor:
         return square_forward(t)
 
-    fn backward(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return square_backward_correct(grad, inp)
 
     _ = check_gradients(forward, backward, x, epsilon=1e-5, tolerance=1e-2)
@@ -304,10 +304,10 @@ fn test_check_gradients_verbose_does_not_mutate_input() raises:
     for i in range(x.numel()):
         before.append(x._get_float64(i))
 
-    fn forward(t: ExTensor) raises escaping -> ExTensor:
+    fn forward(t: AnyTensor) raises escaping -> AnyTensor:
         return square_forward(t)
 
-    fn backward(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return square_backward_correct(grad, inp)
 
     _ = check_gradients_verbose(

--- a/tests/shared/testing/test_gradient_checker_noncont_tensors.mojo
+++ b/tests/shared/testing/test_gradient_checker_noncont_tensors.mojo
@@ -14,7 +14,7 @@ from shared.testing import (
     check_gradients_verbose,
     compute_numerical_gradient,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full, randn
+from shared.core.extensor import AnyTensor, zeros, ones, full, randn
 from shared.core import shape
 from shared.core import matrix
 
@@ -31,14 +31,14 @@ fn test_gradient_check_transposed_input() raises:
     """
     print("Testing gradient checking with transposed input...")
 
-    fn simple_square(x: ExTensor) raises escaping -> ExTensor:
+    fn simple_square(x: AnyTensor) raises escaping -> AnyTensor:
         var result = zeros(x.shape(), x.dtype())
         for i in range(x.numel()):
             var val = x._get_float64(i)
             result._set_float64(i, val * val)
         return result^
 
-    fn simple_square_backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn simple_square_backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var result = zeros(x.shape(), x.dtype())
         for i in range(x.numel()):
             var grad = grad_out._get_float64(i)
@@ -73,14 +73,14 @@ fn test_gradient_check_transposed_relu() raises:
     """
     print("Testing ReLU gradient checking with transposed input...")
 
-    fn relu_forward(x: ExTensor) raises escaping -> ExTensor:
+    fn relu_forward(x: AnyTensor) raises escaping -> AnyTensor:
         var result = zeros(x.shape(), x.dtype())
         for i in range(x.numel()):
             var val = x._get_float64(i)
             result._set_float64(i, max(val, 0.0))
         return result^
 
-    fn relu_backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn relu_backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var result = zeros(x.shape(), x.dtype())
         for i in range(x.numel()):
             var grad = grad_out._get_float64(i)
@@ -118,14 +118,14 @@ fn test_gradient_check_partial_transpose() raises:
     """
     print("Testing gradient checking with partial axis permutation...")
 
-    fn simple_square(x: ExTensor) raises escaping -> ExTensor:
+    fn simple_square(x: AnyTensor) raises escaping -> AnyTensor:
         var result = zeros(x.shape(), x.dtype())
         for i in range(x.numel()):
             var val = x._get_float64(i)
             result._set_float64(i, val * val)
         return result^
 
-    fn simple_square_backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn simple_square_backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var result = zeros(x.shape(), x.dtype())
         for i in range(x.numel()):
             var grad = grad_out._get_float64(i)
@@ -163,14 +163,14 @@ fn test_gradient_check_contiguous_copy() raises:
     """
     print("Testing gradient check after as_contiguous() conversion...")
 
-    fn simple_square(x: ExTensor) raises escaping -> ExTensor:
+    fn simple_square(x: AnyTensor) raises escaping -> AnyTensor:
         var result = zeros(x.shape(), x.dtype())
         for i in range(x.numel()):
             var val = x._get_float64(i)
             result._set_float64(i, val * val)
         return result^
 
-    fn simple_square_backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn simple_square_backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var result = zeros(x.shape(), x.dtype())
         for i in range(x.numel()):
             var grad = grad_out._get_float64(i)
@@ -206,7 +206,7 @@ fn test_numerical_gradient_noncont() raises:
     """
     print("Testing numerical gradient computation on non-contiguous tensor...")
 
-    fn simple_square(x: ExTensor) raises escaping -> ExTensor:
+    fn simple_square(x: AnyTensor) raises escaping -> AnyTensor:
         var result = zeros(x.shape(), x.dtype())
         for i in range(x.numel()):
             var val = x._get_float64(i)
@@ -247,14 +247,14 @@ fn test_gradient_check_verbose_noncont() raises:
     """
     print("Testing verbose gradient checking with non-contiguous tensor...")
 
-    fn simple_square(x: ExTensor) raises escaping -> ExTensor:
+    fn simple_square(x: AnyTensor) raises escaping -> AnyTensor:
         var result = zeros(x.shape(), x.dtype())
         for i in range(x.numel()):
             var val = x._get_float64(i)
             result._set_float64(i, val * val)
         return result^
 
-    fn simple_square_backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn simple_square_backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var result = zeros(x.shape(), x.dtype())
         for i in range(x.numel()):
             var grad = grad_out._get_float64(i)

--- a/tests/shared/testing/test_layer_testers_analytical.mojo
+++ b/tests/shared/testing/test_layer_testers_analytical.mojo
@@ -8,7 +8,7 @@ Example usage:
 """
 
 from shared.testing import LayerTester
-from shared.core.extensor import ExTensor, zeros
+from shared.core.extensor import AnyTensor, zeros
 from shared.core.initializers import kaiming_uniform
 
 

--- a/tests/shared/testing/test_layer_testers_part1.mojo
+++ b/tests/shared/testing/test_layer_testers_part1.mojo
@@ -21,7 +21,7 @@ from shared.testing.special_values import (
 )
 from shared.testing.assertions import assert_true
 from shared.testing.tensor_factory import zeros_tensor
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 
 
 fn test_layer_dtype_consistency_passes() raises:

--- a/tests/shared/testing/test_layer_testers_part2.mojo
+++ b/tests/shared/testing/test_layer_testers_part2.mojo
@@ -23,7 +23,7 @@ from shared.testing.special_values import (
 )
 from shared.testing.assertions import assert_true
 from shared.testing.tensor_factory import zeros_tensor
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 
 
 fn test_activation_layer_backward_tanh() raises:

--- a/tests/shared/testing/test_special_values_part2.mojo
+++ b/tests/shared/testing/test_special_values_part2.mojo
@@ -125,7 +125,7 @@ fn test_dtypes_bfloat16() raises:
     """Test special values work with bfloat16.
 
     Verifies DType.bfloat16 is fully supported in Mojo's DType enum
-    and integrates correctly with the ExTensor special values API.
+    and integrates correctly with the AnyTensor special values API.
 
     Tests:
     - Tensor creation with DType.bfloat16 dtype

--- a/tests/shared/testing/test_test_models_part1.mojo
+++ b/tests/shared/testing/test_test_models_part1.mojo
@@ -18,7 +18,7 @@ from shared.testing import (
     assert_equal,
 )
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     full,

--- a/tests/shared/testing/test_test_models_part2.mojo
+++ b/tests/shared/testing/test_test_models_part2.mojo
@@ -4,7 +4,7 @@ Split from test_test_models.mojo per ADR-009 to avoid Mojo heap corruption.
 
 Coverage:
     - SimpleMLP initialization (1 and 2 hidden layers)
-    - SimpleMLP forward pass (List[Float32] and ExTensor inputs)
+    - SimpleMLP forward pass (List[Float32] and AnyTensor inputs)
 """
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
@@ -17,7 +17,7 @@ from shared.testing import (
     assert_equal,
 )
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
 )
@@ -93,7 +93,7 @@ fn test_simple_mlp_forward_2_hidden() raises:
 
 
 fn test_simple_mlp_forward_extensor_1_hidden() raises:
-    """Test SimpleMLP ExTensor forward pass with 1 hidden layer."""
+    """Test SimpleMLP AnyTensor forward pass with 1 hidden layer."""
     var mlp = SimpleMLP(10, 20, 5, num_hidden_layers=1)
     var input_shape = [10]
     var input = zeros(input_shape, DType.float32)
@@ -111,7 +111,7 @@ fn test_simple_mlp_forward_extensor_1_hidden() raises:
 
 
 fn test_simple_mlp_forward_extensor_2_hidden() raises:
-    """Test SimpleMLP ExTensor forward pass with 2 hidden layers."""
+    """Test SimpleMLP AnyTensor forward pass with 2 hidden layers."""
     var mlp = SimpleMLP(10, 20, 5, num_hidden_layers=2)
     var input_shape = [10]
     var input = ones(input_shape, DType.float32)

--- a/tests/shared/testing/test_test_models_part5.mojo
+++ b/tests/shared/testing/test_test_models_part5.mojo
@@ -25,7 +25,7 @@ from shared.testing import (
     assert_close_float,
 )
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
 )

--- a/tests/shared/testing/test_test_models_simple_mlp2.mojo
+++ b/tests/shared/testing/test_test_models_simple_mlp2.mojo
@@ -17,7 +17,7 @@ from shared.testing import (
     assert_equal,
 )
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
 )

--- a/tests/shared/training/test_accuracy_bugs.mojo
+++ b/tests/shared/training/test_accuracy_bugs.mojo
@@ -11,8 +11,8 @@ Bugs tested:
 - Line 348: per_class_accuracy() - var result_shape = List[Int]()
 """
 
-# Import ExTensor and metrics
-from shared.core.extensor import ExTensor, ones, zeros
+# Import AnyTensor and metrics
+from shared.core.extensor import AnyTensor, ones, zeros
 from shared.training.metrics.accuracy import top1_accuracy, per_class_accuracy
 
 

--- a/tests/shared/training/test_base_part1.mojo
+++ b/tests/shared/training/test_base_part1.mojo
@@ -12,7 +12,7 @@ Split from test_base.mojo per ADR-009 (≤10 fn test_ per file).
 """
 
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     full,
@@ -102,7 +102,7 @@ fn test_compute_gradient_norm_l2() raises:
     ptr[0] = 3.0
     ptr[1] = 4.0
 
-    var params: List[ExTensor] = []
+    var params: List[AnyTensor] = []
     params.append(tensor)
 
     var norm = compute_gradient_norm(params, "L2")
@@ -129,7 +129,7 @@ fn test_compute_gradient_norm_l1() raises:
     ptr[1] = 2.0
     ptr[2] = 3.0
 
-    var params: List[ExTensor] = []
+    var params: List[AnyTensor] = []
     params.append(tensor)
 
     var norm = compute_gradient_norm(params, "L1")
@@ -160,7 +160,7 @@ fn test_compute_gradient_norm_multiple_tensors() raises:
 
     var tensor2 = full(shape2, 0.0, DType.float64)
 
-    var params: List[ExTensor] = []
+    var params: List[AnyTensor] = []
     params.append(tensor1)
     params.append(tensor2)
 

--- a/tests/shared/training/test_base_part2.mojo
+++ b/tests/shared/training/test_base_part2.mojo
@@ -11,7 +11,7 @@ Split from test_base.mojo per ADR-009 (≤10 fn test_ per file).
 """
 
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     full,

--- a/tests/shared/training/test_checkpoint.mojo
+++ b/tests/shared/training/test_checkpoint.mojo
@@ -11,7 +11,7 @@ Test Coverage:
 - Metadata persistence: Epoch, metrics stored correctly
 """
 
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.training.checkpoint import CheckpointManager
 from shared.testing.assertions import (
     assert_true,
@@ -21,9 +21,9 @@ from shared.testing.assertions import (
 from collections import List
 
 
-fn create_test_params() raises -> List[ExTensor]:
+fn create_test_params() raises -> List[AnyTensor]:
     """Create simple test parameters."""
-    var params = List[ExTensor]()
+    var params = List[AnyTensor]()
     params.append(ones([10, 10], DType.float32))  # param1
     params.append(ones([5], DType.float32))  # param2
     return params^
@@ -58,7 +58,7 @@ fn test_save_and_load_checkpoint() raises:
     )
 
     # Load checkpoint
-    var loaded_params = List[ExTensor]()
+    var loaded_params = List[AnyTensor]()
     var loaded_epoch = ckpt_mgr.load_latest(loaded_params, param_names)
 
     # Verify epoch
@@ -73,7 +73,7 @@ fn test_load_latest_no_checkpoint() raises:
     var ckpt_dir = "/tmp/test_checkpoint_no_exist"
     var ckpt_mgr = CheckpointManager(ckpt_dir, max_to_keep=3)
 
-    var params = List[ExTensor]()
+    var params = List[AnyTensor]()
     var param_names = create_param_names()
 
     # Should return epoch 0 when no checkpoint exists
@@ -115,7 +115,7 @@ fn test_save_best_model() raises:
     ckpt_mgr.save_best(params, param_names, epoch=3, metric_value=0.4)
 
     # Load best model
-    var best_params = List[ExTensor]()
+    var best_params = List[AnyTensor]()
     ckpt_mgr.load_best(best_params, param_names)
 
     # Verify best model was loaded
@@ -148,7 +148,7 @@ fn test_resume_training() raises:
         )
 
     # Resume from latest checkpoint
-    var resumed_params = List[ExTensor]()
+    var resumed_params = List[AnyTensor]()
     var start_epoch = ckpt_mgr.load_latest(resumed_params, param_names)
 
     # Should resume from epoch 3
@@ -171,7 +171,7 @@ fn test_multiple_checkpoints() raises:
         )
 
     # Load latest (should be epoch 10)
-    var loaded_params = List[ExTensor]()
+    var loaded_params = List[AnyTensor]()
     var latest_epoch = ckpt_mgr.load_latest(loaded_params, param_names)
 
     assert_equal_int(latest_epoch, 10, "Latest epoch should be 10")
@@ -205,7 +205,7 @@ fn test_best_model_maximize_metric() raises:
     # Verify best model tracking
     # Note: We can't directly check best_metric_value since it's internal
     # but save_best should only save when metric improves
-    var best_params = List[ExTensor]()
+    var best_params = List[AnyTensor]()
     ckpt_mgr.load_best(best_params, param_names)
 
     assert_equal_int(len(best_params), 2, "Should load best model parameters")

--- a/tests/shared/training/test_confusion_matrix_bugs.mojo
+++ b/tests/shared/training/test_confusion_matrix_bugs.mojo
@@ -10,8 +10,8 @@ Bug tested:
 - Line 323: argmax() - var result_shape = List[Int]()
 """
 
-# Import ExTensor and confusion matrix
-from shared.core.extensor import ExTensor, ones, zeros
+# Import AnyTensor and confusion matrix
+from shared.core.extensor import AnyTensor, ones, zeros
 from shared.training.metrics.confusion_matrix import ConfusionMatrix
 
 

--- a/tests/shared/training/test_evaluate.mojo
+++ b/tests/shared/training/test_evaluate.mojo
@@ -15,7 +15,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_almost_equal,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.training.metrics import (
     evaluate_with_predict,
     evaluate_logits_batch,
@@ -32,9 +32,9 @@ from collections import List
 struct MockPredictor:
     """Mock model for testing evaluate() function."""
 
-    var predictions: ExTensor
+    var predictions: AnyTensor
 
-    fn __init__(out self, var predictions: ExTensor):
+    fn __init__(out self, var predictions: AnyTensor):
         """Initialize with fixed predictions.
 
         Args:
@@ -42,7 +42,7 @@ struct MockPredictor:
         """
         self.predictions = predictions^
 
-    fn predict(self, sample: ExTensor) raises -> Int:
+    fn predict(self, sample: AnyTensor) raises -> Int:
         """Mock predict method that uses stored predictions.
 
         Args:

--- a/tests/shared/training/test_evaluation_part1.mojo
+++ b/tests/shared/training/test_evaluation_part1.mojo
@@ -17,7 +17,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_almost_equal,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.training.evaluation import (
     EvaluationResult,
     evaluate_model,

--- a/tests/shared/training/test_evaluation_part2.mojo
+++ b/tests/shared/training/test_evaluation_part2.mojo
@@ -15,7 +15,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_almost_equal,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.training.evaluation import (
     EvaluationResult,
     evaluate_model,

--- a/tests/shared/training/test_gradient_clipping.mojo
+++ b/tests/shared/training/test_gradient_clipping.mojo
@@ -10,7 +10,7 @@ Test Coverage:
 - compute_gradient_statistics: Gradient monitoring and health checks
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.training.gradient_clipping import (
     compute_gradient_norm_list,
     clip_gradients_by_global_norm,
@@ -27,9 +27,9 @@ from collections import List
 from math import sqrt
 
 
-fn create_test_gradients() raises -> List[ExTensor]:
+fn create_test_gradients() raises -> List[AnyTensor]:
     """Create test gradients with known norms."""
-    var grads = List[ExTensor]()
+    var grads = List[AnyTensor]()
 
     # Gradient 1: all ones (norm = sqrt(100) = 10)
     grads.append(ones([100], DType.float32))
@@ -124,7 +124,7 @@ fn test_clip_by_global_norm_with_clipping() raises:
 
 fn test_clip_per_param() raises:
     """Test per-parameter gradient clipping."""
-    var grads = List[ExTensor]()
+    var grads = List[AnyTensor]()
 
     # Gradient 1: all 10.0 (norm = sqrt(100*100) = 100)
     grads.append(full([100], 10.0, DType.float32))
@@ -161,7 +161,7 @@ fn test_clip_per_param() raises:
 
 fn test_clip_by_value() raises:
     """Test gradient clipping by value range."""
-    var grads = List[ExTensor]()
+    var grads = List[AnyTensor]()
 
     # Create gradient with values outside [-1.0, 1.0]
     var grad = full([100], 5.0, DType.float32)
@@ -182,7 +182,7 @@ fn test_clip_by_value() raises:
 
 fn test_clip_by_value_negative() raises:
     """Test gradient clipping with negative values."""
-    var grads = List[ExTensor]()
+    var grads = List[AnyTensor]()
 
     # Create gradient with negative values
     var grad = full([50], -10.0, DType.float32)
@@ -203,7 +203,7 @@ fn test_clip_by_value_negative() raises:
 
 fn test_gradient_statistics() raises:
     """Test gradient statistics computation."""
-    var grads = List[ExTensor]()
+    var grads = List[AnyTensor]()
 
     # Create gradients with known statistics
     grads.append(ones([100], DType.float32))  # 100 ones
@@ -245,7 +245,7 @@ fn test_gradient_statistics() raises:
 
 fn test_gradient_statistics_empty() raises:
     """Test gradient statistics with empty list."""
-    var grads = List[ExTensor]()
+    var grads = List[AnyTensor]()
 
     var stats = compute_gradient_statistics(grads)
 
@@ -260,7 +260,7 @@ fn test_gradient_statistics_empty() raises:
 
 fn test_clip_zero_gradients() raises:
     """Test clipping with zero gradients."""
-    var grads = List[ExTensor]()
+    var grads = List[AnyTensor]()
     grads.append(zeros([100], DType.float32))
 
     # Should not crash with zero gradients

--- a/tests/shared/training/test_gradient_ops_part1.mojo
+++ b/tests/shared/training/test_gradient_ops_part1.mojo
@@ -13,7 +13,7 @@ Test Coverage:
 All tests use small tensors for fast runtime.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.training.gradient_ops import (
     accumulate_gradient_inplace,
     scale_gradient_inplace,

--- a/tests/shared/training/test_gradient_ops_part2.mojo
+++ b/tests/shared/training/test_gradient_ops_part2.mojo
@@ -13,7 +13,7 @@ Test Coverage:
 All tests use small tensors for fast runtime.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.training.gradient_ops import (
     accumulate_gradient_inplace,
     scale_gradient_inplace,

--- a/tests/shared/training/test_lars_part1.mojo
+++ b/tests/shared/training/test_lars_part1.mojo
@@ -26,7 +26,7 @@ from tests.shared.conftest import (
     create_test_vector,
     TestFixtures,
 )
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like
 from shared.core.numerical_safety import compute_tensor_l2_norm
 from shared.training.optimizers.lars import lars_step, lars_step_simple
 

--- a/tests/shared/training/test_lars_part2.mojo
+++ b/tests/shared/training/test_lars_part2.mojo
@@ -21,7 +21,7 @@ from tests.shared.conftest import (
     create_test_vector,
     TestFixtures,
 )
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like
 from shared.core.numerical_safety import compute_tensor_l2_norm
 from shared.training.optimizers.lars import lars_step, lars_step_simple
 

--- a/tests/shared/training/test_metrics_part1.mojo
+++ b/tests/shared/training/test_metrics_part1.mojo
@@ -16,7 +16,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_almost_equal,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.training.metrics import (
     LossTracker,
     Statistics,

--- a/tests/shared/training/test_metrics_part2.mojo
+++ b/tests/shared/training/test_metrics_part2.mojo
@@ -17,7 +17,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_almost_equal,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.training.metrics import (
     LossTracker,
     Statistics,

--- a/tests/shared/training/test_mixed_precision_part1.mojo
+++ b/tests/shared/training/test_mixed_precision_part1.mojo
@@ -7,7 +7,7 @@ Tests gradient scaler initialization, loss scaling, gradient unscaling,
 scaler step updates, backoff, min/max limits, and FP32 master weight conversion.
 """
 
-from shared.core.extensor import ExTensor, full
+from shared.core.extensor import AnyTensor, full
 from shared.training.mixed_precision import (
     GradientScaler,
     convert_to_fp32_master,

--- a/tests/shared/training/test_mixed_precision_part2.mojo
+++ b/tests/shared/training/test_mixed_precision_part2.mojo
@@ -7,7 +7,7 @@ Tests gradient finite checking, gradient clipping by value and norm,
 and basic FP16 tensor operations.
 """
 
-from shared.core.extensor import ExTensor, full
+from shared.core.extensor import AnyTensor, full
 from shared.training.mixed_precision import (
     check_gradients_finite,
     clip_gradients_by_norm,
@@ -102,7 +102,7 @@ fn test_clip_gradients_by_value() raises:
 
     # Create gradients with various values (5 elements)
     var shape: List[Int] = [5]
-    var grads = ExTensor(shape, DType.float32)
+    var grads = AnyTensor(shape, DType.float32)
 
     # Set some values manually
     grads._set_float64(0, -2.0)
@@ -130,7 +130,7 @@ fn test_clip_gradients_by_norm() raises:
 
     # Create gradients with known norm (3 elements)
     var shape: List[Int] = [3]
-    var grads = ExTensor(shape, DType.float32)
+    var grads = AnyTensor(shape, DType.float32)
 
     # Set values: [3.0, 4.0, 0.0] -> norm = sqrt(9 + 16) = 5.0
     grads._set_float64(0, 3.0)

--- a/tests/shared/training/test_mixed_precision_simd.mojo
+++ b/tests/shared/training/test_mixed_precision_simd.mojo
@@ -4,7 +4,7 @@ Tests SIMD-optimized FP16→FP32 and FP32→FP16 conversions with various tensor
 and edge cases.
 """
 
-from shared.core.extensor import ExTensor, full
+from shared.core.extensor import AnyTensor, full
 from shared.training.mixed_precision import (
     convert_to_fp32_master,
     update_model_from_master,
@@ -17,7 +17,7 @@ fn test_convert_fp16_to_fp32_small() raises:
     print("Testing FP16→FP32 conversion (small)...")
 
     # Create small FP16 tensor with known values
-    var fp16_params = ExTensor([8], DType.float16)
+    var fp16_params = AnyTensor([8], DType.float16)
     var fp16_ptr = fp16_params._data.bitcast[Float16]()
 
     # Fill with test values
@@ -49,7 +49,7 @@ fn test_convert_fp16_to_fp32_medium() raises:
     print("Testing FP16→FP32 conversion (medium)...")
 
     # Create medium FP16 tensor (256 elements)
-    var fp16_params = ExTensor([16, 16], DType.float16)
+    var fp16_params = AnyTensor([16, 16], DType.float16)
     var fp16_ptr = fp16_params._data.bitcast[Float16]()
 
     # Fill with special values
@@ -87,7 +87,7 @@ fn test_convert_fp16_to_fp32_large() raises:
     print("Testing FP16→FP32 conversion (large)...")
 
     # Create large FP16 tensor (1024x1024 = 1M elements)
-    var fp16_params = ExTensor([1024, 1024], DType.float16)
+    var fp16_params = AnyTensor([1024, 1024], DType.float16)
     var fp16_ptr = fp16_params._data.bitcast[Float16]()
 
     # Fill with incrementing values
@@ -115,7 +115,7 @@ fn test_convert_fp32_to_fp16_small() raises:
     print("Testing FP32→FP16 conversion (small)...")
 
     # Create small FP32 tensor with known values
-    var fp32_master = ExTensor([8], DType.float32)
+    var fp32_master = AnyTensor([8], DType.float32)
     var fp32_ptr = fp32_master._data.bitcast[Float32]()
 
     # Fill with test values
@@ -123,7 +123,7 @@ fn test_convert_fp32_to_fp16_small() raises:
         fp32_ptr[i] = Float32(i + 1)
 
     # Create FP16 target
-    var fp16_model = ExTensor([8], DType.float16)
+    var fp16_model = AnyTensor([8], DType.float16)
 
     # Update from master
     update_model_from_master(fp16_model, fp32_master)
@@ -146,7 +146,7 @@ fn test_convert_fp32_to_fp16_medium() raises:
     print("Testing FP32→FP16 conversion (medium)...")
 
     # Create medium FP32 tensor
-    var fp32_master = ExTensor([16, 16], DType.float32)
+    var fp32_master = AnyTensor([16, 16], DType.float32)
     var fp32_ptr = fp32_master._data.bitcast[Float32]()
 
     # Fill with special values
@@ -164,7 +164,7 @@ fn test_convert_fp32_to_fp16_medium() raises:
         fp32_ptr[i] = test_values[i % 7]
 
     # Create FP16 target
-    var fp16_model = ExTensor([16, 16], DType.float16)
+    var fp16_model = AnyTensor([16, 16], DType.float16)
 
     # Update from master
     update_model_from_master(fp16_model, fp32_master)
@@ -187,7 +187,7 @@ fn test_convert_fp32_to_fp16_large() raises:
     print("Testing FP32→FP16 conversion (large)...")
 
     # Create large FP32 tensor
-    var fp32_master = ExTensor([1024, 1024], DType.float32)
+    var fp32_master = AnyTensor([1024, 1024], DType.float32)
     var fp32_ptr = fp32_master._data.bitcast[Float32]()
 
     # Fill with incrementing values
@@ -195,7 +195,7 @@ fn test_convert_fp32_to_fp16_large() raises:
         fp32_ptr[i] = Float32((i % 100) / 100.0)
 
     # Create FP16 target
-    var fp16_model = ExTensor([1024, 1024], DType.float16)
+    var fp16_model = AnyTensor([1024, 1024], DType.float16)
 
     # Update from master
     update_model_from_master(fp16_model, fp32_master)
@@ -218,7 +218,7 @@ fn test_roundtrip_fp16_fp32_fp16() raises:
     print("Testing roundtrip FP16→FP32→FP16...")
 
     # Create initial FP16 tensor
-    var fp16_original = ExTensor([64], DType.float16)
+    var fp16_original = AnyTensor([64], DType.float16)
     var fp16_ptr = fp16_original._data.bitcast[Float16]()
 
     for i in range(64):
@@ -228,7 +228,7 @@ fn test_roundtrip_fp16_fp32_fp16() raises:
     var fp32_intermediate = convert_to_fp32_master(fp16_original)
 
     # Convert back to FP16
-    var fp16_roundtrip = ExTensor([64], DType.float16)
+    var fp16_roundtrip = AnyTensor([64], DType.float16)
     update_model_from_master(fp16_roundtrip, fp32_intermediate)
 
     # Verify roundtrip preserves values (with FP16 precision limits)
@@ -249,7 +249,7 @@ fn test_convert_fp32_to_fp32() raises:
     print("Testing FP32→FP32 conversion (SIMD path)...")
 
     # Create FP32 tensor
-    var fp32_params = ExTensor([64], DType.float32)
+    var fp32_params = AnyTensor([64], DType.float32)
     var fp32_ptr = fp32_params._data.bitcast[Float32]()
 
     for i in range(64):
@@ -283,7 +283,7 @@ fn test_non_power_of_2_sizes() raises:
 
     for size in test_sizes:
         # Test FP16→FP32
-        var fp16_tensor = ExTensor([size], DType.float16)
+        var fp16_tensor = AnyTensor([size], DType.float16)
         var fp16_ptr = fp16_tensor._data.bitcast[Float16]()
 
         for i in range(size):
@@ -301,13 +301,13 @@ fn test_non_power_of_2_sizes() raises:
             )
 
         # Test FP32→FP16
-        var fp32_tensor = ExTensor([size], DType.float32)
+        var fp32_tensor = AnyTensor([size], DType.float32)
         fp32_ptr = fp32_tensor._data.bitcast[Float32]()
 
         for i in range(size):
             fp32_ptr[i] = Float32(i % 10)
 
-        var fp16_result = ExTensor([size], DType.float16)
+        var fp16_result = AnyTensor([size], DType.float16)
         update_model_from_master(fp16_result, fp32_tensor)
         fp16_ptr = fp16_result._data.bitcast[Float16]()
 

--- a/tests/shared/training/test_optimizer_utils_part1.mojo
+++ b/tests/shared/training/test_optimizer_utils_part1.mojo
@@ -14,7 +14,7 @@ These tests verify the common utilities available to all optimizer implementatio
 """
 
 from tests.shared.conftest import assert_true, assert_almost_equal, assert_equal
-from shared.core.extensor import ExTensor, zeros, ones, full, zeros_like
+from shared.core.extensor import AnyTensor, zeros, ones, full, zeros_like
 from shared.training.optimizers import (
     initialize_optimizer_state,
     initialize_optimizer_state_from_params,
@@ -49,7 +49,7 @@ fn test_initialize_optimizer_state() raises:
 
 fn test_initialize_optimizer_state_from_params() raises:
     """Test optimizer state initialization from parameters."""
-    var params: List[ExTensor] = []
+    var params: List[AnyTensor] = []
     params.append(ones([2, 3], DType.float32))
     params.append(ones([3], DType.float32))
 
@@ -110,7 +110,7 @@ fn test_compute_global_norm() raises:
     var t1 = full([3], 1.0, DType.float32)
     var t2 = full([4], 2.0, DType.float32)
 
-    var tensors: List[ExTensor] = []
+    var tensors: List[AnyTensor] = []
     tensors.append(t1)
     tensors.append(t2)
 

--- a/tests/shared/training/test_optimizer_utils_part2.mojo
+++ b/tests/shared/training/test_optimizer_utils_part2.mojo
@@ -19,7 +19,7 @@ bug that occurs after ~15 cumulative tests. See Issue #2942.
 """
 
 from tests.shared.conftest import assert_true, assert_almost_equal, assert_equal
-from shared.core.extensor import ExTensor, zeros, ones, full, zeros_like
+from shared.core.extensor import AnyTensor, zeros, ones, full, zeros_like
 from shared.training.optimizers import (
     compute_weight_decay_term,
     apply_weight_decay,
@@ -50,7 +50,7 @@ fn test_clip_global_norm() raises:
     var t1 = full([3], 1.0, DType.float32)
     var t2 = full([4], 2.0, DType.float32)
 
-    var tensors: List[ExTensor] = []
+    var tensors: List[AnyTensor] = []
     tensors.append(t1)
     tensors.append(t2)
 
@@ -117,7 +117,7 @@ fn test_apply_bias_correction() raises:
 
 fn test_validate_optimizer_state_valid() raises:
     """Test validation of valid optimizer state."""
-    var params: List[ExTensor] = []
+    var params: List[AnyTensor] = []
     var shape1 = List[Int]()
     shape1.append(2)
     shape1.append(3)
@@ -126,12 +126,12 @@ fn test_validate_optimizer_state_valid() raises:
     shape2.append(3)
     params.append(ones(shape2, DType.float32))
 
-    var states = List[List[ExTensor]]()
-    states.append(List[ExTensor]())
+    var states = List[List[AnyTensor]]()
+    states.append(List[AnyTensor]())
     states[0].append(zeros_like(params[0]))
     states[0].append(zeros_like(params[0]))
 
-    states.append(List[ExTensor]())
+    states.append(List[AnyTensor]())
     states[1].append(zeros_like(params[1]))
     states[1].append(zeros_like(params[1]))
 

--- a/tests/shared/training/test_optimizers_part1.mojo
+++ b/tests/shared/training/test_optimizers_part1.mojo
@@ -26,7 +26,7 @@ from tests.shared.conftest import (
     create_test_vector,
     TestFixtures,
 )
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like
 from shared.training.optimizers.sgd import sgd_step, sgd_step_simple
 from shared.training.optimizers.adam import adam_step, adam_step_simple
 

--- a/tests/shared/training/test_optimizers_part2.mojo
+++ b/tests/shared/training/test_optimizers_part2.mojo
@@ -28,7 +28,7 @@ from tests.shared.conftest import (
     create_test_vector,
     TestFixtures,
 )
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like
 from shared.training.optimizers.sgd import sgd_step, sgd_step_simple
 from shared.training.optimizers.adam import adam_step, adam_step_simple
 from shared.training.optimizers.adamw import adamw_step
@@ -168,9 +168,9 @@ fn test_rmsprop_parameter_update() raises:
         - params = params - lr * grad / (sqrt(v) + epsilon).
     """
     # TODO(#1538): Implement when RMSprop is available
-    # var params = ExTensor([1], DType.float32)
+    # var params = AnyTensor([1], DType.float32)
     # params._data.bitcast[Float32]()[0] = 1.0
-    # var grads = ExTensor([1], DType.float32)
+    # var grads = AnyTensor([1], DType.float32)
     # grads._data.bitcast[Float32]()[0] = 0.1
     # #
     # var optimizer = RMSprop(learning_rate=0.01, alpha=0.99, epsilon=1e-8)

--- a/tests/shared/training/test_precision_checkpoint.mojo
+++ b/tests/shared/training/test_precision_checkpoint.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     TestFixtures,
 )
 from shared.training.precision_config import PrecisionConfig, PrecisionMode
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from collections import List
 
 

--- a/tests/shared/training/test_precision_config_part1.mojo
+++ b/tests/shared/training/test_precision_config_part1.mojo
@@ -5,7 +5,7 @@ bug that occurs after ~15 cumulative tests. See Issue #2942.
 """
 
 from shared.training.precision_config import PrecisionConfig, PrecisionMode
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 
 
 fn test_precision_mode_values() raises:

--- a/tests/shared/training/test_precision_config_part2.mojo
+++ b/tests/shared/training/test_precision_config_part2.mojo
@@ -4,7 +4,7 @@
 """Tests for PrecisionConfig module (part 2 of 2): scaling, gradients, and clipping."""
 
 from shared.training.precision_config import PrecisionConfig, PrecisionMode
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 
 
 fn test_scale_unscale() raises:

--- a/tests/shared/training/test_results_printer_part1.mojo
+++ b/tests/shared/training/test_results_printer_part1.mojo
@@ -13,7 +13,7 @@ from tests.shared.conftest import (
     assert_false,
     assert_equal,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.training.metrics import (
     print_evaluation_summary,
     print_per_class_accuracy,

--- a/tests/shared/training/test_results_printer_part2.mojo
+++ b/tests/shared/training/test_results_printer_part2.mojo
@@ -14,7 +14,7 @@ from tests.shared.conftest import (
     assert_false,
     assert_equal,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.training.metrics import (
     print_evaluation_summary,
     print_per_class_accuracy,
@@ -70,7 +70,7 @@ fn test_print_per_class_accuracy_with_class_names() raises:
 
     # Create per-class accuracy tensor
     var shape: List[Int] = [3]
-    var accuracies = ExTensor(shape, DType.float64)
+    var accuracies = AnyTensor(shape, DType.float64)
     accuracies._data.bitcast[Float64]()[0] = 0.92
     accuracies._data.bitcast[Float64]()[1] = 0.88
     accuracies._data.bitcast[Float64]()[2] = 0.95
@@ -92,7 +92,7 @@ fn test_print_per_class_accuracy_varied_values() raises:
 
     # Create varied per-class accuracy tensor
     var shape: List[Int] = [5]
-    var accuracies = ExTensor(shape, DType.float64)
+    var accuracies = AnyTensor(shape, DType.float64)
     accuracies._data.bitcast[Float64]()[0] = 0.50
     accuracies._data.bitcast[Float64]()[1] = 0.75
     accuracies._data.bitcast[Float64]()[2] = 0.99
@@ -139,7 +139,7 @@ fn test_print_confusion_matrix_basic() raises:
 
     # Create simple 3x3 confusion matrix
     var shape: List[Int] = [3, 3]
-    var matrix = ExTensor(shape, DType.int32)
+    var matrix = AnyTensor(shape, DType.int32)
 
     # Initialize with simple pattern (diagonal dominance)
     for i in range(3):
@@ -161,7 +161,7 @@ fn test_print_confusion_matrix_with_class_names() raises:
 
     # Create 3x3 confusion matrix
     var shape: List[Int] = [3, 3]
-    var matrix = ExTensor(shape, DType.int32)
+    var matrix = AnyTensor(shape, DType.int32)
 
     # Fill with test data
     matrix._data.bitcast[Int32]()[0] = 90  # 0,0

--- a/tests/shared/training/test_results_printer_part3.mojo
+++ b/tests/shared/training/test_results_printer_part3.mojo
@@ -14,7 +14,7 @@ from tests.shared.conftest import (
     assert_false,
     assert_equal,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.training.metrics import (
     print_evaluation_summary,
     print_per_class_accuracy,
@@ -36,7 +36,7 @@ fn test_print_confusion_matrix_binary() raises:
 
     # Create 2x2 confusion matrix (binary classification)
     var shape: List[Int] = [2, 2]
-    var matrix = ExTensor(shape, DType.int32)
+    var matrix = AnyTensor(shape, DType.int32)
 
     matrix._data.bitcast[Int32]()[0] = 950  # TP
     matrix._data.bitcast[Int32]()[1] = 50  # FP
@@ -58,7 +58,7 @@ fn test_print_confusion_matrix_normalized() raises:
 
     # Create 2x2 normalized confusion matrix (as percentages)
     var shape: List[Int] = [2, 2]
-    var matrix = ExTensor(shape, DType.float32)
+    var matrix = AnyTensor(shape, DType.float32)
 
     matrix._data.bitcast[Float32]()[0] = 0.95  # 95%
     matrix._data.bitcast[Float32]()[1] = 0.05  # 5%
@@ -76,7 +76,7 @@ fn test_print_confusion_matrix_large() raises:
 
     # Create 10x10 confusion matrix
     var shape: List[Int] = [10, 10]
-    var matrix = ExTensor(shape, DType.int32)
+    var matrix = AnyTensor(shape, DType.int32)
 
     # Fill with simple pattern
     for i in range(10):
@@ -200,7 +200,7 @@ fn test_full_training_workflow_output() raises:
 
     # Print per-class accuracy
     var per_class_shape: List[Int] = [5]
-    var per_class = ExTensor(per_class_shape, DType.float64)
+    var per_class = AnyTensor(per_class_shape, DType.float64)
     per_class._data.bitcast[Float64]()[0] = 0.85
     per_class._data.bitcast[Float64]()[1] = 0.92
     per_class._data.bitcast[Float64]()[2] = 0.88
@@ -218,7 +218,7 @@ fn test_full_training_workflow_output() raises:
 
     # Print confusion matrix
     var cm_shape: List[Int] = [5, 5]
-    var cm = ExTensor(cm_shape, DType.int32)
+    var cm = AnyTensor(cm_shape, DType.int32)
     for i in range(5):
         for j in range(5):
             var idx = i * 5 + j

--- a/tests/shared/training/test_rmsprop_part1.mojo
+++ b/tests/shared/training/test_rmsprop_part1.mojo
@@ -21,7 +21,7 @@ from tests.shared.conftest import (
     assert_shape_equal,
     TestFixtures,
 )
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.training.optimizers.rmsprop import rmsprop_step, rmsprop_step_simple
 
 

--- a/tests/shared/training/test_rmsprop_part2.mojo
+++ b/tests/shared/training/test_rmsprop_part2.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     assert_shape_equal,
     TestFixtures,
 )
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.training.optimizers.rmsprop import rmsprop_step, rmsprop_step_simple
 
 

--- a/tests/shared/training/test_trainer_interface_bugs.mojo
+++ b/tests/shared/training/test_trainer_interface_bugs.mojo
@@ -10,8 +10,8 @@ Bug tested:
 - Line 270: DataLoader.next() - var batch_labels_shape = List[Int]()
 """
 
-# Import ExTensor and trainer interface
-from shared.core.extensor import ExTensor, ones
+# Import AnyTensor and trainer interface
+from shared.core.extensor import AnyTensor, ones
 from shared.training.trainer_interface import DataLoader
 
 
@@ -23,7 +23,7 @@ from shared.training.trainer_interface import DataLoader
 fn test_dataloader_next_normal_batch() raises:
     """Test DataLoader.next() with normal batch (triggers bug at line 270).
 
-    Bug: Line 270 uses List[Int]() then is passed to ExTensor.
+    Bug: Line 270 uses List[Int]() then is passed to AnyTensor.
     This crashes because the list has undefined size.
     """
     # Create dummy dataset

--- a/tests/shared/training/test_training_loop.mojo
+++ b/tests/shared/training/test_training_loop.mojo
@@ -7,11 +7,11 @@ Tests cover:
 - Weight updates via optimizer
 - Batch iteration and epoch completion
 
-Issue #2728: Enable Training Loop Tests with SimpleMLP and ExTensor.randn.
+Issue #2728: Enable Training Loop Tests with SimpleMLP and AnyTensor.randn.
 Tests enabled after core infrastructure was completed:
 - MSELoss.compute() implementation
 - SGD/TrainingLoop integration via autograd
-- ExTensor.randn export from shared.core
+- AnyTensor.randn export from shared.core
 """
 
 from tests.shared.conftest import (
@@ -32,7 +32,7 @@ from tests.shared.conftest import (
 )
 from shared.training import SGD, MSELoss, TrainingLoop
 from shared.training.trainer_interface import DataLoader
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.core import ones, zeros, randn, subtract, multiply
 from shared.testing import SimpleMLP
 
@@ -254,9 +254,9 @@ fn test_training_loop_computes_loss() raises:
     """Test training loop computes loss correctly.
 
     API Contract:
-        fn compute_loss(self, outputs: Tensor, targets: Tensor) -> ExTensor
+        fn compute_loss(self, outputs: Tensor, targets: Tensor) -> AnyTensor
         - Calls loss_fn.compute(outputs, targets)
-        - Returns loss value as ExTensor.
+        - Returns loss value as AnyTensor.
     """
     # Create model, optimizer, and loss function
     var model = create_simple_model()
@@ -288,10 +288,10 @@ fn test_training_loop_computes_loss() raises:
 
 
 fn test_training_loop_loss_scalar() raises:
-    """Test training loop returns loss as ExTensor.
+    """Test training loop returns loss as AnyTensor.
 
     API Contract:
-        Loss should be returned as ExTensor containing the reduced loss value.
+        Loss should be returned as AnyTensor containing the reduced loss value.
         The loss tensor typically has shape [1] or [] (scalar).
     """
     # Create model, optimizer, and loss function
@@ -309,7 +309,7 @@ fn test_training_loop_loss_scalar() raises:
     # Run training step
     var loss = training_loop.step(inputs, targets)
 
-    # Loss should be an ExTensor (can extract float value)
+    # Loss should be an AnyTensor (can extract float value)
     var loss_val = loss._get_float32(0)
 
     # Loss value should be a valid number (not NaN or Inf for this simple case)
@@ -730,7 +730,7 @@ fn test_run_epoch_with_batches() raises:
     # Define step function that computes loss from batch
     # For each batch: loss = sum(batch_data) - batch_labels
     # With ones input and zeros labels, each batch should have positive loss
-    fn step_fn(batch_data: ExTensor, batch_labels: ExTensor) raises -> ExTensor:
+    fn step_fn(batch_data: AnyTensor, batch_labels: AnyTensor) raises -> AnyTensor:
         # Simple loss: sum squared differences
         # Since batch_data=ones and batch_labels=zeros, loss will be > 0
         var diff = subtract(batch_data, batch_labels)

--- a/tests/shared/training/test_training_loop_part1.mojo
+++ b/tests/shared/training/test_training_loop_part1.mojo
@@ -9,11 +9,11 @@ ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 high test load. Split from test_training_loop.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 
-Issue #2728: Enable Training Loop Tests with SimpleMLP and ExTensor.randn.
+Issue #2728: Enable Training Loop Tests with SimpleMLP and AnyTensor.randn.
 Tests enabled after core infrastructure was completed:
 - MSELoss.compute() implementation
 - SGD/TrainingLoop integration via autograd
-- ExTensor.randn export from shared.core
+- AnyTensor.randn export from shared.core
 """
 
 from tests.shared.conftest import (
@@ -34,7 +34,7 @@ from tests.shared.conftest import (
 )
 from shared.training import SGD, MSELoss, TrainingLoop
 from shared.training.trainer_interface import DataLoader
-from shared.core.extensor import ExTensor, ones, zeros, randn
+from shared.core.extensor import AnyTensor, ones, zeros, randn
 from shared.testing import SimpleMLP
 
 # TrainingLoop is generic with trait bounds for compile-time type safety.
@@ -242,9 +242,9 @@ fn test_training_loop_computes_loss() raises:
     """Test training loop computes loss correctly.
 
     API Contract:
-        fn compute_loss(self, outputs: Tensor, targets: Tensor) -> ExTensor
+        fn compute_loss(self, outputs: Tensor, targets: Tensor) -> AnyTensor
         - Calls loss_fn.compute(outputs, targets)
-        - Returns loss value as ExTensor.
+        - Returns loss value as AnyTensor.
     """
     # Create model, optimizer, and loss function
     var model = create_simple_model()
@@ -276,10 +276,10 @@ fn test_training_loop_computes_loss() raises:
 
 
 fn test_training_loop_loss_scalar() raises:
-    """Test training loop returns loss as ExTensor.
+    """Test training loop returns loss as AnyTensor.
 
     API Contract:
-        Loss should be returned as ExTensor containing the reduced loss value.
+        Loss should be returned as AnyTensor containing the reduced loss value.
         The loss tensor typically has shape [1] or [] (scalar).
     """
     # Create model, optimizer, and loss function
@@ -297,7 +297,7 @@ fn test_training_loop_loss_scalar() raises:
     # Run training step
     var loss = training_loop.step(inputs, targets)
 
-    # Loss should be an ExTensor (can extract float value)
+    # Loss should be an AnyTensor (can extract float value)
     var loss_val = loss._get_float32(0)
 
     # Loss value should be a valid number (not NaN or Inf for this simple case)

--- a/tests/shared/training/test_training_loop_part2.mojo
+++ b/tests/shared/training/test_training_loop_part2.mojo
@@ -9,11 +9,11 @@ ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 high test load. Split from test_training_loop.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 
-Issue #2728: Enable Training Loop Tests with SimpleMLP and ExTensor.randn.
+Issue #2728: Enable Training Loop Tests with SimpleMLP and AnyTensor.randn.
 Tests enabled after core infrastructure was completed:
 - MSELoss.compute() implementation
 - SGD/TrainingLoop integration via autograd
-- ExTensor.randn export from shared.core
+- AnyTensor.randn export from shared.core
 """
 
 from tests.shared.conftest import (
@@ -34,7 +34,7 @@ from tests.shared.conftest import (
 )
 from shared.training import SGD, MSELoss, TrainingLoop
 from shared.training.trainer_interface import DataLoader
-from shared.core.extensor import ExTensor, ones, zeros, randn
+from shared.core.extensor import AnyTensor, ones, zeros, randn
 from shared.testing import SimpleMLP
 
 # TrainingLoop is generic with trait bounds for compile-time type safety.

--- a/tests/shared/training/test_training_loop_part3.mojo
+++ b/tests/shared/training/test_training_loop_part3.mojo
@@ -10,11 +10,11 @@ ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 high test load. Split from test_training_loop.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 
-Issue #2728: Enable Training Loop Tests with SimpleMLP and ExTensor.randn.
+Issue #2728: Enable Training Loop Tests with SimpleMLP and AnyTensor.randn.
 Tests enabled after core infrastructure was completed:
 - MSELoss.compute() implementation
 - SGD/TrainingLoop integration via autograd
-- ExTensor.randn export from shared.core
+- AnyTensor.randn export from shared.core
 """
 
 from tests.shared.conftest import (

--- a/tests/shared/training/test_validate_returns_tuple.mojo
+++ b/tests/shared/training/test_validate_returns_tuple.mojo
@@ -12,7 +12,7 @@ from tests.shared.conftest import (
 )
 from shared.training.loops.validation_loop import validate
 from shared.training.trainer_interface import DataLoader
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.core import ones, zeros
 
 
@@ -21,12 +21,12 @@ from shared.core import ones, zeros
 # ============================================================================
 
 
-fn simple_forward(data: ExTensor) raises -> ExTensor:
+fn simple_forward(data: AnyTensor) raises -> AnyTensor:
     """Simple forward: returns ones matching data shape."""
     return ones(data.shape(), data.dtype())
 
 
-fn simple_loss(pred: ExTensor, labels: ExTensor) raises -> ExTensor:
+fn simple_loss(pred: AnyTensor, labels: AnyTensor) raises -> AnyTensor:
     """Simple loss: returns scalar ones tensor."""
     return ones([1], DType.float32)
 

--- a/tests/shared/training/test_validation_loop.mojo
+++ b/tests/shared/training/test_validation_loop.mojo
@@ -33,7 +33,7 @@ from shared.training.trainer_interface import (
     TrainingMetrics,
 )
 from shared.training.metrics import ConfusionMatrix
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.core import ones, zeros, randn
 
 
@@ -42,12 +42,12 @@ from shared.core import ones, zeros, randn
 # ============================================================================
 
 
-fn simple_forward(data: ExTensor) raises -> ExTensor:
+fn simple_forward(data: AnyTensor) raises -> AnyTensor:
     """Simple forward: returns ones matching data shape."""
     return ones(data.shape(), data.dtype())
 
 
-fn simple_loss(pred: ExTensor, labels: ExTensor) raises -> ExTensor:
+fn simple_loss(pred: AnyTensor, labels: AnyTensor) raises -> AnyTensor:
     """Simple loss: returns scalar ones tensor."""
     return ones([1], DType.float32)
 
@@ -348,7 +348,7 @@ fn test_validation_loop_confusion_matrix_basic() raises:
     var data_shape = List[Int]()
     data_shape.append(n_samples)
     data_shape.append(2)
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     # Row 0: [1.0, 0.0] -> argmax=0
     data._data.bitcast[Float32]()[0] = Float32(1.0)
     data._data.bitcast[Float32]()[1] = Float32(0.0)
@@ -364,7 +364,7 @@ fn test_validation_loop_confusion_matrix_basic() raises:
 
     var labels_shape = List[Int]()
     labels_shape.append(n_samples)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     labels._data.bitcast[Int32]()[0] = Int32(0)
     labels._data.bitcast[Int32]()[1] = Int32(1)
     labels._data.bitcast[Int32]()[2] = Int32(0)
@@ -390,7 +390,7 @@ fn test_confusion_matrix_binary_counts() raises:
 
     var preds_shape = List[Int]()
     preds_shape.append(4)
-    var preds = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
     preds._data.bitcast[Int32]()[0] = Int32(0)
     preds._data.bitcast[Int32]()[1] = Int32(1)
     preds._data.bitcast[Int32]()[2] = Int32(1)
@@ -398,7 +398,7 @@ fn test_confusion_matrix_binary_counts() raises:
 
     var labels_shape = List[Int]()
     labels_shape.append(4)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     labels._data.bitcast[Int32]()[0] = Int32(0)
     labels._data.bitcast[Int32]()[1] = Int32(1)
     labels._data.bitcast[Int32]()[2] = Int32(0)
@@ -426,7 +426,7 @@ fn test_confusion_matrix_all_correct() raises:
 
     var preds_shape = List[Int]()
     preds_shape.append(4)
-    var preds = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
     preds._data.bitcast[Int32]()[0] = Int32(0)
     preds._data.bitcast[Int32]()[1] = Int32(0)
     preds._data.bitcast[Int32]()[2] = Int32(1)
@@ -434,7 +434,7 @@ fn test_confusion_matrix_all_correct() raises:
 
     var labels_shape = List[Int]()
     labels_shape.append(4)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     labels._data.bitcast[Int32]()[0] = Int32(0)
     labels._data.bitcast[Int32]()[1] = Int32(0)
     labels._data.bitcast[Int32]()[2] = Int32(1)
@@ -460,7 +460,7 @@ fn test_confusion_matrix_all_wrong() raises:
 
     var preds_shape = List[Int]()
     preds_shape.append(4)
-    var preds = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
     preds._data.bitcast[Int32]()[0] = Int32(1)
     preds._data.bitcast[Int32]()[1] = Int32(1)
     preds._data.bitcast[Int32]()[2] = Int32(0)
@@ -468,7 +468,7 @@ fn test_confusion_matrix_all_wrong() raises:
 
     var labels_shape = List[Int]()
     labels_shape.append(4)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     labels._data.bitcast[Int32]()[0] = Int32(0)
     labels._data.bitcast[Int32]()[1] = Int32(0)
     labels._data.bitcast[Int32]()[2] = Int32(1)

--- a/tests/shared/utils/test_serialization.mojo
+++ b/tests/shared/utils/test_serialization.mojo
@@ -4,7 +4,7 @@ Tests checkpoint save/load operations with named tensors and metadata.
 Covers both single tensor and collection operations.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.utils import (
     NamedTensor,
     save_named_tensors,

--- a/tests/test_core_operations.mojo
+++ b/tests/test_core_operations.mojo
@@ -1,7 +1,7 @@
 """Core Operations coordination tests.
 
 Validates integration of all core operations: initializers, metrics, tensor ops,
-and activations from the ExTensor framework.
+and activations from the AnyTensor framework.
 
 Coordination tests (#298-302):
 - #299: Core operations integration
@@ -16,7 +16,7 @@ Testing strategy:
 """
 
 from testing import assert_true, assert_false, assert_equal, assert_almost_equal
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.core.initializers import (
     xavier_uniform,
     xavier_normal,
@@ -108,7 +108,7 @@ fn test_forward_pass_with_metrics() raises:
     # Create fake labels
     var labels_shape = List[Int]()
     labels_shape.append(5)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     labels._data.bitcast[Int32]()[0] = 0
     labels._data.bitcast[Int32]()[1] = 1
     labels._data.bitcast[Int32]()[2] = 2
@@ -174,7 +174,7 @@ fn test_training_loop_simulation() raises:
             )
             var labels_shape = List[Int]()
             labels_shape.append(batch_size)
-            var labels = ExTensor(labels_shape, DType.int32)
+            var labels = AnyTensor(labels_shape, DType.int32)
 
             for i in range(batch_size):
                 labels._data.bitcast[Int32]()[i] = Int32(
@@ -320,7 +320,7 @@ fn test_batch_processing_pipeline() raises:
         var input = normal(input_shape, seed_val=batch_idx)
         var labels_shape = List[Int]()
         labels_shape.append(batch_size)
-        var labels = ExTensor(labels_shape, DType.int32)
+        var labels = AnyTensor(labels_shape, DType.int32)
 
         for i in range(batch_size):
             labels._data.bitcast[Int32]()[i] = Int32(i % num_classes)
@@ -378,7 +378,7 @@ fn test_multi_layer_network_integration() raises:
     var input = normal([4, 784], seed_val=42)
     var labels_shape = List[Int]()
     labels_shape.append(4)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     labels._data.bitcast[Int32]()[0] = 7
     labels._data.bitcast[Int32]()[1] = 2
     labels._data.bitcast[Int32]()[2] = 1
@@ -419,9 +419,9 @@ fn test_error_handling_across_components() raises:
 
     # Test mismatched shapes in metric updates
     var preds_shape = List[Int]()
-    var preds = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
     var labels_shape = List[Int]()
-    var labels = ExTensor(labels_shape, DType.int32)  # Mismatched size
+    var labels = AnyTensor(labels_shape, DType.int32)  # Mismatched size
 
     var accuracy = AccuracyMetric()
 
@@ -474,7 +474,7 @@ fn main() raises:
     print("  ✓ Multi-layer networks work end-to-end")
     print("  ✓ Error handling is graceful and consistent")
     print("\nCore Operations Hierarchy:")
-    print("  ExTensor Framework:")
+    print("  AnyTensor Framework:")
     print("    - Tensor operations (matmul, arithmetic, reductions)")
     print("    - Activation functions (ReLU, sigmoid, tanh, softmax)")
     print("    - Loss functions (MSE, BCE, cross-entropy)")

--- a/tests/test_data_integrity_part1.mojo
+++ b/tests/test_data_integrity_part1.mojo
@@ -1,7 +1,7 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_data_integrity.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Data Integrity Tests for ExTensor Quantization Functions (Part 1).
+"""Data Integrity Tests for AnyTensor Quantization Functions (Part 1).
 
 Tests for Phase 3 data integrity fixes:
 - #1909 (DATA-001): Padding data loss in quantization
@@ -15,7 +15,7 @@ Run with: `mojo test_data_integrity_part1.mojo`
 
 from collections import List
 from memory import UnsafePointer
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from tests.shared.conftest import assert_equal_int, assert_true
 
 

--- a/tests/test_data_integrity_part2.mojo
+++ b/tests/test_data_integrity_part2.mojo
@@ -1,7 +1,7 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_data_integrity.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Data Integrity Tests for ExTensor Quantization Functions (Part 2).
+"""Data Integrity Tests for AnyTensor Quantization Functions (Part 2).
 
 Tests for Phase 3 data integrity fixes:
 - #1912 (DATA-004): Unsafe bitcasts without bounds checks
@@ -14,7 +14,7 @@ Run with: `mojo test_data_integrity_part2.mojo`
 
 from collections import List
 from memory import UnsafePointer
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from tests.shared.conftest import assert_equal_int, assert_true
 
 

--- a/tests/training/test_accuracy.mojo
+++ b/tests/training/test_accuracy.mojo
@@ -13,7 +13,7 @@ Testing strategy:
 """
 
 from testing import assert_true, assert_false, assert_equal, assert_almost_equal
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.training.metrics import (
     top1_accuracy,
     topk_accuracy,
@@ -32,12 +32,12 @@ fn test_top1_accuracy_perfect() raises:
 
     # Logits: make diagonal dominant (correct class has highest score)
     var logits_shape: List[Int] = [batch_size, num_classes]
-    var logits = ExTensor(logits_shape, DType.float32)
+    var logits = AnyTensor(logits_shape, DType.float32)
 
     # Labels: 0, 1, 2, 3, 4, 0, 1, 2, 3, 4
     var labels_shape = List[Int]()
     labels_shape.append(batch_size)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     for i in range(batch_size):
         var true_class = i % num_classes
@@ -67,11 +67,11 @@ fn test_top1_accuracy_half_correct() raises:
     var num_classes = 3
 
     var logits_shape: List[Int] = [batch_size, num_classes]
-    var logits = ExTensor(logits_shape, DType.float32)
+    var logits = AnyTensor(logits_shape, DType.float32)
 
     var labels_shape = List[Int]()
     labels_shape.append(batch_size)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     # First 5 correct, last 5 incorrect
     for i in range(batch_size):
@@ -113,12 +113,12 @@ fn test_top1_accuracy_with_indices() raises:
     # Predicted classes
     var preds_shape = List[Int]()
     preds_shape.append(batch_size)
-    var preds = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
 
     # True labels
     var labels_shape = List[Int]()
     labels_shape.append(batch_size)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     # Set up: first 4 correct, last 4 incorrect
     for i in range(batch_size):
@@ -145,11 +145,11 @@ fn test_topk_accuracy_k1() raises:
     var num_classes = 4
 
     var logits_shape: List[Int] = [batch_size, num_classes]
-    var logits = ExTensor(logits_shape, DType.float32)
+    var logits = AnyTensor(logits_shape, DType.float32)
 
     var labels_shape = List[Int]()
     labels_shape.append(batch_size)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     # Perfect predictions
     for i in range(batch_size):
@@ -184,11 +184,11 @@ fn test_topk_accuracy_k3() raises:
     var num_classes = 5
 
     var logits_shape: List[Int] = [batch_size, num_classes]
-    var logits = ExTensor(logits_shape, DType.float32)
+    var logits = AnyTensor(logits_shape, DType.float32)
 
     var labels_shape = List[Int]()
     labels_shape.append(batch_size)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     # Sample 0: true=0, scores=[5, 4, 3, 2, 1] -> top-3=[0,1,2] -> correct
     # Sample 1: true=1, scores=[1, 2, 5, 4, 3] -> top-3=[2,3,4] -> incorrect
@@ -263,11 +263,11 @@ fn test_per_class_accuracy() raises:
     var num_classes = 3
 
     var logits_shape: List[Int] = [batch_size, num_classes]
-    var logits = ExTensor(logits_shape, DType.float32)
+    var logits = AnyTensor(logits_shape, DType.float32)
 
     var labels_shape = List[Int]()
     labels_shape.append(batch_size)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     # Class 0: 4 samples, 3 correct -> 75%
     # Class 1: 4 samples, 2 correct -> 50%
@@ -339,10 +339,10 @@ fn test_accuracy_metric_incremental() raises:
     # Batch 1: 8 samples, 6 correct
     var batch1_size = 8
     var logits1_shape: List[Int] = [batch1_size, 3]
-    var logits1 = ExTensor(logits1_shape, DType.float32)
+    var logits1 = AnyTensor(logits1_shape, DType.float32)
     var labels1_shape = List[Int]()
     labels1_shape.append(batch1_size)
-    var labels1 = ExTensor(labels1_shape, DType.int32)
+    var labels1 = AnyTensor(labels1_shape, DType.int32)
 
     for i in range(batch1_size):
         var true_class = i % 3
@@ -368,10 +368,10 @@ fn test_accuracy_metric_incremental() raises:
     # Batch 2: 4 samples, 2 correct
     var batch2_size = 4
     var logits2_shape: List[Int] = [batch2_size, 3]
-    var logits2 = ExTensor(logits2_shape, DType.float32)
+    var logits2 = AnyTensor(logits2_shape, DType.float32)
     var labels2_shape = List[Int]()
     labels2_shape.append(batch2_size)
-    var labels2 = ExTensor(labels2_shape, DType.int32)
+    var labels2 = AnyTensor(labels2_shape, DType.int32)
 
     for i in range(batch2_size):
         var true_class = i % 3

--- a/tests/training/test_confusion_matrix_dtype_guard.mojo
+++ b/tests/training/test_confusion_matrix_dtype_guard.mojo
@@ -11,7 +11,7 @@ high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
 from testing import assert_true, assert_raises
-from shared.core import ExTensor
+from shared.core import AnyTensor
 from shared.training.metrics import ConfusionMatrix
 
 
@@ -23,13 +23,13 @@ fn test_float32_labels_raises() raises:
 
     var preds_shape = List[Int]()
     preds_shape.append(2)
-    var preds = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
     preds._data.bitcast[Int32]()[0] = 0
     preds._data.bitcast[Int32]()[1] = 1
 
     var labels_shape = List[Int]()
     labels_shape.append(2)
-    var labels = ExTensor(labels_shape, DType.float32)
+    var labels = AnyTensor(labels_shape, DType.float32)
     labels._data.bitcast[Float32]()[0] = 0.0
     labels._data.bitcast[Float32]()[1] = 1.0
 
@@ -56,13 +56,13 @@ fn test_float64_labels_raises() raises:
 
     var preds_shape = List[Int]()
     preds_shape.append(2)
-    var preds = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
     preds._data.bitcast[Int32]()[0] = 0
     preds._data.bitcast[Int32]()[1] = 1
 
     var labels_shape = List[Int]()
     labels_shape.append(2)
-    var labels = ExTensor(labels_shape, DType.float64)
+    var labels = AnyTensor(labels_shape, DType.float64)
     labels._data.bitcast[Float64]()[0] = 0.0
     labels._data.bitcast[Float64]()[1] = 1.0
 
@@ -89,13 +89,13 @@ fn test_float32_predictions_1d_raises() raises:
 
     var preds_shape = List[Int]()
     preds_shape.append(2)
-    var preds = ExTensor(preds_shape, DType.float32)
+    var preds = AnyTensor(preds_shape, DType.float32)
     preds._data.bitcast[Float32]()[0] = 0.0
     preds._data.bitcast[Float32]()[1] = 1.0
 
     var labels_shape = List[Int]()
     labels_shape.append(2)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     labels._data.bitcast[Int32]()[0] = 0
     labels._data.bitcast[Int32]()[1] = 1
 
@@ -122,14 +122,14 @@ fn test_int32_labels_accepted() raises:
 
     var preds_shape = List[Int]()
     preds_shape.append(3)
-    var preds = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
     preds._data.bitcast[Int32]()[0] = 0
     preds._data.bitcast[Int32]()[1] = 1
     preds._data.bitcast[Int32]()[2] = 2
 
     var labels_shape = List[Int]()
     labels_shape.append(3)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     labels._data.bitcast[Int32]()[0] = 0
     labels._data.bitcast[Int32]()[1] = 1
     labels._data.bitcast[Int32]()[2] = 2
@@ -147,14 +147,14 @@ fn test_int64_labels_accepted() raises:
 
     var preds_shape = List[Int]()
     preds_shape.append(3)
-    var preds = ExTensor(preds_shape, DType.int64)
+    var preds = AnyTensor(preds_shape, DType.int64)
     preds._data.bitcast[Int64]()[0] = 0
     preds._data.bitcast[Int64]()[1] = 1
     preds._data.bitcast[Int64]()[2] = 2
 
     var labels_shape = List[Int]()
     labels_shape.append(3)
-    var labels = ExTensor(labels_shape, DType.int64)
+    var labels = AnyTensor(labels_shape, DType.int64)
     labels._data.bitcast[Int64]()[0] = 0
     labels._data.bitcast[Int64]()[1] = 1
     labels._data.bitcast[Int64]()[2] = 2
@@ -174,7 +174,7 @@ fn test_float32_logits_2d_accepted() raises:
     var preds_shape = List[Int]()
     preds_shape.append(2)
     preds_shape.append(3)
-    var preds = ExTensor(preds_shape, DType.float32)
+    var preds = AnyTensor(preds_shape, DType.float32)
     # Sample 0: logits [1.0, 0.0, 0.0] → argmax=0
     preds._data.bitcast[Float32]()[0] = 1.0
     preds._data.bitcast[Float32]()[1] = 0.0
@@ -186,7 +186,7 @@ fn test_float32_logits_2d_accepted() raises:
 
     var labels_shape = List[Int]()
     labels_shape.append(2)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     labels._data.bitcast[Int32]()[0] = 0
     labels._data.bitcast[Int32]()[1] = 1
 

--- a/tests/training/test_confusion_matrix_part1.mojo
+++ b/tests/training/test_confusion_matrix_part1.mojo
@@ -19,7 +19,7 @@ bug that occurs after ~15 cumulative tests. See Issue #2942.
 """
 
 from testing import assert_true, assert_false, assert_equal, assert_almost_equal
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.training.metrics import ConfusionMatrix
 
 
@@ -38,7 +38,7 @@ fn test_confusion_matrix_basic() raises:
 
     var preds_shape = List[Int]()
     preds_shape.append(5)  # 5 samples
-    var preds = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
     preds._data.bitcast[Int32]()[0] = 0
     preds._data.bitcast[Int32]()[1] = 1
     preds._data.bitcast[Int32]()[2] = 2
@@ -47,7 +47,7 @@ fn test_confusion_matrix_basic() raises:
 
     var labels_shape = List[Int]()
     labels_shape.append(5)  # 5 samples
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     labels._data.bitcast[Int32]()[0] = 0
     labels._data.bitcast[Int32]()[1] = 1
     labels._data.bitcast[Int32]()[2] = 2
@@ -104,10 +104,10 @@ fn test_confusion_matrix_perfect() raises:
     # All predictions correct
     var preds_shape = List[Int]()
     preds_shape.append(6)  # 6 samples
-    var preds = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
     var labels_shape = List[Int]()
     labels_shape.append(6)  # 6 samples
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     for i in range(6):
         var cls = i % 3
@@ -169,10 +169,10 @@ fn test_confusion_matrix_normalize_row() raises:
     # Class 1: 2 samples, 2 correct (100%)
     var preds_shape = List[Int]()
     preds_shape.append(4)  # 4 samples
-    var preds = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
     var labels_shape = List[Int]()
     labels_shape.append(4)  # 4 samples
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     preds._data.bitcast[Int32]()[0] = 0  # ✓
     preds._data.bitcast[Int32]()[1] = 1  # ✗ (true=0)
@@ -217,10 +217,10 @@ fn test_confusion_matrix_normalize_column() raises:
     # Predicted as class 1: 3 samples, 2 correct (67%)
     var preds_shape = List[Int]()
     preds_shape.append(4)  # 4 samples
-    var preds = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
     var labels_shape = List[Int]()
     labels_shape.append(4)  # 4 samples
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     preds._data.bitcast[Int32]()[0] = 0  # ✓
     preds._data.bitcast[Int32]()[1] = 1  # ✗ (true=0)
@@ -266,10 +266,10 @@ fn test_confusion_matrix_normalize_total() raises:
     # 4 total samples
     var preds_shape = List[Int]()
     preds_shape.append(4)  # 4 samples
-    var preds = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
     var labels_shape = List[Int]()
     labels_shape.append(4)  # 4 samples
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     preds._data.bitcast[Int32]()[0] = 0
     preds._data.bitcast[Int32]()[1] = 1
@@ -308,10 +308,10 @@ fn test_confusion_matrix_precision() raises:
     # Class 2: predicted 1 time, 1 correct -> 100%
     var preds_shape = List[Int]()
     preds_shape.append(5)  # 5 samples
-    var preds = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
     var labels_shape = List[Int]()
     labels_shape.append(5)  # 5 samples
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     preds._data.bitcast[Int32]()[0] = 0  # ✓
     preds._data.bitcast[Int32]()[1] = 0  # ✗ (true=1)
@@ -359,10 +359,10 @@ fn test_confusion_matrix_recall() raises:
     # Class 2: 1 sample, 1 correct -> 100%
     var preds_shape = List[Int]()
     preds_shape.append(5)  # 5 samples
-    var preds = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
     var labels_shape = List[Int]()
     labels_shape.append(5)  # 5 samples
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     preds._data.bitcast[Int32]()[0] = 0  # ✓
     preds._data.bitcast[Int32]()[1] = 0  # ✗ (true=1)
@@ -406,10 +406,10 @@ fn test_confusion_matrix_f1_score() raises:
     # Class 1: precision=0.5 (1/2), recall=0.5 (1/2) -> F1=0.5
     var preds_shape = List[Int]()
     preds_shape.append(4)  # 4 samples
-    var preds = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
     var labels_shape = List[Int]()
     labels_shape.append(4)  # 4 samples
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     preds._data.bitcast[Int32]()[0] = 0  # ✓
     preds._data.bitcast[Int32]()[1] = 0  # ✗ (true=1)

--- a/tests/training/test_confusion_matrix_part2.mojo
+++ b/tests/training/test_confusion_matrix_part2.mojo
@@ -18,7 +18,7 @@ bug that occurs after ~15 cumulative tests. See Issue #2942.
 """
 
 from testing import assert_true, assert_false, assert_equal, assert_almost_equal
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.training.metrics import ConfusionMatrix
 
 
@@ -32,10 +32,10 @@ fn test_confusion_matrix_with_logits() raises:
     var logits_shape = List[Int]()
     logits_shape.append(4)
     logits_shape.append(3)
-    var logits = ExTensor(logits_shape, DType.float32)
+    var logits = AnyTensor(logits_shape, DType.float32)
     var labels_shape = List[Int]()
     labels_shape.append(4)  # 4 samples
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     # Sample 0: true=0, logits=[10, 0, 0] -> pred=0 ✓
     logits._data.bitcast[Float32]()[0] = 10.0
@@ -91,10 +91,10 @@ fn test_confusion_matrix_reset() raises:
     # Add some data
     var preds_shape = List[Int]()
     preds_shape.append(2)  # 2 samples
-    var preds = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
     var labels_shape = List[Int]()
     labels_shape.append(2)  # 2 samples
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     preds._data.bitcast[Int32]()[0] = 0
     preds._data.bitcast[Int32]()[1] = 1
     labels._data.bitcast[Int32]()[0] = 0
@@ -156,8 +156,8 @@ fn test_confusion_matrix_single_class() raises:
     # All predictions are class 0, all labels are class 0
     var preds_shape = List[Int]()
     preds_shape.append(3)
-    var preds = ExTensor(preds_shape, DType.int32)
-    var labels = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
+    var labels = AnyTensor(preds_shape, DType.int32)
     preds._data.bitcast[Int32]()[0] = 0
     preds._data.bitcast[Int32]()[1] = 0
     preds._data.bitcast[Int32]()[2] = 0
@@ -185,8 +185,8 @@ fn test_confusion_matrix_misclassification() raises:
 
     var shape = List[Int]()
     shape.append(4)
-    var preds = ExTensor(shape, DType.int32)
-    var labels = ExTensor(shape, DType.int32)
+    var preds = AnyTensor(shape, DType.int32)
+    var labels = AnyTensor(shape, DType.int32)
 
     # 2 correct, 2 wrong
     preds._data.bitcast[Int32]()[0] = 0

--- a/tests/training/test_metrics_coordination_part1.mojo
+++ b/tests/training/test_metrics_coordination_part1.mojo
@@ -20,7 +20,7 @@ Testing strategy:
 """
 
 from testing import assert_true, assert_false, assert_equal, assert_almost_equal
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.training.metrics import (
     Metric,
     MetricResult,
@@ -64,7 +64,7 @@ fn test_metric_result_tensor() raises:
 
     var tensor_shape = List[Int]()
     tensor_shape.append(3)
-    var tensor = ExTensor(tensor_shape, DType.float32)
+    var tensor = AnyTensor(tensor_shape, DType.float32)
     tensor._data.bitcast[Float32]()[0] = 0.9
     tensor._data.bitcast[Float32]()[1] = 0.8
     tensor._data.bitcast[Float32]()[2] = 0.95
@@ -146,10 +146,10 @@ fn test_accuracy_metric_interface_compliance() raises:
     # Create test data
     var preds_shape = List[Int]()
     preds_shape.append(4)
-    var preds = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
     var labels_shape = List[Int]()
     labels_shape.append(4)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     preds._data.bitcast[Int32]()[0] = 0  # ✓
     preds._data.bitcast[Int32]()[1] = 1  # ✓
@@ -184,10 +184,10 @@ fn test_confusion_matrix_integration() raises:
     # Create test data
     var preds_shape = List[Int]()
     preds_shape.append(5)
-    var preds = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
     var labels_shape = List[Int]()
     labels_shape.append(5)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     preds._data.bitcast[Int32]()[0] = 0
     preds._data.bitcast[Int32]()[1] = 1

--- a/tests/training/test_metrics_coordination_part2.mojo
+++ b/tests/training/test_metrics_coordination_part2.mojo
@@ -20,7 +20,7 @@ Testing strategy:
 """
 
 from testing import assert_true, assert_false, assert_equal, assert_almost_equal
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.training.metrics import (
     Metric,
     MetricResult,
@@ -109,10 +109,10 @@ fn test_multi_metric_training_simulation() raises:
             # Create fake batch data
             var preds_shape = List[Int]()
             preds_shape.append(4)
-            var preds = ExTensor(preds_shape, DType.int32)
+            var preds = AnyTensor(preds_shape, DType.int32)
             var labels_shape = List[Int]()
             labels_shape.append(4)
-            var labels = ExTensor(labels_shape, DType.int32)
+            var labels = AnyTensor(labels_shape, DType.int32)
 
             for i in range(4):
                 var pred_class = (i + batch + epoch) % 3
@@ -155,10 +155,10 @@ fn test_metric_interface_consistency() raises:
     # Create test data
     var preds_shape = List[Int]()
     preds_shape.append(2)
-    var preds = ExTensor(preds_shape, DType.int32)
+    var preds = AnyTensor(preds_shape, DType.int32)
     var labels_shape = List[Int]()
     labels_shape.append(2)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
     preds._data.bitcast[Int32]()[0] = 0
     preds._data.bitcast[Int32]()[1] = 1
     labels._data.bitcast[Int32]()[0] = 0

--- a/tests/training/test_sgd.mojo
+++ b/tests/training/test_sgd.mojo
@@ -5,7 +5,7 @@ This module tests the SGD optimizer implementations:
 - sgd_step (SGD with momentum and weight decay)
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.arithmetic import subtract, multiply
 from shared.training.optimizers import sgd_step_simple, sgd_step
 
@@ -16,8 +16,8 @@ fn test_sgd_step_simple_basic() raises:
 
     var shape = List[Int]()
     shape.append(3)
-    var params = ExTensor(shape, DType.float32)
-    var gradients = ExTensor(shape, DType.float32)
+    var params = AnyTensor(shape, DType.float32)
+    var gradients = AnyTensor(shape, DType.float32)
 
     # Initial params: [1, 2, 3]
     params._set_float64(0, 1.0)
@@ -63,7 +63,7 @@ fn test_sgd_step_zero_gradients() raises:
 
     var shape = List[Int]()
     shape.append(3)
-    var params = ExTensor(shape, DType.float32)
+    var params = AnyTensor(shape, DType.float32)
     var gradients = zeros(shape, DType.float32)
 
     # Initial params: [1, 2, 3]
@@ -101,8 +101,8 @@ fn test_sgd_step_large_learning_rate() raises:
 
     var shape = List[Int]()
     shape.append(2)
-    var params = ExTensor(shape, DType.float32)
-    var gradients = ExTensor(shape, DType.float32)
+    var params = AnyTensor(shape, DType.float32)
+    var gradients = AnyTensor(shape, DType.float32)
 
     # Initial params: [10, 20]
     params._set_float64(0, 10.0)
@@ -137,8 +137,8 @@ fn test_sgd_step_negative_gradients() raises:
 
     var shape = List[Int]()
     shape.append(2)
-    var params = ExTensor(shape, DType.float32)
-    var gradients = ExTensor(shape, DType.float32)
+    var params = AnyTensor(shape, DType.float32)
+    var gradients = AnyTensor(shape, DType.float32)
 
     # Initial params: [1, 2]
     params._set_float64(0, 1.0)
@@ -174,8 +174,8 @@ fn test_sgd_step_with_weight_decay() raises:
 
     var shape = List[Int]()
     shape.append(2)
-    var params = ExTensor(shape, DType.float32)
-    var gradients = ExTensor(shape, DType.float32)
+    var params = AnyTensor(shape, DType.float32)
+    var gradients = AnyTensor(shape, DType.float32)
     var velocity = zeros(shape, DType.float32)  # Not used, but required
 
     # Initial params: [1, 2]
@@ -220,7 +220,7 @@ fn test_sgd_multi_step_convergence() raises:
 
     var shape = List[Int]()
     shape.append(1)
-    var params = ExTensor(shape, DType.float32)
+    var params = AnyTensor(shape, DType.float32)
 
     # Start at params = 10, try to reach target = 0
     params._set_float64(0, 10.0)
@@ -236,7 +236,7 @@ fn test_sgd_multi_step_convergence() raises:
         var error = current - target
         var grad = 2.0 * error
 
-        var gradients = ExTensor(shape, DType.float32)
+        var gradients = AnyTensor(shape, DType.float32)
         gradients._set_float64(0, grad)
 
         # Update

--- a/tests/training/test_training_infrastructure.mojo
+++ b/tests/training/test_training_infrastructure.mojo
@@ -17,7 +17,7 @@ Testing strategy:
 """
 
 from testing import assert_true, assert_false, assert_equal, assert_almost_equal
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.training.trainer_interface import (
     TrainerConfig,
     TrainingMetrics,
@@ -38,16 +38,16 @@ from shared.training.trainer import (
 # ==================================================================
 
 
-fn mock_model_forward(input: ExTensor) raises -> ExTensor:
+fn mock_model_forward(input: AnyTensor) raises -> AnyTensor:
     """Mock model forward pass - returns input unchanged."""
     return input
 
 
 fn mock_compute_loss(
-    predictions: ExTensor, labels: ExTensor
-) raises -> ExTensor:
+    predictions: AnyTensor, labels: AnyTensor
+) raises -> AnyTensor:
     """Mock loss computation - returns constant loss."""
-    var loss = ExTensor(List[Int](), DType.float32)
+    var loss = AnyTensor(List[Int](), DType.float32)
     loss._data.bitcast[Float32]()[0] = 0.5
     return loss
 
@@ -189,9 +189,9 @@ fn test_dataloader_basic() raises:
     var data_shape = List[Int]()
     data_shape.append(10)
     data_shape.append(5)
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     var labels_shape = List[Int]()
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     var loader = DataLoader(data, labels, batch_size=3)
 
@@ -209,10 +209,10 @@ fn test_dataloader_iteration() raises:
     var data_shape = List[Int]()
     data_shape.append(10)
     data_shape.append(5)
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     var labels_shape = List[Int]()
     labels_shape.append(10)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     var loader = DataLoader(data, labels, batch_size=3)
 
@@ -299,12 +299,12 @@ fn test_validation_loop_run_updates_val_accuracy() raises:
     var data_shape = List[Int]()
     data_shape.append(4)
     data_shape.append(3)
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
 
     # Labels: shape [4], dtype int32, all zeros (class 0)
     var labels_shape = List[Int]()
     labels_shape.append(4)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     var val_loader = DataLoader(data, labels, batch_size=4)
     var validation_loop = ValidationLoop(compute_accuracy=True)
@@ -430,9 +430,9 @@ fn test_databatch_creation() raises:
     var data_shape = List[Int]()
     data_shape.append(5)
     data_shape.append(10)
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     var labels_shape = List[Int]()
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     var batch = DataBatch(data, labels)
 

--- a/tests/training/test_training_infrastructure_part1.mojo
+++ b/tests/training/test_training_infrastructure_part1.mojo
@@ -17,7 +17,7 @@ Training Infrastructure Tests (#303-322):
 """
 
 from testing import assert_true, assert_false, assert_equal, assert_almost_equal
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.training.trainer_interface import (
     TrainerConfig,
     TrainingMetrics,
@@ -153,10 +153,10 @@ fn test_dataloader_basic() raises:
     var data_shape = List[Int]()
     data_shape.append(10)
     data_shape.append(5)
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     var labels_shape = List[Int]()
     labels_shape.append(10)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     var loader = DataLoader(data, labels, batch_size=3)
 
@@ -174,10 +174,10 @@ fn test_dataloader_iteration() raises:
     var data_shape = List[Int]()
     data_shape.append(10)
     data_shape.append(5)
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     var labels_shape = List[Int]()
     labels_shape.append(10)
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     var loader = DataLoader(data, labels, batch_size=3)
 

--- a/tests/training/test_training_infrastructure_part2.mojo
+++ b/tests/training/test_training_infrastructure_part2.mojo
@@ -22,7 +22,7 @@ Training Infrastructure Tests (#303-322):
 """
 
 from testing import assert_true, assert_false, assert_equal, assert_almost_equal
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.training.trainer_interface import TrainerConfig, TrainingMetrics
 from shared.training.loops.training_loop import TrainingLoop
 from shared.training.loops.validation_loop import ValidationLoop

--- a/tests/training/test_training_infrastructure_part3.mojo
+++ b/tests/training/test_training_infrastructure_part3.mojo
@@ -20,7 +20,7 @@ Training Infrastructure Tests (#303-322):
 """
 
 from testing import assert_true, assert_false, assert_equal, assert_almost_equal
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.training.trainer_interface import (
     TrainerConfig,
     TrainingMetrics,
@@ -81,9 +81,9 @@ fn test_databatch_creation() raises:
     var data_shape = List[Int]()
     data_shape.append(5)
     data_shape.append(10)
-    var data = ExTensor(data_shape, DType.float32)
+    var data = AnyTensor(data_shape, DType.float32)
     var labels_shape = List[Int]()
-    var labels = ExTensor(labels_shape, DType.int32)
+    var labels = AnyTensor(labels_shape, DType.int32)
 
     var batch = DataBatch(data, labels)
 

--- a/tests/unit/test_cross_entropy_crash.mojo
+++ b/tests/unit/test_cross_entropy_crash.mojo
@@ -4,12 +4,12 @@ This test reproduces the segmentation fault that occurs during LeNet-5 training
 when cross_entropy is called with logits shape (2, 47) and one-hot targets.
 
 Stack trace shows crash at:
-#11 shared::core::extensor::ExTensor::__init__ at line 107
+#11 shared::core::extensor::AnyTensor::__init__ at line 107
 #12 shared::core::loss::cross_entropy at line 293
 #13 train::compute_gradients at line 127
 """
 
-from shared.core.extensor import ExTensor, zeros
+from shared.core.extensor import AnyTensor, zeros
 from shared.core.loss import cross_entropy
 from testing import assert_raises
 
@@ -42,7 +42,7 @@ fn test_cross_entropy_small_batch() raises:
     targets._set_float64(47 + 10, 1.0)  # Second sample, class 10
 
     print("Calling cross_entropy...")
-    print("This should crash with segmentation fault at ExTensor.__init__:107")
+    print("This should crash with segmentation fault at AnyTensor.__init__:107")
 
     try:
         var loss = cross_entropy(logits, targets)

--- a/tests/unit/test_extensor_init_large.mojo
+++ b/tests/unit/test_extensor_init_large.mojo
@@ -1,18 +1,18 @@
-"""Test ExTensor initialization with various large shapes.
+"""Test AnyTensor initialization with various large shapes.
 
 This test focuses on line 107 in extensor.mojo which is where the crash occurs.
 Line 107: self._strides.append(0)  # Preallocate
 
-The crash happens during stride calculation in ExTensor.__init__.
+The crash happens during stride calculation in AnyTensor.__init__.
 """
 
-from shared.core.extensor import ExTensor, zeros
+from shared.core.extensor import AnyTensor, zeros
 from testing import assert_equal, assert_true
 
 
 fn test_extensor_init_simple() raises:
-    """Test basic ExTensor initialization."""
-    print("\n=== Test 1: Basic ExTensor Initialization ===")
+    """Test basic AnyTensor initialization."""
+    print("\n=== Test 1: Basic AnyTensor Initialization ===")
 
     # Small tensor
     var shape1 = List[Int]()
@@ -20,7 +20,7 @@ fn test_extensor_init_simple() raises:
     shape1.append(3)
 
     print("Creating tensor shape (2, 3)...")
-    var t1 = ExTensor(shape1, DType.float32)
+    var t1 = AnyTensor(shape1, DType.float32)
     print("SUCCESS: numel =", t1.numel(), "dim =", t1.dim())
 
     # Check strides (need explicit copy since List[Int] isn't ImplicitlyCopyable)
@@ -31,7 +31,7 @@ fn test_extensor_init_simple() raises:
 
 
 fn test_extensor_init_large_shapes() raises:
-    """Test ExTensor with progressively larger shapes."""
+    """Test AnyTensor with progressively larger shapes."""
     print("\n=== Test 2: Large Shape Initialization ===")
 
     # Test case 1: (10, 10)
@@ -71,7 +71,7 @@ fn test_shape_creation(shape: List[Int]) raises:
 
     print("  numel =", numel)
     try:
-        var t = ExTensor(shape, DType.float32)
+        var t = AnyTensor(shape, DType.float32)
         print("  SUCCESS: Created tensor with", t.dim(), "dimensions")
 
         # Verify strides were calculated correctly
@@ -95,14 +95,14 @@ fn test_shape_creation(shape: List[Int]) raises:
 
 
 fn test_extensor_init_multidimensional() raises:
-    """Test ExTensor with various dimensionalities."""
+    """Test AnyTensor with various dimensionalities."""
     print("\n=== Test 3: Multi-Dimensional Tensors ===")
 
     # 1D
     print("\n1D tensor (100)...")
     var shape1 = List[Int]()
     shape1.append(100)
-    var t1 = ExTensor(shape1, DType.float32)
+    var t1 = AnyTensor(shape1, DType.float32)
     print("  SUCCESS: strides =", t1._strides[0])
 
     # 2D
@@ -110,7 +110,7 @@ fn test_extensor_init_multidimensional() raises:
     var shape2 = List[Int]()
     shape2.append(10)
     shape2.append(20)
-    var t2 = ExTensor(shape2, DType.float32)
+    var t2 = AnyTensor(shape2, DType.float32)
     print("  SUCCESS: strides =", t2._strides[0], t2._strides[1])
 
     # 3D
@@ -119,7 +119,7 @@ fn test_extensor_init_multidimensional() raises:
     shape3.append(5)
     shape3.append(10)
     shape3.append(15)
-    var t3 = ExTensor(shape3, DType.float32)
+    var t3 = AnyTensor(shape3, DType.float32)
     print(
         "  SUCCESS: strides =", t3._strides[0], t3._strides[1], t3._strides[2]
     )
@@ -131,7 +131,7 @@ fn test_extensor_init_multidimensional() raises:
     shape4.append(1)
     shape4.append(28)
     shape4.append(28)
-    var t4 = ExTensor(shape4, DType.float32)
+    var t4 = AnyTensor(shape4, DType.float32)
     print(
         "  SUCCESS: strides =",
         t4._strides[0],
@@ -205,9 +205,9 @@ fn test_extensor_stride_preallocate() raises:
             print(strides_test[j], end=" ")
         print()
 
-        # Now test actual ExTensor creation
-        print("  Creating ExTensor with same shape...")
-        var t = ExTensor(shape, DType.float32)
+        # Now test actual AnyTensor creation
+        print("  Creating AnyTensor with same shape...")
+        var t = AnyTensor(shape, DType.float32)
         print("  SUCCESS")
 
 
@@ -219,28 +219,28 @@ fn test_memory_limits() raises:
     print("\nSmall tensor (100 bytes)...")
     var shape1 = List[Int]()
     shape1.append(25)  # 25 * 4 bytes = 100 bytes
-    var t1 = ExTensor(shape1, DType.float32)
+    var t1 = AnyTensor(shape1, DType.float32)
     print("  SUCCESS:", t1.numel() * 4, "bytes")
 
     # Medium tensor (1 MB)
     print("\nMedium tensor (~1 MB)...")
     var shape2 = List[Int]()
     shape2.append(250000)  # 250k * 4 bytes = 1 MB
-    var t2 = ExTensor(shape2, DType.float32)
+    var t2 = AnyTensor(shape2, DType.float32)
     print("  SUCCESS:", t2.numel() * 4, "bytes")
 
     # Large tensor (100 MB)
     print("\nLarge tensor (~100 MB)...")
     var shape3 = List[Int]()
     shape3.append(25000000)  # 25M * 4 bytes = 100 MB
-    var t3 = ExTensor(shape3, DType.float32)
+    var t3 = AnyTensor(shape3, DType.float32)
     print("  SUCCESS:", t3.numel() * 4, "bytes")
 
     # Very large tensor (500 MB - warning threshold)
     print("\nVery large tensor (~500 MB) - should warn...")
     var shape4 = List[Int]()
     shape4.append(125000000)  # 125M * 4 bytes = 500 MB
-    var t4 = ExTensor(shape4, DType.float32)
+    var t4 = AnyTensor(shape4, DType.float32)
     print("  SUCCESS:", t4.numel() * 4, "bytes")
 
     # Exceeds limit (should raise error)
@@ -250,14 +250,14 @@ fn test_memory_limits() raises:
         shape5.append(
             1000000000
         )  # 1B * 4 bytes = 4 GB (exceeds MAX_TENSOR_BYTES)
-        var t5 = ExTensor(shape5, DType.float32)
+        var t5 = AnyTensor(shape5, DType.float32)
         print("  ERROR: Should have raised exception!")
     except e:
         print("  SUCCESS: Caught expected error:", e)
 
 
 fn main() raises:
-    """Run all ExTensor initialization tests."""
+    """Run all AnyTensor initialization tests."""
     print("=" * 60)
     print("EXTENSOR INITIALIZATION TESTS")
     print("=" * 60)

--- a/tests/unit/test_list_append_stress.mojo
+++ b/tests/unit/test_list_append_stress.mojo
@@ -1,8 +1,8 @@
 """Stress test for List[Int] append operations.
 
-The crash occurs during List[Int].append(0) in ExTensor.__init__ at line 107.
+The crash occurs during List[Int].append(0) in AnyTensor.__init__ at line 107.
 This test stresses List operations to identify if there's a memory issue with
-List itself or with the specific pattern used in ExTensor.
+List itself or with the specific pattern used in AnyTensor.
 """
 
 from collections import List
@@ -61,7 +61,7 @@ fn test_list_rapid_allocations() raises:
 
 
 fn test_list_append_pattern_from_extensor() raises:
-    """Test the exact append pattern used in ExTensor.__init__.
+    """Test the exact append pattern used in AnyTensor.__init__.
 
     This reproduces the pattern from lines 104-110:
         self._strides = List[Int]()
@@ -72,7 +72,7 @@ fn test_list_append_pattern_from_extensor() raises:
             self._strides[i] = stride
             stride *= self._shape[i]
     """
-    print("\n=== Test 4: ExTensor Stride Pattern ===")
+    print("\n=== Test 4: AnyTensor Stride Pattern ===")
 
     # Test case 1: 1D shape
     print("\nTest case 1: 1D shape [2]")
@@ -154,7 +154,7 @@ fn test_list_reverse_iteration_append() raises:
 
         var lst = List[Int]()
 
-        # Reverse iteration append (like in ExTensor)
+        # Reverse iteration append (like in AnyTensor)
         print("    Reverse iteration append...")
         for _ in range(size - 1, -1, -1):
             lst.append(0)
@@ -218,7 +218,7 @@ fn test_list_zero_append_stress() raises:
         lst1.append(0)
     print("    len =", len(lst1))
 
-    # Pattern 2: Sequential backward (like ExTensor)
+    # Pattern 2: Sequential backward (like AnyTensor)
     print("\n  Pattern 2: Backward loop, forward append of zeros...")
     var lst2 = List[Int]()
     for _ in range(100 - 1, -1, -1):


### PR DESCRIPTION
## Summary
- Mechanical rename of `ExTensor` → `AnyTensor` across 198 files (1652 replacements)
- Covers tests/models/, tests/shared/training/, tests/shared/autograd/, tests/shared/data/, tests/shared/integration/, tests/shared/testing/, tests/shared/benchmarks/, tests/shared/fuzz/, tests/shared/utils/, tests/training/, tests/unit/, tests/integration/, tests/examples/, tests/helpers/, and examples/
- No test logic or values changed — only type names, imports, and comments

## Test plan
- [ ] Verify no `ExTensor` references remain outside tests/shared/core/ and tests/shared/tensor/
- [ ] CI passes (compilation validates import/type correctness)

Sub-PR for #4998 PR 10b. Part of #4998

🤖 Generated with [Claude Code](https://claude.com/claude-code)