### PR TITLE
refactor(tests): migrate tests/shared/core/ to AnyTensor

### DIFF
--- a/tests/shared/core/layers/DISABLED_test_batchnorm.mojo
+++ b/tests/shared/core/layers/DISABLED_test_batchnorm.mojo
@@ -16,7 +16,7 @@ from shared.testing.assertions import (
     assert_equal_int,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, randn
+from shared.core.extensor import AnyTensor, zeros, ones, randn
 from shared.core.layers.batchnorm import BatchNorm2dLayer
 
 

--- a/tests/shared/core/layers/DISABLED_test_conv2d.mojo
+++ b/tests/shared/core/layers/DISABLED_test_conv2d.mojo
@@ -17,7 +17,7 @@ from shared.testing.assertions import (
     assert_shape,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, randn
+from shared.core.extensor import AnyTensor, zeros, ones, randn
 from shared.core.layers.conv2d import Conv2dLayer
 
 

--- a/tests/shared/core/layers/test_dropout.mojo
+++ b/tests/shared/core/layers/test_dropout.mojo
@@ -10,7 +10,7 @@ Tests cover:
 
 from testing import assert_true, assert_false, assert_almost_equal
 from shared.core.layers import DropoutLayer
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 
 
 fn test_dropout_init_valid() raises:
@@ -97,7 +97,7 @@ fn test_dropout_forward_inference_mode() raises:
     layer.set_training(False)
 
     # Create input
-    var input = ExTensor([4], DType.float32)
+    var input = AnyTensor([4], DType.float32)
     var input_values: List[Float32] = [1.0, 2.0, 3.0, 4.0]
     for i in range(4):
         input._data.bitcast[Float32]()[i] = input_values[i]
@@ -121,7 +121,7 @@ fn test_dropout_forward_training_mode_shape() raises:
     layer.set_training(True)
 
     # Create input with various shapes
-    var input_1d = ExTensor([10], DType.float32)
+    var input_1d = AnyTensor([10], DType.float32)
     for i in range(10):
         input_1d._data.bitcast[Float32]()[i] = Float32(i)
 
@@ -131,7 +131,7 @@ fn test_dropout_forward_training_mode_shape() raises:
         "1D output shape should be preserved",
     )
 
-    var input_2d = ExTensor([4, 5], DType.float32)
+    var input_2d = AnyTensor([4, 5], DType.float32)
     for i in range(20):
         input_2d._data.bitcast[Float32]()[i] = Float32(i)
 
@@ -152,7 +152,7 @@ fn test_dropout_forward_training_mode_zeros() raises:
     layer.set_training(True)
 
     # Create input with all ones
-    var input = ExTensor([100], DType.float32)
+    var input = AnyTensor([100], DType.float32)
     for i in range(100):
         input._data.bitcast[Float32]()[i] = 1.0
 
@@ -181,7 +181,7 @@ fn test_dropout_forward_training_mode_scale() raises:
     layer.set_training(True)
 
     # Create input with all ones
-    var input = ExTensor([100], DType.float32)
+    var input = AnyTensor([100], DType.float32)
     for i in range(100):
         input._data.bitcast[Float32]()[i] = 1.0
 
@@ -205,14 +205,14 @@ fn test_dropout_backward_shape() raises:
     layer.set_training(True)
 
     # Create input and forward pass to get mask
-    var input = ExTensor([4, 5], DType.float32)
+    var input = AnyTensor([4, 5], DType.float32)
     for i in range(20):
         input._data.bitcast[Float32]()[i] = 1.0
 
     var output = layer.forward(input)
 
     # Create gradient
-    var grad_output = ExTensor([4, 5], DType.float32)
+    var grad_output = AnyTensor([4, 5], DType.float32)
     for i in range(20):
         grad_output._data.bitcast[Float32]()[i] = 0.1
 
@@ -234,7 +234,7 @@ fn test_dropout_backward_scaling() raises:
     layer.set_training(True)
 
     # Create input and forward pass
-    var input = ExTensor([4], DType.float32)
+    var input = AnyTensor([4], DType.float32)
     for i in range(4):
         input._data.bitcast[Float32]()[i] = 1.0
 
@@ -242,7 +242,7 @@ fn test_dropout_backward_scaling() raises:
     var mask = layer.last_mask
 
     # Create gradient with all ones
-    var grad_output = ExTensor([4], DType.float32)
+    var grad_output = AnyTensor([4], DType.float32)
     for i in range(4):
         grad_output._data.bitcast[Float32]()[i] = 1.0
 
@@ -279,7 +279,7 @@ fn test_dropout_forward_float64() raises:
     var layer = DropoutLayer(0.5)
     layer.set_training(True)
 
-    var input = ExTensor([50], DType.float64)
+    var input = AnyTensor([50], DType.float64)
     for i in range(50):
         input._data.bitcast[Float64]()[i] = 1.0
 
@@ -306,7 +306,7 @@ fn test_dropout_zero_dropout_rate() raises:
     var layer = DropoutLayer(0.0)
     layer.set_training(True)
 
-    var input = ExTensor([10], DType.float32)
+    var input = AnyTensor([10], DType.float32)
     for i in range(10):
         input._data.bitcast[Float32]()[i] = 1.0
 
@@ -328,7 +328,7 @@ fn test_dropout_high_dropout_rate() raises:
     var layer = DropoutLayer(0.9)
     layer.set_training(True)
 
-    var input = ExTensor([100], DType.float32)
+    var input = AnyTensor([100], DType.float32)
     for i in range(100):
         input._data.bitcast[Float32]()[i] = 1.0
 

--- a/tests/shared/core/layers/test_linear_struct.mojo
+++ b/tests/shared/core/layers/test_linear_struct.mojo
@@ -14,7 +14,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_true,
 )
-from shared.core.extensor import ExTensor, ones, zeros, zeros_like
+from shared.core.extensor import AnyTensor, ones, zeros, zeros_like
 from shared.core.layers.linear import Linear
 
 

--- a/tests/shared/core/layers/test_relu.mojo
+++ b/tests/shared/core/layers/test_relu.mojo
@@ -8,7 +8,7 @@ Tests cover:
 
 from testing import assert_true, assert_false
 from shared.core.layers import ReLULayer
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 
 
 fn test_relu_forward_basic() raises:
@@ -16,7 +16,7 @@ fn test_relu_forward_basic() raises:
     var layer = ReLULayer()
 
     # Create input with mixed positive and negative values
-    var input = ExTensor([5], DType.float32)
+    var input = AnyTensor([5], DType.float32)
     var input_values: List[Float32] = [-2.0, -1.0, 0.0, 1.0, 2.0]
     for i in range(5):
         input._data.bitcast[Float32]()[i] = input_values[i]
@@ -38,7 +38,7 @@ fn test_relu_forward_all_negative() raises:
     """Test ReLU forward pass with all negative inputs."""
     var layer = ReLULayer()
 
-    var input = ExTensor([4], DType.float32)
+    var input = AnyTensor([4], DType.float32)
     var input_values: List[Float32] = [-5.0, -2.0, -0.1, -10.0]
     for i in range(4):
         input._data.bitcast[Float32]()[i] = input_values[i]
@@ -57,7 +57,7 @@ fn test_relu_forward_all_positive() raises:
     """Test ReLU forward pass with all positive inputs."""
     var layer = ReLULayer()
 
-    var input = ExTensor([4], DType.float32)
+    var input = AnyTensor([4], DType.float32)
     var input_values: List[Float32] = [0.5, 1.0, 5.0, 10.0]
     for i in range(4):
         input._data.bitcast[Float32]()[i] = input_values[i]
@@ -79,7 +79,7 @@ fn test_relu_forward_batch() raises:
     var layer = ReLULayer()
 
     # Create 2x3 batch
-    var input = ExTensor([2, 3], DType.float32)
+    var input = AnyTensor([2, 3], DType.float32)
     var input_values: List[Float32] = [-1.0, 0.5, -0.5, 2.0, -2.0, 1.5]
     for i in range(6):
         input._data.bitcast[Float32]()[i] = input_values[i]
@@ -99,13 +99,13 @@ fn test_relu_backward_basic() raises:
     var layer = ReLULayer()
 
     # Input: [-2, -1, 0, 1, 2]
-    var input = ExTensor([5], DType.float32)
+    var input = AnyTensor([5], DType.float32)
     var input_values: List[Float32] = [-2.0, -1.0, 0.0, 1.0, 2.0]
     for i in range(5):
         input._data.bitcast[Float32]()[i] = input_values[i]
 
     # Gradient from upstream: [0.1, 0.2, 0.3, 0.4, 0.5]
-    var grad_output = ExTensor([5], DType.float32)
+    var grad_output = AnyTensor([5], DType.float32)
     var grad_values: List[Float32] = [0.1, 0.2, 0.3, 0.4, 0.5]
     for i in range(5):
         grad_output._data.bitcast[Float32]()[i] = grad_values[i]
@@ -128,12 +128,12 @@ fn test_relu_backward_all_positive() raises:
     """Test ReLU backward pass with all positive inputs."""
     var layer = ReLULayer()
 
-    var input = ExTensor([4], DType.float32)
+    var input = AnyTensor([4], DType.float32)
     var input_values: List[Float32] = [1.0, 2.0, 3.0, 4.0]
     for i in range(4):
         input._data.bitcast[Float32]()[i] = input_values[i]
 
-    var grad_output = ExTensor([4], DType.float32)
+    var grad_output = AnyTensor([4], DType.float32)
     var grad_values: List[Float32] = [0.1, 0.2, 0.3, 0.4]
     for i in range(4):
         grad_output._data.bitcast[Float32]()[i] = grad_values[i]
@@ -155,12 +155,12 @@ fn test_relu_backward_all_negative() raises:
     """Test ReLU backward pass with all negative inputs."""
     var layer = ReLULayer()
 
-    var input = ExTensor([4], DType.float32)
+    var input = AnyTensor([4], DType.float32)
     var input_values: List[Float32] = [-1.0, -2.0, -3.0, -4.0]
     for i in range(4):
         input._data.bitcast[Float32]()[i] = input_values[i]
 
-    var grad_output = ExTensor([4], DType.float32)
+    var grad_output = AnyTensor([4], DType.float32)
     var grad_values: List[Float32] = [0.1, 0.2, 0.3, 0.4]
     for i in range(4):
         grad_output._data.bitcast[Float32]()[i] = grad_values[i]
@@ -188,7 +188,7 @@ fn test_relu_forward_float64() raises:
     """Test ReLU forward pass with float64 dtype."""
     var layer = ReLULayer()
 
-    var input = ExTensor([4], DType.float64)
+    var input = AnyTensor([4], DType.float64)
     var input_values: List[Float64] = [-1.5, 0.5, -2.5, 3.5]
     for i in range(4):
         input._data.bitcast[Float64]()[i] = input_values[i]
@@ -210,12 +210,12 @@ fn test_relu_backward_float64() raises:
     """Test ReLU backward pass with float64 dtype."""
     var layer = ReLULayer()
 
-    var input = ExTensor([4], DType.float64)
+    var input = AnyTensor([4], DType.float64)
     var input_values: List[Float64] = [-1.0, 0.0, 1.0, 2.0]
     for i in range(4):
         input._data.bitcast[Float64]()[i] = input_values[i]
 
-    var grad_output = ExTensor([4], DType.float64)
+    var grad_output = AnyTensor([4], DType.float64)
     var grad_values: List[Float64] = [0.1, 0.2, 0.3, 0.4]
     for i in range(4):
         grad_output._data.bitcast[Float64]()[i] = grad_values[i]

--- a/tests/shared/core/test_activation_funcs_part1.mojo
+++ b/tests/shared/core/test_activation_funcs_part1.mojo
@@ -19,7 +19,7 @@ from tests.shared.conftest import (
     assert_less_or_equal,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.activation import (
     relu,
     relu_backward,

--- a/tests/shared/core/test_activation_funcs_part2.mojo
+++ b/tests/shared/core/test_activation_funcs_part2.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     assert_less_or_equal,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.activation import (
     tanh,
     tanh_backward,

--- a/tests/shared/core/test_activation_funcs_part3.mojo
+++ b/tests/shared/core/test_activation_funcs_part3.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     assert_less_or_equal,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.activation import (
     relu,
     relu_backward,

--- a/tests/shared/core/test_activations_part1.mojo
+++ b/tests/shared/core/test_activations_part1.mojo
@@ -15,7 +15,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     zeros_like,
@@ -101,7 +101,7 @@ fn test_relu_backward() raises:
     x._data.bitcast[Float32]()[3] = 2.0
 
     # Forward function wrapper
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return relu(x)
 
     var y = relu(x)
@@ -109,8 +109,8 @@ fn test_relu_backward() raises:
 
     # Backward function wrapper
     fn backward_wrapper(
-        grad: ExTensor, x: ExTensor
-    ) raises escaping -> ExTensor:
+        grad: AnyTensor, x: AnyTensor
+    ) raises escaping -> AnyTensor:
         return relu_backward(grad, x)
 
     # Use numerical gradient checking (gold standard)

--- a/tests/shared/core/test_activations_part2.mojo
+++ b/tests/shared/core/test_activations_part2.mojo
@@ -14,7 +14,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     full,
     ones_like,
@@ -47,7 +47,7 @@ fn test_leaky_relu_backward() raises:
     x._data.bitcast[Float32]()[1] = 1.0
 
     # Forward function wrapper
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return leaky_relu(x, alpha=0.1)
 
     var y = leaky_relu(x, alpha=0.1)
@@ -55,8 +55,8 @@ fn test_leaky_relu_backward() raises:
 
     # Use numerical gradient checking (gold standard)
     fn backward_wrapper(
-        grad: ExTensor, x: ExTensor
-    ) raises escaping -> ExTensor:
+        grad: AnyTensor, x: AnyTensor
+    ) raises escaping -> AnyTensor:
         return leaky_relu_backward(grad, x, alpha=0.1)
 
     # Note: rtol=1e-3 is appropriate for float32 finite differences
@@ -176,14 +176,14 @@ fn test_prelu_backward() raises:
     alpha._data.bitcast[Float32]()[1] = 0.5
 
     # Forward function wrapper
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return prelu(x, alpha)
 
     var y = prelu(x, alpha)
     var grad_out = ones_like(y)
 
     # Validate gradient w.r.t. input using numerical checking
-    fn backward_input(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward_input(grad: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var result = prelu_backward(grad, x, alpha)
         return result.grad_a
 
@@ -231,14 +231,14 @@ fn test_sigmoid_backward() raises:
     x._data.bitcast[Float32]()[2] = 1.0
 
     # Forward function wrapper
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return sigmoid(x)
 
     var y = sigmoid(x)
     var grad_out = ones_like(y)
 
     # Note: sigmoid_backward takes output y, not input x
-    fn backward_fn(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var out = sigmoid(x)  # Recompute output inside wrapper
         return sigmoid_backward(grad, out)
 

--- a/tests/shared/core/test_activations_part3.mojo
+++ b/tests/shared/core/test_activations_part3.mojo
@@ -14,7 +14,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones_like,
 )
@@ -157,14 +157,14 @@ fn test_tanh_backward() raises:
     x._data.bitcast[Float32]()[2] = 1.0
 
     # Forward function wrapper
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return tanh(x)
 
     var y = tanh(x)
     var grad_out = ones_like(y)
 
     # Note: tanh_backward takes output y, not input x
-    fn backward_fn(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var out = tanh(x)  # Recompute output inside wrapper
         return tanh_backward(grad, out)
 

--- a/tests/shared/core/test_activations_part4.mojo
+++ b/tests/shared/core/test_activations_part4.mojo
@@ -15,7 +15,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     ones_like,
@@ -123,14 +123,14 @@ fn test_softmax_backward() raises:
     x._data.bitcast[Float32]()[5] = 1.5
 
     # Forward function wrapper
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return softmax(x, axis=1)
 
     var y = softmax(x, axis=1)
     var grad_out = ones_like(y)
 
     # Note: softmax_backward takes output y, not input x
-    fn backward_fn(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var out = softmax(x, axis=1)  # Recompute output inside wrapper
         return softmax_backward(grad, out, axis=1)
 

--- a/tests/shared/core/test_activations_part5.mojo
+++ b/tests/shared/core/test_activations_part5.mojo
@@ -14,7 +14,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones_like,
 )
@@ -114,14 +114,14 @@ fn test_gelu_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 0.5
 
     # Forward function wrapper
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return gelu(x, approximate=False)
 
     var y = gelu(x, approximate=False)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         return gelu_backward(grad, x, approximate=False)
 
     # Use numerical gradient checking (gold standard)
@@ -177,14 +177,14 @@ fn test_swish_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 0.5
 
     # Forward function wrapper
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return swish(x)
 
     var y = swish(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         return swish_backward(grad, x)
 
     # Use numerical gradient checking (gold standard)

--- a/tests/shared/core/test_activations_part6.mojo
+++ b/tests/shared/core/test_activations_part6.mojo
@@ -15,7 +15,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     ones_like,
@@ -67,14 +67,14 @@ fn test_mish_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 0.5
 
     # Forward function wrapper
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return mish(x)
 
     var y = mish(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         return mish_backward(grad, x)
 
     # Use numerical gradient checking (gold standard)
@@ -123,14 +123,14 @@ fn test_elu_backward() raises:
     x._data.bitcast[Float32]()[2] = 1.0
 
     # Forward function wrapper
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return elu(x, alpha=1.0)
 
     var y = elu(x, alpha=1.0)
     var grad_out = ones_like(y)
 
     # Note: elu_backward takes x, y, and alpha
-    fn backward_fn(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         return elu_backward(grad, x, alpha=1.0)
 
     # Use numerical gradient checking (gold standard)

--- a/tests/shared/core/test_advanced_activations_part1.mojo
+++ b/tests/shared/core/test_advanced_activations_part1.mojo
@@ -19,7 +19,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.core.activation import (
     swish,
     swish_backward,

--- a/tests/shared/core/test_advanced_activations_part2.mojo
+++ b/tests/shared/core/test_advanced_activations_part2.mojo
@@ -20,7 +20,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.core.activation import (
     mish,
     mish_backward,

--- a/tests/shared/core/test_advanced_activations_part3.mojo
+++ b/tests/shared/core/test_advanced_activations_part3.mojo
@@ -19,7 +19,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.core.activation import (
     elu,
     elu_backward,

--- a/tests/shared/core/test_arithmetic_backward_part1.mojo
+++ b/tests/shared/core/test_arithmetic_backward_part1.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
 )
 from tests.shared.conftest import TestFixtures
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     ones_like,
@@ -61,11 +61,11 @@ fn create_shape_vec(*dims: Int) -> List[Int]:
     return shape^
 
 
-fn fill_tensor_sequential(tensor: ExTensor, start_val: Float32 = 1.0) -> None:
+fn fill_tensor_sequential(tensor: AnyTensor, start_val: Float32 = 1.0) -> None:
     """Fill tensor with sequential values starting from start_val.
 
     Args:
-        tensor: ExTensor to fill.
+        tensor: AnyTensor to fill.
         start_val: Starting value for sequence.
     """
     for i in range(tensor.numel()):

--- a/tests/shared/core/test_arithmetic_backward_part2.mojo
+++ b/tests/shared/core/test_arithmetic_backward_part2.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
 )
 from tests.shared.conftest import TestFixtures
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     ones_like,
@@ -237,10 +237,10 @@ fn test_add_backward_gradient() raises:
         a._data.bitcast[Float32]()[i] = Float32(i) * 0.1 - 1.2
         b._data.bitcast[Float32]()[i] = Float32(i) * 0.15 - 0.8
 
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: AnyTensor) raises -> AnyTensor:
         return add(inp, b)
 
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         var grads = add_backward(grad_out, inp, b)
         return grads.grad_a
 
@@ -269,10 +269,10 @@ fn test_subtract_backward_gradient() raises:
         a._data.bitcast[Float32]()[i] = Float32(i) * 0.1 + 0.5
         b._data.bitcast[Float32]()[i] = Float32(i) * 0.2 - 1.5
 
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: AnyTensor) raises -> AnyTensor:
         return subtract(inp, b)
 
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         var grads = subtract_backward(grad_out, inp, b)
         return grads.grad_a
 
@@ -302,10 +302,10 @@ fn test_multiply_backward_gradient() raises:
         a._data.bitcast[Float32]()[i] = Float32(i) * 0.1 + 0.1
         b._data.bitcast[Float32]()[i] = Float32(i) * 0.15 + 0.2
 
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: AnyTensor) raises -> AnyTensor:
         return multiply(inp, b)
 
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         var grads = multiply_backward(grad_out, inp, b)
         return grads.grad_a
 
@@ -335,10 +335,10 @@ fn test_divide_backward_gradient() raises:
         a._data.bitcast[Float32]()[i] = Float32(i) * 0.2 + 0.5
         b._data.bitcast[Float32]()[i] = Float32(i) * 0.1 + 1.0  # Ensure b > 0
 
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: AnyTensor) raises -> AnyTensor:
         return divide(inp, b)
 
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         var grads = divide_backward(grad_out, inp, b)
         return grads.grad_a
 

--- a/tests/shared/core/test_arithmetic_backward_part3.mojo
+++ b/tests/shared/core/test_arithmetic_backward_part3.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
 )
 from tests.shared.conftest import TestFixtures
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     ones_like,
@@ -80,10 +80,10 @@ fn test_add_backward_b_gradient() raises:
         a._data.bitcast[Float32]()[i] = Float32(i) * 0.1 - 0.5
         b._data.bitcast[Float32]()[i] = Float32(i) * 0.12 + 0.3
 
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: AnyTensor) raises -> AnyTensor:
         return add(a, inp)
 
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         var grads = add_backward(grad_out, a, inp)
         return grads.grad_b
 
@@ -112,10 +112,10 @@ fn test_subtract_backward_b_gradient() raises:
         a._data.bitcast[Float32]()[i] = Float32(i) * 0.15 + 0.2
         b._data.bitcast[Float32]()[i] = Float32(i) * 0.1 - 1.0
 
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: AnyTensor) raises -> AnyTensor:
         return subtract(a, inp)
 
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         var grads = subtract_backward(grad_out, a, inp)
         return grads.grad_b
 
@@ -144,10 +144,10 @@ fn test_multiply_backward_b_gradient() raises:
         a._data.bitcast[Float32]()[i] = Float32(i) * 0.2 + 0.1
         b._data.bitcast[Float32]()[i] = Float32(i) * 0.15 + 0.15
 
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: AnyTensor) raises -> AnyTensor:
         return multiply(a, inp)
 
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         var grads = multiply_backward(grad_out, a, inp)
         return grads.grad_b
 
@@ -176,10 +176,10 @@ fn test_divide_backward_b_gradient() raises:
         a._data.bitcast[Float32]()[i] = Float32(i) * 0.2 + 0.5
         b._data.bitcast[Float32]()[i] = Float32(i) * 0.1 + 1.5  # b > 0
 
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: AnyTensor) raises -> AnyTensor:
         return divide(a, inp)
 
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         var grads = divide_backward(grad_out, a, inp)
         return grads.grad_b
 
@@ -212,10 +212,10 @@ fn test_add_backward_broadcast_gradient() raises:
     for i in range(3):
         b._data.bitcast[Float32]()[i] = Float32(i) * 0.15 - 0.3
 
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: AnyTensor) raises -> AnyTensor:
         return add(a, inp)
 
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         var grads = add_backward(grad_out, a, inp)
         return grads.grad_b
 
@@ -248,10 +248,10 @@ fn test_multiply_backward_broadcast_gradient() raises:
     for i in range(3):
         b._data.bitcast[Float32]()[i] = Float32(i) * 0.2 + 0.2
 
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: AnyTensor) raises -> AnyTensor:
         return multiply(a, inp)
 
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         var grads = multiply_backward(grad_out, a, inp)
         return grads.grad_b
 
@@ -284,10 +284,10 @@ fn test_divide_backward_broadcast_gradient() raises:
     for i in range(3):
         b._data.bitcast[Float32]()[i] = Float32(i) * 0.1 + 1.0  # b > 0
 
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: AnyTensor) raises -> AnyTensor:
         return divide(a, inp)
 
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         var grads = divide_backward(grad_out, a, inp)
         return grads.grad_b
 

