### PR TITLE
ci: add compilation time monitoring for monomorphization bloat

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -124,7 +124,7 @@ jobs:
             echo "⚠️  No shared package found yet"
           fi
 
-      - name: Compile shared package
+      - name: Compile shared package (with timing)
         run: |
           echo "=================================================="
           echo "Compiling shared package..."
@@ -135,6 +135,9 @@ jobs:
           # Count total files for reporting
           total_files=$(find shared -name "*.mojo" -type f | wc -l)
           echo "Total .mojo files in shared/: $total_files"
+
+          # Track compilation time for monomorphization bloat detection (H6)
+          START=$(date +%s)
 
           # Build the shared package inside the container
           if podman compose exec -T projectodyssey-dev bash -c \
@@ -149,11 +152,27 @@ jobs:
             exit 1
           fi
 
+          END=$(date +%s)
+          ELAPSED=$((END - START))
+
+          # Report compilation time to step summary
+          echo "## Compilation Time: ${ELAPSED}s" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Total .mojo files**: ${total_files}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Package compilation**: ${ELAPSED} seconds" >> $GITHUB_STEP_SUMMARY
+          if [ $ELAPSED -gt 300 ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "> **WARNING**: Compilation took over 5 minutes (${ELAPSED}s)." >> $GITHUB_STEP_SUMMARY
+            echo "> This may indicate excessive monomorphization from Tensor[dtype] instantiations." >> $GITHUB_STEP_SUMMARY
+            echo "> See shared/tensor/tensor.mojo H6 comment for details." >> $GITHUB_STEP_SUMMARY
+          fi
+
           # Save compilation summary
           cat > compilation-results/summary.txt << EOF
           Mojo Compilation Check
           ======================
           Total .mojo files: $total_files
+          Compilation time: ${ELAPSED}s
           Status: success
           EOF
 

--- a/shared/tensor/tensor.mojo
+++ b/shared/tensor/tensor.mojo
@@ -35,6 +35,12 @@ comptime TENSOR_PRINT_THRESHOLD: Int = 1000  # Truncate if numel > threshold
 comptime TENSOR_PRINT_SHOW_ELEMENTS: Int = 3  # Show first/last N elements
 
 
+# NOTE(H6): Mojo uses eager monomorphization. Each Tensor[dtype] instantiation
+# generates separate code. Monitor CI compilation times for bloat.
+# Expected instantiations: float16, float32, float64 (3 types x N functions).
+# If compile time exceeds 5 minutes, restrict dtype usage or optimize.
+
+
 struct Tensor[dtype: DType = DType.float32](
     Copyable,
     ImplicitlyCopyable,


### PR DESCRIPTION
## Summary

- Add compilation time tracking to the `mojo-compilation` CI job, reporting elapsed seconds to `$GITHUB_STEP_SUMMARY`
- Warn in the step summary if compilation exceeds 5 minutes (potential `Tensor[dtype]` monomorphization bloat)
- Add `NOTE(H6)` comment to `shared/tensor/tensor.mojo` documenting the monomorphization concern

## Changes

- `.github/workflows/comprehensive-tests.yml`: Wrap the `mojo package` call with `date +%s` timing, write results to step summary, include threshold warning
- `shared/tensor/tensor.mojo`: Add H6 comment block before `struct Tensor` explaining eager monomorphization and expected dtype instantiations

Part of #4998

## Test plan

- [ ] CI workflow YAML passes `check-yaml` pre-commit hook
- [ ] Compilation step still succeeds (timing is additive, no behavioral change)
- [ ] Step summary shows compilation time after a CI run