### PR TITLE
fix(audit): address minor findings from strict repository audit

### DIFF
--- a/shared/__init__.mojo
+++ b/shared/__init__.mojo
@@ -64,7 +64,7 @@ comptime ReLU = ReLULayer
 comptime Dropout = DropoutLayer
 comptime BatchNorm2d = BatchNorm2dLayer
 
-# MaxPool2D, Flatten — NOT YET IMPLEMENTED in shared/core/layers/
+# MaxPool2D, Flatten — pending layer implementation
 
 # Core activations (function form) — all four confirmed in shared/core/activation.mojo
 from shared.core.activation import relu, sigmoid, tanh, softmax
@@ -72,14 +72,12 @@ from shared.core.activation import relu, sigmoid, tanh, softmax
 # Core module system
 # Module is a trait (not a struct) — can be imported but not instantiated directly
 from shared.core.module import Module
-# Sequential — only parametric variants exist (Sequential2, Sequential3, …); no
-# single-type Sequential class yet. NOT YET IMPLEMENTED.
+# Sequential — only parametric variants exist (Sequential2, Sequential3, …)
 
 # Core tensors — AnyTensor is the canonical runtime-typed tensor.
 from shared.core.any_tensor import AnyTensor, zeros, ones, randn
 
-# Training optimizers — only functional step-functions exist (sgd_step, adam_step, etc.);
-# no SGD/Adam/AdamW struct classes yet. NOT YET IMPLEMENTED.
+# Training optimizers — struct classes available via shared.autograd.optimizers
 
 # Training schedulers — struct implementations confirmed in lr_schedulers.mojo
 from shared.training.schedulers.lr_schedulers import StepLR, CosineAnnealingLR
@@ -103,12 +101,9 @@ from shared.autograd.optimizers import SGD, Adam, AdaGrad, RMSprop, AdamW
 # Training callbacks — struct implementations confirmed in shared/training/callbacks.mojo
 from shared.training.callbacks import EarlyStopping, ModelCheckpoint
 
-# Training loops — train_epoch / validate_epoch not implemented; existing functions are
-# train_one_epoch (training_loop.mojo) and validate (validation_loop.mojo).
-# NOT YET IMPLEMENTED with documented API names.
+# Training loops — available as train_one_epoch / validate (see training_loop.mojo)
 
-# Data components — TensorDataset/ImageDataset/DataLoader structs not yet implemented
-# (only AnyTensorDataset exists). NOT YET IMPLEMENTED.
+# Data components — AnyTensorDataset available; typed wrappers pending
 
 # Utils
 from shared.utils.logging import Logger

--- a/shared/core/__init__.mojo
+++ b/shared/core/__init__.mojo
@@ -248,6 +248,14 @@ from shared.core.arithmetic import (
     subtract_backward,
     multiply_backward,
     divide_backward,
+    add_typed,
+    subtract_typed,
+    multiply_typed,
+    divide_typed,
+    floor_divide_typed,
+    modulo_typed,
+    power_typed,
+    multiply_scalar_typed,
 )
 
 # ============================================================================
@@ -262,6 +270,7 @@ from shared.core.matrix import (
     outer,
     matmul_backward,
     transpose_backward,
+    matmul_typed,
     transpose_typed,
     dot_typed,
     outer_typed,
@@ -318,6 +327,9 @@ from shared.core.activation import (
     hard_sigmoid_backward,
     hard_swish_backward,
     hard_tanh_backward,
+    relu_typed,
+    sigmoid_typed,
+    softmax_typed,
 )
 
 from shared.core.activation_ops import (
@@ -454,6 +466,12 @@ from shared.core.elementwise import (
     clip_backward,
     log10_backward,
     log2_backward,
+    exp_typed,
+    log_typed,
+    sqrt_typed,
+    abs_typed,
+    sin_typed,
+    cos_typed,
 )
 
 # ============================================================================

--- a/shared/tensor/tensor.mojo
+++ b/shared/tensor/tensor.mojo
@@ -7,7 +7,7 @@ Uses typed `UnsafePointer[Scalar[dtype]]` storage instead of type-erased
 `UnsafePointer[UInt8]`. Pointer arithmetic auto-scales by element size (H1),
 so no manual `* dtype_size` is needed for element offsets.
 
-Zero-copy conversion to AnyTensor (future AnyTensor) via `as_any()` with shared
+Zero-copy conversion to AnyTensor via `as_any()` with shared
 refcount (B4). Both types share a `TensorLike` trait interface.
 
 Example:


### PR DESCRIPTION
## Summary
- Fix stale "future AnyTensor" comment in tensor.mojo (rename already completed)
- Export all 21 Tensor[dtype] typed op functions from shared/core/__init__.mojo
- Clean up 5 verbose NOT YET IMPLEMENTED comments in shared/__init__.mojo
- Verified WARN_TENSOR_BYTES is actually used (produces warning at 500MB) -- no change needed
- test_review_fixes.mojo does not exist on main -- skipped

## Test plan
- [ ] `just package` compiles
- [ ] `just test-mojo` all tests pass

Closes #4998

🤖 Generated with [Claude Code](https://claude.com/claude-code)