--- a/tests/shared/core/test_arithmetic_contiguous_part1.mojo
+++ b/tests/shared/core/test_arithmetic_contiguous_part1.mojo
@@ -17,7 +17,7 @@ from tests.shared.conftest import (
     assert_shape,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.arithmetic import add, subtract, multiply, divide
 
 

--- a/tests/shared/core/test_arithmetic_contiguous_part2.mojo
+++ b/tests/shared/core/test_arithmetic_contiguous_part2.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     assert_shape,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.arithmetic import add, subtract, multiply, divide
 
 

--- a/tests/shared/core/test_arithmetic_contiguous_part3.mojo
+++ b/tests/shared/core/test_arithmetic_contiguous_part3.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     assert_shape,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.arithmetic import add, subtract, multiply, divide
 
 

--- a/tests/shared/core/test_arithmetic_contiguous_part4.mojo
+++ b/tests/shared/core/test_arithmetic_contiguous_part4.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     assert_shape,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.arithmetic import add, subtract, multiply, divide
 
 

--- a/tests/shared/core/test_arithmetic_noncontiguous_part1.mojo
+++ b/tests/shared/core/test_arithmetic_noncontiguous_part1.mojo
@@ -17,13 +17,13 @@ from tests.shared.conftest import (
     assert_false,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from shared.core.arithmetic import add, subtract, multiply, divide
 from shared.core.matrix import transpose_view
 from shared.core.shape import as_contiguous
 
 
-fn _make_noncontiguous_2x3() raises -> ExTensor:
+fn _make_noncontiguous_2x3() raises -> AnyTensor:
     """Create a non-contiguous 3×2 tensor by transposing a 2×3.
 
     The logical values (row-major for 3×2) are:

--- a/tests/shared/core/test_arithmetic_noncontiguous_part2.mojo
+++ b/tests/shared/core/test_arithmetic_noncontiguous_part2.mojo
@@ -18,13 +18,13 @@ from tests.shared.conftest import (
     assert_false,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from shared.core.arithmetic import add, subtract, multiply
 from shared.core.matrix import transpose_view
 from shared.core.shape import as_contiguous
 
 
-fn _make_nc_2x3() raises -> ExTensor:
+fn _make_nc_2x3() raises -> AnyTensor:
     """Non-contiguous 3×2 tensor (logical values: 0,3,1,4,2,5)."""
     var base = arange(0.0, 6.0, 1.0, DType.float32)
     var shaped = base.reshape([2, 3])

--- a/tests/shared/core/test_arithmetic_part1.mojo
+++ b/tests/shared/core/test_arithmetic_part1.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     assert_numel,
     assert_dtype,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.arithmetic import (
     add,
     add_backward,

--- a/tests/shared/core/test_arithmetic_part2.mojo
+++ b/tests/shared/core/test_arithmetic_part2.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     assert_numel,
     assert_dtype,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.arithmetic import (
     subtract,
     subtract_backward,

--- a/tests/shared/core/test_arithmetic_part3.mojo
+++ b/tests/shared/core/test_arithmetic_part3.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     assert_numel,
     assert_dtype,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.arithmetic import (
     multiply,
     multiply_backward,

--- a/tests/shared/core/test_arithmetic_part4.mojo
+++ b/tests/shared/core/test_arithmetic_part4.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     assert_numel,
     assert_dtype,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.arithmetic import (
     divide,
     divide_backward,

--- a/tests/shared/core/test_arithmetic_part5.mojo
+++ b/tests/shared/core/test_arithmetic_part5.mojo
@@ -14,7 +14,7 @@ from tests.shared.conftest import (
     assert_almost_equal,
     assert_equal_int,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.arithmetic import (
     floor_divide,
     modulo,

--- a/tests/shared/core/test_arithmetic_part6.mojo
+++ b/tests/shared/core/test_arithmetic_part6.mojo
@@ -14,7 +14,7 @@ from tests.shared.conftest import (
     assert_almost_equal,
     assert_equal_int,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.arithmetic import (
     modulo,
     power,

--- a/tests/shared/core/test_arithmetic_part7.mojo
+++ b/tests/shared/core/test_arithmetic_part7.mojo
@@ -14,7 +14,7 @@ from tests.shared.conftest import (
     assert_all_values,
     assert_dtype,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.arithmetic import (
     add,
     multiply,

--- a/tests/shared/core/test_arithmetic_part8.mojo
+++ b/tests/shared/core/test_arithmetic_part8.mojo
@@ -13,7 +13,7 @@ from tests.shared.conftest import (
     assert_dim,
     assert_numel,
 )
-from shared.core.extensor import ExTensor, ones
+from shared.core.extensor import AnyTensor, ones
 from shared.core.arithmetic import (
     add,
     multiply,

--- a/tests/shared/core/test_backward_conv_padding.mojo
+++ b/tests/shared/core/test_backward_conv_padding.mojo
@@ -12,7 +12,7 @@ from tests.shared.conftest import (
     assert_almost_equal,
     assert_equal,
 )
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.conv import conv2d, conv2d_backward
 from shared.testing import check_gradient
 
@@ -51,10 +51,10 @@ fn test_conv2d_backward_grad_input_padding1() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward_input(inp: ExTensor) raises -> ExTensor:
+    fn forward_input(inp: AnyTensor) raises -> AnyTensor:
         return conv2d(inp, kernel, bias, stride=1, padding=1)
 
-    fn backward_input(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward_input(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         var grads = conv2d_backward(grad_out, inp, kernel, stride=1, padding=1)
         return grads.grad_input
 
@@ -105,10 +105,10 @@ fn test_conv2d_backward_grad_weights_padding1() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward_weights(k: ExTensor) raises -> ExTensor:
+    fn forward_weights(k: AnyTensor) raises -> AnyTensor:
         return conv2d(x, k, bias, stride=1, padding=1)
 
-    fn backward_weights(grad_out: ExTensor, k: ExTensor) raises -> ExTensor:
+    fn backward_weights(grad_out: AnyTensor, k: AnyTensor) raises -> AnyTensor:
         var grads = conv2d_backward(grad_out, x, k, stride=1, padding=1)
         return grads.grad_weights
 
@@ -165,10 +165,10 @@ fn test_conv2d_backward_grad_input_padding2() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward_input(inp: ExTensor) raises -> ExTensor:
+    fn forward_input(inp: AnyTensor) raises -> AnyTensor:
         return conv2d(inp, kernel, bias, stride=1, padding=2)
 
-    fn backward_input(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward_input(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         var grads = conv2d_backward(grad_out, inp, kernel, stride=1, padding=2)
         return grads.grad_input
 
@@ -220,10 +220,10 @@ fn test_conv2d_backward_grad_weights_padding2() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward_weights(k: ExTensor) raises -> ExTensor:
+    fn forward_weights(k: AnyTensor) raises -> AnyTensor:
         return conv2d(x, k, bias, stride=1, padding=2)
 
-    fn backward_weights(grad_out: ExTensor, k: ExTensor) raises -> ExTensor:
+    fn backward_weights(grad_out: AnyTensor, k: AnyTensor) raises -> AnyTensor:
         var grads = conv2d_backward(grad_out, x, k, stride=1, padding=2)
         return grads.grad_weights
 

--- a/tests/shared/core/test_backward_conv_pool.mojo
+++ b/tests/shared/core/test_backward_conv_pool.mojo
@@ -7,7 +7,7 @@ from tests.shared.conftest import (
     assert_almost_equal,
     assert_equal,
 )
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.pooling import (
     maxpool2d,
@@ -23,7 +23,7 @@ from shared.testing import check_gradient
 # ============================================================================
 
 
-fn _make_test_conv2d_tensors() raises -> Tuple[ExTensor, ExTensor, ExTensor]:
+fn _make_test_conv2d_tensors() raises -> Tuple[AnyTensor, AnyTensor, AnyTensor]:
     """Create and initialize test tensors for conv2d backward tests.
 
     Returns:
@@ -146,10 +146,10 @@ fn test_conv2d_backward_grad_input_numerical() raises:
     """
     var (x, kernel, bias) = _make_test_conv2d_tensors()
 
-    fn forward_input(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward_input(inp: AnyTensor) raises escaping -> AnyTensor:
         return conv2d(inp, kernel, bias, stride=1, padding=0)
 
-    fn backward_input(grad_out: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward_input(grad_out: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         var grads = conv2d_backward(grad_out, inp, kernel, stride=1, padding=0)
         return grads.grad_input
 
@@ -169,10 +169,10 @@ fn test_conv2d_backward_grad_weights_numerical() raises:
     var (x, kernel, bias) = _make_test_conv2d_tensors()
 
     # Treat kernel as the variable being perturbed; x is held fixed
-    fn forward_weights(k: ExTensor) raises escaping -> ExTensor:
+    fn forward_weights(k: AnyTensor) raises escaping -> AnyTensor:
         return conv2d(x, k, bias, stride=1, padding=0)
 
-    fn backward_weights(grad_out: ExTensor, k: ExTensor) raises escaping -> ExTensor:
+    fn backward_weights(grad_out: AnyTensor, k: AnyTensor) raises escaping -> AnyTensor:
         var grads = conv2d_backward(grad_out, x, k, stride=1, padding=0)
         return grads.grad_weights
 
@@ -318,10 +318,10 @@ fn test_conv2d_backward_gradient() raises:
     bias_shape.append(2)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return conv2d(inp, kernel, bias, stride=1, padding=0)
 
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         var grads = conv2d_backward(grad_out, inp, kernel, stride=1, padding=0)
         return grads.grad_input
 
@@ -341,10 +341,10 @@ fn test_maxpool2d_backward_gradient() raises:
     for i in range(1 * 2 * 4 * 4):
         x.set(i, Float64(Float32(i) * 0.1 - 1.6))
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return maxpool2d(inp, kernel_size=2, stride=2, padding=0)
 
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return maxpool2d_backward(
             grad_out, inp, kernel_size=2, stride=2, padding=0
         )
@@ -365,10 +365,10 @@ fn test_avgpool2d_backward_gradient() raises:
     for i in range(1 * 2 * 4 * 4):
         x.set(i, Float64(Float32(i) * 0.1 - 1.6))
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return avgpool2d(inp, kernel_size=2, stride=2, padding=0)
 
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return avgpool2d_backward(
             grad_out, inp, kernel_size=2, stride=2, padding=0
         )

--- a/tests/shared/core/test_backward_conv_pool_batch.mojo
+++ b/tests/shared/core/test_backward_conv_pool_batch.mojo
@@ -12,7 +12,7 @@ Tests cover:
 """
 
 from tests.shared.conftest import assert_almost_equal, assert_equal
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.core.conv import conv2d, conv2d_backward
 
 

--- a/tests/shared/core/test_backward_linear.mojo
+++ b/tests/shared/core/test_backward_linear.mojo
@@ -8,7 +8,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, ones_like
 from shared.core.linear import linear, linear_backward
 from shared.testing import (
     check_gradient,
@@ -147,7 +147,7 @@ fn test_linear_backward_gradient() raises:
     weights.set(4, Float64(-0.2))
     weights.set(5, Float64(0.5))
 
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: AnyTensor) raises -> AnyTensor:
         var bias_shape = List[Int]()
         bias_shape.append(out_features)
         var bias = zeros(bias_shape, DType.float32)
@@ -155,7 +155,7 @@ fn test_linear_backward_gradient() raises:
         bias.set(1, Float64(-0.2))
         return linear(inp, weights, bias)
 
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         var grads = linear_backward(grad_out, inp, weights)
         return grads.grad_input
 

--- a/tests/shared/core/test_backward_losses.mojo
+++ b/tests/shared/core/test_backward_losses.mojo
@@ -8,7 +8,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, ones_like
 from shared.core.loss import (
     cross_entropy,
     cross_entropy_backward,
@@ -175,10 +175,10 @@ fn test_cross_entropy_backward_gradient() raises:
     targets.set(0, Float64(1.0))
     targets.set(4, Float64(1.0))
 
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: AnyTensor) raises -> AnyTensor:
         return cross_entropy(inp, targets)
 
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         return cross_entropy_backward(grad_out, inp, targets)
 
     var loss = forward(logits)
@@ -212,10 +212,10 @@ fn test_binary_cross_entropy_backward_gradient() raises:
     targets.set(6, Float64(0.0))
     targets.set(7, Float64(1.0))
 
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: AnyTensor) raises -> AnyTensor:
         return binary_cross_entropy(inp, targets)
 
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         return binary_cross_entropy_backward(grad_out, inp, targets)
 
     var loss = forward(predictions)
@@ -261,10 +261,10 @@ fn test_mean_squared_error_backward_gradient() raises:
     targets.set(10, Float64(0.0))
     targets.set(11, Float64(0.6))
 
-    fn forward(inp: ExTensor) raises -> ExTensor:
+    fn forward(inp: AnyTensor) raises -> AnyTensor:
         return mean_squared_error(inp, targets)
 
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         return mean_squared_error_backward(grad_out, inp, targets)
 
     var loss = forward(predictions)

--- a/tests/shared/core/test_broadcasting_part1.mojo
+++ b/tests/shared/core/test_broadcasting_part1.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor broadcasting operations - Part 1: Scalar and vector-to-matrix.
+"""Tests for AnyTensor broadcasting operations - Part 1: Scalar and vector-to-matrix.
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
@@ -7,8 +7,8 @@
 Tests NumPy-style broadcasting rules for scalar and vector-to-matrix cases.
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.arithmetic import add, multiply
 from testing import assert_true
 
@@ -178,7 +178,7 @@ fn test_broadcast_size_one_dim_middle() raises:
 
 fn main() raises:
     """Run broadcasting part 1 tests."""
-    print("Running ExTensor broadcasting tests - Part 1...")
+    print("Running AnyTensor broadcasting tests - Part 1...")
 
     # Scalar broadcasting
     print("  Testing scalar broadcasting...")

--- a/tests/shared/core/test_broadcasting_part2.mojo
+++ b/tests/shared/core/test_broadcasting_part2.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor broadcasting operations - Part 2: Size-1 dims, missing dims, complex multi-dim.
+"""Tests for AnyTensor broadcasting operations - Part 2: Size-1 dims, missing dims, complex multi-dim.
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
@@ -7,8 +7,8 @@
 Tests NumPy-style broadcasting rules for trailing size-1 dimensions, missing dimensions, and complex cases.
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.arithmetic import add, multiply
 from testing import assert_true
 
@@ -223,7 +223,7 @@ fn test_broadcast_output_shape_scalar_1d() raises:
 
 fn main() raises:
     """Run broadcasting part 2 tests."""
-    print("Running ExTensor broadcasting tests - Part 2...")
+    print("Running AnyTensor broadcasting tests - Part 2...")
 
     # Size-1 dimension broadcasting (trailing)
     print("  Testing size-1 dimension broadcasting (trailing)...")

--- a/tests/shared/core/test_broadcasting_part3.mojo
+++ b/tests/shared/core/test_broadcasting_part3.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor broadcasting operations - Part 3: Output shapes, dtype, and integration.
+"""Tests for AnyTensor broadcasting operations - Part 3: Output shapes, dtype, and integration.
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
@@ -7,8 +7,8 @@
 Tests broadcast output shapes, dtype preservation, and integration with comparison/arithmetic ops.
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.arithmetic import add, multiply
 from testing import assert_true
 
@@ -186,7 +186,7 @@ fn test_broadcast_with_divide() raises:
 
 fn main() raises:
     """Run broadcasting part 3 tests."""
-    print("Running ExTensor broadcasting tests - Part 3...")
+    print("Running AnyTensor broadcasting tests - Part 3...")
 
     # Output shape verification
     print("  Testing broadcast output shapes...")

--- a/tests/shared/core/test_broadcasting_part4.mojo
+++ b/tests/shared/core/test_broadcasting_part4.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor broadcasting operations - Part 4: BroadcastIterator implementation.
+"""Tests for AnyTensor broadcasting operations - Part 4: BroadcastIterator implementation.
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
@@ -7,8 +7,8 @@
 Tests the BroadcastIterator implementation for correctness across 1D, 2D, 3D cases.
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.arithmetic import add, multiply
 from testing import assert_true
 
@@ -295,7 +295,7 @@ fn test_broadcast_iterator_exhaustion() raises:
 
 fn main() raises:
     """Run broadcasting part 4 tests."""
-    print("Running ExTensor broadcasting tests - Part 4...")
+    print("Running AnyTensor broadcasting tests - Part 4...")
 
     # Complex 3D broadcasting
     print("  Testing complex 3D broadcasting with multiply...")

--- a/tests/shared/core/test_broadcasting_part5.mojo
+++ b/tests/shared/core/test_broadcasting_part5.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor broadcasting operations - Part 5: are_shapes_broadcastable ndim guard.
+"""Tests for AnyTensor broadcasting operations - Part 5: are_shapes_broadcastable ndim guard.
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
@@ -147,7 +147,7 @@ fn test_are_shapes_broadcastable_scalar_source_to_1d() raises:
 
 fn main() raises:
     """Run broadcasting part 5 tests (ndim guard in are_shapes_broadcastable)."""
-    print("Running ExTensor broadcasting tests - Part 5...")
+    print("Running AnyTensor broadcasting tests - Part 5...")
 
     # ndim reduction cases (must return False)
     print("  Testing ndim reduction returns False...")

--- a/tests/shared/core/test_comparison_ops_part1.mojo
+++ b/tests/shared/core/test_comparison_ops_part1.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor comparison operations - Part 1: equal and not_equal.
+"""Tests for AnyTensor comparison operations - Part 1: equal and not_equal.
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
@@ -9,8 +9,8 @@ equal, not_equal.
 All operations return boolean tensors (DType.bool).
 """
 
-# Import ExTensor and comparison operations
-from shared.core.extensor import ExTensor, full, ones, zeros
+# Import AnyTensor and comparison operations
+from shared.core.extensor import AnyTensor, full, ones, zeros
 from shared.core.comparison import equal, not_equal
 
 # Import test helpers
@@ -126,7 +126,7 @@ fn test_not_equal_with_dunder() raises:
 
 fn main() raises:
     """Run equal and not_equal comparison operation tests."""
-    print("Running ExTensor equal/not_equal comparison operation tests...")
+    print("Running AnyTensor equal/not_equal comparison operation tests...")
 
     # equal() tests
     print("  Testing equal()...")

--- a/tests/shared/core/test_comparison_ops_part2.mojo
+++ b/tests/shared/core/test_comparison_ops_part2.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor comparison operations - Part 2: less and less_equal.
+"""Tests for AnyTensor comparison operations - Part 2: less and less_equal.
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
@@ -9,8 +9,8 @@ less, less_equal.
 All operations return boolean tensors (DType.bool).
 """
 
-# Import ExTensor and comparison operations
-from shared.core.extensor import ExTensor, full, ones, zeros
+# Import AnyTensor and comparison operations
+from shared.core.extensor import AnyTensor, full, ones, zeros
 from shared.core.comparison import less, less_equal
 
 # Import test helpers
@@ -119,7 +119,7 @@ fn test_less_equal_with_dunder() raises:
 
 fn main() raises:
     """Run less and less_equal comparison operation tests."""
-    print("Running ExTensor less/less_equal comparison operation tests...")
+    print("Running AnyTensor less/less_equal comparison operation tests...")
 
     # less() tests
     print("  Testing less()...")

--- a/tests/shared/core/test_comparison_ops_part3.mojo
+++ b/tests/shared/core/test_comparison_ops_part3.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor comparison operations - Part 3: greater, greater_equal, negatives.
+"""Tests for AnyTensor comparison operations - Part 3: greater, greater_equal, negatives.
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
@@ -9,8 +9,8 @@ greater, greater_equal, and edge cases with negative values.
 All operations return boolean tensors (DType.bool).
 """
 
-# Import ExTensor and comparison operations
-from shared.core.extensor import ExTensor, full, ones, zeros
+# Import AnyTensor and comparison operations
+from shared.core.extensor import AnyTensor, full, ones, zeros
 from shared.core.comparison import greater, greater_equal, less
 
 # Import test helpers
@@ -143,7 +143,7 @@ fn main() raises:
     """Run greater, greater_equal, and negative value comparison operation tests.
     """
     print(
-        "Running ExTensor greater/greater_equal comparison operation tests..."
+        "Running AnyTensor greater/greater_equal comparison operation tests..."
     )
 
     # greater() tests

--- a/tests/shared/core/test_composed_op_part1.mojo
+++ b/tests/shared/core/test_composed_op_part1.mojo
@@ -14,7 +14,7 @@ Split from test_composed_op.mojo per ADR-009 (≤10 fn test_ per file).
 
 from testing import assert_true, assert_equal
 from tests.shared.conftest import assert_almost_equal, assert_shape_equal
-from shared.core.extensor import ExTensor, ones, zeros
+from shared.core.extensor import AnyTensor, ones, zeros
 from shared.core.traits import Differentiable, Composable, ComposedOp
 
 
@@ -23,7 +23,7 @@ from shared.core.traits import Differentiable, Composable, ComposedOp
 # ============================================================================
 
 
-fn make_tensor_with_shape(numel: Int) raises -> ExTensor:
+fn make_tensor_with_shape(numel: Int) raises -> AnyTensor:
     """Create a tensor with given number of elements."""
     var shape_list = List[Int]()
     shape_list.append(numel)
@@ -51,14 +51,14 @@ struct ScaleMul(Copyable, Differentiable, Movable):
     """
 
     var scale: Float64
-    var last_input: ExTensor
+    var last_input: AnyTensor
 
     fn __init__(out self, scale: Float64) raises:
         """Initialize with scale factor."""
         self.scale = scale
         self.last_input = make_tensor_with_shape(1)
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass: multiply by scale."""
         self.last_input = input.copy()
         var output = input.copy()
@@ -67,7 +67,7 @@ struct ScaleMul(Copyable, Differentiable, Movable):
             output._set_float64(i, input._get_float64(i) * self.scale)
         return output
 
-    fn backward(self, grad_output: ExTensor) raises -> ExTensor:
+    fn backward(self, grad_output: AnyTensor) raises -> AnyTensor:
         """Backward pass: multiply gradient by scale."""
         # Use clone() for deep copy - copy() creates a shallow view that shares data
         var grad_input = grad_output.clone()
@@ -86,14 +86,14 @@ struct ScaleAdd(Copyable, Differentiable, Movable):
     """
 
     var offset: Float64
-    var last_input: ExTensor
+    var last_input: AnyTensor
 
     fn __init__(out self, offset: Float64) raises:
         """Initialize with offset value."""
         self.offset = offset
         self.last_input = make_tensor_with_shape(1)
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass: add offset."""
         self.last_input = input.copy()
         var output = input.copy()
@@ -102,7 +102,7 @@ struct ScaleAdd(Copyable, Differentiable, Movable):
             output._set_float64(i, input._get_float64(i) + self.offset)
         return output
 
-    fn backward(self, grad_output: ExTensor) raises -> ExTensor:
+    fn backward(self, grad_output: AnyTensor) raises -> AnyTensor:
         """Backward pass: gradient passes through unchanged."""
         # Use clone() for deep copy - copy() creates a shallow view that shares data
         return grad_output.clone()

--- a/tests/shared/core/test_composed_op_part2.mojo
+++ b/tests/shared/core/test_composed_op_part2.mojo
@@ -15,7 +15,7 @@ Split from test_composed_op.mojo per ADR-009 (≤10 fn test_ per file).
 
 from testing import assert_true, assert_equal
 from tests.shared.conftest import assert_almost_equal, assert_shape_equal
-from shared.core.extensor import ExTensor, ones, zeros
+from shared.core.extensor import AnyTensor, ones, zeros
 from shared.core.traits import Differentiable, Composable, ComposedOp
 
 
@@ -24,7 +24,7 @@ from shared.core.traits import Differentiable, Composable, ComposedOp
 # ============================================================================
 
 
-fn make_tensor_with_shape(numel: Int) raises -> ExTensor:
+fn make_tensor_with_shape(numel: Int) raises -> AnyTensor:
     """Create a tensor with given number of elements."""
     var shape_list = List[Int]()
     shape_list.append(numel)
@@ -45,14 +45,14 @@ struct ScaleMul(Copyable, Differentiable, Movable):
     """
 
     var scale: Float64
-    var last_input: ExTensor
+    var last_input: AnyTensor
 
     fn __init__(out self, scale: Float64) raises:
         """Initialize with scale factor."""
         self.scale = scale
         self.last_input = make_tensor_with_shape(1)
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass: multiply by scale."""
         self.last_input = input.copy()
         var output = input.copy()
@@ -61,7 +61,7 @@ struct ScaleMul(Copyable, Differentiable, Movable):
             output._set_float64(i, input._get_float64(i) * self.scale)
         return output
 
-    fn backward(self, grad_output: ExTensor) raises -> ExTensor:
+    fn backward(self, grad_output: AnyTensor) raises -> AnyTensor:
         """Backward pass: multiply gradient by scale."""
         # Use clone() for deep copy - copy() creates a shallow view that shares data
         var grad_input = grad_output.clone()
@@ -80,14 +80,14 @@ struct ScaleAdd(Copyable, Differentiable, Movable):
     """
 
     var offset: Float64
-    var last_input: ExTensor
+    var last_input: AnyTensor
 
     fn __init__(out self, offset: Float64) raises:
         """Initialize with offset value."""
         self.offset = offset
         self.last_input = make_tensor_with_shape(1)
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass: add offset."""
         self.last_input = input.copy()
         var output = input.copy()
@@ -96,7 +96,7 @@ struct ScaleAdd(Copyable, Differentiable, Movable):
             output._set_float64(i, input._get_float64(i) + self.offset)
         return output
 
-    fn backward(self, grad_output: ExTensor) raises -> ExTensor:
+    fn backward(self, grad_output: AnyTensor) raises -> AnyTensor:
         """Backward pass: gradient passes through unchanged."""
         # Use clone() for deep copy - copy() creates a shallow view that shares data
         return grad_output.clone()

--- a/tests/shared/core/test_concatenate_noncontiguous.mojo
+++ b/tests/shared/core/test_concatenate_noncontiguous.mojo
@@ -10,7 +10,7 @@ These tests verify:
 - Incompatible shapes raise the expected error.
 """
 
-from shared.core import ExTensor, zeros, concatenate
+from shared.core import AnyTensor, zeros, concatenate
 from tests.shared.conftest import (
     assert_numel,
     assert_dim,
@@ -37,7 +37,7 @@ fn test_concat_contiguous_axis0() raises:
     for i in range(6):
         b._set_float64(i, 1.0)
 
-    var tensors: List[ExTensor] = []
+    var tensors: List[AnyTensor] = []
     tensors.append(a)
     tensors.append(b)
 
@@ -89,7 +89,7 @@ fn test_concat_noncontiguous_axis0() raises:
 
     # Contiguous pad tensor filled with 0.0
     var pad = zeros(shape, DType.float32)
-    var tensors: List[ExTensor] = []
+    var tensors: List[AnyTensor] = []
     tensors.append(t)
     tensors.append(pad)
 
@@ -129,7 +129,7 @@ fn test_concat_incompatible_shapes_raises() raises:
     shape_b.append(4)  # Different column count — incompatible for axis=0 concat
     var b = zeros(shape_b, DType.float32)
 
-    var tensors: List[ExTensor] = []
+    var tensors: List[AnyTensor] = []
     tensors.append(a)
     tensors.append(b)
 

--- a/tests/shared/core/test_conv.mojo
+++ b/tests/shared/core/test_conv.mojo
@@ -25,7 +25,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, full, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, full, ones_like
 from shared.core.conv import (
     conv2d,
     conv2d_no_bias,
@@ -1056,7 +1056,7 @@ fn test_conv2d_backward_gradient_input() raises:
     var analytical_grad = result.grad_input
 
     # Numerical gradient: forward_fn sums conv output (equivalent to ones grad_output)
-    fn forward_for_input(inp: ExTensor) raises -> ExTensor:
+    fn forward_for_input(inp: AnyTensor) raises -> AnyTensor:
         var out = conv2d_no_bias(inp, kernel, stride, padding)
         var reduced = out
         while reduced.dim() > 0:
@@ -1116,7 +1116,7 @@ fn test_conv2d_backward_gradient_kernel() raises:
     var analytical_grad = result.grad_weights
 
     # Numerical gradient: forward_fn sums conv output (equivalent to ones grad_output)
-    fn forward_for_kernel(k: ExTensor) raises -> ExTensor:
+    fn forward_for_kernel(k: AnyTensor) raises -> AnyTensor:
         var out = conv2d_no_bias(x, k, stride, padding)
         var reduced = out
         while reduced.dim() > 0:
@@ -1187,7 +1187,7 @@ fn test_conv2d_backward_gradient_input_with_padding() raises:
     var result = conv2d_backward(grad_output, x, kernel, stride, padding)
     var analytical_grad = result.grad_input
 
-    fn forward_for_input_p1(inp: ExTensor) raises -> ExTensor:
+    fn forward_for_input_p1(inp: AnyTensor) raises -> AnyTensor:
         var out = conv2d_no_bias(inp, kernel, stride, padding)
         var reduced = out
         while reduced.dim() > 0:
@@ -1213,7 +1213,7 @@ fn test_conv2d_backward_gradient_input_with_padding() raises:
     result = conv2d_backward(grad_output, x, kernel, stride, padding)
     analytical_grad = result.grad_input
 
-    fn forward_for_input_p2(inp: ExTensor) raises -> ExTensor:
+    fn forward_for_input_p2(inp: AnyTensor) raises -> AnyTensor:
         var out = conv2d_no_bias(inp, kernel, stride, padding)
         var reduced = out
         while reduced.dim() > 0:
@@ -1274,7 +1274,7 @@ fn test_conv2d_backward_gradient_kernel_with_padding() raises:
     var result = conv2d_backward(grad_output, x, kernel, stride, padding)
     var analytical_grad = result.grad_weights
 
-    fn forward_for_kernel_p1(k: ExTensor) raises -> ExTensor:
+    fn forward_for_kernel_p1(k: AnyTensor) raises -> AnyTensor:
         var out = conv2d_no_bias(x, k, stride, padding)
         var reduced = out
         while reduced.dim() > 0:
@@ -1300,7 +1300,7 @@ fn test_conv2d_backward_gradient_kernel_with_padding() raises:
     result = conv2d_backward(grad_output, x, kernel, stride, padding)
     analytical_grad = result.grad_weights
 
-    fn forward_for_kernel_p2(k: ExTensor) raises -> ExTensor:
+    fn forward_for_kernel_p2(k: AnyTensor) raises -> AnyTensor:
         var out = conv2d_no_bias(x, k, stride, padding)
         var reduced = out
         while reduced.dim() > 0:

--- a/tests/shared/core/test_conv_noncontiguous_part1.mojo
+++ b/tests/shared/core/test_conv_noncontiguous_part1.mojo
@@ -24,12 +24,12 @@ from tests.shared.conftest import (
     assert_false,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from shared.core.conv import conv2d, conv2d_no_bias
 from shared.core.shape import as_contiguous
 
 
-fn _make_nc_nchw_symmetric() raises -> ExTensor:
+fn _make_nc_nchw_symmetric() raises -> AnyTensor:
     """Create a non-contiguous (1,1,6,4) tensor by transposing (1,1,4,6).
 
     The input (1,1,4,6) has all ones. Transposing H (dim2) and W (dim3)

--- a/tests/shared/core/test_conv_noncontiguous_part2.mojo
+++ b/tests/shared/core/test_conv_noncontiguous_part2.mojo
@@ -21,11 +21,11 @@ from tests.shared.conftest import (
     assert_false,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.conv import conv2d_backward, conv2d_no_bias_backward
 
 
-fn _make_nc_grad_output() raises -> ExTensor:
+fn _make_nc_grad_output() raises -> AnyTensor:
     """Non-contiguous grad_output of logical shape (1,1,4,2).
 
     Base (1,1,2,4) all-ones transposed to (1,1,4,2): strides [8,8,1,4]
@@ -38,7 +38,7 @@ fn _make_nc_grad_output() raises -> ExTensor:
     return nc^
 
 
-fn _make_nc_input() raises -> ExTensor:
+fn _make_nc_input() raises -> AnyTensor:
     """Non-contiguous input of logical shape (1,1,6,4) with all ones.
 
     Base (1,1,4,6) transposed to (1,1,6,4): strides [24,24,1,6]

--- a/tests/shared/core/test_conv_part1.mojo
+++ b/tests/shared/core/test_conv_part1.mojo
@@ -21,7 +21,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.conv import (
     conv2d,
     conv2d_no_bias,

--- a/tests/shared/core/test_conv_part2.mojo
+++ b/tests/shared/core/test_conv_part2.mojo
@@ -22,7 +22,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.conv import (
     conv2d,
     conv2d_no_bias,

--- a/tests/shared/core/test_conv_part3.mojo
+++ b/tests/shared/core/test_conv_part3.mojo
@@ -22,7 +22,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.conv import (
     conv2d,
     conv2d_no_bias,

--- a/tests/shared/core/test_creation_bfloat16.mojo
+++ b/tests/shared/core/test_creation_bfloat16.mojo
@@ -1,7 +1,7 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_creation.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for bfloat16 dtype support in ExTensor factory functions.
+"""Tests for bfloat16 dtype support in AnyTensor factory functions.
 
 Verifies that arange(), eye(), linspace(), and randn() correctly route
 bfloat16 tensors to _set_float64 (floating-point path) rather than
@@ -10,9 +10,9 @@ _set_int64. Regression tests for issue #3906.
 Split per ADR-009 (≤10 fn test_ per file).
 """
 
-# Import ExTensor and creation operations
+# Import AnyTensor and creation operations
 from shared.core import (
-    ExTensor,
+    AnyTensor,
     arange,
     eye,
     linspace,
@@ -156,7 +156,7 @@ fn test_randn_bfloat16_nonzero() raises:
 fn main() raises:
     """Run bfloat16 dtype guard tests for factory functions."""
     print(
-        "Running ExTensor bfloat16 dtype guard tests (issue #3906)..."
+        "Running AnyTensor bfloat16 dtype guard tests (issue #3906)..."
     )
 
     # arange() bfloat16 tests

--- a/tests/shared/core/test_creation_edge_cases.mojo
+++ b/tests/shared/core/test_creation_edge_cases.mojo
@@ -1,14 +1,14 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_creation_part5.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor creation operations - Edge cases.
+"""Tests for AnyTensor creation operations - Edge cases.
 
 Tests edge cases like scalar creation, very large tensors, and high-dimensional tensors.
 Split from test_creation_part5.mojo per ADR-009 (≤10 fn test_ per file).
 """
 
-# Import ExTensor and creation operations
-from shared.core.extensor import ExTensor, zeros
+# Import AnyTensor and creation operations
+from shared.core.extensor import AnyTensor, zeros
 
 # Import test helpers
 from tests.shared.conftest import (
@@ -61,7 +61,7 @@ fn test_creation_high_dimensional() raises:
 
 fn main() raises:
     """Run creation edge case tests."""
-    print("Running ExTensor creation tests - Edge cases...")
+    print("Running AnyTensor creation tests - Edge cases...")
 
     test_creation_0d_scalar()
     test_creation_very_large_1d()

--- a/tests/shared/core/test_creation_part1.mojo
+++ b/tests/shared/core/test_creation_part1.mojo
@@ -1,14 +1,14 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_creation.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor creation operations - Part 1: zeros() and ones().
+"""Tests for AnyTensor creation operations - Part 1: zeros() and ones().
 
 Tests zeros() and ones() creation functions with various shapes and dtypes.
 Split from test_creation.mojo per ADR-009 (≤10 fn test_ per file).
 """
 
-# Import ExTensor and creation operations
-from shared.core.extensor import ExTensor, zeros, ones
+# Import AnyTensor and creation operations
+from shared.core.extensor import AnyTensor, zeros, ones
 
 # Import test helpers
 from tests.shared.conftest import (
@@ -146,7 +146,7 @@ fn test_ones_3d_float64() raises:
 
 fn main() raises:
     """Run zeros() and ones() creation tests."""
-    print("Running ExTensor creation tests - Part 1: zeros() and ones()...")
+    print("Running AnyTensor creation tests - Part 1: zeros() and ones()...")
 
     # zeros() tests
     test_zeros_1d_float32()

--- a/tests/shared/core/test_creation_part2.mojo
+++ b/tests/shared/core/test_creation_part2.mojo
@@ -1,14 +1,14 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_creation.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor creation operations - Part 2: full(), empty(), and from_array() placeholders.
+"""Tests for AnyTensor creation operations - Part 2: full(), empty(), and from_array() placeholders.
 
 Tests full() and empty() creation functions, plus from_array() placeholders.
 Split from test_creation.mojo per ADR-009 (≤10 fn test_ per file).
 """
 
-# Import ExTensor and creation operations
-from shared.core.extensor import ExTensor, full, empty
+# Import AnyTensor and creation operations
+from shared.core.extensor import AnyTensor, full, empty
 
 # Import test helpers
 from tests.shared.conftest import (
@@ -143,7 +143,7 @@ fn test_from_array_1d() raises:
 fn main() raises:
     """Run full(), empty(), and from_array() placeholder creation tests."""
     print(
-        "Running ExTensor creation tests - Part 2: full(), empty(),"
+        "Running AnyTensor creation tests - Part 2: full(), empty(),"
         " from_array()..."
     )
 

--- a/tests/shared/core/test_creation_part3.mojo
+++ b/tests/shared/core/test_creation_part3.mojo
@@ -1,14 +1,14 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_creation.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor creation operations - Part 3: from_array() placeholders, arange(), and eye().
+"""Tests for AnyTensor creation operations - Part 3: from_array() placeholders, arange(), and eye().
 
 Tests arange() and eye() creation functions, plus remaining from_array() placeholders.
 Split from test_creation.mojo per ADR-009 (≤10 fn test_ per file).
 """
 
-# Import ExTensor and creation operations
-from shared.core.extensor import ExTensor, arange, eye
+# Import AnyTensor and creation operations
+from shared.core.extensor import AnyTensor, arange, eye
 
 # Import test helpers
 from tests.shared.conftest import (
@@ -157,7 +157,7 @@ fn main() raises:
     """Run from_array() placeholder, arange(), and eye() (square) creation tests.
     """
     print(
-        "Running ExTensor creation tests - Part 3: from_array placeholders,"
+        "Running AnyTensor creation tests - Part 3: from_array placeholders,"
         " arange(), eye()..."
     )
 

--- a/tests/shared/core/test_creation_part4.mojo
+++ b/tests/shared/core/test_creation_part4.mojo
@@ -1,14 +1,14 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_creation.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor creation operations - Part 4: eye() (rectangular/offset) and linspace().
+"""Tests for AnyTensor creation operations - Part 4: eye() (rectangular/offset) and linspace().
 
 Tests rectangular and offset-diagonal eye() and linspace() creation functions.
 Split from test_creation.mojo per ADR-009 (≤10 fn test_ per file).
 """
 
-# Import ExTensor and creation operations
-from shared.core.extensor import ExTensor, eye, linspace
+# Import AnyTensor and creation operations
+from shared.core.extensor import AnyTensor, eye, linspace
 
 # Import test helpers
 from tests.shared.conftest import (
@@ -148,7 +148,7 @@ fn test_linspace_large_num() raises:
 fn main() raises:
     """Run eye() (rectangular/offset) and linspace() creation tests."""
     print(
-        "Running ExTensor creation tests - Part 4: eye() rectangular/offset and"
+        "Running AnyTensor creation tests - Part 4: eye() rectangular/offset and"
         " linspace()..."
     )
 

--- a/tests/shared/core/test_creation_part5.mojo
+++ b/tests/shared/core/test_creation_part5.mojo
@@ -1,14 +1,14 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_creation.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor creation operations - Part 5: dtype support.
+"""Tests for AnyTensor creation operations - Part 5: dtype support.
 
 Tests dtype support across creation operations.
 Split from test_creation.mojo per ADR-009 (≤10 fn test_ per file).
 Edge cases moved to test_creation_edge_cases.mojo."""
 
-# Import ExTensor and creation operations
-from shared.core.extensor import ExTensor, zeros, ones, full
+# Import AnyTensor and creation operations
+from shared.core.extensor import AnyTensor, zeros, ones, full
 
 # Import test helpers
 from tests.shared.conftest import (
@@ -97,7 +97,7 @@ fn test_creation_bool() raises:
 
 fn main() raises:
     """Run dtype support creation tests."""
-    print("Running ExTensor creation tests - Part 5: dtype support...")
+    print("Running AnyTensor creation tests - Part 5: dtype support...")
 
     test_creation_float16()
     test_creation_float32()

--- a/tests/shared/core/test_creation_part6.mojo
+++ b/tests/shared/core/test_creation_part6.mojo
@@ -1,15 +1,15 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_creation.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor creation operations - Part 6: NaN/Inf dtype validation.
+"""Tests for AnyTensor creation operations - Part 6: NaN/Inf dtype validation.
 
 Tests nan_tensor(), inf_tensor(), and neg_inf_tensor() with supported float dtypes
 and verifies rejection of unsupported dtypes (int32, bfloat16).
 Split from test_creation.mojo per ADR-009 (≤10 fn test_ per file).
 """
 
-# Import ExTensor and creation operations
-from shared.core.extensor import ExTensor, nan_tensor, inf_tensor, neg_inf_tensor
+# Import AnyTensor and creation operations
+from shared.core.extensor import AnyTensor, nan_tensor, inf_tensor, neg_inf_tensor
 
 # Import test helpers
 from tests.shared.conftest import (
@@ -154,7 +154,7 @@ fn test_inf_tensor_rejects_int32() raises:
 
 fn main() raises:
     """Run NaN/Inf creation tests with dtype validation."""
-    print("Running ExTensor creation tests - Part 6: NaN/Inf dtype validation...")
+    print("Running AnyTensor creation tests - Part 6: NaN/Inf dtype validation...")
 
     # bfloat16 rejection tests (not in nan/inf supported dtype list)
     test_nan_tensor_rejects_bfloat16()

--- a/tests/shared/core/test_depthwise_conv_grad_check.mojo
+++ b/tests/shared/core/test_depthwise_conv_grad_check.mojo
@@ -10,7 +10,7 @@ from tests.shared.conftest import (
     assert_almost_equal,
     assert_equal,
 )
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.conv import depthwise_conv2d, depthwise_conv2d_backward
 from shared.testing import check_gradient
 
@@ -91,10 +91,10 @@ fn test_depthwise_conv2d_backward_stride1_padding0_grad_input() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward_input(inp: ExTensor) raises -> ExTensor:
+    fn forward_input(inp: AnyTensor) raises -> AnyTensor:
         return depthwise_conv2d(inp, kernel, bias, stride=1, padding=0)
 
-    fn backward_input(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward_input(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         var grads = depthwise_conv2d_backward(grad_out, inp, kernel, stride=1, padding=0)
         return grads.grad_input
 
@@ -135,10 +135,10 @@ fn test_depthwise_conv2d_backward_stride2_grad_input() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward_input(inp: ExTensor) raises -> ExTensor:
+    fn forward_input(inp: AnyTensor) raises -> AnyTensor:
         return depthwise_conv2d(inp, kernel, bias, stride=2, padding=0)
 
-    fn backward_input(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward_input(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         var grads = depthwise_conv2d_backward(grad_out, inp, kernel, stride=2, padding=0)
         return grads.grad_input
 
@@ -179,10 +179,10 @@ fn test_depthwise_conv2d_backward_padding1_grad_input() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward_input(inp: ExTensor) raises -> ExTensor:
+    fn forward_input(inp: AnyTensor) raises -> AnyTensor:
         return depthwise_conv2d(inp, kernel, bias, stride=1, padding=1)
 
-    fn backward_input(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward_input(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         var grads = depthwise_conv2d_backward(grad_out, inp, kernel, stride=1, padding=1)
         return grads.grad_input
 
@@ -224,10 +224,10 @@ fn test_depthwise_conv2d_backward_multichannel_grad_input() raises:
     bias_shape.append(channels)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward_input(inp: ExTensor) raises -> ExTensor:
+    fn forward_input(inp: AnyTensor) raises -> AnyTensor:
         return depthwise_conv2d(inp, kernel, bias, stride=1, padding=0)
 
-    fn backward_input(grad_out: ExTensor, inp: ExTensor) raises -> ExTensor:
+    fn backward_input(grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
         var grads = depthwise_conv2d_backward(grad_out, inp, kernel, stride=1, padding=0)
         return grads.grad_input
 
@@ -269,10 +269,10 @@ fn test_depthwise_conv2d_backward_grad_weights_numerical() raises:
     var bias = zeros(bias_shape, DType.float32)
 
     # Perturb kernel, hold x fixed
-    fn forward_weights(k: ExTensor) raises -> ExTensor:
+    fn forward_weights(k: AnyTensor) raises -> AnyTensor:
         return depthwise_conv2d(x, k, bias, stride=1, padding=0)
 
-    fn backward_weights(grad_out: ExTensor, k: ExTensor) raises -> ExTensor:
+    fn backward_weights(grad_out: AnyTensor, k: AnyTensor) raises -> AnyTensor:
         var grads = depthwise_conv2d_backward(grad_out, x, k, stride=1, padding=0)
         return grads.grad_weights
 
@@ -367,10 +367,10 @@ fn test_depthwise_conv2d_backward_grad_weights_multichannel() raises:
     bias_shape.append(channels)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward_weights(k: ExTensor) raises -> ExTensor:
+    fn forward_weights(k: AnyTensor) raises -> AnyTensor:
         return depthwise_conv2d(x, k, bias, stride=1, padding=0)
 
-    fn backward_weights(grad_out: ExTensor, k: ExTensor) raises -> ExTensor:
+    fn backward_weights(grad_out: AnyTensor, k: AnyTensor) raises -> AnyTensor:
         var grads = depthwise_conv2d_backward(grad_out, x, k, stride=1, padding=0)
         return grads.grad_weights
 

--- a/tests/shared/core/test_dropout_part1.mojo
+++ b/tests/shared/core/test_dropout_part1.mojo
@@ -22,7 +22,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.dropout import (
     dropout,
     dropout2d,
@@ -239,7 +239,7 @@ fn test_dropout_backward_gradient() raises:
 
     # Forward function wrapper - manually apply the SAME mask
     # This makes the function deterministic for gradient checking
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         # Apply the same mask that was generated initially
         from shared.core.arithmetic import multiply
         from shared.core.extensor import full_like
@@ -250,7 +250,7 @@ fn test_dropout_backward_gradient() raises:
         return multiply(masked, scale_tensor)
 
     # Backward function wrapper - use the same stored mask
-    fn backward(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         # Use the mask from forward pass to ensure consistency
         return dropout_backward(grad, mask, p=p)
 

--- a/tests/shared/core/test_dropout_part2.mojo
+++ b/tests/shared/core/test_dropout_part2.mojo
@@ -21,7 +21,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.dropout import (
     dropout,
     dropout2d,
@@ -160,7 +160,7 @@ fn test_dropout2d_backward_gradient() raises:
 
     # Forward function wrapper - manually apply the SAME mask
     # This makes the function deterministic for gradient checking
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         # Apply the same mask that was generated initially
         from shared.core.arithmetic import multiply
         from shared.core.extensor import full_like
@@ -171,7 +171,7 @@ fn test_dropout2d_backward_gradient() raises:
         return multiply(masked, scale_tensor)
 
     # Backward function wrapper - use stored mask instead of regenerating
-    fn backward(grad: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         # Use the mask from forward pass to ensure consistency
         return dropout2d_backward(grad, mask, p=p)
 

--- a/tests/shared/core/test_dtype_dispatch_part1.mojo
+++ b/tests/shared/core/test_dtype_dispatch_part1.mojo
@@ -13,7 +13,7 @@ from tests.shared.conftest import (
     assert_almost_equal,
     assert_equal_int,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.dtype_dispatch import (
     dispatch_unary,
     dispatch_binary,

--- a/tests/shared/core/test_dtype_dispatch_part2.mojo
+++ b/tests/shared/core/test_dtype_dispatch_part2.mojo
@@ -14,7 +14,7 @@ from tests.shared.conftest import (
     assert_equal_int,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.dtype_dispatch import (
     dispatch_binary,
     dispatch_scalar,

--- a/tests/shared/core/test_dtype_dispatch_part3.mojo
+++ b/tests/shared/core/test_dtype_dispatch_part3.mojo
@@ -14,7 +14,7 @@ from tests.shared.conftest import (
     assert_equal_int,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.dtype_dispatch import (
     dispatch_unary,
     dispatch_binary,

--- a/tests/shared/core/test_edge_cases_part1.mojo
+++ b/tests/shared/core/test_edge_cases_part1.mojo
@@ -1,7 +1,7 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_edge_cases.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor edge cases - Part 1: Empty tensors, 0D scalars, large tensors.
+"""Tests for AnyTensor edge cases - Part 1: Empty tensors, 0D scalars, large tensors.
 
 Split from test_edge_cases.mojo per ADR-009 (≤10 fn test_ functions per file).
 """
@@ -13,9 +13,9 @@ from math import isnan, isinf
 # forces the JIT to compile all 37,401 lines across 60+ modules via __init__.mojo,
 # which intermittently overflows a JIT-internal buffer and triggers __fortify_fail_abort.
 # Run 20+ times to observe: `for i in $(seq 1 20); do pixi run mojo run tests/shared/core/test_edge_cases_part1.mojo 2>&1 | grep -E "OK|crashed|PASS"; done`
-# Import ExTensor and operations
+# Import AnyTensor and operations
 from shared.core import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     full,
@@ -162,7 +162,7 @@ fn test_large_dimension_count() raises:
 
 fn main() raises:
     """Run edge case tests - Part 1."""
-    print("Running ExTensor edge case tests (Part 1)...")
+    print("Running AnyTensor edge case tests (Part 1)...")
 
     # Empty tensors
     print("  Testing empty tensors...")

--- a/tests/shared/core/test_edge_cases_part2.mojo
+++ b/tests/shared/core/test_edge_cases_part2.mojo
@@ -1,15 +1,15 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_edge_cases.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor edge cases - Part 2: NaN handling and infinity handling.
+"""Tests for AnyTensor edge cases - Part 2: NaN handling and infinity handling.
 
 Split from test_edge_cases.mojo per ADR-009 (≤10 fn test_ functions per file).
 """
 
 from math import isnan, isinf
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange, nan_tensor, inf_tensor, neg_inf_tensor
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange, nan_tensor, inf_tensor, neg_inf_tensor
 from shared.core.arithmetic import add, subtract, multiply, divide, floor_divide, modulo, power
 from shared.core.comparison import equal, not_equal, less, less_equal, greater, greater_equal
 
@@ -155,7 +155,7 @@ fn test_inf_comparison() raises:
 
 fn main() raises:
     """Run edge case tests - Part 2."""
-    print("Running ExTensor edge case tests (Part 2)...")
+    print("Running AnyTensor edge case tests (Part 2)...")
 
     # NaN handling
     print("  Testing NaN handling...")

--- a/tests/shared/core/test_edge_cases_part3.mojo
+++ b/tests/shared/core/test_edge_cases_part3.mojo
@@ -1,15 +1,15 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_edge_cases.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor edge cases - Part 3: Overflow, underflow, and division by zero.
+"""Tests for AnyTensor edge cases - Part 3: Overflow, underflow, and division by zero.
 
 Split from test_edge_cases.mojo per ADR-009 (≤10 fn test_ functions per file).
 """
 
 from math import isnan, isinf
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange, nan_tensor, inf_tensor, neg_inf_tensor
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange, nan_tensor, inf_tensor, neg_inf_tensor
 from shared.core.arithmetic import add, subtract, multiply, divide, floor_divide, modulo, power
 from shared.core.comparison import equal, not_equal, less, less_equal, greater, greater_equal
 
@@ -135,7 +135,7 @@ fn test_divide_negative_by_zero() raises:
 
 fn main() raises:
     """Run edge case tests - Part 3."""
-    print("Running ExTensor edge case tests (Part 3)...")
+    print("Running AnyTensor edge case tests (Part 3)...")
 
     # Overflow
     print("  Testing overflow...")

--- a/tests/shared/core/test_edge_cases_part4.mojo
+++ b/tests/shared/core/test_edge_cases_part4.mojo
@@ -1,15 +1,15 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_edge_cases.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor edge cases - Part 4: Modulo and power edge cases.
+"""Tests for AnyTensor edge cases - Part 4: Modulo and power edge cases.
 
 Split from test_edge_cases.mojo per ADR-009 (≤10 fn test_ functions per file).
 """
 
 from math import isnan, isinf
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange, nan_tensor, inf_tensor, neg_inf_tensor
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange, nan_tensor, inf_tensor, neg_inf_tensor
 from shared.core.arithmetic import add, subtract, multiply, divide, floor_divide, modulo, power
 from shared.core.comparison import equal, not_equal, less, less_equal, greater, greater_equal
 
@@ -130,7 +130,7 @@ fn test_power_zero_base_positive_exp() raises:
 
 fn main() raises:
     """Run edge case tests - Part 4."""
-    print("Running ExTensor edge case tests (Part 4)...")
+    print("Running AnyTensor edge case tests (Part 4)...")
 
     # Modulo edge cases
     print("  Testing modulo edge cases...")

--- a/tests/shared/core/test_edge_cases_part5.mojo
+++ b/tests/shared/core/test_edge_cases_part5.mojo
@@ -1,15 +1,15 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_edge_cases.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor edge cases - Part 5: Floor divide, comparison, subnormal, and numerical stability.
+"""Tests for AnyTensor edge cases - Part 5: Floor divide, comparison, subnormal, and numerical stability.
 
 Split from test_edge_cases.mojo per ADR-009 (≤10 fn test_ functions per file).
 """
 
 from math import isnan, isinf
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange, nan_tensor, inf_tensor, neg_inf_tensor
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange, nan_tensor, inf_tensor, neg_inf_tensor
 from shared.core.arithmetic import add, subtract, multiply, divide, floor_divide, modulo, power
 from shared.core.comparison import equal, not_equal, less, less_equal, greater, greater_equal
 
@@ -153,7 +153,7 @@ fn test_subnormal_numbers() raises:
 
 fn main() raises:
     """Run edge case tests - Part 5."""
-    print("Running ExTensor edge case tests (Part 5)...")
+    print("Running AnyTensor edge case tests (Part 5)...")
 
     # Floor divide edge cases
     print("  Testing floor_divide edge cases...")

--- a/tests/shared/core/test_edge_cases_part6.mojo
+++ b/tests/shared/core/test_edge_cases_part6.mojo
@@ -1,15 +1,15 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_edge_cases.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor edge cases - Part 6: Numerical stability and special dtype behaviors.
+"""Tests for AnyTensor edge cases - Part 6: Numerical stability and special dtype behaviors.
 
 Split from test_edge_cases.mojo per ADR-009 (≤10 fn test_ functions per file).
 """
 
 from math import isnan, isinf
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange, nan_tensor, inf_tensor, neg_inf_tensor
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange, nan_tensor, inf_tensor, neg_inf_tensor
 from shared.core.arithmetic import add, subtract, multiply, divide, floor_divide, modulo, power
 from shared.core.comparison import equal, not_equal, less, less_equal, greater, greater_equal
 
@@ -120,7 +120,7 @@ fn test_uint8_range() raises:
 
 fn main() raises:
     """Run edge case tests - Part 6."""
-    print("Running ExTensor edge case tests (Part 6)...")
+    print("Running AnyTensor edge case tests (Part 6)...")
 
     # Numerical stability
     print("  Testing numerical stability...")

--- a/tests/shared/core/test_elementwise_dispatch_part1.mojo
+++ b/tests/shared/core/test_elementwise_dispatch_part1.mojo
@@ -8,7 +8,7 @@ from tests.shared.conftest import (
     assert_equal_int,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.elementwise_dispatch import (
     ElementwiseUnaryOp,
     ElementwiseBinaryOp,

--- a/tests/shared/core/test_elementwise_dispatch_part2.mojo
+++ b/tests/shared/core/test_elementwise_dispatch_part2.mojo
@@ -8,7 +8,7 @@ from tests.shared.conftest import (
     assert_equal_int,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.elementwise_dispatch import (
     ElementwiseUnaryOp,
     ElementwiseBinaryOp,

--- a/tests/shared/core/test_elementwise_dispatch_part3.mojo
+++ b/tests/shared/core/test_elementwise_dispatch_part3.mojo
@@ -8,7 +8,7 @@ from tests.shared.conftest import (
     assert_equal_int,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.elementwise_dispatch import (
     ElementwiseUnaryOp,
     ElementwiseBinaryOp,

--- a/tests/shared/core/test_elementwise_dispatch_part4.mojo
+++ b/tests/shared/core/test_elementwise_dispatch_part4.mojo
@@ -8,7 +8,7 @@ from tests.shared.conftest import (
     assert_equal_int,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.elementwise_dispatch import (
     ElementwiseUnaryOp,
     ElementwiseBinaryOp,

--- a/tests/shared/core/test_elementwise_dispatch_part5.mojo
+++ b/tests/shared/core/test_elementwise_dispatch_part5.mojo
@@ -8,7 +8,7 @@ from tests.shared.conftest import (
     assert_equal_int,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.elementwise_dispatch import (
     ElementwiseUnaryOp,
     ElementwiseBinaryOp,

--- a/tests/shared/core/test_elementwise_dispatch_part6.mojo
+++ b/tests/shared/core/test_elementwise_dispatch_part6.mojo
@@ -8,7 +8,7 @@ from tests.shared.conftest import (
     assert_equal_int,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.elementwise_dispatch import (
     ElementwiseUnaryOp,
     ElementwiseBinaryOp,

--- a/tests/shared/core/test_elementwise_edge_cases_part1.mojo
+++ b/tests/shared/core/test_elementwise_edge_cases_part1.mojo
@@ -12,8 +12,8 @@ Tests edge cases for sqrt operations including:
 
 from math import isnan, isinf, sqrt
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.elementwise import (
     sqrt as sqrt_op,
 )
@@ -119,7 +119,7 @@ fn test_sqrt_vector() raises:
     vals.append(4.0)
     vals.append(9.0)
     vals.append(16.0)
-    var t = ExTensor(shape, DType.float32)
+    var t = AnyTensor(shape, DType.float32)
     for i in range(4):
         t._set_float32(i, vals[i])
 

--- a/tests/shared/core/test_elementwise_edge_cases_part2.mojo
+++ b/tests/shared/core/test_elementwise_edge_cases_part2.mojo
@@ -11,8 +11,8 @@ Tests edge cases for log operations including:
 
 from math import isnan, isinf, log
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.elementwise import (
     log as log_op,
 )

--- a/tests/shared/core/test_elementwise_edge_cases_part3.mojo
+++ b/tests/shared/core/test_elementwise_edge_cases_part3.mojo
@@ -13,8 +13,8 @@ Tests edge cases for exp operations including:
 
 from math import isnan, isinf, exp
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.elementwise import (
     exp as exp_op,
 )

--- a/tests/shared/core/test_elementwise_edge_cases_part4.mojo
+++ b/tests/shared/core/test_elementwise_edge_cases_part4.mojo
@@ -11,8 +11,8 @@ Tests edge cases for tanh and trigonometric operations including:
 
 from math import isnan, isinf, sin, cos, tanh
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.activation import tanh as tanh_op
 
 # Import test helpers

--- a/tests/shared/core/test_elementwise_forward_part1.mojo
+++ b/tests/shared/core/test_elementwise_forward_part1.mojo
@@ -1,12 +1,12 @@
-"""Tests for ExTensor element-wise mathematical operations - Part 1: abs and sign.
+"""Tests for AnyTensor element-wise mathematical operations - Part 1: abs and sign.
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_elementwise_forward.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from shared.core.elementwise import abs, sign
 
 # Import test helpers
@@ -134,7 +134,7 @@ fn test_sign_mixed() raises:
 
 fn main() raises:
     """Run abs and sign element-wise math tests."""
-    print("Running ExTensor element-wise math tests (Part 1: abs, sign)...")
+    print("Running AnyTensor element-wise math tests (Part 1: abs, sign)...")
 
     # abs() tests
     print("  Testing abs()...")

--- a/tests/shared/core/test_elementwise_forward_part2.mojo
+++ b/tests/shared/core/test_elementwise_forward_part2.mojo
@@ -1,11 +1,11 @@
-"""Tests for ExTensor element-wise mathematical operations - Part 2: exp and log.
+"""Tests for AnyTensor element-wise mathematical operations - Part 2: exp and log.
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_elementwise_forward.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
+# Import AnyTensor and operations
 from shared.core.extensor import zeros, ones, full
 from shared.core.elementwise import exp, log
 
@@ -110,7 +110,7 @@ fn test_log_powers_of_2() raises:
 
 fn main() raises:
     """Run exp and log element-wise math tests."""
-    print("Running ExTensor element-wise math tests (Part 2: exp, log)...")
+    print("Running AnyTensor element-wise math tests (Part 2: exp, log)...")
 
     # exp() tests
     print("  Testing exp()...")

--- a/tests/shared/core/test_elementwise_forward_part3.mojo
+++ b/tests/shared/core/test_elementwise_forward_part3.mojo
@@ -1,12 +1,12 @@
-"""Tests for ExTensor element-wise mathematical operations - Part 3: sqrt and sin.
+"""Tests for AnyTensor element-wise mathematical operations - Part 3: sqrt and sin.
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_elementwise_forward.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.elementwise import sqrt, sin
 
 # Import test helpers
@@ -26,7 +26,7 @@ fn test_sqrt_perfect_squares() raises:
     # Create array: [1, 4, 9, 16, 25]
     var shape = List[Int]()
     shape.append(5)
-    var a = ExTensor(shape, DType.float32)
+    var a = AnyTensor(shape, DType.float32)
     a._set_float64(0, 1.0)
     a._set_float64(1, 4.0)
     a._set_float64(2, 9.0)
@@ -120,7 +120,7 @@ fn test_sin_pi() raises:
 
 fn main() raises:
     """Run sqrt and sin element-wise math tests."""
-    print("Running ExTensor element-wise math tests (Part 3: sqrt, sin)...")
+    print("Running AnyTensor element-wise math tests (Part 3: sqrt, sin)...")
 
     # sqrt() tests
     print("  Testing sqrt()...")

--- a/tests/shared/core/test_elementwise_forward_part4.mojo
+++ b/tests/shared/core/test_elementwise_forward_part4.mojo
@@ -1,11 +1,11 @@
-"""Tests for ExTensor element-wise mathematical operations - Part 4: cos and tanh.
+"""Tests for AnyTensor element-wise mathematical operations - Part 4: cos and tanh.
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_elementwise_forward.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
+# Import AnyTensor and operations
 from shared.core.extensor import zeros, ones, full
 from shared.core.elementwise import cos, tanh
 
@@ -110,7 +110,7 @@ fn test_tanh_small_values() raises:
 
 fn main() raises:
     """Run cos and tanh element-wise math tests."""
-    print("Running ExTensor element-wise math tests (Part 4: cos, tanh)...")
+    print("Running AnyTensor element-wise math tests (Part 4: cos, tanh)...")
 
     # cos() tests
     print("  Testing cos()...")

--- a/tests/shared/core/test_elementwise_forward_part5.mojo
+++ b/tests/shared/core/test_elementwise_forward_part5.mojo
@@ -1,11 +1,11 @@
-"""Tests for ExTensor element-wise mathematical operations - Part 5: clip and dtype.
+"""Tests for AnyTensor element-wise mathematical operations - Part 5: clip and dtype.
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_elementwise_forward.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
+# Import AnyTensor and operations
 from shared.core.extensor import ones, full, arange
 from shared.core.elementwise import abs, sign, exp, log, sqrt, clip
 
@@ -93,7 +93,7 @@ fn test_operations_preserve_dtype() raises:
 
 fn main() raises:
     """Run clip and dtype preservation element-wise math tests."""
-    print("Running ExTensor element-wise math tests (Part 5: clip, dtype)...")
+    print("Running AnyTensor element-wise math tests (Part 5: clip, dtype)...")
 
     # clip() tests
     print("  Testing clip()...")

--- a/tests/shared/core/test_elementwise_logical_xor.mojo
+++ b/tests/shared/core/test_elementwise_logical_xor.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros
+from shared.core.extensor import AnyTensor, zeros
 from shared.core.elementwise import logical_xor
 
 

--- a/tests/shared/core/test_elementwise_part1.mojo
+++ b/tests/shared/core/test_elementwise_part1.mojo
@@ -20,7 +20,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.elementwise import (
     abs,
     sign,
@@ -140,14 +140,14 @@ fn test_abs_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 1.5
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return abs(inp)
 
     var y = abs(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return abs_backward(grad, inp)
 
     # Use numerical gradient checking (gold standard)

--- a/tests/shared/core/test_elementwise_part2.mojo
+++ b/tests/shared/core/test_elementwise_part2.mojo
@@ -20,7 +20,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.elementwise import (
     abs,
     sign,
@@ -129,14 +129,14 @@ fn test_exp_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 0.5
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return exp(inp)
 
     var y = exp(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return exp_backward(grad, inp)
 
     # Use numerical gradient checking (gold standard)
@@ -218,14 +218,14 @@ fn test_log_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 2.0
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return log(inp)
 
     var y = log(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return log_backward(grad, inp)
 
     # Use numerical gradient checking (gold standard)

--- a/tests/shared/core/test_elementwise_part3.mojo
+++ b/tests/shared/core/test_elementwise_part3.mojo
@@ -20,7 +20,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.elementwise import (
     abs,
     sign,
@@ -90,14 +90,14 @@ fn test_log10_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 2.0
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return log10(inp)
 
     var y = log10(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return log10_backward(grad, inp)
 
     # Use numerical gradient checking (gold standard)
@@ -140,14 +140,14 @@ fn test_log2_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 2.0
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return log2(inp)
 
     var y = log2(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return log2_backward(grad, inp)
 
     # Use numerical gradient checking (gold standard)
@@ -234,14 +234,14 @@ fn test_sqrt_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 2.0
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return sqrt(inp)
 
     var y = sqrt(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return sqrt_backward(grad, inp)
 
     # Use numerical gradient checking (gold standard)

--- a/tests/shared/core/test_elementwise_part4.mojo
+++ b/tests/shared/core/test_elementwise_part4.mojo
@@ -20,7 +20,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.elementwise import (
     abs,
     sign,
@@ -145,14 +145,14 @@ fn test_sin_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 0.5
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return sin(inp)
 
     var y = sin(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return sin_backward(grad, inp)
 
     # Use numerical gradient checking (gold standard)
@@ -197,14 +197,14 @@ fn test_cos_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 0.5
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return cos(inp)
 
     var y = cos(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return cos_backward(grad, inp)
 
     # Use numerical gradient checking (gold standard)

--- a/tests/shared/core/test_elementwise_part5.mojo
+++ b/tests/shared/core/test_elementwise_part5.mojo
@@ -21,7 +21,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.elementwise import (
     abs,
     sign,
@@ -150,14 +150,14 @@ fn test_clip_backward_gradient() raises:
     x._data.bitcast[Float32]()[2] = 0.5
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return clip(inp, min_val=-1.0, max_val=1.0)
 
     var y = clip(x, min_val=-1.0, max_val=1.0)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward_fn(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return clip_backward(grad, inp, min_val=-1.0, max_val=1.0)
 
     # Use numerical gradient checking (gold standard)

--- a/tests/shared/core/test_extensor_abs_ops.mojo
+++ b/tests/shared/core/test_extensor_abs_ops.mojo
@@ -1,9 +1,9 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_extensor_unary_ops.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor __abs__ operator and combined unary/binary operations."""
+"""Tests for AnyTensor __abs__ operator and combined unary/binary operations."""
 
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from tests.shared.conftest import assert_true, assert_almost_equal, assert_equal
 
 

--- a/tests/shared/core/test_extensor_dtype_roundtrip.mojo
+++ b/tests/shared/core/test_extensor_dtype_roundtrip.mojo
@@ -11,7 +11,7 @@ Note: Split into a dedicated file following ADR-009 pattern — heap corruption 
 ~15 cumulative tests in a single file in Mojo 0.26.1.
 """
 
-from shared.core.extensor import ExTensor, zeros
+from shared.core.extensor import AnyTensor, zeros
 from tests.shared.conftest import assert_true, assert_almost_equal, assert_equal
 
 
@@ -216,62 +216,62 @@ fn test_dtype_sizes() raises:
     at compile time as a regression test.
     """
     assert_equal(
-        ExTensor._get_dtype_size_static(DType.float16),
+        AnyTensor._get_dtype_size_static(DType.float16),
         2,
         "float16 should be 2 bytes",
     )
     assert_equal(
-        ExTensor._get_dtype_size_static(DType.bfloat16),
+        AnyTensor._get_dtype_size_static(DType.bfloat16),
         2,
         "bfloat16 should be 2 bytes",
     )
     assert_equal(
-        ExTensor._get_dtype_size_static(DType.float32),
+        AnyTensor._get_dtype_size_static(DType.float32),
         4,
         "float32 should be 4 bytes",
     )
     assert_equal(
-        ExTensor._get_dtype_size_static(DType.float64),
+        AnyTensor._get_dtype_size_static(DType.float64),
         8,
         "float64 should be 8 bytes",
     )
     assert_equal(
-        ExTensor._get_dtype_size_static(DType.int8),
+        AnyTensor._get_dtype_size_static(DType.int8),
         1,
         "int8 should be 1 byte",
     )
     assert_equal(
-        ExTensor._get_dtype_size_static(DType.uint8),
+        AnyTensor._get_dtype_size_static(DType.uint8),
         1,
         "uint8 should be 1 byte",
     )
     assert_equal(
-        ExTensor._get_dtype_size_static(DType.int16),
+        AnyTensor._get_dtype_size_static(DType.int16),
         2,
         "int16 should be 2 bytes",
     )
     assert_equal(
-        ExTensor._get_dtype_size_static(DType.uint16),
+        AnyTensor._get_dtype_size_static(DType.uint16),
         2,
         "uint16 should be 2 bytes",
     )
     assert_equal(
-        ExTensor._get_dtype_size_static(DType.int32),
+        AnyTensor._get_dtype_size_static(DType.int32),
         4,
         "int32 should be 4 bytes",
     )
     assert_equal(
-        ExTensor._get_dtype_size_static(DType.uint32),
+        AnyTensor._get_dtype_size_static(DType.uint32),
         4,
         "uint32 should be 4 bytes",
     )
     assert_equal(
-        ExTensor._get_dtype_size_static(DType.int64),
+        AnyTensor._get_dtype_size_static(DType.int64),
         8,
         "int64 should be 8 bytes",
     )
     assert_equal(
-        ExTensor._get_dtype_size_static(DType.uint64),
+        AnyTensor._get_dtype_size_static(DType.uint64),
         8,
         "uint64 should be 8 bytes",
     )

--- a/tests/shared/core/test_extensor_getset_float32.mojo
+++ b/tests/shared/core/test_extensor_getset_float32.mojo
@@ -1,10 +1,10 @@
-"""Tests for ExTensor _get_float32 and _set_float32 methods.
+"""Tests for AnyTensor _get_float32 and _set_float32 methods.
 
 Note: Split from test_extensor_new_methods.mojo due to Mojo 0.26.1 heap
 corruption bug that occurs after ~15 cumulative tests. See ADR-009.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from tests.shared.conftest import assert_true, assert_almost_equal, assert_equal
 
 

--- a/tests/shared/core/test_extensor_inplace_ops.mojo
+++ b/tests/shared/core/test_extensor_inplace_ops.mojo
@@ -1,10 +1,10 @@
-"""Tests for ExTensor in-place operators (__iadd__, __isub__, __imul__, __itruediv__).
+"""Tests for AnyTensor in-place operators (__iadd__, __isub__, __imul__, __itruediv__).
 
 Note: Split from test_extensor_operators.mojo due to Mojo 0.26.1 heap
 corruption bug that occurs after ~15 cumulative tests. See ADR-009.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from tests.shared.conftest import assert_true, assert_almost_equal, assert_equal
 
 

--- a/tests/shared/core/test_extensor_int_str.mojo
+++ b/tests/shared/core/test_extensor_int_str.mojo
@@ -1,11 +1,11 @@
-"""Tests for ExTensor __str__ on integer types (int8, int16, int32, int64, uint8, uint16, uint32, uint64).
+"""Tests for AnyTensor __str__ on integer types (int8, int16, int32, int64, uint8, uint16, uint32, uint64).
 
 Verifies that _format_element() correctly handles all integer dtype paths for string representation.
 
 Related: issue #4047, issue #3376
 """
 
-from shared.core.extensor import ExTensor, zeros, full, arange
+from shared.core.extensor import AnyTensor, zeros, full, arange
 from tests.shared.conftest import assert_true, assert_equal
 
 
@@ -105,7 +105,7 @@ fn test_str_uint8_negative_not_in_output() raises:
 
 fn main() raises:
     """Run integer dtype __str__ tests."""
-    print("Running ExTensor __str__ integer dtype tests...")
+    print("Running AnyTensor __str__ integer dtype tests...")
 
     test_str_int8()
     print("  [OK] test_str_int8")
@@ -137,4 +137,4 @@ fn main() raises:
     test_str_uint8_negative_not_in_output()
     print("  [OK] test_str_uint8_negative_not_in_output")
 
-    print("All ExTensor __str__ integer dtype tests passed!")
+    print("All AnyTensor __str__ integer dtype tests passed!")

--- a/tests/shared/core/test_extensor_method_api.mojo
+++ b/tests/shared/core/test_extensor_method_api.mojo
@@ -1,14 +1,14 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor method-style API: split and split_with_indices.
+"""Tests for AnyTensor method-style API: split and split_with_indices.
 
-Verifies that the thin wrapper methods on ExTensor produce identical results
+Verifies that the thin wrapper methods on AnyTensor produce identical results
 to the functional implementations in shared.core.shape. Follows #3243 and #3804.
 """
 
 from shared.core import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     full,
@@ -159,8 +159,8 @@ fn test_split_with_indices_method_vs_free_fn() raises:
 
 
 fn main() raises:
-    """Run ExTensor method API tests for split and split_with_indices."""
-    print("Testing ExTensor method API: split and split_with_indices...")
+    """Run AnyTensor method API tests for split and split_with_indices."""
+    print("Testing AnyTensor method API: split and split_with_indices...")
 
     print("  Testing split() method (equal splits)...")
     test_split_method_equal()
@@ -177,4 +177,4 @@ fn main() raises:
     print("  Testing split_with_indices() method vs free function...")
     test_split_with_indices_method_vs_free_fn()
 
-    print("All ExTensor method API tests passed!")
+    print("All AnyTensor method API tests passed!")

--- a/tests/shared/core/test_extensor_multidim_int_str.mojo
+++ b/tests/shared/core/test_extensor_multidim_int_str.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor __str__ on multi-dimensional int32 and bool tensors.
+"""Tests for AnyTensor __str__ on multi-dimensional int32 and bool tensors.
 
 Verifies that __str__ correctly renders shape information for 2D+ tensors with
 non-float dtypes, alongside integer formatting via _format_element().
@@ -6,7 +6,7 @@ non-float dtypes, alongside integer formatting via _format_element().
 Related: issue #4048, issue #3376
 """
 
-from shared.core.extensor import ExTensor, zeros, full
+from shared.core.extensor import AnyTensor, zeros, full
 from tests.shared.conftest import assert_true
 
 
@@ -95,7 +95,7 @@ fn test_str_uint16_2d_tensor() raises:
 
 fn main() raises:
     """Run multi-dimensional int/bool __str__ tests."""
-    print("Running ExTensor __str__ multi-dimensional integer tests...")
+    print("Running AnyTensor __str__ multi-dimensional integer tests...")
 
     test_str_int32_2d_tensor()
     print("  [OK] test_str_int32_2d_tensor")
@@ -124,4 +124,4 @@ fn main() raises:
     test_str_uint16_2d_tensor()
     print("  [OK] test_str_uint16_2d_tensor")
 
-    print("All ExTensor __str__ multi-dimensional integer tests passed!")
+    print("All AnyTensor __str__ multi-dimensional integer tests passed!")

--- a/tests/shared/core/test_extensor_multidim_step.mojo
+++ b/tests/shared/core/test_extensor_multidim_step.mojo
@@ -1,14 +1,14 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split per file convention. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor multi-dimensional slicing with step support.
+"""Tests for AnyTensor multi-dimensional slicing with step support.
 
 The *slices overload of __getitem__ now supports non-unit steps on all
 dimensions, consistent with the 1D __getitem__(Slice) overload.  These
 tests verify that step slicing produces correct shapes and values.
 """
 
-from shared.core.extensor import ExTensor, zeros, arange
+from shared.core.extensor import AnyTensor, zeros, arange
 from tests.shared.conftest import assert_true, assert_equal
 
 

--- a/tests/shared/core/test_extensor_neg_pos.mojo
+++ b/tests/shared/core/test_extensor_neg_pos.mojo
@@ -1,9 +1,9 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_extensor_unary_ops.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor __neg__ and __pos__ unary operators."""
+"""Tests for AnyTensor __neg__ and __pos__ unary operators."""
 
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from tests.shared.conftest import assert_true, assert_almost_equal, assert_equal
 
 

--- a/tests/shared/core/test_extensor_randn.mojo
+++ b/tests/shared/core/test_extensor_randn.mojo
@@ -1,10 +1,10 @@
-"""Tests for ExTensor randn() method.
+"""Tests for AnyTensor randn() method.
 
 Note: Split from test_extensor_new_methods.mojo due to Mojo 0.26.1 heap
 corruption bug that occurs after ~15 cumulative tests. See ADR-009.
 """
 
-from shared.core.extensor import ExTensor, zeros, randn
+from shared.core.extensor import AnyTensor, zeros, randn
 from tests.shared.conftest import assert_true, assert_almost_equal, assert_equal
 from math import sqrt
 

--- a/tests/shared/core/test_extensor_reflected_ops.mojo
+++ b/tests/shared/core/test_extensor_reflected_ops.mojo
@@ -1,10 +1,10 @@
-"""Tests for ExTensor reflected operators (__radd__, __rsub__, __rmul__, __rtruediv__).
+"""Tests for AnyTensor reflected operators (__radd__, __rsub__, __rmul__, __rtruediv__).
 
 Note: Split from test_extensor_operators.mojo due to Mojo 0.26.1 heap
 corruption bug that occurs after ~15 cumulative tests. See ADR-009.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from tests.shared.conftest import assert_true, assert_almost_equal, assert_equal
 
 

--- a/tests/shared/core/test_extensor_repr.mojo
+++ b/tests/shared/core/test_extensor_repr.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor __repr__ truncation behavior.
+"""Tests for AnyTensor __repr__ truncation behavior.
 
 Verifies NumPy-style truncation: tensors with more than 1000 elements
 show first 3 and last 3 elements with '...' in between.
@@ -6,7 +6,7 @@ show first 3 and last 3 elements with '...' in between.
 Related: issue #4038, follow-up from #3375
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from tests.shared.conftest import assert_true, assert_equal
 
 
@@ -119,7 +119,7 @@ fn test_repr_empty_tensor_float16() raises:
 
 fn main() raises:
     """Run __repr__ truncation tests."""
-    print("Running ExTensor __repr__ truncation tests...")
+    print("Running AnyTensor __repr__ truncation tests...")
 
     test_repr_empty_tensor()
     print("  [OK] test_repr_empty_tensor")
@@ -154,4 +154,4 @@ fn main() raises:
     test_repr_empty_tensor_float16()
     print("  [OK] test_repr_empty_tensor_float16")
 
-    print("All ExTensor __repr__ truncation tests passed!")
+    print("All AnyTensor __repr__ truncation tests passed!")

--- a/tests/shared/core/test_extensor_serialization.mojo
+++ b/tests/shared/core/test_extensor_serialization.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor serialization and deserialization.
+"""Tests for AnyTensor serialization and deserialization.
 
 Tests the save_tensor() and load_tensor() standalone functions for:
 - Single tensor round-trip (save -> load -> compare values)
@@ -9,7 +9,7 @@ Tests the save_tensor() and load_tensor() standalone functions for:
 Runs as: pixi run mojo ./tests/shared/core/test_extensor_serialization.mojo
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, arange
+from shared.core.extensor import AnyTensor, zeros, ones, arange
 from shared.utils.serialization import save_tensor, load_tensor
 
 
@@ -234,7 +234,7 @@ fn test_large_tensor_serialization() raises:
 fn main() raises:
     """Run all serialization tests."""
     print("\n" + "#" * 80)
-    print("# ExTensor Serialization Tests")
+    print("# AnyTensor Serialization Tests")
     print("#" * 80)
 
     test_save_load_float32()

--- a/tests/shared/core/test_extensor_setitem.mojo
+++ b/tests/shared/core/test_extensor_setitem.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor __setitem__ with flat and multi-dimensional index support.
+"""Tests for AnyTensor __setitem__ with flat and multi-dimensional index support.
 
 Covers:
 - Flat Int index overloads (Float64, Int64, Float32)
@@ -9,7 +9,7 @@ Covers:
 CI verification: issue #3840. All 17 tests verified passing in CI.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from tests.shared.conftest import assert_true, assert_almost_equal, assert_equal
 
 
@@ -119,7 +119,7 @@ fn test_setitem_multidim_float64_dtype() raises:
     # flat = 1*3 + 1 = 4
     # Note: __getitem__ returns Float32 lvalue, so 3.14159 is stored at
     # Float32 precision even on a float64 tensor. Use Float32 tolerance.
-    # Long-term fix: make ExTensor parametric on dtype (see GitHub epic).
+    # Long-term fix: make AnyTensor parametric on dtype (see GitHub epic).
     assert_almost_equal(t._get_float64(4), 3.14159, tolerance=1e-6)
 
 

--- a/tests/shared/core/test_extensor_setitem_multidim.mojo
+++ b/tests/shared/core/test_extensor_setitem_multidim.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor __setitem__ with multi-dimensional indices.
+"""Tests for AnyTensor __setitem__ with multi-dimensional indices.
 
 Covers stride-aware flat index calculation for 2D and 3D tensor assignment.
 Tests verify that t[i, j] = val correctly computes row-major flat index
@@ -6,7 +6,7 @@ i * stride_i + j * stride_j and writes to the correct memory location.
 
 Follow-up to #3165 (1D __setitem__). Tracks issue #3388.
 
-NOTE: All tests are currently skipped because ExTensor does not yet support
+NOTE: All tests are currently skipped because AnyTensor does not yet support
 multi-dimensional __setitem__ (e.g., t[i, j] = val). Only single-index
 __setitem__(index: Int, value: Float64) is implemented.
 TODO: Re-enable tests once multi-dimensional __setitem__ is implemented.
@@ -15,6 +15,6 @@ TODO: Re-enable tests once multi-dimensional __setitem__ is implemented.
 
 fn main() raises:
     print(
-        "SKIPPED: ExTensor multi-dimensional __setitem__ tests -"
-        " multi-index __setitem__ not yet implemented on ExTensor"
+        "SKIPPED: AnyTensor multi-dimensional __setitem__ tests -"
+        " multi-index __setitem__ not yet implemented on AnyTensor"
     )

--- a/tests/shared/core/test_extensor_slicing_1d.mojo
+++ b/tests/shared/core/test_extensor_slicing_1d.mojo
@@ -1,9 +1,9 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_extensor_slicing.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor 1D slicing operations (basic and strided)."""
+"""Tests for AnyTensor 1D slicing operations (basic and strided)."""
 
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from tests.shared.conftest import assert_true, assert_almost_equal, assert_equal
 
 

--- a/tests/shared/core/test_extensor_slicing_2d.mojo
+++ b/tests/shared/core/test_extensor_slicing_2d.mojo
@@ -1,9 +1,9 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_extensor_slicing.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor multi-dimensional slicing and batch extraction."""
+"""Tests for AnyTensor multi-dimensional slicing and batch extraction."""
 
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from tests.shared.conftest import assert_true, assert_almost_equal, assert_equal
 
 

--- a/tests/shared/core/test_extensor_slicing_edge.mojo
+++ b/tests/shared/core/test_extensor_slicing_edge.mojo
@@ -1,9 +1,9 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_extensor_slicing.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor slice edge cases and copy semantics."""
+"""Tests for AnyTensor slice edge cases and copy semantics."""
 
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from tests.shared.conftest import assert_true, assert_almost_equal, assert_equal
 
 

--- a/tests/shared/core/test_extensor_slicing_fast_path.mojo
+++ b/tests/shared/core/test_extensor_slicing_fast_path.mojo
@@ -1,7 +1,7 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_extensor_slicing.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Unit tests for ExTensor first-axis-only fast-path memcpy optimization (#3697).
+"""Unit tests for AnyTensor first-axis-only fast-path memcpy optimization (#3697).
 
 Tests cover:
 - Fast-path shape correctness for N-D first-axis-only slices
@@ -12,7 +12,7 @@ Tests cover:
 Following TDD principles - tests written before implementation.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from tests.shared.conftest import assert_true, assert_almost_equal, assert_equal
 
 

--- a/tests/shared/core/test_extensor_slicing_multidim.mojo
+++ b/tests/shared/core/test_extensor_slicing_multidim.mojo
@@ -1,7 +1,7 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_extensor_slicing.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor multi-dimensional slicing.
+"""Tests for AnyTensor multi-dimensional slicing.
 
 Covers:
 - __getitem__(*slices: Slice) for N-D tensors (one Slice per dimension)
@@ -13,7 +13,7 @@ the slice(start, end, axis) method. The *slices overload does not support
 step; only start:end per dimension.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from tests.shared.conftest import assert_true, assert_almost_equal, assert_equal
 
 

--- a/tests/shared/core/test_extensor_slicing_part1.mojo
+++ b/tests/shared/core/test_extensor_slicing_part1.mojo
@@ -1,7 +1,7 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_extensor_slicing.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Unit tests for ExTensor basic 1D and strided slicing operations (#3013).
+"""Unit tests for AnyTensor basic 1D and strided slicing operations (#3013).
 
 Tests cover:
 - Basic 1D slicing (tensor[start:end])
@@ -11,7 +11,7 @@ Tests cover:
 Following TDD principles - tests written before implementation.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from tests.shared.conftest import assert_true, assert_almost_equal, assert_equal
 
 

--- a/tests/shared/core/test_extensor_slicing_part2.mojo
+++ b/tests/shared/core/test_extensor_slicing_part2.mojo
@@ -1,7 +1,7 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_extensor_slicing.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Unit tests for ExTensor multi-dimensional slicing and batch extraction (#3013).
+"""Unit tests for AnyTensor multi-dimensional slicing and batch extraction (#3013).
 
 Tests cover:
 - Multi-dimensional slicing (tensor[a:b, c:d])
@@ -11,7 +11,7 @@ Tests cover:
 Following TDD principles - tests written before implementation.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from tests.shared.conftest import assert_true, assert_almost_equal, assert_equal
 
 

--- a/tests/shared/core/test_extensor_slicing_part3.mojo
+++ b/tests/shared/core/test_extensor_slicing_part3.mojo
@@ -1,7 +1,7 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_extensor_slicing.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Unit tests for ExTensor edge cases and view semantics (#3013).
+"""Unit tests for AnyTensor edge cases and view semantics (#3013).
 
 Tests cover:
 - Edge cases (out-of-bounds clamping)
@@ -10,7 +10,7 @@ Tests cover:
 Following TDD principles - tests written before implementation.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from tests.shared.conftest import assert_true, assert_almost_equal, assert_equal
 
 

--- a/tests/shared/core/test_extensor_slicing_view.mojo
+++ b/tests/shared/core/test_extensor_slicing_view.mojo
@@ -1,14 +1,14 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split per ADR-009. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor slice() view semantics (#3799).
+"""Tests for AnyTensor slice() view semantics (#3799).
 
 Verifies that slice() returns a zero-copy view using view_with_strides,
 element access on sliced views returns correct values, writes through
 views affect the original, and slice + transpose composition works.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, arange
+from shared.core.extensor import AnyTensor, zeros, ones, arange
 from tests.shared.conftest import assert_true, assert_false, assert_almost_equal, assert_equal
 
 

--- a/tests/shared/core/test_extensor_slicing_view_strides.mojo
+++ b/tests/shared/core/test_extensor_slicing_view_strides.mojo
@@ -1,15 +1,15 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split per ADR-009. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor view/stride semantics via transpose and reshape.
+"""Tests for AnyTensor view/stride semantics via transpose and reshape.
 
 The methods view_with_strides() and _nd_index_to_flat_offset() were removed
-from ExTensor. These tests validate the same stride-based view behaviour
+from AnyTensor. These tests validate the same stride-based view behaviour
 using the current public API: transpose(), reshape(), view() from shape.mojo,
 and multi-dimensional __getitem__.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, arange
+from shared.core.extensor import AnyTensor, zeros, ones, arange
 from shared.core.shape import view
 from tests.shared.conftest import assert_true, assert_false, assert_almost_equal, assert_equal
 

--- a/tests/shared/core/test_extensor_str.mojo
+++ b/tests/shared/core/test_extensor_str.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor __str__ truncation behavior.
+"""Tests for AnyTensor __str__ truncation behavior.
 
 Verifies NumPy-style truncation: tensors with more than 1000 elements
 show first 3 and last 3 elements with '...' in between.
@@ -6,7 +6,7 @@ show first 3 and last 3 elements with '...' in between.
 Related: issue #3375
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from tests.shared.conftest import assert_true, assert_equal
 
 
@@ -137,7 +137,7 @@ fn test_str_empty_multidim_tensor_int32() raises:
 
 fn main() raises:
     """Run __str__ truncation tests."""
-    print("Running ExTensor __str__ truncation tests...")
+    print("Running AnyTensor __str__ truncation tests...")
 
     test_str_empty_tensor()
     print("  [OK] test_str_empty_tensor")
@@ -178,4 +178,4 @@ fn main() raises:
     test_str_empty_multidim_tensor_int32()
     print("  [OK] test_str_empty_multidim_tensor_int32")
 
-    print("All ExTensor __str__ truncation tests passed!")
+    print("All AnyTensor __str__ truncation tests passed!")

--- a/tests/shared/core/test_gradient_checking_basic.mojo
+++ b/tests/shared/core/test_gradient_checking_basic.mojo
@@ -10,7 +10,7 @@ corruption bug that occurs after ~15 cumulative tests. See ADR-009.
 
 from tests.shared.conftest import assert_true
 from shared.testing import check_gradients
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.activation import (
     relu,
     relu_backward,
@@ -34,10 +34,10 @@ fn test_relu_gradient() raises:
     shape.append(4)
     var input = full(shape, 2.0, DType.float32)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return relu(x)
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         return relu_backward(grad_out, x)
 
     var passed = check_gradients(forward, backward, input)
@@ -51,10 +51,10 @@ fn test_relu_negative_inputs() raises:
     shape.append(4)
     var input = full(shape, -2.0, DType.float32)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return relu(x)
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         return relu_backward(grad_out, x)
 
     var passed = check_gradients(forward, backward, input)
@@ -82,10 +82,10 @@ fn test_relu_mixed_inputs() raises:
     input._set_float64(10, 0.1)
     input._set_float64(11, -0.1)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return relu(x)
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         return relu_backward(grad_out, x)
 
     var passed = check_gradients(forward, backward, input)
@@ -99,10 +99,10 @@ fn test_sigmoid_gradient() raises:
     shape.append(4)
     var input = full(shape, 0.5, DType.float32)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return sigmoid(x)
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var output = sigmoid(x)
         return sigmoid_backward(grad_out, output)
 
@@ -117,10 +117,10 @@ fn test_tanh_gradient() raises:
     shape.append(4)
     var input = full(shape, 0.5, DType.float32)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return tanh(x)
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var output = tanh(x)
         return tanh_backward(grad_out, output)
 
@@ -136,10 +136,10 @@ fn test_add_gradient() raises:
     var input_a = ones(shape, DType.float32)
     var input_b = ones(shape, DType.float32)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return add(x, input_b)
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var grads = add_backward(grad_out, x, input_b)
         return grads.grad_a
 
@@ -155,10 +155,10 @@ fn test_multiply_gradient() raises:
     var input_a = full(shape, 2.0, DType.float32)
     var input_b = full(shape, 3.0, DType.float32)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return multiply(x, input_b)
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var grads = multiply_backward(grad_out, x, input_b)
         return grads.grad_a
 
@@ -173,10 +173,10 @@ fn test_gradient_at_zero() raises:
     shape.append(2)
     var input = full(shape, 0.01, DType.float32)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return relu(x)
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         return relu_backward(grad_out, x)
 
     var passed = check_gradients(forward, backward, input)
@@ -190,10 +190,10 @@ fn test_gradient_small_tensor() raises:
     shape.append(1)
     var input = full(shape, 2.0, DType.float32)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return relu(x)
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         return relu_backward(grad_out, x)
 
     var passed = check_gradients(forward, backward, input)

--- a/tests/shared/core/test_gradient_checking_batch_norm.mojo
+++ b/tests/shared/core/test_gradient_checking_batch_norm.mojo
@@ -13,7 +13,7 @@ corruption bug that occurs after ~15 cumulative tests. See ADR-009.
 
 from tests.shared.conftest import assert_true
 from shared.testing import check_gradients
-from shared.core import ExTensor, zeros, ones
+from shared.core import AnyTensor, zeros, ones
 from shared.core.normalization import batch_norm2d, batch_norm2d_backward
 
 
@@ -36,11 +36,11 @@ fn test_batch_norm_gradient_batch_size_1() raises:
     var running_mean = zeros(mean_shape, DType.float32)
     var running_var = ones(mean_shape, DType.float32)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         var result = batch_norm2d(x, gamma, training=True)
         return result[0]
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var result = batch_norm2d_backward(
             grad_out, x, gamma, running_mean, running_var, training=True
         )
@@ -68,11 +68,11 @@ fn test_batch_norm_gradient_batch_size_2() raises:
     var running_mean = zeros(mean_shape, DType.float32)
     var running_var = ones(mean_shape, DType.float32)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         var result = batch_norm2d(x, gamma, training=True)
         return result[0]
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var result = batch_norm2d_backward(
             grad_out, x, gamma, running_mean, running_var, training=True
         )
@@ -100,11 +100,11 @@ fn test_batch_norm_gradient_batch_size_4() raises:
     var running_mean = zeros(mean_shape, DType.float32)
     var running_var = ones(mean_shape, DType.float32)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         var result = batch_norm2d(x, gamma, training=True)
         return result[0]
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var result = batch_norm2d_backward(
             grad_out, x, gamma, running_mean, running_var, training=True
         )
@@ -132,11 +132,11 @@ fn test_batch_norm_gamma_gradient_batch_size_2() raises:
     var running_mean = zeros(mean_shape, DType.float32)
     var running_var = ones(mean_shape, DType.float32)
 
-    fn forward(g: ExTensor) raises escaping -> ExTensor:
+    fn forward(g: AnyTensor) raises escaping -> AnyTensor:
         var result = batch_norm2d(input, g, training=True)
         return result[0]
 
-    fn backward(grad_out: ExTensor, g: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, g: AnyTensor) raises escaping -> AnyTensor:
         var result = batch_norm2d_backward(
             grad_out, input, g, running_mean, running_var, training=True
         )

--- a/tests/shared/core/test_gradient_checking_conv2d.mojo
+++ b/tests/shared/core/test_gradient_checking_conv2d.mojo
@@ -19,7 +19,7 @@ References:
 """
 
 from shared.core.conv import conv2d, conv2d_backward
-from shared.core.extensor import ExTensor, zeros
+from shared.core.extensor import AnyTensor, zeros
 from shared.testing.gradient_checker import check_gradients
 from shared.testing.assertions import assert_true
 
@@ -48,10 +48,10 @@ fn test_conv2d_same_padding_grad_input() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return conv2d(inp, kernel, bias, stride=1, padding=1)
 
-    fn backward_fn(grad_out: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad_out: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         var result = conv2d_backward(grad_out, inp, kernel, stride=1, padding=1)
         return result.grad_input
 
@@ -83,10 +83,10 @@ fn test_conv2d_same_padding_grad_weights() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward(k: ExTensor) raises escaping -> ExTensor:
+    fn forward(k: AnyTensor) raises escaping -> AnyTensor:
         return conv2d(x, k, bias, stride=1, padding=1)
 
-    fn backward_fn(grad_out: ExTensor, k: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad_out: AnyTensor, k: AnyTensor) raises escaping -> AnyTensor:
         var result = conv2d_backward(grad_out, x, k, stride=1, padding=1)
         return result.grad_weights
 
@@ -118,10 +118,10 @@ fn test_conv2d_same_padding_grad_bias() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward(b: ExTensor) raises escaping -> ExTensor:
+    fn forward(b: AnyTensor) raises escaping -> AnyTensor:
         return conv2d(x, kernel, b, stride=1, padding=1)
 
-    fn backward_fn(grad_out: ExTensor, b: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad_out: AnyTensor, b: AnyTensor) raises escaping -> AnyTensor:
         var result = conv2d_backward(grad_out, x, kernel, stride=1, padding=1)
         return result.grad_bias
 
@@ -153,10 +153,10 @@ fn test_conv2d_strided_grad_input() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return conv2d(inp, kernel, bias, stride=2, padding=0)
 
-    fn backward_fn(grad_out: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad_out: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         var result = conv2d_backward(grad_out, inp, kernel, stride=2, padding=0)
         return result.grad_input
 
@@ -188,10 +188,10 @@ fn test_conv2d_strided_grad_weights() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward(k: ExTensor) raises escaping -> ExTensor:
+    fn forward(k: AnyTensor) raises escaping -> AnyTensor:
         return conv2d(x, k, bias, stride=2, padding=0)
 
-    fn backward_fn(grad_out: ExTensor, k: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad_out: AnyTensor, k: AnyTensor) raises escaping -> AnyTensor:
         var result = conv2d_backward(grad_out, x, k, stride=2, padding=0)
         return result.grad_weights
 
@@ -223,10 +223,10 @@ fn test_conv2d_strided_grad_bias() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward(b: ExTensor) raises escaping -> ExTensor:
+    fn forward(b: AnyTensor) raises escaping -> AnyTensor:
         return conv2d(x, kernel, b, stride=2, padding=0)
 
-    fn backward_fn(grad_out: ExTensor, b: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad_out: AnyTensor, b: AnyTensor) raises escaping -> AnyTensor:
         var result = conv2d_backward(grad_out, x, kernel, stride=2, padding=0)
         return result.grad_bias
 
@@ -258,10 +258,10 @@ fn test_conv2d_multichannel_grad_input() raises:
     bias_shape.append(3)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return conv2d(inp, kernel, bias, stride=1, padding=1)
 
-    fn backward_fn(grad_out: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad_out: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         var result = conv2d_backward(grad_out, inp, kernel, stride=1, padding=1)
         return result.grad_input
 
@@ -293,10 +293,10 @@ fn test_conv2d_multichannel_grad_weights() raises:
     bias_shape.append(3)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward(k: ExTensor) raises escaping -> ExTensor:
+    fn forward(k: AnyTensor) raises escaping -> AnyTensor:
         return conv2d(x, k, bias, stride=1, padding=1)
 
-    fn backward_fn(grad_out: ExTensor, k: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad_out: AnyTensor, k: AnyTensor) raises escaping -> AnyTensor:
         var result = conv2d_backward(grad_out, x, k, stride=1, padding=1)
         return result.grad_weights
 
@@ -328,10 +328,10 @@ fn test_conv2d_multichannel_grad_bias() raises:
     bias_shape.append(3)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward(b: ExTensor) raises escaping -> ExTensor:
+    fn forward(b: AnyTensor) raises escaping -> AnyTensor:
         return conv2d(x, kernel, b, stride=1, padding=1)
 
-    fn backward_fn(grad_out: ExTensor, b: ExTensor) raises escaping -> ExTensor:
+    fn backward_fn(grad_out: AnyTensor, b: AnyTensor) raises escaping -> AnyTensor:
         var result = conv2d_backward(grad_out, x, kernel, stride=1, padding=1)
         return result.grad_bias
 

--- a/tests/shared/core/test_gradient_checking_depthwise_conv2d.mojo
+++ b/tests/shared/core/test_gradient_checking_depthwise_conv2d.mojo
@@ -10,7 +10,7 @@ corruption bug that occurs after ~15 cumulative tests. See ADR-009.
 
 from tests.shared.conftest import assert_true
 from shared.testing import check_gradients
-from shared.core import ExTensor, zeros, ones
+from shared.core import AnyTensor, zeros, ones
 from shared.core.conv import depthwise_conv2d, depthwise_conv2d_backward
 
 
@@ -30,10 +30,10 @@ fn test_depthwise_conv2d_gradient_kernel_basic() raises:
     kernel_shape.append(3)  # kernel width
     var kernel = ones(kernel_shape, DType.float32)
 
-    fn forward(k: ExTensor) raises escaping -> ExTensor:
+    fn forward(k: AnyTensor) raises escaping -> AnyTensor:
         return depthwise_conv2d(input, k, stride=1, padding=1)
 
-    fn backward(grad_out: ExTensor, k: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, k: AnyTensor) raises escaping -> AnyTensor:
         var result = depthwise_conv2d_backward(grad_out, input, k, stride=1, padding=1)
         return result.grad_b
 
@@ -61,10 +61,10 @@ fn test_depthwise_conv2d_gradient_bias_basic() raises:
     bias_shape.append(2)  # channels
     var bias = ones(bias_shape, DType.float32)
 
-    fn forward(b: ExTensor) raises escaping -> ExTensor:
+    fn forward(b: AnyTensor) raises escaping -> AnyTensor:
         return depthwise_conv2d(input, kernel, bias, stride=1, padding=1)
 
-    fn backward(grad_out: ExTensor, b: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, b: AnyTensor) raises escaping -> AnyTensor:
         var result = depthwise_conv2d_backward(grad_out, input, kernel, stride=1, padding=1)
         return result.grad_c
 
@@ -88,10 +88,10 @@ fn test_depthwise_conv2d_gradient_input_basic() raises:
     kernel_shape.append(3)  # kernel width
     var kernel = ones(kernel_shape, DType.float32)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return depthwise_conv2d(x, kernel, stride=1, padding=1)
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var result = depthwise_conv2d_backward(grad_out, x, kernel, stride=1, padding=1)
         return result.grad_a
 
@@ -115,10 +115,10 @@ fn test_depthwise_conv2d_gradient_kernel_strided() raises:
     kernel_shape.append(3)  # kernel width
     var kernel = ones(kernel_shape, DType.float32)
 
-    fn forward(k: ExTensor) raises escaping -> ExTensor:
+    fn forward(k: AnyTensor) raises escaping -> AnyTensor:
         return depthwise_conv2d(input, k, stride=2, padding=1)
 
-    fn backward(grad_out: ExTensor, k: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, k: AnyTensor) raises escaping -> AnyTensor:
         var result = depthwise_conv2d_backward(grad_out, input, k, stride=2, padding=1)
         return result.grad_b
 

--- a/tests/shared/core/test_gradient_checking_dtype.mojo
+++ b/tests/shared/core/test_gradient_checking_dtype.mojo
@@ -10,7 +10,7 @@ corruption bug that occurs after ~15 cumulative tests. See ADR-009.
 
 from tests.shared.conftest import assert_true
 from shared.testing import check_gradients
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.activation import (
     relu,
     relu_backward,
@@ -32,11 +32,11 @@ fn test_composite_relu_multiply() raises:
     var input_a = full(shape, 2.0, DType.float32)
     var input_b = full(shape, 3.0, DType.float32)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         var mul_result = multiply(x, input_b)
         return relu(mul_result)
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var mul_result = multiply(x, input_b)
         var grad_relu = relu_backward(grad_out, mul_result)
         var grads = multiply_backward(grad_relu, x, input_b)
@@ -62,10 +62,10 @@ fn test_linear_gradient_fp32() raises:
     bias_shape.append(3)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return linear(x, weights, bias)
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var grads = linear_backward(grad_out, x, weights)
         return grads.grad_input
 
@@ -93,10 +93,10 @@ fn test_linear_gradient_fp16() raises:
     bias_shape.append(3)
     var bias = config.cast_to_compute(zeros(bias_shape, DType.float32))
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return linear(x, weights, bias)
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var grads = linear_backward(grad_out, x, weights)
         return grads.grad_input
 
@@ -126,10 +126,10 @@ fn test_conv2d_gradient_fp32() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return conv2d(x, kernel, bias, stride=1, padding=0)
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var grads = conv2d_backward(grad_out, x, kernel, stride=1, padding=0)
         return grads.grad_input
 
@@ -160,10 +160,10 @@ fn test_conv2d_grad_3x3_same_padding() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return conv2d(x, kernel, bias, stride=1, padding=1)
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var grads = conv2d_backward(grad_out, x, kernel, stride=1, padding=1)
         return grads.grad_input
 
@@ -196,10 +196,10 @@ fn test_conv2d_grad_3x3_strided() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return conv2d(x, kernel, bias, stride=2, padding=0)
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var grads = conv2d_backward(grad_out, x, kernel, stride=2, padding=0)
         return grads.grad_input
 
@@ -230,10 +230,10 @@ fn test_conv2d_grad_multichannel() raises:
     bias_shape.append(3)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return conv2d(x, kernel, bias, stride=1, padding=0)
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var grads = conv2d_backward(grad_out, x, kernel, stride=1, padding=0)
         return grads.grad_input
 
@@ -262,10 +262,10 @@ fn test_cross_entropy_gradient_fp32() raises:
     var labels = zeros(labels_shape, DType.float32)
     labels._set_float64(0, 1.0)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return cross_entropy(x, labels)
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         return cross_entropy_backward(grad_out, x, labels)
 
     var passed = check_gradients(
@@ -305,12 +305,12 @@ fn test_conv2d_gradient_fp16() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         var result = conv2d(x, kernel, bias, stride=1, padding=0)
         # Conv computes in FP32 for numerical stability
         return result^
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         var grads = conv2d_backward(grad_out, x, kernel, stride=1, padding=0)
         return grads.grad_input
 
@@ -350,10 +350,10 @@ fn test_cross_entropy_gradient_fp16() raises:
     labels_fp32._set_float64(0, 1.0)  # Sample 0: class 0
     var labels = config.cast_to_compute(labels_fp32)
 
-    fn forward(x: ExTensor) raises escaping -> ExTensor:
+    fn forward(x: AnyTensor) raises escaping -> AnyTensor:
         return cross_entropy(x, labels)
 
-    fn backward(grad_out: ExTensor, x: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, x: AnyTensor) raises escaping -> AnyTensor:
         return cross_entropy_backward(grad_out, x, labels)
 
     # FP16 with relaxed tolerance for exp/log operations

--- a/tests/shared/core/test_gradient_validation.mojo
+++ b/tests/shared/core/test_gradient_validation.mojo
@@ -18,7 +18,7 @@ from shared.core.activation import relu, sigmoid, tanh, gelu
 from shared.core.activation import relu_backward, sigmoid_backward, tanh_backward, gelu_backward
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.linear import linear, linear_backward
-from shared.core.extensor import ExTensor, full, zeros
+from shared.core.extensor import AnyTensor, full, zeros
 from shared.core.initializers import kaiming_uniform
 from shared.testing.gradient_checker import check_gradients
 from shared.testing.special_values import (
@@ -38,12 +38,12 @@ fn test_relu_gradient_positive_values() raises:
         [2, 3], DType.float32, seed=42, low=0.1, high=2.0
     )
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return relu(inp)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         return relu_backward(grad_out, inp)
 
     var passed = check_gradients(
@@ -58,12 +58,12 @@ fn test_relu_gradient_negative_values() raises:
         [2, 3], DType.float32, seed=123, low=-2.0, high=-0.1
     )
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return relu(inp)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         return relu_backward(grad_out, inp)
 
     var passed = check_gradients(
@@ -78,12 +78,12 @@ fn test_relu_gradient_mixed_values() raises:
         [2, 3], DType.float32, seed=999, low=-1.0, high=1.0
     )
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return relu(inp)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         return relu_backward(grad_out, inp)
 
     var passed = check_gradients(
@@ -103,12 +103,12 @@ fn test_relu_gradient_near_zero() raises:
         [2, 3], DType.float32, seed=555, low=-0.01, high=0.01
     )
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return relu(inp)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         return relu_backward(grad_out, inp)
 
     var passed = check_gradients(
@@ -128,12 +128,12 @@ fn test_relu_gradient_large_values() raises:
         [2, 3], DType.float32, seed=42, low=10.0, high=20.0
     )
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return relu(inp)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         return relu_backward(grad_out, inp)
 
     # Use wider tolerance (5%) for large values due to numerical precision
@@ -157,12 +157,12 @@ fn test_sigmoid_gradient_normal_range() raises:
         [2, 3], DType.float32, seed=42, low=-2.0, high=2.0
     )
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return sigmoid(inp)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         var output = sigmoid(inp)  # Compute sigmoid(x) first
         return sigmoid_backward(grad_out, output)
 
@@ -183,12 +183,12 @@ fn test_sigmoid_gradient_saturation_positive() raises:
     shape.append(3)
     var x = full(shape, 10.0, DType.float32)
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return sigmoid(inp)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         var output = sigmoid(inp)  # Compute sigmoid(x) first
         return sigmoid_backward(grad_out, output)
 
@@ -210,12 +210,12 @@ fn test_sigmoid_gradient_saturation_negative() raises:
     shape.append(3)
     var x = full(shape, -10.0, DType.float32)
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return sigmoid(inp)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         var output = sigmoid(inp)  # Compute sigmoid(x) first
         return sigmoid_backward(grad_out, output)
 
@@ -240,12 +240,12 @@ fn test_tanh_gradient() raises:
         [2, 3], DType.float32, seed=42, low=-2.0, high=2.0
     )
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return tanh(inp)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         var output = tanh(inp)  # Compute tanh(x) first
         return tanh_backward(grad_out, output)
 
@@ -264,12 +264,12 @@ fn test_gelu_gradient() raises:
         [2, 3], DType.float32, seed=42, low=-2.0, high=2.0
     )
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return gelu(inp)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         return gelu_backward(grad_out, inp)
 
     var passed = check_gradients(
@@ -314,12 +314,12 @@ fn test_conv2d_gradient_input() raises:
     input_shape.append(8)
     var x = create_seeded_random_tensor(input_shape, DType.float32, seed=42)
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return conv2d(inp, kernel, bias, stride=1, padding=1)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         var result = conv2d_backward(grad_out, inp, kernel, stride=1, padding=1)
         return result.grad_input
 
@@ -357,12 +357,12 @@ fn test_linear_gradient_input() raises:
     input_shape.append(in_features)
     var x = create_seeded_random_tensor(input_shape, DType.float32, seed=42)
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return linear(inp, weights, bias)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         var result = linear_backward(grad_out, inp, weights)
         return result.grad_input
 

--- a/tests/shared/core/test_gradient_validation_activations.mojo
+++ b/tests/shared/core/test_gradient_validation_activations.mojo
@@ -20,7 +20,7 @@ References:
 
 from shared.core.activation import relu, sigmoid
 from shared.core.activation import relu_backward, sigmoid_backward
-from shared.core.extensor import ExTensor, full
+from shared.core.extensor import AnyTensor, full
 from shared.testing.gradient_checker import check_gradients
 from shared.testing.special_values import create_seeded_random_tensor
 from shared.testing.assertions import assert_true
@@ -32,12 +32,12 @@ fn test_relu_gradient_positive_values() raises:
         [2, 3], DType.float32, seed=42, low=0.1, high=2.0
     )
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return relu(inp)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         return relu_backward(grad_out, inp)
 
     var passed = check_gradients(
@@ -52,12 +52,12 @@ fn test_relu_gradient_negative_values() raises:
         [2, 3], DType.float32, seed=123, low=-2.0, high=-0.1
     )
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return relu(inp)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         return relu_backward(grad_out, inp)
 
     var passed = check_gradients(
@@ -72,12 +72,12 @@ fn test_relu_gradient_mixed_values() raises:
         [2, 3], DType.float32, seed=999, low=-1.0, high=1.0
     )
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return relu(inp)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         return relu_backward(grad_out, inp)
 
     var passed = check_gradients(
@@ -97,12 +97,12 @@ fn test_relu_gradient_near_zero() raises:
         [2, 3], DType.float32, seed=555, low=-0.01, high=0.01
     )
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return relu(inp)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         return relu_backward(grad_out, inp)
 
     var passed = check_gradients(
@@ -122,12 +122,12 @@ fn test_relu_gradient_large_values() raises:
         [2, 3], DType.float32, seed=42, low=10.0, high=20.0
     )
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return relu(inp)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         return relu_backward(grad_out, inp)
 
     # Use wider tolerance (5%) for large values due to numerical precision
@@ -146,12 +146,12 @@ fn test_sigmoid_gradient_normal_range() raises:
         [2, 3], DType.float32, seed=42, low=-2.0, high=2.0
     )
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return sigmoid(inp)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         var output = sigmoid(inp)  # Compute sigmoid(x) first
         return sigmoid_backward(grad_out, output)
 
@@ -172,12 +172,12 @@ fn test_sigmoid_gradient_saturation_positive() raises:
     shape.append(3)
     var x = full(shape, 10.0, DType.float32)
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return sigmoid(inp)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         var output = sigmoid(inp)  # Compute sigmoid(x) first
         return sigmoid_backward(grad_out, output)
 
@@ -199,12 +199,12 @@ fn test_sigmoid_gradient_saturation_negative() raises:
     shape.append(3)
     var x = full(shape, -10.0, DType.float32)
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return sigmoid(inp)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         var output = sigmoid(inp)  # Compute sigmoid(x) first
         return sigmoid_backward(grad_out, output)
 

--- a/tests/shared/core/test_gradient_validation_layers.mojo
+++ b/tests/shared/core/test_gradient_validation_layers.mojo
@@ -22,7 +22,7 @@ from shared.core.activation import tanh, gelu
 from shared.core.activation import tanh_backward, gelu_backward
 from shared.core.conv import conv2d, conv2d_backward
 from shared.core.linear import linear, linear_backward
-from shared.core.extensor import ExTensor, zeros
+from shared.core.extensor import AnyTensor, zeros
 from shared.core.initializers import kaiming_uniform
 from shared.testing.gradient_checker import check_gradients
 from shared.testing.special_values import create_seeded_random_tensor
@@ -38,12 +38,12 @@ fn test_tanh_gradient() raises:
         [2, 3], DType.float32, seed=42, low=-2.0, high=2.0
     )
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return tanh(inp)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         var output = tanh(inp)  # Compute tanh(x) first
         return tanh_backward(grad_out, output)
 
@@ -62,12 +62,12 @@ fn test_gelu_gradient() raises:
         [2, 3], DType.float32, seed=42, low=-2.0, high=2.0
     )
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return gelu(inp)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         return gelu_backward(grad_out, inp)
 
     var passed = check_gradients(
@@ -107,12 +107,12 @@ fn test_conv2d_gradient_input() raises:
     input_shape.append(8)
     var x = create_seeded_random_tensor(input_shape, DType.float32, seed=42)
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return conv2d(inp, kernel, bias, stride=1, padding=1)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         var result = conv2d_backward(grad_out, inp, kernel, stride=1, padding=1)
         return result.grad_input
 
@@ -150,12 +150,12 @@ fn test_linear_gradient_input() raises:
     input_shape.append(in_features)
     var x = create_seeded_random_tensor(input_shape, DType.float32, seed=42)
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return linear(inp, weights, bias)
 
     fn backward_fn(
-        grad_out: ExTensor, inp: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, inp: AnyTensor
+    ) raises escaping -> AnyTensor:
         var result = linear_backward(grad_out, inp, weights)
         return result.grad_input
 

--- a/tests/shared/core/test_hash.mojo
+++ b/tests/shared/core/test_hash.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor __hash__ NaN stability (issue #3382).
+"""Tests for AnyTensor __hash__ NaN stability (issue #3382).
 
 Verifies that different NaN bit patterns (quiet NaN, signaling NaN, negative NaN,
 different NaN payloads) all produce the same hash, ensuring deterministic hash
@@ -7,7 +7,7 @@ behavior for tensors containing NaN values.
 
 from memory import UnsafePointer
 from shared.core import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     full,
@@ -24,47 +24,47 @@ from tests.shared.conftest import (
 # ============================================================================
 
 
-fn make_f32_nan_tensor(bits: UInt32) raises -> ExTensor:
+fn make_f32_nan_tensor(bits: UInt32) raises -> AnyTensor:
     """Create a scalar float32 tensor whose single element has the given raw bits.
 
     Args:
         bits: The IEEE 754 bit pattern to store. Must represent a NaN.
 
     Returns:
-        A scalar (0-D) ExTensor with DType.float32 containing that bit pattern.
+        A scalar (0-D) AnyTensor with DType.float32 containing that bit pattern.
     """
     var shape = List[Int]()
-    var t = ExTensor(shape, DType.float32)
+    var t = AnyTensor(shape, DType.float32)
     t._data.bitcast[UInt32]()[] = bits
     return t^
 
 
-fn make_f64_nan_tensor(bits: UInt64) raises -> ExTensor:
+fn make_f64_nan_tensor(bits: UInt64) raises -> AnyTensor:
     """Create a scalar float64 tensor whose single element has the given raw bits.
 
     Args:
         bits: The IEEE 754 bit pattern to store. Must represent a NaN.
 
     Returns:
-        A scalar (0-D) ExTensor with DType.float64 containing that bit pattern.
+        A scalar (0-D) AnyTensor with DType.float64 containing that bit pattern.
     """
     var shape = List[Int]()
-    var t = ExTensor(shape, DType.float64)
+    var t = AnyTensor(shape, DType.float64)
     t._data.bitcast[UInt64]()[] = bits
     return t^
 
 
-fn make_f16_nan_tensor(bits: UInt16) raises -> ExTensor:
+fn make_f16_nan_tensor(bits: UInt16) raises -> AnyTensor:
     """Create a scalar float16 tensor whose single element has the given raw bits.
 
     Args:
         bits: The IEEE 754 bit pattern to store. Must represent a NaN.
 
     Returns:
-        A scalar (0-D) ExTensor with DType.float16 containing that bit pattern.
+        A scalar (0-D) AnyTensor with DType.float16 containing that bit pattern.
     """
     var shape = List[Int]()
-    var t = ExTensor(shape, DType.float16)
+    var t = AnyTensor(shape, DType.float16)
     t._data.bitcast[UInt16]()[] = bits
     return t^
 
@@ -263,12 +263,12 @@ fn test_hash_mixed_nan_different_nan_patterns() raises:
     shape.append(2)
 
     # First tensor: element 0 = positive quiet NaN, element 1 = 1.0
-    var a = ExTensor(shape, DType.float32)
+    var a = AnyTensor(shape, DType.float32)
     a._data.bitcast[UInt32]()[0] = UInt32(0x7FC00000)  # +qNaN
     a._data.bitcast[Float32]()[1] = Float32(1.0)
 
     # Second tensor: element 0 = negative quiet NaN, element 1 = 1.0
-    var b = ExTensor(shape, DType.float32)
+    var b = AnyTensor(shape, DType.float32)
     b._data.bitcast[UInt32]()[0] = UInt32(0xFFC00000)  # -qNaN
     b._data.bitcast[Float32]()[1] = Float32(1.0)
 
@@ -448,11 +448,11 @@ fn test_hash_nan_canonicalization_scalar() raises:
     """
     # Positive quiet NaN
     var shape = List[Int]()
-    var pos_nan = ExTensor(shape, DType.float32)
+    var pos_nan = AnyTensor(shape, DType.float32)
     pos_nan._data.bitcast[UInt32]()[] = UInt32(0x7FC00000)
 
     # Negative quiet NaN
-    var neg_nan = ExTensor(shape, DType.float32)
+    var neg_nan = AnyTensor(shape, DType.float32)
     neg_nan._data.bitcast[UInt32]()[] = UInt32(0xFFC00000)
 
     assert_equal_int(

--- a/tests/shared/core/test_high_dimensional_part1.mojo
+++ b/tests/shared/core/test_high_dimensional_part1.mojo
@@ -7,8 +7,8 @@ high test load. Split from test_high_dimensional.mojo. See docs/adr/ADR-009-heap
 Tests 5D tensor creation and arithmetic operations.
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from shared.core.arithmetic import add, multiply, subtract
 from shared.core.reduction import sum, mean, max_reduce, min_reduce
 

--- a/tests/shared/core/test_high_dimensional_part2.mojo
+++ b/tests/shared/core/test_high_dimensional_part2.mojo
@@ -7,8 +7,8 @@ high test load. Split from test_high_dimensional.mojo. See docs/adr/ADR-009-heap
 Tests 6D/7D tensor operations, broadcasting, and large tensors.
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from shared.core.arithmetic import add, multiply, subtract
 from shared.core.reduction import sum, mean, max_reduce, min_reduce
 

--- a/tests/shared/core/test_high_dimensional_part3.mojo
+++ b/tests/shared/core/test_high_dimensional_part3.mojo
@@ -7,8 +7,8 @@ high test load. Split from test_high_dimensional.mojo. See docs/adr/ADR-009-heap
 Tests large tensor operations, precision with reductions, and numerical behavior.
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from shared.core.arithmetic import add, multiply, subtract
 from shared.core.reduction import sum, mean, max_reduce, min_reduce
 

--- a/tests/shared/core/test_initializers_part1.mojo
+++ b/tests/shared/core/test_initializers_part1.mojo
@@ -19,7 +19,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_true,
 )
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.core.initializers import (
     xavier_uniform,
     xavier_normal,
@@ -32,7 +32,7 @@ from math import sqrt
 # ============================================================================
 
 
-fn compute_mean(tensor: ExTensor) -> Float64:
+fn compute_mean(tensor: AnyTensor) -> Float64:
     """Compute mean of tensor values."""
     var sum = Float64(0.0)
     var size = tensor.numel()
@@ -53,7 +53,7 @@ fn compute_mean(tensor: ExTensor) -> Float64:
     return sum / Float64(size)
 
 
-fn compute_variance(tensor: ExTensor, mean: Float64) -> Float64:
+fn compute_variance(tensor: AnyTensor, mean: Float64) -> Float64:
     """Compute variance of tensor values."""
     var sum_sq_diff = Float64(0.0)
     var size = tensor.numel()
@@ -77,12 +77,12 @@ fn compute_variance(tensor: ExTensor, mean: Float64) -> Float64:
     return sum_sq_diff / Float64(size)
 
 
-fn compute_std(tensor: ExTensor, mean: Float64) -> Float64:
+fn compute_std(tensor: AnyTensor, mean: Float64) -> Float64:
     """Compute standard deviation of tensor values."""
     return sqrt(compute_variance(tensor, mean))
 
 
-fn compute_min_max(tensor: ExTensor) -> Tuple[Float64, Float64]:
+fn compute_min_max(tensor: AnyTensor) -> Tuple[Float64, Float64]:
     """Compute min and max values in tensor."""
     var size = tensor.numel()
     var min_val = Float64(1e308)

--- a/tests/shared/core/test_initializers_part2.mojo
+++ b/tests/shared/core/test_initializers_part2.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_true,
 )
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.core.initializers import (
     xavier_uniform,
     xavier_normal,
@@ -32,7 +32,7 @@ from math import sqrt
 # ============================================================================
 
 
-fn compute_mean(tensor: ExTensor) -> Float64:
+fn compute_mean(tensor: AnyTensor) -> Float64:
     """Compute mean of tensor values."""
     var sum = Float64(0.0)
     var size = tensor.numel()
@@ -53,7 +53,7 @@ fn compute_mean(tensor: ExTensor) -> Float64:
     return sum / Float64(size)
 
 
-fn compute_variance(tensor: ExTensor, mean: Float64) -> Float64:
+fn compute_variance(tensor: AnyTensor, mean: Float64) -> Float64:
     """Compute variance of tensor values."""
     var sum_sq_diff = Float64(0.0)
     var size = tensor.numel()
@@ -77,12 +77,12 @@ fn compute_variance(tensor: ExTensor, mean: Float64) -> Float64:
     return sum_sq_diff / Float64(size)
 
 
-fn compute_std(tensor: ExTensor, mean: Float64) -> Float64:
+fn compute_std(tensor: AnyTensor, mean: Float64) -> Float64:
     """Compute standard deviation of tensor values."""
     return sqrt(compute_variance(tensor, mean))
 
 
-fn compute_min_max(tensor: ExTensor) -> Tuple[Float64, Float64]:
+fn compute_min_max(tensor: AnyTensor) -> Tuple[Float64, Float64]:
     """Compute min and max values in tensor."""
     var size = tensor.numel()
     var min_val = Float64(1e308)

--- a/tests/shared/core/test_initializers_part3.mojo
+++ b/tests/shared/core/test_initializers_part3.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_true,
 )
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.core.initializers import (
     kaiming_uniform,
     kaiming_normal,
@@ -32,7 +32,7 @@ from math import sqrt
 # ============================================================================
 
 
-fn compute_mean(tensor: ExTensor) -> Float64:
+fn compute_mean(tensor: AnyTensor) -> Float64:
     """Compute mean of tensor values."""
     var sum = Float64(0.0)
     var size = tensor.numel()
@@ -53,7 +53,7 @@ fn compute_mean(tensor: ExTensor) -> Float64:
     return sum / Float64(size)
 
 
-fn compute_variance(tensor: ExTensor, mean: Float64) -> Float64:
+fn compute_variance(tensor: AnyTensor, mean: Float64) -> Float64:
     """Compute variance of tensor values."""
     var sum_sq_diff = Float64(0.0)
     var size = tensor.numel()
@@ -77,7 +77,7 @@ fn compute_variance(tensor: ExTensor, mean: Float64) -> Float64:
     return sum_sq_diff / Float64(size)
 
 
-fn compute_std(tensor: ExTensor, mean: Float64) -> Float64:
+fn compute_std(tensor: AnyTensor, mean: Float64) -> Float64:
     """Compute standard deviation of tensor values."""
     return sqrt(compute_variance(tensor, mean))
 

--- a/tests/shared/core/test_initializers_part4.mojo
+++ b/tests/shared/core/test_initializers_part4.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_true,
 )
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.core.initializers import (
     uniform,
     normal,
@@ -31,7 +31,7 @@ from math import sqrt
 # ============================================================================
 
 
-fn compute_mean(tensor: ExTensor) -> Float64:
+fn compute_mean(tensor: AnyTensor) -> Float64:
     """Compute mean of tensor values."""
     var sum = Float64(0.0)
     var size = tensor.numel()
@@ -52,7 +52,7 @@ fn compute_mean(tensor: ExTensor) -> Float64:
     return sum / Float64(size)
 
 
-fn compute_variance(tensor: ExTensor, mean: Float64) -> Float64:
+fn compute_variance(tensor: AnyTensor, mean: Float64) -> Float64:
     """Compute variance of tensor values."""
     var sum_sq_diff = Float64(0.0)
     var size = tensor.numel()
@@ -76,12 +76,12 @@ fn compute_variance(tensor: ExTensor, mean: Float64) -> Float64:
     return sum_sq_diff / Float64(size)
 
 
-fn compute_std(tensor: ExTensor, mean: Float64) -> Float64:
+fn compute_std(tensor: AnyTensor, mean: Float64) -> Float64:
     """Compute standard deviation of tensor values."""
     return sqrt(compute_variance(tensor, mean))
 
 
-fn compute_min_max(tensor: ExTensor) -> Tuple[Float64, Float64]:
+fn compute_min_max(tensor: AnyTensor) -> Tuple[Float64, Float64]:
     """Compute min and max values in tensor."""
     var size = tensor.numel()
     var min_val = Float64(1e308)

--- a/tests/shared/core/test_initializers_part5.mojo
+++ b/tests/shared/core/test_initializers_part5.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_true,
 )
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.core.initializers import (
     xavier_uniform,
     xavier_normal,
@@ -32,7 +32,7 @@ from math import sqrt
 # ============================================================================
 
 
-fn compute_mean(tensor: ExTensor) -> Float64:
+fn compute_mean(tensor: AnyTensor) -> Float64:
     """Compute mean of tensor values."""
     var sum = Float64(0.0)
     var size = tensor.numel()
@@ -53,7 +53,7 @@ fn compute_mean(tensor: ExTensor) -> Float64:
     return sum / Float64(size)
 
 
-fn compute_variance(tensor: ExTensor, mean: Float64) -> Float64:
+fn compute_variance(tensor: AnyTensor, mean: Float64) -> Float64:
     """Compute variance of tensor values."""
     var sum_sq_diff = Float64(0.0)
     var size = tensor.numel()

--- a/tests/shared/core/test_initializers_part6.mojo
+++ b/tests/shared/core/test_initializers_part6.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_true,
 )
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.core.initializers import (
     xavier_uniform,
     kaiming_uniform,
@@ -35,7 +35,7 @@ from math import sqrt
 # ============================================================================
 
 
-fn compute_mean(tensor: ExTensor) -> Float64:
+fn compute_mean(tensor: AnyTensor) -> Float64:
     """Compute mean of tensor values."""
     var sum = Float64(0.0)
     var size = tensor.numel()
@@ -56,7 +56,7 @@ fn compute_mean(tensor: ExTensor) -> Float64:
     return sum / Float64(size)
 
 
-fn compute_variance(tensor: ExTensor, mean: Float64) -> Float64:
+fn compute_variance(tensor: AnyTensor, mean: Float64) -> Float64:
     """Compute variance of tensor values."""
     var sum_sq_diff = Float64(0.0)
     var size = tensor.numel()

--- a/tests/shared/core/test_initializers_validation.mojo
+++ b/tests/shared/core/test_initializers_validation.mojo
@@ -12,7 +12,7 @@ Validation strategy:
 - Statistical correctness (mean, variance, distribution shape)
 - API consistency (parameters, return types, error handling)
 - Reproducibility (seeding behavior)
-- Integration (interoperability with ExTensor)
+- Integration (interoperability with AnyTensor)
 """
 
 from tests.shared.conftest import (
@@ -24,11 +24,11 @@ from tests.shared.conftest import (
     assert_true,
 )
 from math import sqrt
-from shared.core.extensor import ExTensor
+from shared.core.extensor import AnyTensor
 from shared.core.initializers import xavier_uniform, xavier_normal, kaiming_uniform, kaiming_normal, uniform, normal, constant
 
 
-fn compute_mean(tensor: ExTensor) -> Float64:
+fn compute_mean(tensor: AnyTensor) -> Float64:
     """Compute mean of tensor values."""
     var sum = Float64(0.0)
     var size = tensor.numel()
@@ -46,7 +46,7 @@ fn compute_mean(tensor: ExTensor) -> Float64:
     return sum / Float64(size)
 
 
-fn compute_variance(tensor: ExTensor, mean: Float64) -> Float64:
+fn compute_variance(tensor: AnyTensor, mean: Float64) -> Float64:
     """Compute variance of tensor values."""
     var sum_sq = Float64(0.0)
     var size = tensor.numel()
@@ -71,7 +71,7 @@ fn compute_variance(tensor: ExTensor, mean: Float64) -> Float64:
 
 
 fn test_all_initializers_produce_tensors() raises:
-    """Validate that all initializers produce valid ExTensor objects."""
+    """Validate that all initializers produce valid AnyTensor objects."""
     print("Testing all initializers produce valid tensors...")
 
     var shape: List[Int] = [100, 100]
@@ -450,14 +450,14 @@ fn test_initializers_api_consistency() raises:
     var n = normal(shape, 0.0, 0.01, DType.float32, 42)
     var c = constant(shape, 0.5, DType.float32)
 
-    # All should return ExTensor
-    assert_equal(xu.numel(), 10000, "Xavier uniform returns ExTensor")
-    assert_equal(xn.numel(), 10000, "Xavier normal returns ExTensor")
-    assert_equal(ku.numel(), 10000, "Kaiming uniform returns ExTensor")
-    assert_equal(kn.numel(), 10000, "Kaiming normal returns ExTensor")
-    assert_equal(u.numel(), 10000, "Uniform returns ExTensor")
-    assert_equal(n.numel(), 10000, "Normal returns ExTensor")
-    assert_equal(c.numel(), 10000, "Constant returns ExTensor")
+    # All should return AnyTensor
+    assert_equal(xu.numel(), 10000, "Xavier uniform returns AnyTensor")
+    assert_equal(xn.numel(), 10000, "Xavier normal returns AnyTensor")
+    assert_equal(ku.numel(), 10000, "Kaiming uniform returns AnyTensor")
+    assert_equal(kn.numel(), 10000, "Kaiming normal returns AnyTensor")
+    assert_equal(u.numel(), 10000, "Uniform returns AnyTensor")
+    assert_equal(n.numel(), 10000, "Normal returns AnyTensor")
+    assert_equal(c.numel(), 10000, "Constant returns AnyTensor")
 
     # All should raise on invalid inputs (tested in individual test files)
 

--- a/tests/shared/core/test_integration_part1.mojo
+++ b/tests/shared/core/test_integration_part1.mojo
@@ -1,4 +1,4 @@
-"""Integration tests for ExTensor operations - Part 1: Chained and Creation Patterns.
+"""Integration tests for AnyTensor operations - Part 1: Chained and Creation Patterns.
 
 Tests chained arithmetic operations and creation + arithmetic patterns.
 Split from test_integration.mojo per ADR-009 to avoid heap corruption.
@@ -8,8 +8,8 @@ Split from test_integration.mojo per ADR-009 to avoid heap corruption.
 # high test load. Split from test_integration.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange, eye, linspace
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange, eye, linspace
 from shared.core.arithmetic import add, subtract, multiply
 
 # Import test helpers
@@ -146,7 +146,7 @@ fn test_linspace_operations() raises:
 
 fn main() raises:
     """Run integration tests part 1: chained and creation patterns."""
-    print("Running ExTensor integration tests (part 1)...")
+    print("Running AnyTensor integration tests (part 1)...")
 
     # Chained operations
     print("  Testing chained operations...")

--- a/tests/shared/core/test_integration_part2.mojo
+++ b/tests/shared/core/test_integration_part2.mojo
@@ -1,4 +1,4 @@
-"""Integration tests for ExTensor operations - Part 2: Dtype and Multi-dimensional.
+"""Integration tests for AnyTensor operations - Part 2: Dtype and Multi-dimensional.
 
 Tests multiple dtype operations, multi-dimensional operations, and ML-like patterns.
 Split from test_integration.mojo per ADR-009 to avoid heap corruption.
@@ -8,8 +8,8 @@ Split from test_integration.mojo per ADR-009 to avoid heap corruption.
 # high test load. Split from test_integration.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange, eye, linspace
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange, eye, linspace
 from shared.core.arithmetic import add, subtract, multiply
 
 # Import test helpers
@@ -153,7 +153,7 @@ fn test_batch_normalization_pattern() raises:
 fn main() raises:
     """Run integration tests part 2: dtype, multi-dimensional, and ML patterns.
     """
-    print("Running ExTensor integration tests (part 2)...")
+    print("Running AnyTensor integration tests (part 2)...")
 
     # Multiple dtypes
     print("  Testing dtype operations...")

--- a/tests/shared/core/test_integration_part3.mojo
+++ b/tests/shared/core/test_integration_part3.mojo
@@ -1,4 +1,4 @@
-"""Integration tests for ExTensor operations - Part 3: Identity, Scalar, and Large Tensors.
+"""Integration tests for AnyTensor operations - Part 3: Identity, Scalar, and Large Tensors.
 
 Tests zero and identity element behavior, scalar patterns, and large tensor operations.
 Split from test_integration.mojo per ADR-009 to avoid heap corruption.
@@ -8,8 +8,8 @@ Split from test_integration.mojo per ADR-009 to avoid heap corruption.
 # high test load. Split from test_integration.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange, eye, linspace
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange, eye, linspace
 from shared.core.arithmetic import add, subtract, multiply
 
 # Import test helpers
@@ -113,7 +113,7 @@ fn test_large_tensor_operations() raises:
 fn main() raises:
     """Run integration tests part 3: identity elements, scalar, and large tensor ops.
     """
-    print("Running ExTensor integration tests (part 3)...")
+    print("Running AnyTensor integration tests (part 3)...")
 
     # Identity elements
     print("  Testing identity element behavior...")

--- a/tests/shared/core/test_jit_crash_heavy_import.mojo
+++ b/tests/shared/core/test_jit_crash_heavy_import.mojo
@@ -6,7 +6,7 @@ Run 30+ times to observe intermittent 'execution crashed'.
 
 See docs/dev/mojo-jit-crash-workaround.md for context.
 """
-from shared.core import ExTensor, zeros, ones, full, arange, relu, sigmoid, matmul, softmax
+from shared.core import AnyTensor, zeros, ones, full, arange, relu, sigmoid, matmul, softmax
 from testing import assert_true
 
 

--- a/tests/shared/core/test_jit_crash_light_import.mojo
+++ b/tests/shared/core/test_jit_crash_light_import.mojo
@@ -5,7 +5,7 @@ Should never crash even after 100+ runs.
 
 See docs/dev/mojo-jit-crash-workaround.md for context.
 """
-from shared.core.extensor import ExTensor, zeros
+from shared.core.extensor import AnyTensor, zeros
 from testing import assert_true
 
 

--- a/tests/shared/core/test_layers_part1.mojo
+++ b/tests/shared/core/test_layers_part1.mojo
@@ -19,7 +19,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.core.linear import linear, linear_no_bias
 from shared.core.activation import relu, sigmoid, tanh, softmax
 

--- a/tests/shared/core/test_layers_part2.mojo
+++ b/tests/shared/core/test_layers_part2.mojo
@@ -20,7 +20,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.core.linear import linear, linear_no_bias
 from shared.core.activation import relu, sigmoid, tanh, softmax
 
@@ -188,7 +188,7 @@ fn test_maxpool2d_max_selection() raises:
     # # Create input with known values
     # # [[1, 2], [3, 4]] -> max = 4
     # var data = [1.0, 2.0, 3.0, 4.0]
-    # var input = ExTensor([1, 1, 2, 2], DType.float32)
+    # var input = AnyTensor([1, 1, 2, 2], DType.float32)
     # # Fill with data
     # var output = pool.forward(input)
     #

--- a/tests/shared/core/test_layers_part3.mojo
+++ b/tests/shared/core/test_layers_part3.mojo
@@ -19,7 +19,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.core.linear import linear, linear_no_bias
 from shared.core.activation import relu, sigmoid, tanh, softmax
 

--- a/tests/shared/core/test_lazy_expression.mojo
+++ b/tests/shared/core/test_lazy_expression.mojo
@@ -1,7 +1,7 @@
 """Basic tests for lazy expression evaluation."""
 
 from collections import List
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.lazy_expression import expr, TensorExpr
 from shared.core.lazy_eval import evaluate
 from shared.core.arithmetic import add, subtract, multiply, divide

--- a/tests/shared/core/test_linear_part1.mojo
+++ b/tests/shared/core/test_linear_part1.mojo
@@ -26,7 +26,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.linear import (
     linear,
     linear_no_bias,

--- a/tests/shared/core/test_linear_part2.mojo
+++ b/tests/shared/core/test_linear_part2.mojo
@@ -26,7 +26,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.linear import (
     linear,
     linear_no_bias,

--- a/tests/shared/core/test_loss_funcs_part1.mojo
+++ b/tests/shared/core/test_loss_funcs_part1.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     assert_true,
     assert_close_float,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.loss import (
     cross_entropy,
     cross_entropy_backward,

--- a/tests/shared/core/test_loss_funcs_part2.mojo
+++ b/tests/shared/core/test_loss_funcs_part2.mojo
@@ -19,7 +19,7 @@ from tests.shared.conftest import (
     assert_true,
     assert_close_float,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.loss import (
     cross_entropy,
     cross_entropy_backward,

--- a/tests/shared/core/test_loss_utils_part1.mojo
+++ b/tests/shared/core/test_loss_utils_part1.mojo
@@ -19,7 +19,7 @@ from tests.shared.conftest import (
     assert_true,
     assert_close_float,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.loss_utils import (
     clip_predictions,
     create_epsilon_tensor,

--- a/tests/shared/core/test_loss_utils_part2.mojo
+++ b/tests/shared/core/test_loss_utils_part2.mojo
@@ -15,7 +15,7 @@ from tests.shared.conftest import (
     assert_almost_equal,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.loss_utils import (
     validate_tensor_dtypes,
     compute_one_minus_tensor,

--- a/tests/shared/core/test_loss_utils_part3.mojo
+++ b/tests/shared/core/test_loss_utils_part3.mojo
@@ -16,7 +16,7 @@ from tests.shared.conftest import (
     assert_almost_equal,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.loss_utils import (
     blend_tensors,
     compute_difference,

--- a/tests/shared/core/test_loss_utils_part4.mojo
+++ b/tests/shared/core/test_loss_utils_part4.mojo
@@ -14,7 +14,7 @@ from tests.shared.conftest import (
     assert_almost_equal,
     assert_greater_or_equal,
 )
-from shared.core.extensor import ExTensor, zeros, full
+from shared.core.extensor import AnyTensor, zeros, full
 from shared.core.loss_utils import (
     compute_ratio,
     negate_tensor,

--- a/tests/shared/core/test_losses_part1.mojo
+++ b/tests/shared/core/test_losses_part1.mojo
@@ -16,7 +16,7 @@ from tests.shared.conftest import (
     assert_almost_equal,
     assert_close_float,
 )
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.loss import binary_cross_entropy, binary_cross_entropy_backward
 from shared.core.loss import mean_squared_error, mean_squared_error_backward
 from shared.core.reduction import mean
@@ -28,8 +28,8 @@ fn test_binary_cross_entropy_perfect_prediction() raises:
 
     var shape = List[Int]()
     shape.append(4)
-    var predictions = ExTensor(shape, DType.float32)
-    var targets = ExTensor(shape, DType.float32)
+    var predictions = AnyTensor(shape, DType.float32)
+    var targets = AnyTensor(shape, DType.float32)
 
     # Perfect predictions: pred = target
     for i in range(4):
@@ -56,8 +56,8 @@ fn test_binary_cross_entropy_worst_prediction() raises:
 
     var shape = List[Int]()
     shape.append(4)
-    var predictions = ExTensor(shape, DType.float32)
-    var targets = ExTensor(shape, DType.float32)
+    var predictions = AnyTensor(shape, DType.float32)
+    var targets = AnyTensor(shape, DType.float32)
 
     # Worst predictions: pred = 1 - target
     for i in range(4):
@@ -85,8 +85,8 @@ fn test_binary_cross_entropy_gradient_shape() raises:
 
     var shape = List[Int]()
     shape.append(3)
-    var predictions = ExTensor(shape, DType.float32)
-    var targets = ExTensor(shape, DType.float32)
+    var predictions = AnyTensor(shape, DType.float32)
+    var targets = AnyTensor(shape, DType.float32)
 
     for i in range(3):
         predictions._set_float64(i, 0.5)
@@ -116,8 +116,8 @@ fn test_mean_squared_error_zero_loss() raises:
 
     var shape = List[Int]()
     shape.append(5)
-    var predictions = ExTensor(shape, DType.float32)
-    var targets = ExTensor(shape, DType.float32)
+    var predictions = AnyTensor(shape, DType.float32)
+    var targets = AnyTensor(shape, DType.float32)
 
     # Identical values
     for i in range(5):
@@ -144,8 +144,8 @@ fn test_mean_squared_error_known_values() raises:
 
     var shape = List[Int]()
     shape.append(3)
-    var predictions = ExTensor(shape, DType.float32)
-    var targets = ExTensor(shape, DType.float32)
+    var predictions = AnyTensor(shape, DType.float32)
+    var targets = AnyTensor(shape, DType.float32)
 
     # Predictions: [2, 3, 4]
     # Targets:     [1, 3, 5]
@@ -182,8 +182,8 @@ fn test_mean_squared_error_gradient() raises:
 
     var shape = List[Int]()
     shape.append(3)
-    var predictions = ExTensor(shape, DType.float32)
-    var targets = ExTensor(shape, DType.float32)
+    var predictions = AnyTensor(shape, DType.float32)
+    var targets = AnyTensor(shape, DType.float32)
 
     # Simple case: predictions = [2, 3, 4], targets = [1, 3, 5]
     # Gradient should be 2 * (predictions - targets) = 2 * [1, 0, -1] = [2, 0, -2]
@@ -230,8 +230,8 @@ fn test_loss_numerical_stability() raises:
 
     var shape = List[Int]()
     shape.append(2)
-    var predictions = ExTensor(shape, DType.float32)
-    var targets = ExTensor(shape, DType.float32)
+    var predictions = AnyTensor(shape, DType.float32)
+    var targets = AnyTensor(shape, DType.float32)
 
     # Test BCE with values close to 0 and 1 (should be clipped)
     predictions._set_float64(0, 0.0)  # Should be clipped to epsilon

--- a/tests/shared/core/test_losses_part2.mojo
+++ b/tests/shared/core/test_losses_part2.mojo
@@ -17,7 +17,7 @@ from tests.shared.conftest import (
     assert_almost_equal,
     assert_close_float,
 )
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.loss import binary_cross_entropy, binary_cross_entropy_backward
 from shared.core.loss import mean_squared_error, mean_squared_error_backward
 from shared.core.loss import smooth_l1_loss, smooth_l1_loss_backward
@@ -46,11 +46,11 @@ fn test_binary_cross_entropy_backward_gradient() raises:
     targets._set_float64(3, 0.0)
 
     # Forward function wrapper
-    fn forward(pred: ExTensor) raises escaping -> ExTensor:
+    fn forward(pred: AnyTensor) raises escaping -> AnyTensor:
         return binary_cross_entropy(pred, targets)
 
     # Backward function wrapper
-    fn backward(grad_out: ExTensor, pred: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, pred: AnyTensor) raises escaping -> AnyTensor:
         return binary_cross_entropy_backward(grad_out, pred, targets)
 
     var loss = forward(predictions)
@@ -87,11 +87,11 @@ fn test_mean_squared_error_backward_gradient() raises:
     targets._set_float64(4, 0.8)
 
     # Forward function wrapper
-    fn forward(pred: ExTensor) raises escaping -> ExTensor:
+    fn forward(pred: AnyTensor) raises escaping -> AnyTensor:
         return mean_squared_error(pred, targets)
 
     # Backward function wrapper
-    fn backward(grad_out: ExTensor, pred: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, pred: AnyTensor) raises escaping -> AnyTensor:
         return mean_squared_error_backward(grad_out, pred, targets)
 
     var loss = forward(predictions)
@@ -111,8 +111,8 @@ fn test_smooth_l1_zero_beta_boundary() raises:
 
     var shape = List[Int]()
     shape.append(3)
-    var predictions = ExTensor(shape, DType.float32)
-    var targets = ExTensor(shape, DType.float32)
+    var predictions = AnyTensor(shape, DType.float32)
+    var targets = AnyTensor(shape, DType.float32)
 
     # Test with differences exactly at beta (1.0)
     # At |x| = beta: both formulas should give same value
@@ -148,8 +148,8 @@ fn test_smooth_l1_quadratic_region() raises:
 
     var shape = List[Int]()
     shape.append(1)
-    var predictions = ExTensor(shape, DType.float32)
-    var targets = ExTensor(shape, DType.float32)
+    var predictions = AnyTensor(shape, DType.float32)
+    var targets = AnyTensor(shape, DType.float32)
 
     # Small difference (0.1) with beta=1.0 should be in quadratic region
     # L = 0.5 * 0.1^2 / 1.0 = 0.005
@@ -178,8 +178,8 @@ fn test_smooth_l1_linear_region() raises:
 
     var shape = List[Int]()
     shape.append(1)
-    var predictions = ExTensor(shape, DType.float32)
-    var targets = ExTensor(shape, DType.float32)
+    var predictions = AnyTensor(shape, DType.float32)
+    var targets = AnyTensor(shape, DType.float32)
 
     # Large difference (2.0) with beta=1.0 should be in linear region
     # L = 2.0 - 0.5 * 1.0 = 1.5
@@ -208,8 +208,8 @@ fn test_smooth_l1_backward_quadratic() raises:
 
     var shape = List[Int]()
     shape.append(1)
-    var predictions = ExTensor(shape, DType.float32)
-    var targets = ExTensor(shape, DType.float32)
+    var predictions = AnyTensor(shape, DType.float32)
+    var targets = AnyTensor(shape, DType.float32)
 
     # Small difference (0.1) with beta=1.0
     # Gradient should be: diff / beta = 0.1 / 1.0 = 0.1
@@ -243,8 +243,8 @@ fn test_smooth_l1_backward_linear() raises:
 
     var shape = List[Int]()
     shape.append(1)
-    var predictions = ExTensor(shape, DType.float32)
-    var targets = ExTensor(shape, DType.float32)
+    var predictions = AnyTensor(shape, DType.float32)
+    var targets = AnyTensor(shape, DType.float32)
 
     # Large difference (2.0) with beta=1.0
     # Gradient should be: sign(diff) = sign(2.0) = 1.0

--- a/tests/shared/core/test_losses_part3.mojo
+++ b/tests/shared/core/test_losses_part3.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     assert_almost_equal,
     assert_close_float,
 )
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.loss import smooth_l1_loss, smooth_l1_loss_backward
 from shared.core.loss import hinge_loss, hinge_loss_backward
 from shared.core.loss import focal_loss, focal_loss_backward
@@ -49,11 +49,11 @@ fn test_smooth_l1_backward_gradient() raises:
     targets._set_float64(3, 0.5)
 
     # Forward function wrapper
-    fn forward(pred: ExTensor) raises escaping -> ExTensor:
+    fn forward(pred: AnyTensor) raises escaping -> AnyTensor:
         return smooth_l1_loss(pred, targets, beta=beta)
 
     # Backward function wrapper
-    fn backward(grad_out: ExTensor, pred: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, pred: AnyTensor) raises escaping -> AnyTensor:
         return smooth_l1_loss_backward(grad_out, pred, targets, beta=beta)
 
     var loss = forward(predictions)
@@ -73,8 +73,8 @@ fn test_hinge_loss_correct_prediction() raises:
 
     var shape = List[Int]()
     shape.append(3)
-    var predictions = ExTensor(shape, DType.float32)
-    var targets = ExTensor(shape, DType.float32)
+    var predictions = AnyTensor(shape, DType.float32)
+    var targets = AnyTensor(shape, DType.float32)
 
     # Correct predictions with high confidence
     # y*pred = 1*2.0 = 2.0, so loss = max(0, 1 - 2.0) = max(0, -1.0) = 0.0
@@ -102,8 +102,8 @@ fn test_hinge_loss_wrong_prediction() raises:
 
     var shape = List[Int]()
     shape.append(2)
-    var predictions = ExTensor(shape, DType.float32)
-    var targets = ExTensor(shape, DType.float32)
+    var predictions = AnyTensor(shape, DType.float32)
+    var targets = AnyTensor(shape, DType.float32)
 
     # Wrong predictions (margin violated)
     # y*pred = 1*(-0.5) = -0.5, so loss = max(0, 1 - (-0.5)) = 1.5
@@ -134,8 +134,8 @@ fn test_hinge_loss_at_margin() raises:
 
     var shape = List[Int]()
     shape.append(2)
-    var predictions = ExTensor(shape, DType.float32)
-    var targets = ExTensor(shape, DType.float32)
+    var predictions = AnyTensor(shape, DType.float32)
+    var targets = AnyTensor(shape, DType.float32)
 
     # At the margin: y*pred = 1, so loss = max(0, 1 - 1) = 0
     predictions._set_float64(0, 1.0)
@@ -163,8 +163,8 @@ fn test_hinge_loss_backward() raises:
 
     var shape = List[Int]()
     shape.append(3)
-    var predictions = ExTensor(shape, DType.float32)
-    var targets = ExTensor(shape, DType.float32)
+    var predictions = AnyTensor(shape, DType.float32)
+    var targets = AnyTensor(shape, DType.float32)
 
     # Mix of correct and wrong predictions
     # Case 1: y*pred = 2.0 > 1 (correct), grad should be 0
@@ -222,11 +222,11 @@ fn test_hinge_loss_backward_gradient() raises:
     targets._set_float64(3, 1.0)
 
     # Forward function wrapper
-    fn forward(pred: ExTensor) raises escaping -> ExTensor:
+    fn forward(pred: AnyTensor) raises escaping -> AnyTensor:
         return hinge_loss(pred, targets)
 
     # Backward function wrapper
-    fn backward(grad_out: ExTensor, pred: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, pred: AnyTensor) raises escaping -> AnyTensor:
         return hinge_loss_backward(grad_out, pred, targets)
 
     var loss = forward(predictions)
@@ -246,8 +246,8 @@ fn test_focal_loss_perfect_prediction() raises:
 
     var shape = List[Int]()
     shape.append(4)
-    var predictions = ExTensor(shape, DType.float32)
-    var targets = ExTensor(shape, DType.float32)
+    var predictions = AnyTensor(shape, DType.float32)
+    var targets = AnyTensor(shape, DType.float32)
 
     # Perfect predictions: pred = target
     for i in range(4):

--- a/tests/shared/core/test_losses_part4.mojo
+++ b/tests/shared/core/test_losses_part4.mojo
@@ -17,7 +17,7 @@ from tests.shared.conftest import (
     assert_almost_equal,
     assert_close_float,
 )
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.loss import focal_loss, focal_loss_backward
 from shared.core.loss import kl_divergence, kl_divergence_backward
 from shared.core.reduction import mean
@@ -30,8 +30,8 @@ fn test_focal_loss_hard_examples() raises:
 
     var shape = List[Int]()
     shape.append(2)
-    var predictions = ExTensor(shape, DType.float32)
-    var targets = ExTensor(shape, DType.float32)
+    var predictions = AnyTensor(shape, DType.float32)
+    var targets = AnyTensor(shape, DType.float32)
 
     # Easy example: p=0.9, target=1 (easy positive)
     predictions._set_float64(0, 0.9)
@@ -64,8 +64,8 @@ fn test_focal_loss_backward_shape() raises:
 
     var shape = List[Int]()
     shape.append(3)
-    var predictions = ExTensor(shape, DType.float32)
-    var targets = ExTensor(shape, DType.float32)
+    var predictions = AnyTensor(shape, DType.float32)
+    var targets = AnyTensor(shape, DType.float32)
 
     for i in range(3):
         predictions._set_float64(i, 0.5)
@@ -103,11 +103,11 @@ fn test_focal_loss_backward_gradient() raises:
     targets._set_float64(3, 0.0)
 
     # Forward function wrapper
-    fn forward(pred: ExTensor) raises escaping -> ExTensor:
+    fn forward(pred: AnyTensor) raises escaping -> AnyTensor:
         return focal_loss(pred, targets)
 
     # Backward function wrapper
-    fn backward(grad_out: ExTensor, pred: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, pred: AnyTensor) raises escaping -> AnyTensor:
         return focal_loss_backward(grad_out, pred, targets)
 
     var loss = forward(predictions)
@@ -127,8 +127,8 @@ fn test_kl_divergence_same_distribution() raises:
 
     var shape = List[Int]()
     shape.append(4)
-    var p = ExTensor(shape, DType.float32)
-    var q = ExTensor(shape, DType.float32)
+    var p = AnyTensor(shape, DType.float32)
+    var q = AnyTensor(shape, DType.float32)
 
     # Same distribution
     for i in range(4):
@@ -157,8 +157,8 @@ fn test_kl_divergence_different_distributions() raises:
 
     var shape = List[Int]()
     shape.append(3)
-    var p = ExTensor(shape, DType.float32)
-    var q = ExTensor(shape, DType.float32)
+    var p = AnyTensor(shape, DType.float32)
+    var q = AnyTensor(shape, DType.float32)
 
     # Distribution p: [0.5, 0.3, 0.2]
     p._set_float64(0, 0.5)
@@ -191,8 +191,8 @@ fn test_kl_divergence_backward_shape() raises:
 
     var shape = List[Int]()
     shape.append(4)
-    var p = ExTensor(shape, DType.float32)
-    var q = ExTensor(shape, DType.float32)
+    var p = AnyTensor(shape, DType.float32)
+    var q = AnyTensor(shape, DType.float32)
 
     # Initialize with valid probability distributions
     for i in range(4):
@@ -231,13 +231,13 @@ fn test_kl_divergence_backward_gradient() raises:
     q._set_float64(3, 0.1)
 
     # Forward function wrapper
-    fn forward(q_dist: ExTensor) raises escaping -> ExTensor:
+    fn forward(q_dist: AnyTensor) raises escaping -> AnyTensor:
         return kl_divergence(p, q_dist)
 
     # Backward function wrapper
     fn backward(
-        grad_out: ExTensor, q_dist: ExTensor
-    ) raises escaping -> ExTensor:
+        grad_out: AnyTensor, q_dist: AnyTensor
+    ) raises escaping -> AnyTensor:
         return kl_divergence_backward(grad_out, p, q_dist)
 
     var kl = forward(q)

--- a/tests/shared/core/test_matmul_part1.mojo
+++ b/tests/shared/core/test_matmul_part1.mojo
@@ -24,7 +24,7 @@ from tests.shared.conftest import (
     assert_value_at,
 )
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     zeros_like,

--- a/tests/shared/core/test_matmul_part2.mojo
+++ b/tests/shared/core/test_matmul_part2.mojo
@@ -23,7 +23,7 @@ from tests.shared.conftest import (
     assert_value_at,
 )
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     zeros_like,

--- a/tests/shared/core/test_matmul_part3.mojo
+++ b/tests/shared/core/test_matmul_part3.mojo
@@ -24,7 +24,7 @@ from tests.shared.conftest import (
     assert_value_at,
 )
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     zeros_like,

--- a/tests/shared/core/test_matrix_edge_cases_part1.mojo
+++ b/tests/shared/core/test_matrix_edge_cases_part1.mojo
@@ -9,8 +9,8 @@ Tests edge cases for matmul and shape operations on matrices including:
 # high test load. Split from test_matrix_edge_cases.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, zeros_like, eye
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, zeros_like, eye
 from shared.core.matrix import matmul
 
 # Import test helpers

--- a/tests/shared/core/test_matrix_edge_cases_part2.mojo
+++ b/tests/shared/core/test_matrix_edge_cases_part2.mojo
@@ -10,8 +10,8 @@ Tests edge cases for matmul including:
 # high test load. Split from test_matrix_edge_cases.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, zeros_like, eye
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, zeros_like, eye
 from shared.core.matrix import matmul
 
 # Import test helpers
@@ -121,11 +121,11 @@ fn test_matmul_known_result() raises:
     shape_b.append(2)
     shape_b.append(1)
 
-    var a = ExTensor(shape_a, DType.float32)
+    var a = AnyTensor(shape_a, DType.float32)
     a._set_float32(0, 1.0)
     a._set_float32(1, 2.0)
 
-    var b = ExTensor(shape_b, DType.float32)
+    var b = AnyTensor(shape_b, DType.float32)
     b._set_float32(0, 3.0)
     b._set_float32(1, 4.0)
 

--- a/tests/shared/core/test_matrix_part1.mojo
+++ b/tests/shared/core/test_matrix_part1.mojo
@@ -29,7 +29,7 @@ from tests.shared.conftest import (
 )
 from tests.shared.conftest import TestFixtures
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     zeros_like,

--- a/tests/shared/core/test_matrix_part2.mojo
+++ b/tests/shared/core/test_matrix_part2.mojo
@@ -31,7 +31,7 @@ from tests.shared.conftest import (
 )
 from tests.shared.conftest import TestFixtures
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     zeros_like,
@@ -203,11 +203,11 @@ fn test_matmul_backward_gradient_a() raises:
         b._data.bitcast[Float32]()[i] = Float32(i) * 0.2 + 0.1
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return matmul(inp, b)
 
     # Backward function wrapper for grad_a
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         var grads = matmul_backward(grad_out, inp, b)
         return grads.grad_a
 
@@ -250,11 +250,11 @@ fn test_matmul_backward_gradient_b() raises:
         b._data.bitcast[Float32]()[i] = Float32(i) * 0.2 + 0.1
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return matmul(a, inp)
 
     # Backward function wrapper for grad_b
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         var grads = matmul_backward(grad_out, a, inp)
         return grads.grad_b
 

--- a/tests/shared/core/test_matrix_part3.mojo
+++ b/tests/shared/core/test_matrix_part3.mojo
@@ -31,7 +31,7 @@ from tests.shared.conftest import (
 )
 from tests.shared.conftest import TestFixtures
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     zeros_like,

--- a/tests/shared/core/test_matrix_part4.mojo
+++ b/tests/shared/core/test_matrix_part4.mojo
@@ -33,7 +33,7 @@ from tests.shared.conftest import (
 )
 from tests.shared.conftest import TestFixtures
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     zeros_like,
@@ -256,11 +256,11 @@ fn test_transpose_backward_gradient() raises:
         x._data.bitcast[Float32]()[i] = Float32(i) * 0.15 - 2.0
 
     # Forward function wrapper
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return transpose(inp)
 
     # Backward function wrapper
-    fn backward(grad_out: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad_out: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return transpose_backward(grad_out)
 
     var output = forward(x)

--- a/tests/shared/core/test_matrix_part5.mojo
+++ b/tests/shared/core/test_matrix_part5.mojo
@@ -30,7 +30,7 @@ from tests.shared.conftest import (
 )
 from tests.shared.conftest import TestFixtures
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     zeros_like,

--- a/tests/shared/core/test_matrix_part6.mojo
+++ b/tests/shared/core/test_matrix_part6.mojo
@@ -30,7 +30,7 @@ from tests.shared.conftest import (
 )
 from tests.shared.conftest import TestFixtures
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     zeros_like,

--- a/tests/shared/core/test_matrix_part7.mojo
+++ b/tests/shared/core/test_matrix_part7.mojo
@@ -31,7 +31,7 @@ from tests.shared.conftest import (
 )
 from tests.shared.conftest import TestFixtures
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     zeros_like,

--- a/tests/shared/core/test_matrix_part8.mojo
+++ b/tests/shared/core/test_matrix_part8.mojo
@@ -31,7 +31,7 @@ from tests.shared.conftest import (
 )
 from tests.shared.conftest import TestFixtures
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     zeros_like,

--- a/tests/shared/core/test_memory_leaks.mojo
+++ b/tests/shared/core/test_memory_leaks.mojo
@@ -1,4 +1,4 @@
-"""Memory leak detection tests for ExTensor.
+"""Memory leak detection tests for AnyTensor.
 
 Tests verify:
 1. Reference counting correctness
@@ -28,7 +28,7 @@ Note: These tests work around Mojo v0.26.1 limitations:
 - Tests use reference count as proxy for memory safety
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from tests.shared.conftest import assert_true, assert_equal_int
 
 
@@ -69,7 +69,7 @@ fn test_multiple_copies_refcount() raises:
     )
 
 
-fn _copy_and_check_refcount(tensor1: ExTensor) -> Int:
+fn _copy_and_check_refcount(tensor1: AnyTensor) -> Int:
     """Helper: copy tensor in inner scope and return inner refcount."""
     var tensor2 = tensor1
     return tensor1._refcount[]
@@ -88,7 +88,7 @@ fn test_scope_exit_decrements_refcount() raises:
     assert_equal_int(outer_refcount, 1, "Refcount should be 1 after scope exit")
 
 
-fn _modify_through_copy(tensor1: ExTensor) raises:
+fn _modify_through_copy(tensor1: AnyTensor) raises:
     """Helper: copy tensor in inner scope and modify shared data."""
     var tensor2 = tensor1
     assert_true(tensor1._data == tensor2._data, "Should share data")
@@ -221,7 +221,7 @@ fn test_view_flag_on_reshape() raises:
     assert_true(tensor._data == reshaped._data, "View should share data")
 
 
-fn _create_and_drop_view(original: ExTensor) raises:
+fn _create_and_drop_view(original: AnyTensor) raises:
     """Helper: create view in inner scope (dropped on return)."""
     var shape = List[Int]()
     shape.append(3)
@@ -315,7 +315,7 @@ fn test_destructor_with_valid_refcount() raises:
     assert_true(True, "Destructor edge case test completed")
 
 
-fn _check_view_refcount(original: ExTensor, initial_refcount: Int) raises -> Int:
+fn _check_view_refcount(original: AnyTensor, initial_refcount: Int) raises -> Int:
     """Helper: create view in inner scope, check refcount, return inner value."""
     var shape = List[Int]()
     shape.append(3)

--- a/tests/shared/core/test_memory_leaks_part1.mojo
+++ b/tests/shared/core/test_memory_leaks_part1.mojo
@@ -1,14 +1,14 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_memory_leaks.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Memory leak detection tests for ExTensor - Part 1: Reference Counting & Allocation.
+"""Memory leak detection tests for AnyTensor - Part 1: Reference Counting & Allocation.
 
 Tests verify:
 1. Reference counting correctness
 2. Memory deallocation on scope exit
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from tests.shared.conftest import assert_true, assert_equal_int
 
 
@@ -49,7 +49,7 @@ fn test_multiple_copies_refcount() raises:
     )
 
 
-fn _copy_and_check_refcount(tensor1: ExTensor) -> Int:
+fn _copy_and_check_refcount(tensor1: AnyTensor) -> Int:
     """Helper: copy tensor in inner scope and return inner refcount."""
     var tensor2 = tensor1
     return tensor1._refcount[]
@@ -68,7 +68,7 @@ fn test_scope_exit_decrements_refcount() raises:
     assert_equal_int(outer_refcount, 1, "Refcount should be 1 after scope exit")
 
 
-fn _modify_through_copy(tensor1: ExTensor) raises:
+fn _modify_through_copy(tensor1: AnyTensor) raises:
     """Helper: copy tensor in inner scope and modify shared data."""
     var tensor2 = tensor1
     assert_true(tensor1._data == tensor2._data, "Should share data")

--- a/tests/shared/core/test_memory_leaks_part2.mojo
+++ b/tests/shared/core/test_memory_leaks_part2.mojo
@@ -1,14 +1,14 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_memory_leaks.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Memory leak detection tests for ExTensor - Part 2: Stress Tests & View Lifetime.
+"""Memory leak detection tests for AnyTensor - Part 2: Stress Tests & View Lifetime.
 
 Tests verify:
 1. No memory leaks in repeated operations
 2. View lifetime management
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from tests.shared.conftest import assert_true, assert_equal_int
 
 

--- a/tests/shared/core/test_memory_leaks_part3.mojo
+++ b/tests/shared/core/test_memory_leaks_part3.mojo
@@ -1,14 +1,14 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_memory_leaks.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Memory leak detection tests for ExTensor - Part 3: Edge Cases & Destructor.
+"""Memory leak detection tests for AnyTensor - Part 3: Edge Cases & Destructor.
 
 Tests verify:
 1. Edge cases (empty tensor, 1D tensor, different dtypes)
 2. Destructor edge cases
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from tests.shared.conftest import assert_true, assert_equal_int
 
 
@@ -72,7 +72,7 @@ fn test_destructor_with_valid_refcount() raises:
     assert_true(True, "Destructor edge case test completed")
 
 
-fn _check_view_refcount(original: ExTensor, initial_refcount: Int) raises -> Int:
+fn _check_view_refcount(original: AnyTensor, initial_refcount: Int) raises -> Int:
     """Helper: create view in inner scope, check refcount, return inner value."""
     var shape = List[Int]()
     shape.append(3)

--- a/tests/shared/core/test_memory_pool_part1.mojo
+++ b/tests/shared/core/test_memory_pool_part1.mojo
@@ -17,7 +17,7 @@ from shared.core.memory_pool import (
     pooled_alloc,
     pooled_free,
 )
-from shared.core.extensor import ExTensor, zeros
+from shared.core.extensor import AnyTensor, zeros
 
 
 fn test_pool_default_init() raises:

--- a/tests/shared/core/test_memory_pool_part2.mojo
+++ b/tests/shared/core/test_memory_pool_part2.mojo
@@ -5,7 +5,7 @@
 
 Tests cover:
 - Memory management (clear)
-- ExTensor integration with pool
+- AnyTensor integration with pool
 - Reference counting with pooled memory
 - pooled_alloc/pooled_free functions
 """
@@ -17,7 +17,7 @@ from shared.core.memory_pool import (
     pooled_alloc,
     pooled_free,
 )
-from shared.core.extensor import ExTensor, zeros
+from shared.core.extensor import AnyTensor, zeros
 
 
 fn test_trim_releases_memory() raises:
@@ -75,7 +75,7 @@ fn test_clear_releases_all() raises:
 
 
 fn test_extensor_uses_pool() raises:
-    """Verify ExTensor allocations work correctly."""
+    """Verify AnyTensor allocations work correctly."""
     # Create a tensor - it will use pooled_alloc internally
     var shape = List[Int]()
     shape.append(10)

--- a/tests/shared/core/test_module.mojo
+++ b/tests/shared/core/test_module.mojo
@@ -5,7 +5,7 @@ a simple module implementation.
 """
 
 from shared.core.module import Module
-from shared.core.extensor import ExTensor, zeros
+from shared.core.extensor import AnyTensor, zeros
 from tests.shared.conftest import assert_true, assert_equal_int
 
 
@@ -29,7 +29,7 @@ struct DummyModule:
         self.output_size = output_size
         self.is_training = True
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Forward pass returns zeros of specified size.
 
         Args:
@@ -41,13 +41,13 @@ struct DummyModule:
         var shape: List[Int] = [1, self.output_size]
         return zeros(shape, DType.float32)
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Return empty parameter list.
 
         Returns:
             Empty list (no trainable parameters).
         """
-        return List[ExTensor]()
+        return List[AnyTensor]()
 
     fn train(mut self):
         """Set to training mode."""

--- a/tests/shared/core/test_normalization_part1.mojo
+++ b/tests/shared/core/test_normalization_part1.mojo
@@ -30,7 +30,7 @@ from shared.testing import (
     compute_numerical_gradient,
     assert_gradients_close,
 )
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.normalization import (
     batch_norm2d,
     batch_norm2d_backward,
@@ -345,7 +345,7 @@ fn test_batch_norm2d_backward_gradient_input() raises:
     # Numerical gradient via finite differences.
     # forward_for_grad computes weighted sum: sum(output * grad_output)
     # so the numerical gradient matches what the backward should compute.
-    fn forward_for_grad(inp: ExTensor) raises -> ExTensor:
+    fn forward_for_grad(inp: AnyTensor) raises -> AnyTensor:
         var result_nested = batch_norm2d(
             inp,
             gamma,
@@ -452,7 +452,7 @@ fn test_batch_norm2d_backward_gradient_input_inference_mode() raises:
     var grad_input = result_bwd[0]
 
     # Numerical gradient: closure uses training=False with fixed running stats
-    fn forward_for_grad_infer(inp: ExTensor) raises -> ExTensor:
+    fn forward_for_grad_infer(inp: AnyTensor) raises -> AnyTensor:
         var res = batch_norm2d(
             inp,
             gamma,
@@ -542,7 +542,7 @@ fn test_batch_norm2d_backward_gradient_gamma() raises:
     # Numerical gradient: perturb gamma
     # The forward closure computes: sum(batch_norm2d(x, g, ...) * grad_output)
     # so the numerical gradient matches what batch_norm2d_backward should produce.
-    fn forward_for_gamma(g: ExTensor) raises -> ExTensor:
+    fn forward_for_gamma(g: AnyTensor) raises -> AnyTensor:
         var res = batch_norm2d(
             x, g, beta, running_mean, running_var, training=True, epsilon=1e-5
         )

--- a/tests/shared/core/test_normalization_part2.mojo
+++ b/tests/shared/core/test_normalization_part2.mojo
@@ -30,7 +30,7 @@ from shared.testing import (
     compute_numerical_gradient,
     assert_gradients_close,
 )
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.normalization import (
     batch_norm2d,
     batch_norm2d_backward,
@@ -100,7 +100,7 @@ fn test_batch_norm2d_backward_gradient_beta() raises:
     var grad_beta_analytical = result_bwd[2]
 
     # Numerical gradient: perturb beta
-    fn forward_for_beta(b: ExTensor) raises -> ExTensor:
+    fn forward_for_beta(b: AnyTensor) raises -> AnyTensor:
         var res = batch_norm2d(
             x, gamma, b, running_mean, running_var, training=True, epsilon=1e-5
         )

--- a/tests/shared/core/test_normalization_part3.mojo
+++ b/tests/shared/core/test_normalization_part3.mojo
@@ -26,7 +26,7 @@ from shared.testing import (
     compute_numerical_gradient,
     assert_gradients_close,
 )
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.normalization import (
     batch_norm2d,
     batch_norm2d_backward,
@@ -231,7 +231,7 @@ fn test_layer_norm_backward_gradient_input() raises:
     # Numerical gradient via finite differences.
     # The scalar loss is sum(layer_norm(x) * grad_output), so the numerical
     # gradient matches what layer_norm_backward(grad_output, x, gamma) computes.
-    fn forward_for_grad(inp: ExTensor) raises -> ExTensor:
+    fn forward_for_grad(inp: AnyTensor) raises -> AnyTensor:
         var out = layer_norm(inp, gamma, beta, epsilon=1e-5)
         # Weighted sum: sum(out * grad_output) matches backward with non-uniform grad_output
         var weighted = multiply(out, grad_output)
@@ -344,7 +344,7 @@ fn test_layer_norm_backward_gradient_input_4d() raises:
     # Numerical gradient via finite differences.
     # The scalar loss is sum(layer_norm(x) * grad_output), so the numerical
     # gradient matches what layer_norm_backward(grad_output, x, gamma) computes.
-    fn forward_for_grad_4d(inp: ExTensor) raises -> ExTensor:
+    fn forward_for_grad_4d(inp: AnyTensor) raises -> AnyTensor:
         var out = layer_norm(inp, gamma, beta, epsilon=1e-5)
         # Weighted sum: sum(out * grad_output) matches backward with non-uniform grad_output
         var weighted = multiply(out, grad_output)
@@ -521,7 +521,7 @@ fn test_batch_norm2d_backward_gradient_gamma_inference_mode() raises:
     var grad_gamma_analytical = result_bwd[1]
 
     # Numerical gradient: perturb gamma in inference mode
-    fn forward_for_gamma_infer(g: ExTensor) raises -> ExTensor:
+    fn forward_for_gamma_infer(g: AnyTensor) raises -> AnyTensor:
         var res = batch_norm2d(
             x, g, beta, running_mean, running_var, training=False, epsilon=1e-5
         )
@@ -605,7 +605,7 @@ fn test_batch_norm2d_backward_gradient_beta_inference_mode() raises:
     var grad_beta_analytical = result_bwd[2]
 
     # Numerical gradient: perturb beta in inference mode
-    fn forward_for_beta_infer(b: ExTensor) raises -> ExTensor:
+    fn forward_for_beta_infer(b: AnyTensor) raises -> AnyTensor:
         var res = batch_norm2d(
             x, gamma, b, running_mean, running_var, training=False, epsilon=1e-5
         )

--- a/tests/shared/core/test_normalization_part4.mojo
+++ b/tests/shared/core/test_normalization_part4.mojo
@@ -23,7 +23,7 @@ from shared.testing import (
     compute_numerical_gradient,
     assert_gradients_close,
 )
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like
 from shared.core.normalization import (
     batch_norm2d,
     batch_norm2d_backward,
@@ -103,7 +103,7 @@ fn _check_grad_input_batch_size(batch_size: Int) raises:
             )
     else:
         # Standard gradient check for batch_size=2 and batch_size=4.
-        fn forward_for_grad(inp: ExTensor) raises -> ExTensor:
+        fn forward_for_grad(inp: AnyTensor) raises -> AnyTensor:
             var res = batch_norm2d(
                 inp,
                 gamma,
@@ -191,7 +191,7 @@ fn _check_grad_gamma_batch_size(batch_size: Int) raises:
             )
     else:
         # Standard gradient check: perturb gamma.
-        fn forward_for_gamma(g: ExTensor) raises -> ExTensor:
+        fn forward_for_gamma(g: AnyTensor) raises -> AnyTensor:
             var res = batch_norm2d(
                 x, g, beta, running_mean, running_var, training=True, epsilon=1e-5
             )
@@ -276,7 +276,7 @@ fn _check_grad_beta_batch_size(batch_size: Int) raises:
             )
     else:
         # Standard gradient check: perturb beta.
-        fn forward_for_beta(b: ExTensor) raises -> ExTensor:
+        fn forward_for_beta(b: AnyTensor) raises -> AnyTensor:
             var res = batch_norm2d(
                 x, gamma, b, running_mean, running_var, training=True, epsilon=1e-5
             )

--- a/tests/shared/core/test_normalize_slice_indices.mojo
+++ b/tests/shared/core/test_normalize_slice_indices.mojo
@@ -1,17 +1,17 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Unit tests for ExTensor._normalize_slice_indices helper."""
+"""Unit tests for AnyTensor._normalize_slice_indices helper."""
 
-from shared.core.extensor import ExTensor, zeros
+from shared.core.extensor import AnyTensor, zeros
 from tests.shared.conftest import assert_equal
 
 
-fn _make_1d(size: Int) raises -> ExTensor:
+fn _make_1d(size: Int) raises -> AnyTensor:
     """Create a 1D tensor of the given size."""
     var shape = List[Int]()
     shape.append(size)
-    return ExTensor(shape, DType.float32)
+    return AnyTensor(shape, DType.float32)
 
 
 fn test_normalize_forward_full() raises:

--- a/tests/shared/core/test_pooling_part1.mojo
+++ b/tests/shared/core/test_pooling_part1.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     assert_shape,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.pooling import (
     maxpool2d,
     maxpool2d_backward,

--- a/tests/shared/core/test_pooling_part2.mojo
+++ b/tests/shared/core/test_pooling_part2.mojo
@@ -18,7 +18,7 @@ from tests.shared.conftest import (
     assert_shape,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.pooling import (
     maxpool2d,
     maxpool2d_backward,

--- a/tests/shared/core/test_pooling_part3.mojo
+++ b/tests/shared/core/test_pooling_part3.mojo
@@ -17,7 +17,7 @@ from tests.shared.conftest import (
     assert_shape,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full
+from shared.core.extensor import AnyTensor, zeros, ones, full
 from shared.core.pooling import (
     maxpool2d,
     maxpool2d_backward,

--- a/tests/shared/core/test_properties_part1.mojo
+++ b/tests/shared/core/test_properties_part1.mojo
@@ -1,12 +1,12 @@
-"""Tests for ExTensor shape and dtype properties (Part 1 of 5).
+"""Tests for AnyTensor shape and dtype properties (Part 1 of 5).
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_properties.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange, eye
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange, eye
 
 # Import test helpers
 from tests.shared.conftest import (
@@ -121,7 +121,7 @@ fn test_dtype_int64() raises:
 
 fn main() raises:
     """Run shape and dtype property tests (Part 1)."""
-    print("Running ExTensor shape and dtype property tests (Part 1)...")
+    print("Running AnyTensor shape and dtype property tests (Part 1)...")
 
     # Shape property tests
     print("  Testing shape property...")

--- a/tests/shared/core/test_properties_part2.mojo
+++ b/tests/shared/core/test_properties_part2.mojo
@@ -1,12 +1,12 @@
-"""Tests for ExTensor dtype bool and numel properties (Part 2 of 5).
+"""Tests for AnyTensor dtype bool and numel properties (Part 2 of 5).
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_properties.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange, eye
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange, eye
 
 # Import test helpers
 from tests.shared.conftest import (
@@ -122,7 +122,7 @@ fn test_strides_2d_row_major() raises:
 
 fn main() raises:
     """Run dtype bool, numel, and stride property tests (Part 2)."""
-    print("Running ExTensor dtype bool, numel, and stride tests (Part 2)...")
+    print("Running AnyTensor dtype bool, numel, and stride tests (Part 2)...")
 
     # DType bool test
     print("  Testing dtype bool...")

--- a/tests/shared/core/test_properties_part3.mojo
+++ b/tests/shared/core/test_properties_part3.mojo
@@ -1,12 +1,12 @@
-"""Tests for ExTensor stride (3D), contiguity, and dimension properties (Part 3 of 5).
+"""Tests for AnyTensor stride (3D), contiguity, and dimension properties (Part 3 of 5).
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_properties.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange, eye
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange, eye
 
 # Import test helpers
 from tests.shared.conftest import (
@@ -115,7 +115,7 @@ fn test_dim_3d() raises:
 fn main() raises:
     """Run stride 3D, contiguity, and dimension property tests (Part 3)."""
     print(
-        "Running ExTensor stride, contiguity, and dimension tests (Part 3)..."
+        "Running AnyTensor stride, contiguity, and dimension tests (Part 3)..."
     )
 
     # Stride 3D test

--- a/tests/shared/core/test_properties_part4.mojo
+++ b/tests/shared/core/test_properties_part4.mojo
@@ -1,12 +1,12 @@
-"""Tests for ExTensor scalar dim, value access, and creation patterns (Part 4 of 5).
+"""Tests for AnyTensor scalar dim, value access, and creation patterns (Part 4 of 5).
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_properties.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange, eye
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange, eye
 
 # Import test helpers
 from tests.shared.conftest import (
@@ -121,7 +121,7 @@ fn test_full_pattern() raises:
 fn main() raises:
     """Run scalar dim, value access, and creation pattern tests (Part 4)."""
     print(
-        "Running ExTensor scalar dim, value access, and creation pattern tests"
+        "Running AnyTensor scalar dim, value access, and creation pattern tests"
         " (Part 4)..."
     )
 

--- a/tests/shared/core/test_properties_part5.mojo
+++ b/tests/shared/core/test_properties_part5.mojo
@@ -1,12 +1,12 @@
-"""Tests for ExTensor arange/eye patterns, is_view, and dtype size (Part 5 of 5).
+"""Tests for AnyTensor arange/eye patterns, is_view, and dtype size (Part 5 of 5).
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_properties.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange, eye
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange, eye
 
 # Import test helpers
 from tests.shared.conftest import (
@@ -104,7 +104,7 @@ fn test_dtype_size_int32() raises:
 fn main() raises:
     """Run arange/eye patterns, is_view, and dtype size tests (Part 5)."""
     print(
-        "Running ExTensor arange/eye patterns, is_view, and dtype size tests"
+        "Running AnyTensor arange/eye patterns, is_view, and dtype size tests"
         " (Part 5)..."
     )
 

--- a/tests/shared/core/test_reduction_edge_cases_part1.mojo
+++ b/tests/shared/core/test_reduction_edge_cases_part1.mojo
@@ -11,8 +11,8 @@ Tests edge cases for sum, mean, max_reduce, min_reduce operations including:
 # high test load. Split from test_reduction_edge_cases.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from shared.core.reduction import sum, mean, max_reduce, min_reduce
 
 # Import test helpers

--- a/tests/shared/core/test_reduction_edge_cases_part2.mojo
+++ b/tests/shared/core/test_reduction_edge_cases_part2.mojo
@@ -10,8 +10,8 @@ Tests edge cases for sum, mean, max_reduce, min_reduce operations including:
 # high test load. Split from test_reduction_edge_cases.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from shared.core.reduction import sum, mean, max_reduce, min_reduce
 
 # Import test helpers

--- a/tests/shared/core/test_reduction_forward_part1.mojo
+++ b/tests/shared/core/test_reduction_forward_part1.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor reduction operations - Part 1: sum() basics.
+"""Tests for AnyTensor reduction operations - Part 1: sum() basics.
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
@@ -8,8 +8,8 @@ Tests reduction operations following the Array API Standard:
 sum (all-elements and basic mean) with all-elements reduction (axis=-1).
 """
 
-# Import ExTensor and reduction operations
-from shared.core.extensor import ExTensor, full, ones, zeros, arange
+# Import AnyTensor and reduction operations
+from shared.core.extensor import AnyTensor, full, ones, zeros, arange
 from shared.core.reduction import sum, mean, max_reduce, min_reduce
 
 # Import test helpers
@@ -127,7 +127,7 @@ fn test_mean_arange() raises:
 
 fn main() raises:
     """Run sum and basic mean reduction tests."""
-    print("Running ExTensor reduction forward tests - Part 1...")
+    print("Running AnyTensor reduction forward tests - Part 1...")
 
     # sum() tests
     print("  Testing sum()...")

--- a/tests/shared/core/test_reduction_forward_part2.mojo
+++ b/tests/shared/core/test_reduction_forward_part2.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor reduction operations - Part 2: mean() and max_reduce() basics.
+"""Tests for AnyTensor reduction operations - Part 2: mean() and max_reduce() basics.
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
@@ -8,8 +8,8 @@ Tests reduction operations following the Array API Standard:
 mean (keepdims/dtype) and max_reduce (all-elements) with axis=-1.
 """
 
-# Import ExTensor and reduction operations
-from shared.core.extensor import ExTensor, full, ones, zeros, arange
+# Import AnyTensor and reduction operations
+from shared.core.extensor import AnyTensor, full, ones, zeros, arange
 from shared.core.reduction import sum, mean, max_reduce, min_reduce
 
 # Import test helpers
@@ -125,7 +125,7 @@ fn test_min_all_same() raises:
 
 fn main() raises:
     """Run mean (keepdims/dtype) and max_reduce basic tests."""
-    print("Running ExTensor reduction forward tests - Part 2...")
+    print("Running AnyTensor reduction forward tests - Part 2...")
 
     # mean() keepdims/dtype tests
     print("  Testing mean() keepdims and dtype...")

--- a/tests/shared/core/test_reduction_forward_part3.mojo
+++ b/tests/shared/core/test_reduction_forward_part3.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor reduction operations - Part 3: min_reduce() and axis-specific sum/mean.
+"""Tests for AnyTensor reduction operations - Part 3: min_reduce() and axis-specific sum/mean.
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
@@ -8,8 +8,8 @@ Tests reduction operations following the Array API Standard:
 min_reduce (all-elements) and sum/mean with axis parameter.
 """
 
-# Import ExTensor and reduction operations
-from shared.core.extensor import ExTensor, full, ones, zeros, arange
+# Import AnyTensor and reduction operations
+from shared.core.extensor import AnyTensor, full, ones, zeros, arange
 from shared.core.reduction import sum, mean, max_reduce, min_reduce
 
 # Import test helpers
@@ -140,7 +140,7 @@ fn test_mean_axis_0() raises:
 
 fn main() raises:
     """Run min_reduce and axis-specific sum/mean tests."""
-    print("Running ExTensor reduction forward tests - Part 3...")
+    print("Running AnyTensor reduction forward tests - Part 3...")
 
     # min_reduce() tests
     print("  Testing min_reduce()...")

--- a/tests/shared/core/test_reduction_forward_part4.mojo
+++ b/tests/shared/core/test_reduction_forward_part4.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor reduction operations - Part 4: axis-specific max/min and consistency.
+"""Tests for AnyTensor reduction operations - Part 4: axis-specific max/min and consistency.
 
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
@@ -8,8 +8,8 @@ Tests reduction operations following the Array API Standard:
 mean axis=1, max_reduce/min_reduce with axis parameter, and cross-reduction consistency.
 """
 
-# Import ExTensor and reduction operations
-from shared.core.extensor import ExTensor, full, ones, zeros, arange
+# Import AnyTensor and reduction operations
+from shared.core.extensor import AnyTensor, full, ones, zeros, arange
 from shared.core.reduction import sum, mean, max_reduce, min_reduce
 
 # Import test helpers
@@ -133,7 +133,7 @@ fn test_reductions_consistent() raises:
 
 fn main() raises:
     """Run axis-specific max/min and consistency tests."""
-    print("Running ExTensor reduction forward tests - Part 4...")
+    print("Running AnyTensor reduction forward tests - Part 4...")
 
     # Axis-specific mean test
     print("  Testing axis-specific mean()...")

--- a/tests/shared/core/test_reduction_noncontiguous_part1.mojo
+++ b/tests/shared/core/test_reduction_noncontiguous_part1.mojo
@@ -17,12 +17,12 @@ from tests.shared.conftest import (
     assert_false,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from shared.core.reduction import sum, mean
 from shared.core.matrix import transpose_view
 
 
-fn _make_nc_2x3() raises -> ExTensor:
+fn _make_nc_2x3() raises -> AnyTensor:
     """Non-contiguous 3×2 tensor (transpose of 2×3 sequential).
 
     Logical layout (3×2 row-major): 0,3,1,4,2,5

--- a/tests/shared/core/test_reduction_noncontiguous_part2.mojo
+++ b/tests/shared/core/test_reduction_noncontiguous_part2.mojo
@@ -16,12 +16,12 @@ from tests.shared.conftest import (
     assert_equal_int,
     assert_false,
 )
-from shared.core.extensor import ExTensor, zeros, arange
+from shared.core.extensor import AnyTensor, zeros, arange
 from shared.core.reduction import max_reduce, min_reduce
 from shared.core.matrix import transpose_view
 
 
-fn _make_nc_2x3() raises -> ExTensor:
+fn _make_nc_2x3() raises -> AnyTensor:
     """Non-contiguous 3×2 tensor (transpose of 2×3 sequential).
 
     Logical layout (3×2 row-major): 0,3,1,4,2,5

--- a/tests/shared/core/test_reduction_part1.mojo
+++ b/tests/shared/core/test_reduction_part1.mojo
@@ -22,7 +22,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.reduction import (
     sum,
     mean,
@@ -83,14 +83,14 @@ fn test_sum_backward_gradient() raises:
     x._data.bitcast[Float32]()[5] = 0.7
 
     # Forward function wrapper (sum along axis 1)
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return sum(inp, axis=1)
 
     var y = forward(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return sum_backward(grad, inp, axis=1)
 
     # Use numerical gradient checking (gold standard)
@@ -145,14 +145,14 @@ fn test_mean_backward_gradient() raises:
     x._data.bitcast[Float32]()[5] = 0.7
 
     # Forward function wrapper (mean along axis 1)
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return mean(inp, axis=1)
 
     var y = forward(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return mean_backward(grad, inp, axis=1)
 
     # Use numerical gradient checking (gold standard)
@@ -205,14 +205,14 @@ fn test_max_reduce_backward_gradient() raises:
     x._data.bitcast[Float32]()[5] = 0.7
 
     # Forward function wrapper (max along axis 1)
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return max_reduce(inp, axis=1)
 
     var y = forward(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return max_reduce_backward(grad, inp, axis=1)
 
     # Use numerical gradient checking (gold standard)
@@ -265,14 +265,14 @@ fn test_min_reduce_backward_gradient() raises:
     x._data.bitcast[Float32]()[5] = 0.7
 
     # Forward function wrapper (min along axis 1)
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return min_reduce(inp, axis=1)
 
     var y = forward(x)
     var grad_out = ones_like(y)
 
     # Backward function wrapper
-    fn backward(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return min_reduce_backward(grad, inp, axis=1)
 
     # Use numerical gradient checking (gold standard)

--- a/tests/shared/core/test_reduction_part2.mojo
+++ b/tests/shared/core/test_reduction_part2.mojo
@@ -22,7 +22,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.reduction import (
     variance,
     std,
@@ -124,13 +124,13 @@ fn test_var_backward_gradient() raises:
     x._data.bitcast[Float32]()[4] = 0.1
     x._data.bitcast[Float32]()[5] = 0.7
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return variance(inp, axis=1, ddof=0)
 
     var y = forward(x)
     var grad_out = ones_like(y)
 
-    fn backward(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return variance_backward(grad, inp, axis=1, ddof=0)
 
     check_gradient(forward, backward, x, grad_out, rtol=2e-3, atol=1e-6)
@@ -169,13 +169,13 @@ fn test_std_backward_gradient() raises:
     x._data.bitcast[Float32]()[4] = 0.1
     x._data.bitcast[Float32]()[5] = 0.7
 
-    fn forward(inp: ExTensor) raises escaping -> ExTensor:
+    fn forward(inp: AnyTensor) raises escaping -> AnyTensor:
         return std(inp, axis=1, ddof=0)
 
     var y = forward(x)
     var grad_out = ones_like(y)
 
-    fn backward(grad: ExTensor, inp: ExTensor) raises escaping -> ExTensor:
+    fn backward(grad: AnyTensor, inp: AnyTensor) raises escaping -> AnyTensor:
         return std_backward(grad, inp, axis=1, ddof=0)
 
     check_gradient(forward, backward, x, grad_out, rtol=2e-3, atol=1e-6)

--- a/tests/shared/core/test_reduction_part3.mojo
+++ b/tests/shared/core/test_reduction_part3.mojo
@@ -19,7 +19,7 @@ from tests.shared.conftest import (
     assert_true,
 )
 from tests.shared.conftest import TestFixtures
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.reduction import (
     median,
     percentile,

--- a/tests/shared/core/test_reshape_noncontiguous.mojo
+++ b/tests/shared/core/test_reshape_noncontiguous.mojo
@@ -4,7 +4,7 @@ Verifies that reshape() correctly handles non-contiguous tensors by using
 stride-based element access instead of flat-index access.
 """
 
-from shared.core import ExTensor, arange, reshape
+from shared.core import AnyTensor, arange, reshape
 from shared.core.shape import is_contiguous
 
 from tests.shared.conftest import (

--- a/tests/shared/core/test_sequential.mojo
+++ b/tests/shared/core/test_sequential.mojo
@@ -13,7 +13,7 @@ Design Note:
 """
 
 from shared.core.module import Module
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.core.sequential import Sequential2, Sequential3
 from tests.shared.conftest import (
     assert_true,
@@ -40,7 +40,7 @@ struct IdentityModule(Module, Movable):
         """Initialize identity module."""
         self.is_training = True
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Return input unchanged.
 
         Args:
@@ -51,13 +51,13 @@ struct IdentityModule(Module, Movable):
         """
         return input
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Return empty parameter list.
 
         Returns:
             Empty list (no trainable parameters).
         """
-        return List[ExTensor]()
+        return List[AnyTensor]()
 
     fn train(mut self):
         """Set to training mode."""
@@ -87,7 +87,7 @@ struct ScaleModule(Module, Movable):
         self.scale = scale
         self.is_training = True
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Scale all elements by self.scale.
 
         Args:
@@ -104,13 +104,13 @@ struct ScaleModule(Module, Movable):
             )
         return result
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Return empty parameter list.
 
         Returns:
             Empty list (no trainable parameters).
         """
-        return List[ExTensor]()
+        return List[AnyTensor]()
 
     fn train(mut self):
         """Set to training mode."""
@@ -136,7 +136,7 @@ struct CountingModule:
         self.call_count = 0
         self.is_training = True
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Increment call count and return input unchanged.
 
         Args:
@@ -148,13 +148,13 @@ struct CountingModule:
         self.call_count += 1
         return input
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Return empty parameter list.
 
         Returns:
             Empty list (no trainable parameters).
         """
-        return List[ExTensor]()
+        return List[AnyTensor]()
 
     fn train(mut self):
         """Set to training mode."""
@@ -183,7 +183,7 @@ struct DummyModuleWithParams(Module, Movable):
         self.num_params = num_params
         self.is_training = True
 
-    fn forward(mut self, input: ExTensor) raises -> ExTensor:
+    fn forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Return input unchanged.
 
         Args:
@@ -194,13 +194,13 @@ struct DummyModuleWithParams(Module, Movable):
         """
         return input
 
-    fn parameters(self) raises -> List[ExTensor]:
+    fn parameters(self) raises -> List[AnyTensor]:
         """Return dummy parameter list of specified size.
 
         Returns:
             List of scalar zero tensors, length == self.num_params.
         """
-        var params: List[ExTensor] = []
+        var params: List[AnyTensor] = []
         for _ in range(self.num_params):
             var shape: List[Int] = [1]
             params.append(zeros(shape, DType.float32))

--- a/tests/shared/core/test_setitem_view_part1.mojo
+++ b/tests/shared/core/test_setitem_view_part1.mojo
@@ -12,7 +12,7 @@ Covers:
 Issue: #4076 — Verify multi-dim __setitem__ works with non-contiguous (view) tensors
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, arange
+from shared.core.extensor import AnyTensor, zeros, ones, arange
 from tests.shared.conftest import (
     assert_true,
     assert_almost_equal,

--- a/tests/shared/core/test_setitem_view_part2.mojo
+++ b/tests/shared/core/test_setitem_view_part2.mojo
@@ -12,7 +12,7 @@ Covers:
 Issue: #4076 — Verify multi-dim __setitem__ works with non-contiguous (view) tensors
 """
 
-from shared.core.extensor import ExTensor, zeros, ones, arange
+from shared.core.extensor import AnyTensor, zeros, ones, arange
 from tests.shared.conftest import (
     assert_true,
     assert_almost_equal,

--- a/tests/shared/core/test_shape.mojo
+++ b/tests/shared/core/test_shape.mojo
@@ -1,11 +1,11 @@
-"""Tests for ExTensor shape manipulation operations.
+"""Tests for AnyTensor shape manipulation operations.
 
 Tests shape manipulation including reshape, squeeze, unsqueeze, expand_dims,
 flatten, ravel, concatenate, stack, split, tile, repeat, broadcast_to, permute.
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from shared.core.shape import (
     reshape,
     squeeze,
@@ -221,7 +221,7 @@ fn test_concatenate_axis_0() raises:
     var a = ones(shape_a, DType.float32)  # 2x3
     var b = full(shape_b, 2.0, DType.float32)  # 3x3
 
-    var tensors: List[ExTensor] = []
+    var tensors: List[AnyTensor] = []
     tensors.append(a)
     tensors.append(b)
     var c = concatenate(tensors, axis=0)
@@ -252,7 +252,7 @@ fn test_concatenate_axis_1() raises:
     var a = ones(shape_a, DType.float32)  # 3x2
     var b = full(shape_b, 2.0, DType.float32)  # 3x4
 
-    var tensors: List[ExTensor] = []
+    var tensors: List[AnyTensor] = []
     tensors.append(a)
     tensors.append(b)
     var c = concatenate(tensors, axis=1)
@@ -280,7 +280,7 @@ fn test_stack_new_axis() raises:
     var a = ones(shape, DType.float32)  # 2x3
     var b = full(shape, 2.0, DType.float32)  # 2x3
 
-    var tensors: List[ExTensor] = []
+    var tensors: List[AnyTensor] = []
     tensors.append(a)
     tensors.append(b)
     var c = stack(tensors, axis=0)
@@ -311,7 +311,7 @@ fn test_stack_axis_1() raises:
     var a = ones(shape, DType.float32)
     var b = full(shape, 2.0, DType.float32)
 
-    var tensors: List[ExTensor] = []
+    var tensors: List[AnyTensor] = []
     tensors.append(a)
     tensors.append(b)
     var c = stack(tensors, axis=1)
@@ -653,7 +653,7 @@ fn test_flatten_to_2d_preserves_dtype() raises:
 
 fn main() raises:
     """Run all shape manipulation tests."""
-    print("Running ExTensor shape manipulation tests...")
+    print("Running AnyTensor shape manipulation tests...")
 
     # reshape() tests
     print("  Testing reshape()...")

--- a/tests/shared/core/test_shape_edge_cases_part1.mojo
+++ b/tests/shared/core/test_shape_edge_cases_part1.mojo
@@ -9,8 +9,8 @@ Tests edge cases for reshape operations including:
 - Reshape between dimensions
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from shared.core.shape import reshape, squeeze, unsqueeze, concatenate, stack
 
 # Import test helpers

--- a/tests/shared/core/test_shape_edge_cases_part2.mojo
+++ b/tests/shared/core/test_shape_edge_cases_part2.mojo
@@ -9,8 +9,8 @@ Tests edge cases for squeeze and unsqueeze operations including:
 - Unsqueeze at various positions
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from shared.core.shape import reshape, squeeze, unsqueeze, concatenate, stack
 
 # Import test helpers

--- a/tests/shared/core/test_shape_edge_cases_part3.mojo
+++ b/tests/shared/core/test_shape_edge_cases_part3.mojo
@@ -10,8 +10,8 @@ Tests edge cases for concatenate operations including:
 - Concatenate 1D tensors
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from shared.core.shape import reshape, squeeze, unsqueeze, concatenate, stack
 
 # Import test helpers
@@ -37,7 +37,7 @@ fn test_concatenate_single_tensor() raises:
     shape.append(4)
     var t = ones(shape, DType.float32)
 
-    var tensors = List[ExTensor]()
+    var tensors = List[AnyTensor]()
     tensors.append(t)
     var result = concatenate(tensors, 0)
 
@@ -54,7 +54,7 @@ fn test_concatenate_along_axis_0() raises:
     var t1 = ones(shape, DType.float32)
     var t2 = full(shape, 2.0, DType.float32)
 
-    var tensors = List[ExTensor]()
+    var tensors = List[AnyTensor]()
     tensors.append(t1)
     tensors.append(t2)
     var result = concatenate(tensors, 0)
@@ -76,7 +76,7 @@ fn test_concatenate_along_axis_1() raises:
     var t1 = ones(shape_a, DType.float32)
     var t2 = full(shape_b, 2.0, DType.float32)
 
-    var tensors = List[ExTensor]()
+    var tensors = List[AnyTensor]()
     tensors.append(t1)
     tensors.append(t2)
     var result = concatenate(tensors, 1)
@@ -98,7 +98,7 @@ fn test_concatenate_with_empty() raises:
     var t1 = zeros(shape_a, DType.float32)
     var t2 = ones(shape_b, DType.float32)
 
-    var tensors = List[ExTensor]()
+    var tensors = List[AnyTensor]()
     tensors.append(t1)
     tensors.append(t2)
     var result = concatenate(tensors, 1)
@@ -114,7 +114,7 @@ fn test_concatenate_1d_tensors() raises:
     var t1 = full(shape, 1.0, DType.float32)
     var t2 = full(shape, 2.0, DType.float32)
 
-    var tensors = List[ExTensor]()
+    var tensors = List[AnyTensor]()
     tensors.append(t1)
     tensors.append(t2)
     var result = concatenate(tensors, 0)

--- a/tests/shared/core/test_shape_edge_cases_part4.mojo
+++ b/tests/shared/core/test_shape_edge_cases_part4.mojo
@@ -10,8 +10,8 @@ Tests edge cases for stack operations and dimension preservation including:
 - Reshape/squeeze/unsqueeze preserve element count
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from shared.core.shape import reshape, squeeze, unsqueeze, concatenate, stack
 
 # Import test helpers
@@ -36,7 +36,7 @@ fn test_stack_single_tensor() raises:
     shape.append(3)
     var t = ones(shape, DType.float32)
 
-    var tensors = List[ExTensor]()
+    var tensors = List[AnyTensor]()
     tensors.append(t)
     var result = stack(tensors, 0)
 
@@ -53,7 +53,7 @@ fn test_stack_2d_tensors() raises:
     var t1 = ones(shape, DType.float32)
     var t2 = full(shape, 2.0, DType.float32)
 
-    var tensors = List[ExTensor]()
+    var tensors = List[AnyTensor]()
     tensors.append(t1)
     tensors.append(t2)
     var result = stack(tensors, 0)
@@ -71,7 +71,7 @@ fn test_stack_along_different_axis() raises:
     var t1 = ones(shape, DType.float32)
     var t2 = full(shape, 2.0, DType.float32)
 
-    var tensors = List[ExTensor]()
+    var tensors = List[AnyTensor]()
     tensors.append(t1)
     tensors.append(t2)
     var result = stack(tensors, 1)

--- a/tests/shared/core/test_shape_noncontiguous_values.mojo
+++ b/tests/shared/core/test_shape_noncontiguous_values.mojo
@@ -17,9 +17,9 @@ Non-contiguous setup pattern (transpose_view):
       [0,4,8,  1,5,9,  2,6,10,  3,7,11]
 """
 
-# Import ExTensor and shape operations
+# Import AnyTensor and shape operations
 from shared.core import (
-    ExTensor,
+    AnyTensor,
     arange,
     reshape,
     flatten,
@@ -45,7 +45,7 @@ from tests.shared.conftest import (
 # ============================================================================
 
 
-fn make_noncontiguous_4x3() raises -> ExTensor:
+fn make_noncontiguous_4x3() raises -> AnyTensor:
     """Return a (4,3) non-contiguous tensor via transpose_view of arange(12) reshaped (3,4).
 
     Flat memory order: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
@@ -135,7 +135,7 @@ fn test_concatenate_noncontiguous_values() raises:
     Total 24 elements: first 12 from t_nc, second 12 same.
     """
     var t_nc = make_noncontiguous_4x3()
-    var tensors: List[ExTensor] = [t_nc, t_nc]
+    var tensors: List[AnyTensor] = [t_nc, t_nc]
     var result = concatenate(tensors, axis=0)
 
     var result_shape = result.shape()

--- a/tests/shared/core/test_shape_part1.mojo
+++ b/tests/shared/core/test_shape_part1.mojo
@@ -1,13 +1,13 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_shape.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor shape manipulation: reshape, squeeze, unsqueeze, expand_dims, flatten.
+"""Tests for AnyTensor shape manipulation: reshape, squeeze, unsqueeze, expand_dims, flatten.
 
 Split from test_shape.mojo per ADR-009 (≤10 fn test_ per file).
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from shared.core.shape import reshape, squeeze, unsqueeze, expand_dims, flatten, ravel
 
 # Import test helpers
@@ -180,7 +180,7 @@ fn test_ravel_view() raises:
 fn main() raises:
     """Run shape manipulation tests part 1 (reshape, squeeze, unsqueeze, flatten).
     """
-    print("Running ExTensor shape manipulation tests (part 1)...")
+    print("Running AnyTensor shape manipulation tests (part 1)...")
 
     # reshape() tests
     print("  Testing reshape()...")

--- a/tests/shared/core/test_shape_part2.mojo
+++ b/tests/shared/core/test_shape_part2.mojo
@@ -1,13 +1,13 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_shape.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor shape manipulation: concatenate, stack, split, tile.
+"""Tests for AnyTensor shape manipulation: concatenate, stack, split, tile.
 
 Split from test_shape.mojo per ADR-009 (≤10 fn test_ per file).
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from shared.core.shape import concatenate, stack
 
 # Import test helpers
@@ -37,7 +37,7 @@ fn test_concatenate_axis_0() raises:
     var a = ones(shape_a, DType.float32)  # 2x3
     var b = full(shape_b, 2.0, DType.float32)  # 3x3
 
-    var tensors: List[ExTensor] = []
+    var tensors: List[AnyTensor] = []
     tensors.append(a)
     tensors.append(b)
     var c = concatenate(tensors, axis=0)
@@ -59,7 +59,7 @@ fn test_concatenate_axis_1() raises:
     var a = ones(shape_a, DType.float32)  # 3x2
     var b = full(shape_b, 2.0, DType.float32)  # 3x4
 
-    var tensors: List[ExTensor] = []
+    var tensors: List[AnyTensor] = []
     tensors.append(a)
     tensors.append(b)
     var c = concatenate(tensors, axis=1)
@@ -97,7 +97,7 @@ fn test_stack_new_axis() raises:
     var a = ones(shape, DType.float32)  # 2x3
     var b = full(shape, 2.0, DType.float32)  # 2x3
 
-    var tensors: List[ExTensor] = []
+    var tensors: List[AnyTensor] = []
     tensors.append(a)
     tensors.append(b)
     var c = stack(tensors, axis=0)
@@ -116,7 +116,7 @@ fn test_stack_axis_1() raises:
     var a = ones(shape, DType.float32)
     var b = full(shape, 2.0, DType.float32)
 
-    var tensors: List[ExTensor] = []
+    var tensors: List[AnyTensor] = []
     tensors.append(a)
     tensors.append(b)
     var c = stack(tensors, axis=1)
@@ -227,7 +227,7 @@ fn test_tile_multidim() raises:
 
 fn main() raises:
     """Run shape manipulation tests part 2 (concatenate, stack, split, tile)."""
-    print("Running ExTensor shape manipulation tests (part 2)...")
+    print("Running AnyTensor shape manipulation tests (part 2)...")
 
     # concatenate() tests
     print("  Testing concatenate()...")

--- a/tests/shared/core/test_shape_part3.mojo
+++ b/tests/shared/core/test_shape_part3.mojo
@@ -1,13 +1,13 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_shape.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor shape manipulation: repeat, broadcast_to, permute, dtype preservation.
+"""Tests for AnyTensor shape manipulation: repeat, broadcast_to, permute, dtype preservation.
 
 Split from test_shape.mojo per ADR-009 (≤10 fn test_ per file).
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange
 from shared.core.shape import broadcast_to, reshape
 
 # Import test helpers
@@ -249,7 +249,7 @@ fn test_flatten_to_2d_basic() raises:
 fn main() raises:
     """Run shape manipulation tests part 3 (repeat, broadcast_to, permute, dtype, flatten_to_2d).
     """
-    print("Running ExTensor shape manipulation tests (part 3)...")
+    print("Running AnyTensor shape manipulation tests (part 3)...")
 
     # repeat() tests
     print("  Testing repeat()...")

--- a/tests/shared/core/test_shape_part4.mojo
+++ b/tests/shared/core/test_shape_part4.mojo
@@ -1,13 +1,13 @@
 # ADR-009: This file is intentionally limited to ≤10 fn test_ functions.
 # Mojo v0.26.1 heap corruption (libKGENCompilerRTShared.so) triggers under
 # high test load. Split from test_shape.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
-"""Tests for ExTensor shape manipulation: flatten_to_2d additional cases.
+"""Tests for AnyTensor shape manipulation: flatten_to_2d additional cases.
 
 Split from test_shape.mojo per ADR-009 (≤10 fn test_ per file).
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, ones, zeros, arange
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, ones, zeros, arange
 from shared.core.shape import flatten_to_2d, concatenate, as_contiguous
 
 # Import test helpers
@@ -67,7 +67,7 @@ fn test_concatenate_axis_1_per_row_values() raises:
     var b = arange(6.0, 12.0, 1.0, DType.float32)
     b = b.reshape(shape)  # [[6,7],[8,9],[10,11]]
 
-    var tensors: List[ExTensor] = List[ExTensor]()
+    var tensors: List[AnyTensor] = List[AnyTensor]()
     tensors.append(a)
     tensors.append(b)
     var result = concatenate(tensors, 1)  # 3x4
@@ -117,7 +117,7 @@ fn test_as_contiguous_3d_non_contiguous() raises:
 
 fn main() raises:
     """Run shape manipulation tests part 4."""
-    print("Running ExTensor shape manipulation tests (part 4)...")
+    print("Running AnyTensor shape manipulation tests (part 4)...")
 
     print("  Testing flatten_to_2d() additional cases...")
     test_flatten_to_2d_single_batch()

--- a/tests/shared/core/test_shape_regression.mojo
+++ b/tests/shared/core/test_shape_regression.mojo
@@ -14,8 +14,8 @@ Bugs tested:
 - Line 296: concatenate() - var result_shape = List[Int]()
 """
 
-# Import ExTensor and shape operations
-from shared.core.extensor import ExTensor, ones, zeros, arange
+# Import AnyTensor and shape operations
+from shared.core.extensor import AnyTensor, ones, zeros, arange
 from shared.core.shape import reshape, squeeze, unsqueeze, flatten, concatenate
 
 # Import test helpers
@@ -197,7 +197,7 @@ fn test_concatenate_along_axis() raises:
     var b = ones(shape2, DType.float32)  # 3x3
 
     # Concatenate along axis 0
-    var tensors: List[ExTensor] = []
+    var tensors: List[AnyTensor] = []
     tensors.append(a)
     tensors.append(b)
 

--- a/tests/shared/core/test_slicing_part1.mojo
+++ b/tests/shared/core/test_slicing_part1.mojo
@@ -12,7 +12,7 @@ Test Categories:
 Total: 8 tests.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from tests.shared.conftest import assert_equal, assert_almost_equal
 
 

--- a/tests/shared/core/test_slicing_part2.mojo
+++ b/tests/shared/core/test_slicing_part2.mojo
@@ -10,7 +10,7 @@ Test Categories:
 Total: 6 tests.
 """
 
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.data import extract_batch, extract_batch_pair
 from tests.shared.conftest import assert_equal, assert_almost_equal
 

--- a/tests/shared/core/test_strassen.mojo
+++ b/tests/shared/core/test_strassen.mojo
@@ -19,7 +19,7 @@ from tests.shared.conftest import (
     assert_equal_int,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, zeros_like
+from shared.core.extensor import AnyTensor, zeros, ones, zeros_like
 from shared.core.strassen import matmul_strassen, next_power_of_2
 from shared.core.matmul import matmul_tiled
 

--- a/tests/shared/core/test_tensors_part1.mojo
+++ b/tests/shared/core/test_tensors_part1.mojo
@@ -20,7 +20,7 @@ from tests.shared.conftest import (
 )
 from tests.shared.conftest import TestFixtures
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     full,

--- a/tests/shared/core/test_tensors_part2.mojo
+++ b/tests/shared/core/test_tensors_part2.mojo
@@ -22,7 +22,7 @@ from tests.shared.conftest import (
 )
 from tests.shared.conftest import TestFixtures
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     full,

--- a/tests/shared/core/test_tensors_part3.mojo
+++ b/tests/shared/core/test_tensors_part3.mojo
@@ -22,7 +22,7 @@ from tests.shared.conftest import (
 )
 from tests.shared.conftest import TestFixtures
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     full,

--- a/tests/shared/core/test_utilities.mojo
+++ b/tests/shared/core/test_utilities.mojo
@@ -7,7 +7,7 @@ This module tests the utility functions:
 """
 
 from shared.core.extensor import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     full,

--- a/tests/shared/core/test_utility.mojo
+++ b/tests/shared/core/test_utility.mojo
@@ -1,12 +1,12 @@
-"""Tests for ExTensor utility operations.
+"""Tests for AnyTensor utility operations.
 
 Tests utility functions including copy, clone, properties, conversions,
 and helper methods like numel, dim, size, stride, is_contiguous.
 """
 
-# Import ExTensor and operations
+# Import AnyTensor and operations
 from shared.core import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     full,
@@ -845,7 +845,7 @@ fn test_hash_empty_tensor_dtype_differs() raises:
         )
 
 
-fn make_bf16_nan_tensor(raw_bits: UInt16) raises -> ExTensor:
+fn make_bf16_nan_tensor(raw_bits: UInt16) raises -> AnyTensor:
     """Create a scalar BF16 tensor with the given raw NaN bit pattern.
 
     Bypasses _set_float64 by writing raw UInt16 bits directly via pointer cast,
@@ -862,11 +862,11 @@ fn make_bf16_nan_tensor(raw_bits: UInt16) raises -> ExTensor:
         raw_bits: Raw UInt16 bit pattern for a BF16 NaN value.
 
     Returns:
-        Scalar ExTensor with DType.bfloat16 containing the given bit pattern.
+        Scalar AnyTensor with DType.bfloat16 containing the given bit pattern.
     """
     var shape = List[Int]()
     shape.append(1)
-    var tensor = ExTensor(shape, DType.bfloat16)
+    var tensor = AnyTensor(shape, DType.bfloat16)
     var ptr = tensor._data.bitcast[UInt16]()
     ptr[] = raw_bits
     return tensor^
@@ -993,7 +993,7 @@ fn test_diff_higher_order() raises:
 
 fn main() raises:
     """Run all utility operation tests."""
-    print("Running ExTensor utility operation tests...")
+    print("Running AnyTensor utility operation tests...")
 
     # copy() and clone() tests
     print("  Testing copy() and clone()...")

--- a/tests/shared/core/test_utility_part1.mojo
+++ b/tests/shared/core/test_utility_part1.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor utility operations - Part 1: copy/clone and property accessors.
+"""Tests for AnyTensor utility operations - Part 1: copy/clone and property accessors.
 
 Tests utility functions including copy, clone, numel, dim, shape, dtype,
 and stride calculations.
@@ -8,8 +8,8 @@ and stride calculations.
 # high test load. Split from test_utility.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange, clone, item, diff
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange, clone, item, diff
 from shared.core.shape import as_contiguous
 from shared.core.matrix import transpose_view
 
@@ -142,7 +142,7 @@ fn test_stride_row_major() raises:
 fn main() raises:
     """Run utility operation tests - Part 1: copy/clone and property accessors.
     """
-    print("Running ExTensor utility operation tests (Part 1)...")
+    print("Running AnyTensor utility operation tests (Part 1)...")
 
     # copy() and clone() tests
     print("  Testing copy() and clone()...")

--- a/tests/shared/core/test_utility_part2.mojo
+++ b/tests/shared/core/test_utility_part2.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor utility operations - Part 2: contiguity, item(), and tolist().
+"""Tests for AnyTensor utility operations - Part 2: contiguity, item(), and tolist().
 
 Tests contiguity checks, as_contiguous(), item() scalar extraction,
 and tolist() conversion methods.
@@ -8,9 +8,9 @@ and tolist() conversion methods.
 # high test load. Split from test_utility.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
+# Import AnyTensor and operations
 from shared.core import (
-    ExTensor,
+    AnyTensor,
     zeros,
     ones,
     full,
@@ -206,7 +206,7 @@ fn test_tolist_nested() raises:
 fn main() raises:
     """Run utility operation tests - Part 2: contiguity, item(), and tolist().
     """
-    print("Running ExTensor utility operation tests (Part 2)...")
+    print("Running AnyTensor utility operation tests (Part 2)...")
 
     # Contiguity
     print("  Testing contiguity...")

--- a/tests/shared/core/test_utility_part3.mojo
+++ b/tests/shared/core/test_utility_part3.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor utility operations - Part 3: __len__, __setitem__, __bool__, and partial __hash__.
+"""Tests for AnyTensor utility operations - Part 3: __len__, __setitem__, __bool__, and partial __hash__.
 
 Tests length accessor, item assignment, boolean conversion via __bool__,
 and hash consistency for large and small float values.
@@ -8,8 +8,8 @@ and hash consistency for large and small float values.
 # high test load. Split from test_utility.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange, clone, item, diff
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange, clone, item, diff
 from shared.core.shape import as_contiguous
 from shared.core.matrix import transpose_view
 
@@ -184,7 +184,7 @@ fn test_hash_small_values_distinguish() raises:
 fn main() raises:
     """Run utility operation tests - Part 3: __len__, __setitem__, __bool__, and partial __hash__.
     """
-    print("Running ExTensor utility operation tests (Part 3)...")
+    print("Running AnyTensor utility operation tests (Part 3)...")
 
     # __len__
     print("  Testing __len__...")

--- a/tests/shared/core/test_utility_part4.mojo
+++ b/tests/shared/core/test_utility_part4.mojo
@@ -1,4 +1,4 @@
-"""Tests for ExTensor utility operations - Part 4: type conversions, __str__/__repr__, __hash__, and diff().
+"""Tests for AnyTensor utility operations - Part 4: type conversions, __str__/__repr__, __hash__, and diff().
 
 Tests type conversions, string representations, hash consistency,
 and consecutive difference computations.
@@ -8,8 +8,8 @@ and consecutive difference computations.
 # high test load. Split from test_utility.mojo. See docs/adr/ADR-009-heap-corruption-workaround.md
 """
 
-# Import ExTensor and operations
-from shared.core.extensor import ExTensor, zeros, ones, full, arange, clone, item, diff
+# Import AnyTensor and operations
+from shared.core.extensor import AnyTensor, zeros, ones, full, arange, clone, item, diff
 from shared.core.shape import as_contiguous
 from shared.core.matrix import transpose_view
 
@@ -151,7 +151,7 @@ fn test_diff_higher_order() raises:
 fn main() raises:
     """Run utility operation tests - Part 4: conversions, str/repr, hash, and diff.
     """
-    print("Running ExTensor utility operation tests (Part 4)...")
+    print("Running AnyTensor utility operation tests (Part 4)...")
 
     # Type conversions
     print("  Testing type conversions...")

--- a/tests/shared/core/test_utils_part1.mojo
+++ b/tests/shared/core/test_utils_part1.mojo
@@ -16,7 +16,7 @@ from tests.shared.conftest import (
     assert_true,
     assert_close_float,
 )
-from shared.core.extensor import ExTensor, zeros, ones, arange
+from shared.core.extensor import AnyTensor, zeros, ones, arange
 from shared.core.utils import (
     argmax,
     top_k_indices,

--- a/tests/shared/core/test_utils_part2.mojo
+++ b/tests/shared/core/test_utils_part2.mojo
@@ -16,7 +16,7 @@ from tests.shared.conftest import (
     assert_true,
     assert_close_float,
 )
-from shared.core.extensor import ExTensor, zeros, ones, arange
+from shared.core.extensor import AnyTensor, zeros, ones, arange
 from shared.core.utils import (
     top_k_indices,
     top_k,

--- a/tests/shared/core/test_utils_part3.mojo
+++ b/tests/shared/core/test_utils_part3.mojo
@@ -14,7 +14,7 @@ from tests.shared.conftest import (
     assert_true,
     assert_close_float,
 )
-from shared.core.extensor import ExTensor, zeros, ones, arange
+from shared.core.extensor import AnyTensor, zeros, ones, arange
 from shared.core.utils import (
     argsort,
 )

--- a/tests/shared/core/test_validation_extended.mojo
+++ b/tests/shared/core/test_validation_extended.mojo
@@ -17,7 +17,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.core.validation import (
     validate_1d_input,
     validate_3d_input,

--- a/tests/shared/core/test_validation_part1.mojo
+++ b/tests/shared/core/test_validation_part1.mojo
@@ -11,7 +11,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.core.validation import (
     validate_tensor_shape,
 )

--- a/tests/shared/core/test_validation_part2.mojo
+++ b/tests/shared/core/test_validation_part2.mojo
@@ -12,7 +12,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.core.validation import (
     validate_tensor_dtype,
     validate_matching_tensors,

--- a/tests/shared/core/test_validation_part3.mojo
+++ b/tests/shared/core/test_validation_part3.mojo
@@ -12,7 +12,7 @@ from tests.shared.conftest import (
     assert_equal,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones
+from shared.core.extensor import AnyTensor, zeros, ones
 from shared.core.validation import (
     validate_2d_input,
     validate_4d_input,

--- a/tests/shared/core/test_variable_backward.mojo
+++ b/tests/shared/core/test_variable_backward.mojo
@@ -15,7 +15,7 @@ from tests.shared.conftest import (
     assert_equal_int,
     assert_true,
 )
-from shared.core.extensor import ExTensor, zeros, ones, ones_like
+from shared.core.extensor import AnyTensor, zeros, ones, ones_like
 from shared.autograd.variable import (
     Variable,
     variable_add,


### PR DESCRIPTION
## Summary
- Mechanical rename of `ExTensor` to `AnyTensor` in imports and type annotations across 242 test files in `tests/shared/core/`
- String assertions checking `__str__`/`__repr__` output (e.g., `"ExTensor([..."`) are preserved since the output format rename is Phase 7e
- No changes to test logic, function signatures, or test values -- purely a type name migration

## Test plan
- [ ] CI passes (this is a behavioral no-op due to `comptime ExTensor = AnyTensor` alias)
- [ ] Verify no remaining `ExTensor` references outside string assertions: `grep -rn "ExTensor" tests/shared/core/ --include="*.mojo" | grep -v '"ExTensor('`

Part of #4998

🤖 Generated with [Claude Code](https://claude.com/claude-code)