### PR TITLE
feat(ops): native Tensor[dtype] shape, comparison, and remaining ops

### DIFF
--- a/shared/core/comparison.mojo
+++ b/shared/core/comparison.mojo
@@ -1,35 +1,72 @@
-"""Comparison operations for AnyTensor with broadcasting support.
+"""Comparison operations with native Tensor[dtype] implementations.
 
-Implements element-wise comparison operations following NumPy-style broadcasting
+Implements element-wise comparison operations following NumPy-style broadcasting.
+
+Architecture: Tensor[dtype] typed implementations are the core (zero dtype branches).
+AnyTensor versions dispatch to typed implementations via ordinal-based table.
+
+Layer 1 (outer): AnyTensor public API (equal, less, greater, etc.)
+Layer 2: dtype dispatch table (ordinal-based)
+Layer 3 (core): Tensor[dtype] native implementation
 """
 
 from collections import List
 from .any_tensor import AnyTensor
 from shared.tensor.tensor import Tensor
 from shared.base.broadcasting import broadcast_shapes, compute_broadcast_strides
+from shared.base.dtype_ordinal import (
+    dtype_to_ordinal,
+    DTYPE_FLOAT16,
+    DTYPE_FLOAT32,
+    DTYPE_FLOAT64,
+    DTYPE_INT8,
+    DTYPE_INT16,
+    DTYPE_INT32,
+    DTYPE_INT64,
+    DTYPE_UINT8,
+    DTYPE_UINT16,
+    DTYPE_UINT32,
+    DTYPE_UINT64,
+)
 
 
 # ============================================================================
-# Dtype-specialized comparison helpers
+# Layer 3 (Core): Native Tensor[dtype] Comparison Implementations
 # ============================================================================
+# Each comparison op has its own typed core function that uses Tensor[dtype]._data
+# directly -- zero bitcasts, zero dtype branches.
 
 
-@always_inline
-fn _compare_equal_impl[
+fn _equal_typed[
     dtype: DType
-](
-    result: AnyTensor,
-    a: AnyTensor,
-    b: AnyTensor,
-    strides_a: List[Int],
-    strides_b: List[Int],
-    result_shape: List[Int],
-    total_elems: Int,
-):
-    """Dtype-specialized equal comparison."""
-    var a_ptr = a._data.bitcast[Scalar[dtype]]()
-    var b_ptr = b._data.bitcast[Scalar[dtype]]()
-    var out_ptr = result._data.bitcast[Scalar[DType.bool]]()
+](a: Tensor[dtype], b: Tensor[dtype]) raises -> Tensor[DType.bool]:
+    """Element-wise equality on native Tensor[dtype] (core).
+
+    Parameters:
+        dtype: Compile-time dtype parameter.
+
+    Args:
+        a: First typed tensor.
+        b: Second typed tensor.
+
+    Returns:
+        Boolean result tensor.
+    """
+    var a_shape = a.shape()
+    var b_shape = b.shape()
+    var result_shape = broadcast_shapes(a_shape, b_shape)
+    var result = Tensor[DType.bool](result_shape)
+
+    var strides_a = compute_broadcast_strides(a_shape, result_shape)
+    var strides_b = compute_broadcast_strides(b_shape, result_shape)
+
+    var total_elems = 1
+    for i in range(len(result_shape)):
+        total_elems *= result_shape[i]
+
+    var a_ptr = a._data
+    var b_ptr = b._data
+    var out_ptr = result._data
 
     for result_idx in range(total_elems):
         var remaining = result_idx
@@ -43,70 +80,39 @@ fn _compare_equal_impl[
 
         out_ptr[result_idx] = a_ptr[idx_a] == b_ptr[idx_b]
 
-
-fn _dispatch_compare_equal(
-    result: AnyTensor,
-    a: AnyTensor,
-    b: AnyTensor,
-    strides_a: List[Int],
-    strides_b: List[Int],
-    result_shape: List[Int],
-    total_elems: Int,
-) raises:
-    """Runtime dispatch for equal comparison."""
-    var dtype = a.dtype()
-    if dtype == DType.float16:
-        _compare_equal_impl[DType.float16](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.float32:
-        _compare_equal_impl[DType.float32](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.float64:
-        _compare_equal_impl[DType.float64](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int8:
-        _compare_equal_impl[DType.int8](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int16:
-        _compare_equal_impl[DType.int16](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int32:
-        _compare_equal_impl[DType.int32](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int64:
-        _compare_equal_impl[DType.int64](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.bool:
-        _compare_equal_impl[DType.bool](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    else:
-        raise Error("equal: unsupported dtype")
+    return result^
 
 
-@always_inline
-fn _compare_not_equal_impl[
+fn _not_equal_typed[
     dtype: DType
-](
-    result: AnyTensor,
-    a: AnyTensor,
-    b: AnyTensor,
-    strides_a: List[Int],
-    strides_b: List[Int],
-    result_shape: List[Int],
-    total_elems: Int,
-):
-    """Dtype-specialized not_equal comparison."""
-    var a_ptr = a._data.bitcast[Scalar[dtype]]()
-    var b_ptr = b._data.bitcast[Scalar[dtype]]()
-    var out_ptr = result._data.bitcast[Scalar[DType.bool]]()
+](a: Tensor[dtype], b: Tensor[dtype]) raises -> Tensor[DType.bool]:
+    """Element-wise inequality on native Tensor[dtype] (core).
+
+    Parameters:
+        dtype: Compile-time dtype parameter.
+
+    Args:
+        a: First typed tensor.
+        b: Second typed tensor.
+
+    Returns:
+        Boolean result tensor.
+    """
+    var a_shape = a.shape()
+    var b_shape = b.shape()
+    var result_shape = broadcast_shapes(a_shape, b_shape)
+    var result = Tensor[DType.bool](result_shape)
+
+    var strides_a = compute_broadcast_strides(a_shape, result_shape)
+    var strides_b = compute_broadcast_strides(b_shape, result_shape)
+
+    var total_elems = 1
+    for i in range(len(result_shape)):
+        total_elems *= result_shape[i]
+
+    var a_ptr = a._data
+    var b_ptr = b._data
+    var out_ptr = result._data
 
     for result_idx in range(total_elems):
         var remaining = result_idx
@@ -120,70 +126,39 @@ fn _compare_not_equal_impl[
 
         out_ptr[result_idx] = a_ptr[idx_a] != b_ptr[idx_b]
 
-
-fn _dispatch_compare_not_equal(
-    result: AnyTensor,
-    a: AnyTensor,
-    b: AnyTensor,
-    strides_a: List[Int],
-    strides_b: List[Int],
-    result_shape: List[Int],
-    total_elems: Int,
-) raises:
-    """Runtime dispatch for not_equal comparison."""
-    var dtype = a.dtype()
-    if dtype == DType.float16:
-        _compare_not_equal_impl[DType.float16](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.float32:
-        _compare_not_equal_impl[DType.float32](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.float64:
-        _compare_not_equal_impl[DType.float64](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int8:
-        _compare_not_equal_impl[DType.int8](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int16:
-        _compare_not_equal_impl[DType.int16](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int32:
-        _compare_not_equal_impl[DType.int32](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int64:
-        _compare_not_equal_impl[DType.int64](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.bool:
-        _compare_not_equal_impl[DType.bool](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    else:
-        raise Error("not_equal: unsupported dtype")
+    return result^
 
 
-@always_inline
-fn _compare_less_impl[
+fn _less_typed[
     dtype: DType
-](
-    result: AnyTensor,
-    a: AnyTensor,
-    b: AnyTensor,
-    strides_a: List[Int],
-    strides_b: List[Int],
-    result_shape: List[Int],
-    total_elems: Int,
-):
-    """Dtype-specialized less comparison."""
-    var a_ptr = a._data.bitcast[Scalar[dtype]]()
-    var b_ptr = b._data.bitcast[Scalar[dtype]]()
-    var out_ptr = result._data.bitcast[Scalar[DType.bool]]()
+](a: Tensor[dtype], b: Tensor[dtype]) raises -> Tensor[DType.bool]:
+    """Element-wise less-than on native Tensor[dtype] (core).
+
+    Parameters:
+        dtype: Compile-time dtype parameter.
+
+    Args:
+        a: First typed tensor.
+        b: Second typed tensor.
+
+    Returns:
+        Boolean result tensor.
+    """
+    var a_shape = a.shape()
+    var b_shape = b.shape()
+    var result_shape = broadcast_shapes(a_shape, b_shape)
+    var result = Tensor[DType.bool](result_shape)
+
+    var strides_a = compute_broadcast_strides(a_shape, result_shape)
+    var strides_b = compute_broadcast_strides(b_shape, result_shape)
+
+    var total_elems = 1
+    for i in range(len(result_shape)):
+        total_elems *= result_shape[i]
+
+    var a_ptr = a._data
+    var b_ptr = b._data
+    var out_ptr = result._data
 
     for result_idx in range(total_elems):
         var remaining = result_idx
@@ -197,70 +172,39 @@ fn _compare_less_impl[
 
         out_ptr[result_idx] = a_ptr[idx_a] < b_ptr[idx_b]
 
-
-fn _dispatch_compare_less(
-    result: AnyTensor,
-    a: AnyTensor,
-    b: AnyTensor,
-    strides_a: List[Int],
-    strides_b: List[Int],
-    result_shape: List[Int],
-    total_elems: Int,
-) raises:
-    """Runtime dispatch for less comparison."""
-    var dtype = a.dtype()
-    if dtype == DType.float16:
-        _compare_less_impl[DType.float16](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.float32:
-        _compare_less_impl[DType.float32](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.float64:
-        _compare_less_impl[DType.float64](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int8:
-        _compare_less_impl[DType.int8](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int16:
-        _compare_less_impl[DType.int16](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int32:
-        _compare_less_impl[DType.int32](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int64:
-        _compare_less_impl[DType.int64](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.bool:
-        _compare_less_impl[DType.bool](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    else:
-        raise Error("less: unsupported dtype")
+    return result^
 
 
-@always_inline
-fn _compare_less_equal_impl[
+fn _less_equal_typed[
     dtype: DType
-](
-    result: AnyTensor,
-    a: AnyTensor,
-    b: AnyTensor,
-    strides_a: List[Int],
-    strides_b: List[Int],
-    result_shape: List[Int],
-    total_elems: Int,
-):
-    """Dtype-specialized less_equal comparison."""
-    var a_ptr = a._data.bitcast[Scalar[dtype]]()
-    var b_ptr = b._data.bitcast[Scalar[dtype]]()
-    var out_ptr = result._data.bitcast[Scalar[DType.bool]]()
+](a: Tensor[dtype], b: Tensor[dtype]) raises -> Tensor[DType.bool]:
+    """Element-wise less-equal on native Tensor[dtype] (core).
+
+    Parameters:
+        dtype: Compile-time dtype parameter.
+
+    Args:
+        a: First typed tensor.
+        b: Second typed tensor.
+
+    Returns:
+        Boolean result tensor.
+    """
+    var a_shape = a.shape()
+    var b_shape = b.shape()
+    var result_shape = broadcast_shapes(a_shape, b_shape)
+    var result = Tensor[DType.bool](result_shape)
+
+    var strides_a = compute_broadcast_strides(a_shape, result_shape)
+    var strides_b = compute_broadcast_strides(b_shape, result_shape)
+
+    var total_elems = 1
+    for i in range(len(result_shape)):
+        total_elems *= result_shape[i]
+
+    var a_ptr = a._data
+    var b_ptr = b._data
+    var out_ptr = result._data
 
     for result_idx in range(total_elems):
         var remaining = result_idx
@@ -274,70 +218,39 @@ fn _compare_less_equal_impl[
 
         out_ptr[result_idx] = a_ptr[idx_a] <= b_ptr[idx_b]
 
-
-fn _dispatch_compare_less_equal(
-    result: AnyTensor,
-    a: AnyTensor,
-    b: AnyTensor,
-    strides_a: List[Int],
-    strides_b: List[Int],
-    result_shape: List[Int],
-    total_elems: Int,
-) raises:
-    """Runtime dispatch for less_equal comparison."""
-    var dtype = a.dtype()
-    if dtype == DType.float16:
-        _compare_less_equal_impl[DType.float16](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.float32:
-        _compare_less_equal_impl[DType.float32](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.float64:
-        _compare_less_equal_impl[DType.float64](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int8:
-        _compare_less_equal_impl[DType.int8](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int16:
-        _compare_less_equal_impl[DType.int16](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int32:
-        _compare_less_equal_impl[DType.int32](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int64:
-        _compare_less_equal_impl[DType.int64](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.bool:
-        _compare_less_equal_impl[DType.bool](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    else:
-        raise Error("less_equal: unsupported dtype")
+    return result^
 
 
-@always_inline
-fn _compare_greater_impl[
+fn _greater_typed[
     dtype: DType
-](
-    result: AnyTensor,
-    a: AnyTensor,
-    b: AnyTensor,
-    strides_a: List[Int],
-    strides_b: List[Int],
-    result_shape: List[Int],
-    total_elems: Int,
-):
-    """Dtype-specialized greater comparison."""
-    var a_ptr = a._data.bitcast[Scalar[dtype]]()
-    var b_ptr = b._data.bitcast[Scalar[dtype]]()
-    var out_ptr = result._data.bitcast[Scalar[DType.bool]]()
+](a: Tensor[dtype], b: Tensor[dtype]) raises -> Tensor[DType.bool]:
+    """Element-wise greater-than on native Tensor[dtype] (core).
+
+    Parameters:
+        dtype: Compile-time dtype parameter.
+
+    Args:
+        a: First typed tensor.
+        b: Second typed tensor.
+
+    Returns:
+        Boolean result tensor.
+    """
+    var a_shape = a.shape()
+    var b_shape = b.shape()
+    var result_shape = broadcast_shapes(a_shape, b_shape)
+    var result = Tensor[DType.bool](result_shape)
+
+    var strides_a = compute_broadcast_strides(a_shape, result_shape)
+    var strides_b = compute_broadcast_strides(b_shape, result_shape)
+
+    var total_elems = 1
+    for i in range(len(result_shape)):
+        total_elems *= result_shape[i]
+
+    var a_ptr = a._data
+    var b_ptr = b._data
+    var out_ptr = result._data
 
     for result_idx in range(total_elems):
         var remaining = result_idx
@@ -351,70 +264,39 @@ fn _compare_greater_impl[
 
         out_ptr[result_idx] = a_ptr[idx_a] > b_ptr[idx_b]
 
-
-fn _dispatch_compare_greater(
-    result: AnyTensor,
-    a: AnyTensor,
-    b: AnyTensor,
-    strides_a: List[Int],
-    strides_b: List[Int],
-    result_shape: List[Int],
-    total_elems: Int,
-) raises:
-    """Runtime dispatch for greater comparison."""
-    var dtype = a.dtype()
-    if dtype == DType.float16:
-        _compare_greater_impl[DType.float16](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.float32:
-        _compare_greater_impl[DType.float32](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.float64:
-        _compare_greater_impl[DType.float64](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int8:
-        _compare_greater_impl[DType.int8](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int16:
-        _compare_greater_impl[DType.int16](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int32:
-        _compare_greater_impl[DType.int32](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int64:
-        _compare_greater_impl[DType.int64](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.bool:
-        _compare_greater_impl[DType.bool](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    else:
-        raise Error("greater: unsupported dtype")
+    return result^
 
 
-@always_inline
-fn _compare_greater_equal_impl[
+fn _greater_equal_typed[
     dtype: DType
-](
-    result: AnyTensor,
-    a: AnyTensor,
-    b: AnyTensor,
-    strides_a: List[Int],
-    strides_b: List[Int],
-    result_shape: List[Int],
-    total_elems: Int,
-):
-    """Dtype-specialized greater_equal comparison."""
-    var a_ptr = a._data.bitcast[Scalar[dtype]]()
-    var b_ptr = b._data.bitcast[Scalar[dtype]]()
-    var out_ptr = result._data.bitcast[Scalar[DType.bool]]()
+](a: Tensor[dtype], b: Tensor[dtype]) raises -> Tensor[DType.bool]:
+    """Element-wise greater-equal on native Tensor[dtype] (core).
+
+    Parameters:
+        dtype: Compile-time dtype parameter.
+
+    Args:
+        a: First typed tensor.
+        b: Second typed tensor.
+
+    Returns:
+        Boolean result tensor.
+    """
+    var a_shape = a.shape()
+    var b_shape = b.shape()
+    var result_shape = broadcast_shapes(a_shape, b_shape)
+    var result = Tensor[DType.bool](result_shape)
+
+    var strides_a = compute_broadcast_strides(a_shape, result_shape)
+    var strides_b = compute_broadcast_strides(b_shape, result_shape)
+
+    var total_elems = 1
+    for i in range(len(result_shape)):
+        total_elems *= result_shape[i]
+
+    var a_ptr = a._data
+    var b_ptr = b._data
+    var out_ptr = result._data
 
     for result_idx in range(total_elems):
         var remaining = result_idx
@@ -428,52 +310,65 @@ fn _compare_greater_equal_impl[
 
         out_ptr[result_idx] = a_ptr[idx_a] >= b_ptr[idx_b]
 
+    return result^
 
-fn _dispatch_compare_greater_equal(
-    result: AnyTensor,
-    a: AnyTensor,
-    b: AnyTensor,
-    strides_a: List[Int],
-    strides_b: List[Int],
-    result_shape: List[Int],
-    total_elems: Int,
-) raises:
-    """Runtime dispatch for greater_equal comparison."""
-    var dtype = a.dtype()
-    if dtype == DType.float16:
-        _compare_greater_equal_impl[DType.float16](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.float32:
-        _compare_greater_equal_impl[DType.float32](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.float64:
-        _compare_greater_equal_impl[DType.float64](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int8:
-        _compare_greater_equal_impl[DType.int8](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int16:
-        _compare_greater_equal_impl[DType.int16](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int32:
-        _compare_greater_equal_impl[DType.int32](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.int64:
-        _compare_greater_equal_impl[DType.int64](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    elif dtype == DType.bool:
-        _compare_greater_equal_impl[DType.bool](
-            result, a, b, strides_a, strides_b, result_shape, total_elems
-        )
-    else:
-        raise Error("greater_equal: unsupported dtype")
+
+# ============================================================================
+# Layer 2: AnyTensor dispatch helpers (as_tensor -> typed core -> as_any)
+# ============================================================================
+
+
+fn _equal_dispatch[
+    dtype: DType
+](a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
+    return _equal_typed[dtype](
+        a.as_tensor[dtype](), b.as_tensor[dtype]()
+    ).as_any()
+
+
+fn _not_equal_dispatch[
+    dtype: DType
+](a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
+    return _not_equal_typed[dtype](
+        a.as_tensor[dtype](), b.as_tensor[dtype]()
+    ).as_any()
+
+
+fn _less_dispatch[
+    dtype: DType
+](a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
+    return _less_typed[dtype](
+        a.as_tensor[dtype](), b.as_tensor[dtype]()
+    ).as_any()
+
+
+fn _less_equal_dispatch[
+    dtype: DType
+](a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
+    return _less_equal_typed[dtype](
+        a.as_tensor[dtype](), b.as_tensor[dtype]()
+    ).as_any()
+
+
+fn _greater_dispatch[
+    dtype: DType
+](a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
+    return _greater_typed[dtype](
+        a.as_tensor[dtype](), b.as_tensor[dtype]()
+    ).as_any()
+
+
+fn _greater_equal_dispatch[
+    dtype: DType
+](a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
+    return _greater_equal_typed[dtype](
+        a.as_tensor[dtype](), b.as_tensor[dtype]()
+    ).as_any()
+
+
+# ============================================================================
+# Layer 1: AnyTensor Public API
+# ============================================================================
 
 
 fn equal(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
@@ -522,20 +417,36 @@ fn equal(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
     if a.dtype() != b.dtype():
         raise Error("Cannot compare tensors with different dtypes")
 
-    var result_shape = broadcast_shapes(a.shape(), b.shape())
-    var result = AnyTensor(result_shape, DType.bool)
+    # Handle DType.bool separately (not in ordinal table)
+    if a.dtype() == DType.bool:
+        return _equal_dispatch[DType.bool](a, b)
 
-    var strides_a = compute_broadcast_strides(a.shape(), result_shape)
-    var strides_b = compute_broadcast_strides(b.shape(), result_shape)
+    var ordinal = dtype_to_ordinal(a.dtype())
 
-    var total_elems = 1
-    for i in range(len(result_shape)):
-        total_elems *= result_shape[i]
-
-    _dispatch_compare_equal(
-        result, a, b, strides_a, strides_b, result_shape, total_elems
-    )
-    return result^
+    if ordinal == DTYPE_FLOAT16:
+        return _equal_dispatch[DType.float16](a, b)
+    elif ordinal == DTYPE_FLOAT32:
+        return _equal_dispatch[DType.float32](a, b)
+    elif ordinal == DTYPE_FLOAT64:
+        return _equal_dispatch[DType.float64](a, b)
+    elif ordinal == DTYPE_INT8:
+        return _equal_dispatch[DType.int8](a, b)
+    elif ordinal == DTYPE_INT16:
+        return _equal_dispatch[DType.int16](a, b)
+    elif ordinal == DTYPE_INT32:
+        return _equal_dispatch[DType.int32](a, b)
+    elif ordinal == DTYPE_INT64:
+        return _equal_dispatch[DType.int64](a, b)
+    elif ordinal == DTYPE_UINT8:
+        return _equal_dispatch[DType.uint8](a, b)
+    elif ordinal == DTYPE_UINT16:
+        return _equal_dispatch[DType.uint16](a, b)
+    elif ordinal == DTYPE_UINT32:
+        return _equal_dispatch[DType.uint32](a, b)
+    elif ordinal == DTYPE_UINT64:
+        return _equal_dispatch[DType.uint64](a, b)
+    else:
+        raise Error("equal: unsupported dtype")
 
 
 fn not_equal(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
@@ -561,20 +472,35 @@ fn not_equal(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
     if a.dtype() != b.dtype():
         raise Error("Cannot compare tensors with different dtypes")
 
-    var result_shape = broadcast_shapes(a.shape(), b.shape())
-    var result = AnyTensor(result_shape, DType.bool)
+    if a.dtype() == DType.bool:
+        return _not_equal_dispatch[DType.bool](a, b)
 
-    var strides_a = compute_broadcast_strides(a.shape(), result_shape)
-    var strides_b = compute_broadcast_strides(b.shape(), result_shape)
+    var ordinal = dtype_to_ordinal(a.dtype())
 
-    var total_elems = 1
-    for i in range(len(result_shape)):
-        total_elems *= result_shape[i]
-
-    _dispatch_compare_not_equal(
-        result, a, b, strides_a, strides_b, result_shape, total_elems
-    )
-    return result^
+    if ordinal == DTYPE_FLOAT16:
+        return _not_equal_dispatch[DType.float16](a, b)
+    elif ordinal == DTYPE_FLOAT32:
+        return _not_equal_dispatch[DType.float32](a, b)
+    elif ordinal == DTYPE_FLOAT64:
+        return _not_equal_dispatch[DType.float64](a, b)
+    elif ordinal == DTYPE_INT8:
+        return _not_equal_dispatch[DType.int8](a, b)
+    elif ordinal == DTYPE_INT16:
+        return _not_equal_dispatch[DType.int16](a, b)
+    elif ordinal == DTYPE_INT32:
+        return _not_equal_dispatch[DType.int32](a, b)
+    elif ordinal == DTYPE_INT64:
+        return _not_equal_dispatch[DType.int64](a, b)
+    elif ordinal == DTYPE_UINT8:
+        return _not_equal_dispatch[DType.uint8](a, b)
+    elif ordinal == DTYPE_UINT16:
+        return _not_equal_dispatch[DType.uint16](a, b)
+    elif ordinal == DTYPE_UINT32:
+        return _not_equal_dispatch[DType.uint32](a, b)
+    elif ordinal == DTYPE_UINT64:
+        return _not_equal_dispatch[DType.uint64](a, b)
+    else:
+        raise Error("not_equal: unsupported dtype")
 
 
 fn less(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
@@ -600,20 +526,35 @@ fn less(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
     if a.dtype() != b.dtype():
         raise Error("Cannot compare tensors with different dtypes")
 
-    var result_shape = broadcast_shapes(a.shape(), b.shape())
-    var result = AnyTensor(result_shape, DType.bool)
+    if a.dtype() == DType.bool:
+        return _less_dispatch[DType.bool](a, b)
 
-    var strides_a = compute_broadcast_strides(a.shape(), result_shape)
-    var strides_b = compute_broadcast_strides(b.shape(), result_shape)
+    var ordinal = dtype_to_ordinal(a.dtype())
 
-    var total_elems = 1
-    for i in range(len(result_shape)):
-        total_elems *= result_shape[i]
-
-    _dispatch_compare_less(
-        result, a, b, strides_a, strides_b, result_shape, total_elems
-    )
-    return result^
+    if ordinal == DTYPE_FLOAT16:
+        return _less_dispatch[DType.float16](a, b)
+    elif ordinal == DTYPE_FLOAT32:
+        return _less_dispatch[DType.float32](a, b)
+    elif ordinal == DTYPE_FLOAT64:
+        return _less_dispatch[DType.float64](a, b)
+    elif ordinal == DTYPE_INT8:
+        return _less_dispatch[DType.int8](a, b)
+    elif ordinal == DTYPE_INT16:
+        return _less_dispatch[DType.int16](a, b)
+    elif ordinal == DTYPE_INT32:
+        return _less_dispatch[DType.int32](a, b)
+    elif ordinal == DTYPE_INT64:
+        return _less_dispatch[DType.int64](a, b)
+    elif ordinal == DTYPE_UINT8:
+        return _less_dispatch[DType.uint8](a, b)
+    elif ordinal == DTYPE_UINT16:
+        return _less_dispatch[DType.uint16](a, b)
+    elif ordinal == DTYPE_UINT32:
+        return _less_dispatch[DType.uint32](a, b)
+    elif ordinal == DTYPE_UINT64:
+        return _less_dispatch[DType.uint64](a, b)
+    else:
+        raise Error("less: unsupported dtype")
 
 
 fn less_equal(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
@@ -639,20 +580,35 @@ fn less_equal(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
     if a.dtype() != b.dtype():
         raise Error("Cannot compare tensors with different dtypes")
 
-    var result_shape = broadcast_shapes(a.shape(), b.shape())
-    var result = AnyTensor(result_shape, DType.bool)
+    if a.dtype() == DType.bool:
+        return _less_equal_dispatch[DType.bool](a, b)
 
-    var strides_a = compute_broadcast_strides(a.shape(), result_shape)
-    var strides_b = compute_broadcast_strides(b.shape(), result_shape)
+    var ordinal = dtype_to_ordinal(a.dtype())
 
-    var total_elems = 1
-    for i in range(len(result_shape)):
-        total_elems *= result_shape[i]
-
-    _dispatch_compare_less_equal(
-        result, a, b, strides_a, strides_b, result_shape, total_elems
-    )
-    return result^
+    if ordinal == DTYPE_FLOAT16:
+        return _less_equal_dispatch[DType.float16](a, b)
+    elif ordinal == DTYPE_FLOAT32:
+        return _less_equal_dispatch[DType.float32](a, b)
+    elif ordinal == DTYPE_FLOAT64:
+        return _less_equal_dispatch[DType.float64](a, b)
+    elif ordinal == DTYPE_INT8:
+        return _less_equal_dispatch[DType.int8](a, b)
+    elif ordinal == DTYPE_INT16:
+        return _less_equal_dispatch[DType.int16](a, b)
+    elif ordinal == DTYPE_INT32:
+        return _less_equal_dispatch[DType.int32](a, b)
+    elif ordinal == DTYPE_INT64:
+        return _less_equal_dispatch[DType.int64](a, b)
+    elif ordinal == DTYPE_UINT8:
+        return _less_equal_dispatch[DType.uint8](a, b)
+    elif ordinal == DTYPE_UINT16:
+        return _less_equal_dispatch[DType.uint16](a, b)
+    elif ordinal == DTYPE_UINT32:
+        return _less_equal_dispatch[DType.uint32](a, b)
+    elif ordinal == DTYPE_UINT64:
+        return _less_equal_dispatch[DType.uint64](a, b)
+    else:
+        raise Error("less_equal: unsupported dtype")
 
 
 fn greater(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
@@ -678,20 +634,35 @@ fn greater(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
     if a.dtype() != b.dtype():
         raise Error("Cannot compare tensors with different dtypes")
 
-    var result_shape = broadcast_shapes(a.shape(), b.shape())
-    var result = AnyTensor(result_shape, DType.bool)
+    if a.dtype() == DType.bool:
+        return _greater_dispatch[DType.bool](a, b)
 
-    var strides_a = compute_broadcast_strides(a.shape(), result_shape)
-    var strides_b = compute_broadcast_strides(b.shape(), result_shape)
+    var ordinal = dtype_to_ordinal(a.dtype())
 
-    var total_elems = 1
-    for i in range(len(result_shape)):
-        total_elems *= result_shape[i]
-
-    _dispatch_compare_greater(
-        result, a, b, strides_a, strides_b, result_shape, total_elems
-    )
-    return result^
+    if ordinal == DTYPE_FLOAT16:
+        return _greater_dispatch[DType.float16](a, b)
+    elif ordinal == DTYPE_FLOAT32:
+        return _greater_dispatch[DType.float32](a, b)
+    elif ordinal == DTYPE_FLOAT64:
+        return _greater_dispatch[DType.float64](a, b)
+    elif ordinal == DTYPE_INT8:
+        return _greater_dispatch[DType.int8](a, b)
+    elif ordinal == DTYPE_INT16:
+        return _greater_dispatch[DType.int16](a, b)
+    elif ordinal == DTYPE_INT32:
+        return _greater_dispatch[DType.int32](a, b)
+    elif ordinal == DTYPE_INT64:
+        return _greater_dispatch[DType.int64](a, b)
+    elif ordinal == DTYPE_UINT8:
+        return _greater_dispatch[DType.uint8](a, b)
+    elif ordinal == DTYPE_UINT16:
+        return _greater_dispatch[DType.uint16](a, b)
+    elif ordinal == DTYPE_UINT32:
+        return _greater_dispatch[DType.uint32](a, b)
+    elif ordinal == DTYPE_UINT64:
+        return _greater_dispatch[DType.uint64](a, b)
+    else:
+        raise Error("greater: unsupported dtype")
 
 
 fn greater_equal(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
@@ -717,24 +688,39 @@ fn greater_equal(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
     if a.dtype() != b.dtype():
         raise Error("Cannot compare tensors with different dtypes")
 
-    var result_shape = broadcast_shapes(a.shape(), b.shape())
-    var result = AnyTensor(result_shape, DType.bool)
+    if a.dtype() == DType.bool:
+        return _greater_equal_dispatch[DType.bool](a, b)
 
-    var strides_a = compute_broadcast_strides(a.shape(), result_shape)
-    var strides_b = compute_broadcast_strides(b.shape(), result_shape)
+    var ordinal = dtype_to_ordinal(a.dtype())
 
-    var total_elems = 1
-    for i in range(len(result_shape)):
-        total_elems *= result_shape[i]
-
-    _dispatch_compare_greater_equal(
-        result, a, b, strides_a, strides_b, result_shape, total_elems
-    )
-    return result^
+    if ordinal == DTYPE_FLOAT16:
+        return _greater_equal_dispatch[DType.float16](a, b)
+    elif ordinal == DTYPE_FLOAT32:
+        return _greater_equal_dispatch[DType.float32](a, b)
+    elif ordinal == DTYPE_FLOAT64:
+        return _greater_equal_dispatch[DType.float64](a, b)
+    elif ordinal == DTYPE_INT8:
+        return _greater_equal_dispatch[DType.int8](a, b)
+    elif ordinal == DTYPE_INT16:
+        return _greater_equal_dispatch[DType.int16](a, b)
+    elif ordinal == DTYPE_INT32:
+        return _greater_equal_dispatch[DType.int32](a, b)
+    elif ordinal == DTYPE_INT64:
+        return _greater_equal_dispatch[DType.int64](a, b)
+    elif ordinal == DTYPE_UINT8:
+        return _greater_equal_dispatch[DType.uint8](a, b)
+    elif ordinal == DTYPE_UINT16:
+        return _greater_equal_dispatch[DType.uint16](a, b)
+    elif ordinal == DTYPE_UINT32:
+        return _greater_equal_dispatch[DType.uint32](a, b)
+    elif ordinal == DTYPE_UINT64:
+        return _greater_equal_dispatch[DType.uint64](a, b)
+    else:
+        raise Error("greater_equal: unsupported dtype")
 
 
 # ============================================================================
-# Typed Tensor[dtype] overloads — wrap AnyTensor versions via as_any/as_tensor
+# Typed Tensor[dtype] overloads — delegate to typed cores directly
 # ============================================================================
 
 
@@ -750,7 +736,7 @@ fn equal_typed[dt: DType](
     Returns:
         A new Tensor[DType.bool] with element-wise equality results.
     """
-    return equal(a.as_any(), b.as_any()).as_tensor[DType.bool]()
+    return _equal_typed[dt](a, b)
 
 
 fn not_equal_typed[dt: DType](
@@ -765,7 +751,7 @@ fn not_equal_typed[dt: DType](
     Returns:
         A new Tensor[DType.bool] with element-wise inequality results.
     """
-    return not_equal(a.as_any(), b.as_any()).as_tensor[DType.bool]()
+    return _not_equal_typed[dt](a, b)
 
 
 fn less_typed[dt: DType](
@@ -780,7 +766,22 @@ fn less_typed[dt: DType](
     Returns:
         A new Tensor[DType.bool] with element-wise less-than results.
     """
-    return less(a.as_any(), b.as_any()).as_tensor[DType.bool]()
+    return _less_typed[dt](a, b)
+
+
+fn less_equal_typed[dt: DType](
+    a: Tensor[dt], b: Tensor[dt]
+) raises -> Tensor[DType.bool]:
+    """Element-wise less-than-or-equal comparison (typed version).
+
+    Args:
+        a: First input tensor.
+        b: Second input tensor.
+
+    Returns:
+        A new Tensor[DType.bool] with element-wise less-equal results.
+    """
+    return _less_equal_typed[dt](a, b)
 
 
 fn greater_typed[dt: DType](
@@ -795,4 +796,19 @@ fn greater_typed[dt: DType](
     Returns:
         A new Tensor[DType.bool] with element-wise greater-than results.
     """
-    return greater(a.as_any(), b.as_any()).as_tensor[DType.bool]()
+    return _greater_typed[dt](a, b)
+
+
+fn greater_equal_typed[dt: DType](
+    a: Tensor[dt], b: Tensor[dt]
+) raises -> Tensor[DType.bool]:
+    """Element-wise greater-than-or-equal comparison (typed version).
+
+    Args:
+        a: First input tensor.
+        b: Second input tensor.
+
+    Returns:
+        A new Tensor[DType.bool] with element-wise greater-equal results.
+    """
+    return _greater_equal_typed[dt](a, b)

--- a/shared/core/loss.mojo
+++ b/shared/core/loss.mojo
@@ -1029,6 +1029,11 @@ fn kl_divergence_backward(
 # Typed overloads for Tensor[dtype] (compile-time typed wrappers)
 # ============================================================================
 
+# ============================================================================
+# Typed Tensor[dtype] overloads — typed entry points for forward loss functions
+# ============================================================================
+# Backward functions stay on AnyTensor (gradient computation is dtype-generic).
+
 from shared.tensor.tensor import Tensor
 
 
@@ -1037,12 +1042,14 @@ fn mean_squared_error_typed[
 ](predictions: Tensor[dt], targets: Tensor[dt]) raises -> Tensor[dt]:
     """Typed overload of mean_squared_error for Tensor[dtype].
 
+    Provides compile-time type safety for the MSE forward pass.
+
     Args:
         predictions: Model predictions.
         targets: Ground truth targets.
 
     Returns:
-        Scalar MSE loss tensor.
+        Squared error tensor, same shape as inputs.
 
     Raises:
         Error if tensor operations fail.
@@ -1054,39 +1061,105 @@ fn mean_squared_error_typed[
 
 fn cross_entropy_typed[
     dt: DType
-](predictions: Tensor[dt], targets: Tensor[dt]) raises -> Tensor[dt]:
+](
+    logits: Tensor[dt],
+    targets: Tensor[dt],
+    axis: Int = -1,
+    epsilon: Float64 = 1e-7,
+) raises -> Tensor[dt]:
     """Typed overload of cross_entropy for Tensor[dtype].
 
+    Provides compile-time type safety for the cross-entropy forward pass.
+
     Args:
-        predictions: Model predictions (logits or probabilities).
-        targets: Ground truth targets (one-hot or class indices).
+        logits: Raw model outputs (before softmax).
+        targets: One-hot encoded ground truth.
+        axis: Axis for softmax (default: -1).
+        epsilon: Numerical stability constant.
 
     Returns:
-        Scalar cross-entropy loss tensor.
+        Cross-entropy loss tensor.
 
     Raises:
         Error if tensor operations fail.
     """
     return cross_entropy(
-        predictions.as_any(), targets.as_any()
+        logits.as_any(), targets.as_any(), axis, epsilon
     ).as_tensor[dt]()
 
 
 fn binary_cross_entropy_typed[
     dt: DType
-](predictions: Tensor[dt], targets: Tensor[dt]) raises -> Tensor[dt]:
+](
+    predictions: Tensor[dt],
+    targets: Tensor[dt],
+    epsilon: Float64 = 1e-7,
+) raises -> Tensor[dt]:
     """Typed overload of binary_cross_entropy for Tensor[dtype].
+
+    Provides compile-time type safety for the BCE forward pass.
 
     Args:
         predictions: Model predictions in [0, 1].
         targets: Binary labels (0 or 1).
+        epsilon: Numerical stability constant.
 
     Returns:
-        Scalar BCE loss tensor.
+        BCE loss tensor, same shape as inputs.
 
     Raises:
         Error if tensor operations fail.
     """
     return binary_cross_entropy(
-        predictions.as_any(), targets.as_any()
+        predictions.as_any(), targets.as_any(), epsilon
+    ).as_tensor[dt]()
+
+
+fn smooth_l1_loss_typed[
+    dt: DType
+](
+    predictions: Tensor[dt],
+    targets: Tensor[dt],
+    beta: Float64 = 1.0,
+) raises -> Tensor[dt]:
+    """Typed overload of smooth_l1_loss for Tensor[dtype].
+
+    Args:
+        predictions: Model predictions.
+        targets: Ground truth targets.
+        beta: Threshold for switching between L1 and L2 (default: 1.0).
+
+    Returns:
+        Smooth L1 loss tensor.
+
+    Raises:
+        Error if tensor operations fail.
+    """
+    return smooth_l1_loss(
+        predictions.as_any(), targets.as_any(), beta
+    ).as_tensor[dt]()
+
+
+fn kl_divergence_typed[
+    dt: DType
+](
+    p: Tensor[dt],
+    q: Tensor[dt],
+    epsilon: Float64 = 1e-10,
+) raises -> Tensor[dt]:
+    """Typed overload of kl_divergence for Tensor[dtype].
+
+    Args:
+        p: True distribution (probabilities).
+        q: Approximate distribution (probabilities).
+        epsilon: Numerical stability constant.
+
+    Returns:
+        KL divergence loss tensor.
+
+    Raises:
+        Error if tensor operations fail.
+    """
+    return kl_divergence(
+        p.as_any(), q.as_any(), epsilon
     ).as_tensor[dt]()

--- a/shared/core/normalization.mojo
+++ b/shared/core/normalization.mojo
@@ -2849,8 +2849,11 @@ fn instance_norm_backward(
 
 
 # ============================================================================
-# Typed overloads for Tensor[dtype] (compile-time typed wrappers)
+# Typed Tensor[dtype] overloads — typed entry points for forward functions
 # ============================================================================
+# Backward functions stay on AnyTensor (gradient computation is dtype-generic).
+# Forward functions provide typed entry points that delegate to the internal
+# AnyTensor implementation (which already has dtype-specific fast paths).
 
 from shared.tensor.tensor import Tensor
 
@@ -2869,9 +2872,9 @@ fn batch_norm2d_typed[
 ) raises -> Tuple[Tensor[dt], Tensor[dt], Tensor[dt]]:
     """Typed overload of batch_norm2d for Tensor[dtype].
 
-    Wraps the AnyTensor batch_norm2d function with compile-time type
-    safety. Converts inputs to AnyTensor, calls batch_norm2d, and
-    converts outputs back to Tensor[dt].
+    Provides compile-time type safety. Converts Tensor[dt] inputs to AnyTensor,
+    calls the internal batch_norm2d implementation (which has dtype-specific
+    fast paths), and converts outputs back to Tensor[dt].
 
     Args:
         x: Input tensor of shape (batch, channels, height, width).
@@ -2900,3 +2903,35 @@ fn batch_norm2d_typed[
         epsilon,
     )
     return (out.as_tensor[dt](), rm.as_tensor[dt](), rv.as_tensor[dt]())
+
+
+fn layer_norm_typed[
+    dt: DType
+](
+    x: Tensor[dt],
+    gamma: Tensor[dt],
+    beta: Tensor[dt],
+    epsilon: Float64 = 1e-5,
+) raises -> Tensor[dt]:
+    """Typed overload of layer_norm for Tensor[dtype].
+
+    Provides compile-time type safety for the layer normalization forward pass.
+
+    Args:
+        x: Input tensor of shape (batch, features) or (batch, channels, height, width).
+        gamma: Scale parameter.
+        beta: Shift parameter.
+        epsilon: Numerical stability constant (default: 1e-5).
+
+    Returns:
+        Normalized Tensor[dt], same shape as input.
+
+    Raises:
+        Error if tensor operations fail.
+    """
+    return layer_norm(
+        x.as_any(),
+        gamma.as_any(),
+        beta.as_any(),
+        epsilon,
+    ).as_tensor[dt]()

--- a/shared/core/numerical_safety.mojo
+++ b/shared/core/numerical_safety.mojo
@@ -1,10 +1,13 @@
-"""Numerical safety utilities for detecting and preventing numerical instabilities.
+"""Numerical safety utilities with native Tensor[dtype] implementations.
 
 This module provides tools for:
 - NaN/Inf detection in tensors
 - Gradient explosion/vanishing detection
 - Numerical range checking
 - Compile-time optional safety checks (zero overhead when disabled)
+
+Architecture: Tensor[dtype] typed implementations are the core.
+AnyTensor versions dispatch to typed implementations via ordinal-based table.
 
 All safety checks use @parameter for compile-time enable/disable, ensuring zero
 runtime overhead when safety mode is disabled.
@@ -25,6 +28,224 @@ Example:
 from .any_tensor import AnyTensor
 from math import isnan, isinf, sqrt
 from collections import List
+from shared.tensor.tensor import Tensor
+from shared.base.dtype_ordinal import (
+    dtype_to_ordinal,
+    DTYPE_FLOAT16,
+    DTYPE_FLOAT32,
+    DTYPE_FLOAT64,
+    DTYPE_INT8,
+    DTYPE_INT16,
+    DTYPE_INT32,
+    DTYPE_INT64,
+    DTYPE_UINT8,
+    DTYPE_UINT16,
+    DTYPE_UINT32,
+    DTYPE_UINT64,
+)
+
+
+# ============================================================================
+# Layer 3 (Core): Native Tensor[dtype] implementations
+# ============================================================================
+
+
+fn _has_nan_core[dtype: DType](tensor: Tensor[dtype]) -> Bool:
+    """Check if typed tensor contains any NaN values (core implementation).
+
+    Parameters:
+        dtype: Compile-time dtype parameter.
+
+    Args:
+        tensor: Input typed tensor to check.
+
+    Returns:
+        True if any element is NaN, False otherwise.
+    """
+    # Integer/unsigned types cannot have NaN
+    @parameter
+    if dtype == DType.int8 or dtype == DType.int16 or dtype == DType.int32 or dtype == DType.int64 or dtype == DType.uint8 or dtype == DType.uint16 or dtype == DType.uint32 or dtype == DType.uint64 or dtype == DType.bool:
+        return False
+
+    var size = tensor.numel()
+    var ptr = tensor._data
+    for i in range(size):
+        @parameter
+        if dtype == DType.float16:
+            if isnan(Float32(ptr[i])):
+                return True
+        else:
+            if isnan(ptr[i]):
+                return True
+    return False
+
+
+fn _has_inf_core[dtype: DType](tensor: Tensor[dtype]) -> Bool:
+    """Check if typed tensor contains any Inf values (core implementation).
+
+    Parameters:
+        dtype: Compile-time dtype parameter.
+
+    Args:
+        tensor: Input typed tensor to check.
+
+    Returns:
+        True if any element is Inf or -Inf, False otherwise.
+    """
+    @parameter
+    if dtype == DType.int8 or dtype == DType.int16 or dtype == DType.int32 or dtype == DType.int64 or dtype == DType.uint8 or dtype == DType.uint16 or dtype == DType.uint32 or dtype == DType.uint64 or dtype == DType.bool:
+        return False
+
+    var size = tensor.numel()
+    var ptr = tensor._data
+    for i in range(size):
+        @parameter
+        if dtype == DType.float16:
+            if isinf(Float32(ptr[i])):
+                return True
+        else:
+            if isinf(ptr[i]):
+                return True
+    return False
+
+
+fn _count_nan_core[dtype: DType](tensor: Tensor[dtype]) -> Int:
+    """Count NaN values in typed tensor (core implementation).
+
+    Parameters:
+        dtype: Compile-time dtype parameter.
+
+    Args:
+        tensor: Input typed tensor.
+
+    Returns:
+        Number of NaN elements.
+    """
+    @parameter
+    if dtype == DType.int8 or dtype == DType.int16 or dtype == DType.int32 or dtype == DType.int64 or dtype == DType.uint8 or dtype == DType.uint16 or dtype == DType.uint32 or dtype == DType.uint64 or dtype == DType.bool:
+        return 0
+
+    var size = tensor.numel()
+    var count = 0
+    var ptr = tensor._data
+    for i in range(size):
+        @parameter
+        if dtype == DType.float16:
+            if isnan(Float32(ptr[i])):
+                count += 1
+        else:
+            if isnan(ptr[i]):
+                count += 1
+    return count
+
+
+fn _count_inf_core[dtype: DType](tensor: Tensor[dtype]) -> Int:
+    """Count Inf values in typed tensor (core implementation).
+
+    Parameters:
+        dtype: Compile-time dtype parameter.
+
+    Args:
+        tensor: Input typed tensor.
+
+    Returns:
+        Number of Inf/-Inf elements.
+    """
+    @parameter
+    if dtype == DType.int8 or dtype == DType.int16 or dtype == DType.int32 or dtype == DType.int64 or dtype == DType.uint8 or dtype == DType.uint16 or dtype == DType.uint32 or dtype == DType.uint64 or dtype == DType.bool:
+        return 0
+
+    var size = tensor.numel()
+    var count = 0
+    var ptr = tensor._data
+    for i in range(size):
+        @parameter
+        if dtype == DType.float16:
+            if isinf(Float32(ptr[i])):
+                count += 1
+        else:
+            if isinf(ptr[i]):
+                count += 1
+    return count
+
+
+fn _tensor_min_core[dtype: DType](tensor: Tensor[dtype]) -> Float64:
+    """Find minimum value in typed tensor (core implementation).
+
+    Parameters:
+        dtype: Compile-time dtype parameter.
+
+    Args:
+        tensor: Input typed tensor.
+
+    Returns:
+        Minimum value as Float64.
+    """
+    var size = tensor.numel()
+    if size == 0:
+        return 0.0
+
+    var min_val = Float64(1e308)
+    var ptr = tensor._data
+    for i in range(size):
+        var val = Float64(ptr[i])
+        if val < min_val:
+            min_val = val
+    return min_val
+
+
+fn _tensor_max_core[dtype: DType](tensor: Tensor[dtype]) -> Float64:
+    """Find maximum value in typed tensor (core implementation).
+
+    Parameters:
+        dtype: Compile-time dtype parameter.
+
+    Args:
+        tensor: Input typed tensor.
+
+    Returns:
+        Maximum value as Float64.
+    """
+    var size = tensor.numel()
+    if size == 0:
+        return 0.0
+
+    var max_val = Float64(-1e308)
+    var ptr = tensor._data
+    for i in range(size):
+        var val = Float64(ptr[i])
+        if val > max_val:
+            max_val = val
+    return max_val
+
+
+fn _compute_l2_norm_core[dtype: DType](tensor: Tensor[dtype]) -> Float64:
+    """Compute L2 norm of typed tensor (core implementation).
+
+    Parameters:
+        dtype: Compile-time dtype parameter.
+
+    Args:
+        tensor: Input typed tensor.
+
+    Returns:
+        L2 norm as Float64.
+    """
+    var size = tensor.numel()
+    var sum_sq = Float64(0.0)
+    var ptr = tensor._data
+    for i in range(size):
+        var val = Float64(ptr[i])
+        sum_sq += val * val
+    return sqrt(sum_sq)
+
+
+# ============================================================================
+# Layer 2: AnyTensor dispatch (ordinal-based)
+# ============================================================================
+# For Bool-returning functions, we dispatch via ordinal to typed cores.
+# Only float types are relevant for NaN/Inf checks but we dispatch all
+# for consistency (integer types return False/0 via compile-time guard).
 
 
 fn has_nan(tensor: AnyTensor) -> Bool:
@@ -45,23 +266,23 @@ fn has_nan(tensor: AnyTensor) -> Bool:
     Note:
             Checks all elements regardless of dtype. Supports all floating-point types.
     """
-    var size = tensor.numel()
-
-    if tensor.dtype() == DType.float32:
-        var ptr = tensor._data.bitcast[Float32]()
-        for i in range(size):
-            if isnan(ptr[i]):
-                return True
-    elif tensor.dtype() == DType.float64:
-        var ptr = tensor._data.bitcast[Float64]()
-        for i in range(size):
-            if isnan(ptr[i]):
-                return True
-    elif tensor.dtype() == DType.float16:
-        var ptr = tensor._data.bitcast[Float16]()
-        for i in range(size):
-            if isnan(Float32(ptr[i])):  # Convert to float32 for isnan check
-                return True
+    # Only float types can have NaN - fast path for integers
+    var dtype = tensor.dtype()
+    if dtype == DType.float32:
+        try:
+            return _has_nan_core[DType.float32](tensor.as_tensor[DType.float32]())
+        except:
+            return False
+    elif dtype == DType.float64:
+        try:
+            return _has_nan_core[DType.float64](tensor.as_tensor[DType.float64]())
+        except:
+            return False
+    elif dtype == DType.float16:
+        try:
+            return _has_nan_core[DType.float16](tensor.as_tensor[DType.float16]())
+        except:
+            return False
     # Integer types cannot have NaN
     return False
 
@@ -84,24 +305,22 @@ fn has_inf(tensor: AnyTensor) -> Bool:
     Note:
             Checks all elements regardless of dtype. Supports all floating-point types.
     """
-    var size = tensor.numel()
-
-    if tensor.dtype() == DType.float32:
-        var ptr = tensor._data.bitcast[Float32]()
-        for i in range(size):
-            if isinf(ptr[i]):
-                return True
-    elif tensor.dtype() == DType.float64:
-        var ptr = tensor._data.bitcast[Float64]()
-        for i in range(size):
-            if isinf(ptr[i]):
-                return True
-    elif tensor.dtype() == DType.float16:
-        var ptr = tensor._data.bitcast[Float16]()
-        for i in range(size):
-            if isinf(Float32(ptr[i])):
-                return True
-    # Integer types cannot have Inf
+    var dtype = tensor.dtype()
+    if dtype == DType.float32:
+        try:
+            return _has_inf_core[DType.float32](tensor.as_tensor[DType.float32]())
+        except:
+            return False
+    elif dtype == DType.float64:
+        try:
+            return _has_inf_core[DType.float64](tensor.as_tensor[DType.float64]())
+        except:
+            return False
+    elif dtype == DType.float16:
+        try:
+            return _has_inf_core[DType.float16](tensor.as_tensor[DType.float16]())
+        except:
+            return False
     return False
 
 
@@ -120,26 +339,23 @@ fn count_nan(tensor: AnyTensor) -> Int:
             assert_equal(count_nan(x), 2)
             ```
     """
-    var size = tensor.numel()
-    var count = 0
-
-    if tensor.dtype() == DType.float32:
-        var ptr = tensor._data.bitcast[Float32]()
-        for i in range(size):
-            if isnan(ptr[i]):
-                count += 1
-    elif tensor.dtype() == DType.float64:
-        var ptr = tensor._data.bitcast[Float64]()
-        for i in range(size):
-            if isnan(ptr[i]):
-                count += 1
-    elif tensor.dtype() == DType.float16:
-        var ptr = tensor._data.bitcast[Float16]()
-        for i in range(size):
-            if isnan(Float32(ptr[i])):
-                count += 1
-
-    return count
+    var dtype = tensor.dtype()
+    if dtype == DType.float32:
+        try:
+            return _count_nan_core[DType.float32](tensor.as_tensor[DType.float32]())
+        except:
+            return 0
+    elif dtype == DType.float64:
+        try:
+            return _count_nan_core[DType.float64](tensor.as_tensor[DType.float64]())
+        except:
+            return 0
+    elif dtype == DType.float16:
+        try:
+            return _count_nan_core[DType.float16](tensor.as_tensor[DType.float16]())
+        except:
+            return 0
+    return 0
 
 
 fn count_inf(tensor: AnyTensor) -> Int:
@@ -157,26 +373,23 @@ fn count_inf(tensor: AnyTensor) -> Int:
             assert_equal(count_inf(x), 2)
             ```
     """
-    var size = tensor.numel()
-    var count = 0
-
-    if tensor.dtype() == DType.float32:
-        var ptr = tensor._data.bitcast[Float32]()
-        for i in range(size):
-            if isinf(ptr[i]):
-                count += 1
-    elif tensor.dtype() == DType.float64:
-        var ptr = tensor._data.bitcast[Float64]()
-        for i in range(size):
-            if isinf(ptr[i]):
-                count += 1
-    elif tensor.dtype() == DType.float16:
-        var ptr = tensor._data.bitcast[Float16]()
-        for i in range(size):
-            if isinf(Float32(ptr[i])):
-                count += 1
-
-    return count
+    var dtype = tensor.dtype()
+    if dtype == DType.float32:
+        try:
+            return _count_inf_core[DType.float32](tensor.as_tensor[DType.float32]())
+        except:
+            return 0
+    elif dtype == DType.float64:
+        try:
+            return _count_inf_core[DType.float64](tensor.as_tensor[DType.float64]())
+        except:
+            return 0
+    elif dtype == DType.float16:
+        try:
+            return _count_inf_core[DType.float16](tensor.as_tensor[DType.float16]())
+        except:
+            return 0
+    return 0
 
 
 @parameter
@@ -235,32 +448,23 @@ fn tensor_min(tensor: AnyTensor) -> Float64:
             assert_equal(tensor_min(x), -5.0)
             ```
     """
-    var size = tensor.numel()
-    if size == 0:
-        return 0.0
-
-    var min_val = Float64(1e308)  # Very large positive number
-
-    if tensor.dtype() == DType.float32:
-        var ptr = tensor._data.bitcast[Float32]()
-        for i in range(size):
-            var val = Float64(ptr[i])
-            if val < min_val:
-                min_val = val
-    elif tensor.dtype() == DType.float64:
-        var ptr = tensor._data.bitcast[Float64]()
-        for i in range(size):
-            var val = ptr[i]
-            if val < min_val:
-                min_val = val
-    elif tensor.dtype() == DType.float16:
-        var ptr = tensor._data.bitcast[Float16]()
-        for i in range(size):
-            var val = Float64(Float32(ptr[i]))
-            if val < min_val:
-                min_val = val
-
-    return min_val
+    var dtype = tensor.dtype()
+    if dtype == DType.float32:
+        try:
+            return _tensor_min_core[DType.float32](tensor.as_tensor[DType.float32]())
+        except:
+            return 0.0
+    elif dtype == DType.float64:
+        try:
+            return _tensor_min_core[DType.float64](tensor.as_tensor[DType.float64]())
+        except:
+            return 0.0
+    elif dtype == DType.float16:
+        try:
+            return _tensor_min_core[DType.float16](tensor.as_tensor[DType.float16]())
+        except:
+            return 0.0
+    return 0.0
 
 
 fn tensor_max(tensor: AnyTensor) -> Float64:
@@ -278,32 +482,23 @@ fn tensor_max(tensor: AnyTensor) -> Float64:
             assert_equal(tensor_max(x), 10.0)
             ```
     """
-    var size = tensor.numel()
-    if size == 0:
-        return 0.0
-
-    var max_val = Float64(-1e308)  # Very large negative number
-
-    if tensor.dtype() == DType.float32:
-        var ptr = tensor._data.bitcast[Float32]()
-        for i in range(size):
-            var val = Float64(ptr[i])
-            if val > max_val:
-                max_val = val
-    elif tensor.dtype() == DType.float64:
-        var ptr = tensor._data.bitcast[Float64]()
-        for i in range(size):
-            var val = ptr[i]
-            if val > max_val:
-                max_val = val
-    elif tensor.dtype() == DType.float16:
-        var ptr = tensor._data.bitcast[Float16]()
-        for i in range(size):
-            var val = Float64(Float32(ptr[i]))
-            if val > max_val:
-                max_val = val
-
-    return max_val
+    var dtype = tensor.dtype()
+    if dtype == DType.float32:
+        try:
+            return _tensor_max_core[DType.float32](tensor.as_tensor[DType.float32]())
+        except:
+            return 0.0
+    elif dtype == DType.float64:
+        try:
+            return _tensor_max_core[DType.float64](tensor.as_tensor[DType.float64]())
+        except:
+            return 0.0
+    elif dtype == DType.float16:
+        try:
+            return _tensor_max_core[DType.float16](tensor.as_tensor[DType.float16]())
+        except:
+            return 0.0
+    return 0.0
 
 
 fn check_tensor_range(
@@ -363,26 +558,23 @@ fn compute_tensor_l2_norm(tensor: AnyTensor) -> Float64:
             assert_equal(compute_tensor_l2_norm(x), 5.0)  # sqrt(9 + 16)
             ```
     """
-    var size = tensor.numel()
-    var sum_sq = Float64(0.0)
-
-    if tensor.dtype() == DType.float32:
-        var ptr = tensor._data.bitcast[Float32]()
-        for i in range(size):
-            var val = Float64(ptr[i])
-            sum_sq += val * val
-    elif tensor.dtype() == DType.float64:
-        var ptr = tensor._data.bitcast[Float64]()
-        for i in range(size):
-            var val = ptr[i]
-            sum_sq += val * val
-    elif tensor.dtype() == DType.float16:
-        var ptr = tensor._data.bitcast[Float16]()
-        for i in range(size):
-            var val = Float64(Float32(ptr[i]))
-            sum_sq += val * val
-
-    return sqrt(sum_sq)
+    var dtype = tensor.dtype()
+    if dtype == DType.float32:
+        try:
+            return _compute_l2_norm_core[DType.float32](tensor.as_tensor[DType.float32]())
+        except:
+            return 0.0
+    elif dtype == DType.float64:
+        try:
+            return _compute_l2_norm_core[DType.float64](tensor.as_tensor[DType.float64]())
+        except:
+            return 0.0
+    elif dtype == DType.float16:
+        try:
+            return _compute_l2_norm_core[DType.float16](tensor.as_tensor[DType.float16]())
+        except:
+            return 0.0
+    return 0.0
 
 
 fn check_gradient_norm(
@@ -621,10 +813,8 @@ fn clip_grad_global_norm_(
 
 
 # ============================================================================
-# Typed overloads for Tensor[dtype] (compile-time typed wrappers)
+# Typed overloads for Tensor[dtype] — delegate to typed cores directly
 # ============================================================================
-
-from shared.tensor.tensor import Tensor
 
 
 fn has_nan_typed[dt: DType](tensor: Tensor[dt]) raises -> Bool:
@@ -639,7 +829,7 @@ fn has_nan_typed[dt: DType](tensor: Tensor[dt]) raises -> Bool:
     Raises:
         Error if conversion fails.
     """
-    return has_nan(tensor.as_any())
+    return _has_nan_core[dt](tensor)
 
 
 fn has_inf_typed[dt: DType](tensor: Tensor[dt]) raises -> Bool:
@@ -654,7 +844,7 @@ fn has_inf_typed[dt: DType](tensor: Tensor[dt]) raises -> Bool:
     Raises:
         Error if conversion fails.
     """
-    return has_inf(tensor.as_any())
+    return _has_inf_core[dt](tensor)
 
 
 fn tensor_min_typed[dt: DType](tensor: Tensor[dt]) raises -> Float64:
@@ -669,7 +859,7 @@ fn tensor_min_typed[dt: DType](tensor: Tensor[dt]) raises -> Float64:
     Raises:
         Error if conversion fails.
     """
-    return tensor_min(tensor.as_any())
+    return _tensor_min_core[dt](tensor)
 
 
 fn tensor_max_typed[dt: DType](tensor: Tensor[dt]) raises -> Float64:
@@ -684,4 +874,4 @@ fn tensor_max_typed[dt: DType](tensor: Tensor[dt]) raises -> Float64:
     Raises:
         Error if conversion fails.
     """
-    return tensor_max(tensor.as_any())
+    return _tensor_max_core[dt](tensor)

--- a/shared/core/shape.mojo
+++ b/shared/core/shape.mojo
@@ -1,7 +1,15 @@
-"""Shape manipulation operations for AnyTensor.
+"""Shape manipulation operations with native Tensor[dtype] implementations.
 
 Implements shape operations like reshape, squeeze, unsqueeze, flatten, concatenate, stack, split
 Following the Python Array API Standard 2023.12.
+
+Architecture: Tensor[dtype] typed implementations are the core (zero dtype branches).
+AnyTensor versions dispatch to typed implementations via ordinal-based table.
+Collection ops (concatenate, stack, split) stay on AnyTensor (they use List[AnyTensor]).
+
+Layer 1 (outer): AnyTensor public API (reshape, flatten, etc.)
+Layer 2: dtype dispatch table (ordinal-based)
+Layer 3 (core): Tensor[dtype] native implementation (_reshape_typed, etc.)
 
 Optimizations:
 - Zero-copy views with stride-based indexing
@@ -13,6 +21,20 @@ from collections import List
 from memory import memcpy, UnsafePointer
 from .any_tensor import AnyTensor
 from shared.tensor.tensor import Tensor
+from shared.base.dtype_ordinal import (
+    dtype_to_ordinal,
+    DTYPE_FLOAT16,
+    DTYPE_FLOAT32,
+    DTYPE_FLOAT64,
+    DTYPE_INT8,
+    DTYPE_INT16,
+    DTYPE_INT32,
+    DTYPE_INT64,
+    DTYPE_UINT8,
+    DTYPE_UINT16,
+    DTYPE_UINT32,
+    DTYPE_UINT64,
+)
 
 
 # ============================================================================
@@ -41,6 +63,66 @@ fn is_contiguous(tensor: AnyTensor) -> Bool:
     return tensor.is_contiguous()
 
 
+# ============================================================================
+# Layer 3 (Core): Native Tensor[dtype] as_contiguous implementation
+# ============================================================================
+
+
+fn _as_contiguous_typed[
+    dtype: DType
+](tensor: Tensor[dtype]) raises -> Tensor[dtype]:
+    """Convert tensor to contiguous memory layout (native Tensor[dtype] core).
+
+    Zero dtype branches, zero bitcasts.
+
+    Parameters:
+        dtype: Compile-time dtype parameter.
+
+    Args:
+        tensor: Input typed tensor.
+
+    Returns:
+        A new contiguous Tensor[dtype] with the same data.
+    """
+    var shape = tensor.shape()
+    var numel = tensor.numel()
+    var result = Tensor[dtype](shape)
+    var src_ptr = tensor._data
+    var dst_ptr = result._data
+
+    if tensor.is_contiguous():
+        # Fast path: direct typed copy
+        for i in range(numel):
+            dst_ptr[i] = src_ptr[i]
+    else:
+        # Slow path: stride-based indexing
+        var ndim = len(shape)
+        for i in range(numel):
+            var src_elem_offset = 0
+            var remaining = i
+            for d in range(ndim - 1, -1, -1):
+                var coord = remaining % shape[d]
+                remaining //= shape[d]
+                src_elem_offset += coord * tensor._strides[d]
+            dst_ptr[i] = src_ptr[src_elem_offset]
+
+    return result^
+
+
+# ============================================================================
+# Layer 2: AnyTensor dispatch for as_contiguous
+# ============================================================================
+
+
+fn _as_contiguous_dispatch[
+    dtype: DType
+](tensor: AnyTensor) raises -> AnyTensor:
+    """Dispatch as_contiguous to typed core."""
+    return _as_contiguous_typed[dtype](
+        tensor.as_tensor[dtype]()
+    ).as_any()
+
+
 fn as_contiguous(tensor: AnyTensor) raises -> AnyTensor:
     """Convert tensor to contiguous memory layout if needed.
 
@@ -60,44 +142,32 @@ fn as_contiguous(tensor: AnyTensor) raises -> AnyTensor:
             This function always copies data. For zero-copy operations, check
             is_contiguous() first.
     """
-    if is_contiguous(tensor):
-        # Already contiguous - just copy
-        var shape = tensor.shape()
-        var result = AnyTensor(shape, tensor.dtype())
-        var numel = tensor.numel()
+    var ordinal = dtype_to_ordinal(tensor.dtype())
 
-        # Use memcpy for efficient bulk copy
-        var dtype_size = tensor._get_dtype_size()
-        var total_bytes = numel * dtype_size
-        memcpy(dest=result._data, src=tensor._data, count=total_bytes)
-
-        return result^
+    if ordinal == DTYPE_FLOAT16:
+        return _as_contiguous_dispatch[DType.float16](tensor)
+    elif ordinal == DTYPE_FLOAT32:
+        return _as_contiguous_dispatch[DType.float32](tensor)
+    elif ordinal == DTYPE_FLOAT64:
+        return _as_contiguous_dispatch[DType.float64](tensor)
+    elif ordinal == DTYPE_INT8:
+        return _as_contiguous_dispatch[DType.int8](tensor)
+    elif ordinal == DTYPE_INT16:
+        return _as_contiguous_dispatch[DType.int16](tensor)
+    elif ordinal == DTYPE_INT32:
+        return _as_contiguous_dispatch[DType.int32](tensor)
+    elif ordinal == DTYPE_INT64:
+        return _as_contiguous_dispatch[DType.int64](tensor)
+    elif ordinal == DTYPE_UINT8:
+        return _as_contiguous_dispatch[DType.uint8](tensor)
+    elif ordinal == DTYPE_UINT16:
+        return _as_contiguous_dispatch[DType.uint16](tensor)
+    elif ordinal == DTYPE_UINT32:
+        return _as_contiguous_dispatch[DType.uint32](tensor)
+    elif ordinal == DTYPE_UINT64:
+        return _as_contiguous_dispatch[DType.uint64](tensor)
     else:
-        # Non-contiguous - use stride-based indexing to read source elements
-        var shape = tensor.shape()
-        var ndim = len(shape)
-        var result = AnyTensor(shape, tensor.dtype())
-        var numel = tensor.numel()
-        var dtype_size = tensor._get_dtype_size()
-        var src_ptr = tensor._data
-        var dst_ptr = result._data
-
-        for i in range(numel):
-            # Convert flat output index i to multi-dimensional coords (C-order),
-            # then compute source byte offset using the tensor's actual strides.
-            var src_elem_offset = 0
-            var remaining = i
-            for d in range(ndim - 1, -1, -1):
-                var coord = remaining % shape[d]
-                remaining //= shape[d]
-                src_elem_offset += coord * tensor._strides[d]
-
-            var src_byte_offset = src_elem_offset * dtype_size
-            var dst_byte_offset = i * dtype_size
-            for b in range(dtype_size):
-                dst_ptr[dst_byte_offset + b] = src_ptr[src_byte_offset + b]
-
-        return result^
+        raise Error("as_contiguous: unsupported dtype")
 
 
 fn view(tensor: AnyTensor, new_shape: List[Int]) raises -> AnyTensor:
@@ -150,6 +220,134 @@ fn view(tensor: AnyTensor, new_shape: List[Int]) raises -> AnyTensor:
     return tensor.reshape(new_shape)
 
 
+# ============================================================================
+# Layer 3 (Core): Native Tensor[dtype] reshape implementation
+# ============================================================================
+
+
+fn _resolve_shape(
+    new_shape: List[Int], total_elements: Int
+) raises -> List[Int]:
+    """Resolve -1 dimension and validate shape.
+
+    Args:
+        new_shape: Target shape (may contain -1).
+        total_elements: Total elements in source tensor.
+
+    Returns:
+        Resolved shape with no -1 values.
+
+    Raises:
+        Error: If shape is invalid.
+    """
+    var inferred_dim = -1
+    var known_product: Int = 1
+    var new_len = len(new_shape)
+
+    for i in range(new_len):
+        if new_shape[i] == -1:
+            if inferred_dim != -1:
+                raise Error(
+                    "reshape: can only specify one unknown dimension (-1)"
+                )
+            inferred_dim = i
+        elif new_shape[i] < 0:
+            raise Error("reshape: shape dimensions must be positive or -1")
+        else:
+            known_product *= new_shape[i]
+
+    var final_shape = List[Int]()
+
+    if inferred_dim != -1:
+        if total_elements % known_product != 0:
+            raise Error("reshape: cannot infer dimension, incompatible size")
+        var inferred_size = total_elements // known_product
+
+        for i in range(new_len):
+            if i == inferred_dim:
+                final_shape.append(inferred_size)
+            else:
+                final_shape.append(new_shape[i])
+    else:
+        for i in range(new_len):
+            final_shape.append(new_shape[i])
+
+    var new_total: Int = 1
+    for i in range(new_len):
+        new_total *= final_shape[i]
+
+    if new_total != total_elements:
+        raise Error("reshape: new shape must have same number of elements")
+
+    return final_shape^
+
+
+fn _reshape_typed[
+    dtype: DType
+](tensor: Tensor[dtype], new_shape: List[Int]) raises -> Tensor[dtype]:
+    """Reshape tensor to new shape (native Tensor[dtype] core).
+
+    This is the core implementation -- zero dtype branches, zero bitcasts.
+    Tensor[dtype]._data is already typed as UnsafePointer[Scalar[dtype]].
+
+    Parameters:
+        dtype: Compile-time dtype parameter.
+
+    Args:
+        tensor: Input typed tensor.
+        new_shape: Target shape (must have same total number of elements).
+
+    Returns:
+        A new Tensor[dtype] with the specified shape.
+
+    Raises:
+        Error: If new shape has different number of elements.
+    """
+    var total_elements = tensor.numel()
+    var final_shape = _resolve_shape(new_shape, total_elements)
+
+    # Create new tensor with new shape
+    var result = Tensor[dtype](final_shape)
+
+    # Copy data using typed pointers -- zero bitcasts
+    if tensor.is_contiguous():
+        # Fast path: direct typed copy
+        var src_ptr = tensor._data
+        var dst_ptr = result._data
+        for i in range(total_elements):
+            dst_ptr[i] = src_ptr[i]
+    else:
+        # Slow path: compute stride-based offset for each element
+        var src_shape = tensor.shape()
+        var ndim = len(src_shape)
+        var src_ptr = tensor._data
+        var dst_ptr = result._data
+        for i in range(total_elements):
+            var remaining = i
+            var src_elem_offset = 0
+            for d in range(ndim - 1, -1, -1):
+                var coord = remaining % src_shape[d]
+                remaining //= src_shape[d]
+                src_elem_offset += coord * tensor._strides[d]
+            dst_ptr[i] = src_ptr[src_elem_offset]
+
+    return result^
+
+
+# ============================================================================
+# Layer 2: AnyTensor dispatch helpers (as_tensor -> typed core -> as_any)
+# ============================================================================
+
+
+fn _reshape_dispatch[
+    dtype: DType
+](tensor: AnyTensor, new_shape: List[Int]) raises -> AnyTensor:
+    """Dispatch reshape to typed core."""
+    return _reshape_typed[dtype](
+        tensor.as_tensor[dtype](), new_shape
+    ).as_any()
+
+
 fn reshape(tensor: AnyTensor, new_shape: List[Int]) raises -> AnyTensor:
     """Reshape tensor to new shape.
 
@@ -173,81 +371,47 @@ fn reshape(tensor: AnyTensor, new_shape: List[Int]) raises -> AnyTensor:
             var c = reshape(a, [3, -1])  # Shape (3, 4) - infers 4
     ```
     """
-    # Calculate total elements in new shape (handling -1 for inference)
-    var inferred_dim = -1
-    var known_product: Int = 1
-    var new_len = len(new_shape)
+    var ordinal = dtype_to_ordinal(tensor.dtype())
 
-    for i in range(new_len):
-        if new_shape[i] == -1:
-            if inferred_dim != -1:
-                raise Error(
-                    "reshape: can only specify one unknown dimension (-1)"
-                )
-            inferred_dim = i
-        elif new_shape[i] < 0:
-            raise Error("reshape: shape dimensions must be positive or -1")
-        else:
-            known_product *= new_shape[i]
-
-    # If we have -1, infer that dimension
-    var final_shape = List[Int]()
-    var total_elements = tensor.numel()
-
-    if inferred_dim != -1:
-        # Infer the -1 dimension
-        if total_elements % known_product != 0:
-            raise Error("reshape: cannot infer dimension, incompatible size")
-        var inferred_size = total_elements // known_product
-
-        for i in range(new_len):
-            if i == inferred_dim:
-                final_shape.append(inferred_size)
-            else:
-                final_shape.append(new_shape[i])
+    if ordinal == DTYPE_FLOAT16:
+        return _reshape_dispatch[DType.float16](tensor, new_shape)
+    elif ordinal == DTYPE_FLOAT32:
+        return _reshape_dispatch[DType.float32](tensor, new_shape)
+    elif ordinal == DTYPE_FLOAT64:
+        return _reshape_dispatch[DType.float64](tensor, new_shape)
+    elif ordinal == DTYPE_INT8:
+        return _reshape_dispatch[DType.int8](tensor, new_shape)
+    elif ordinal == DTYPE_INT16:
+        return _reshape_dispatch[DType.int16](tensor, new_shape)
+    elif ordinal == DTYPE_INT32:
+        return _reshape_dispatch[DType.int32](tensor, new_shape)
+    elif ordinal == DTYPE_INT64:
+        return _reshape_dispatch[DType.int64](tensor, new_shape)
+    elif ordinal == DTYPE_UINT8:
+        return _reshape_dispatch[DType.uint8](tensor, new_shape)
+    elif ordinal == DTYPE_UINT16:
+        return _reshape_dispatch[DType.uint16](tensor, new_shape)
+    elif ordinal == DTYPE_UINT32:
+        return _reshape_dispatch[DType.uint32](tensor, new_shape)
+    elif ordinal == DTYPE_UINT64:
+        return _reshape_dispatch[DType.uint64](tensor, new_shape)
     else:
-        # No -1, just copy
-        for i in range(new_len):
-            final_shape.append(new_shape[i])
+        raise Error("reshape: unsupported dtype")
 
-    # Verify total elements match
-    var new_total: Int = 1
-    for i in range(new_len):
-        new_total *= final_shape[i]
+fn reshape[dt: DType](tensor: Tensor[dt], new_shape: List[Int]) raises -> Tensor[dt]:
+    """Reshape tensor to new shape (typed overload).
 
-    if new_total != total_elements:
-        raise Error("reshape: new shape must have same number of elements")
+    Parameters:
+        dt: Compile-time dtype parameter.
 
-    # Create new tensor with new shape (data copy)
-    var result = AnyTensor(final_shape, tensor.dtype())
+    Args:
+        tensor: Input typed tensor.
+        new_shape: Target shape (must have same total elements).
 
-    # Copy data respecting tensor strides (handles non-contiguous inputs)
-    if is_contiguous(tensor):
-        # Fast path: flat index maps directly to memory
-        for i in range(total_elements):
-            var val = tensor._get_float64(i)
-            result._set_float64(i, val)
-    else:
-        # Slow path: compute stride-based byte offset for each element
-        # Convert flat output index i -> multi-dim coords -> strided source offset
-        var src_shape = tensor.shape()
-        var ndim = len(src_shape)
-        var dtype_size = tensor._get_dtype_size()
-        var src_ptr = tensor._data
-        var dst_ptr = result._data
-        for i in range(total_elements):
-            var remaining = i
-            var src_elem_offset = 0
-            for d in range(ndim - 1, -1, -1):
-                var coord = remaining % src_shape[d]
-                remaining //= src_shape[d]
-                src_elem_offset += coord * tensor._strides[d]
-            var src_byte_offset = src_elem_offset * dtype_size
-            var dst_byte_offset = i * dtype_size
-            for b in range(dtype_size):
-                dst_ptr[dst_byte_offset + b] = src_ptr[src_byte_offset + b]
-
-    return result^
+    Returns:
+        A new Tensor[dt] with the given shape.
+    """
+    return _reshape_typed[dt](tensor, new_shape)
 
 
 fn squeeze(tensor: AnyTensor, axis: Int = -999) raises -> AnyTensor:
@@ -1261,6 +1425,84 @@ fn repeat(tensor: AnyTensor, n: Int, axis: Int = -1) raises -> AnyTensor:
         return result^
 
 
+# ============================================================================
+# Layer 3 (Core): Native Tensor[dtype] broadcast_to implementation
+# ============================================================================
+
+
+fn _broadcast_to_typed[
+    dtype: DType
+](tensor: Tensor[dtype], target_shape: List[Int]) raises -> Tensor[dtype]:
+    """Broadcast tensor to target shape (native Tensor[dtype] core).
+
+    Zero dtype branches, zero bitcasts.
+
+    Parameters:
+        dtype: Compile-time dtype parameter.
+
+    Args:
+        tensor: Input typed tensor.
+        target_shape: Target shape to broadcast to.
+
+    Returns:
+        Broadcasted Tensor[dtype].
+    """
+    from shared.base.broadcasting import (
+        are_shapes_broadcastable,
+        compute_broadcast_strides,
+    )
+
+    var shape = tensor.shape()
+
+    if len(target_shape) < len(shape):
+        raise Error("broadcast_to: cannot broadcast to fewer dimensions")
+
+    if not are_shapes_broadcastable(shape, target_shape):
+        raise Error("broadcast_to: shapes are not broadcast-compatible")
+
+    var broadcast_strides = compute_broadcast_strides(shape, target_shape)
+
+    var result = Tensor[dtype](target_shape)
+    var result_numel = result.numel()
+
+    var src_ptr = tensor._data
+    var dst_ptr = result._data
+
+    for i in range(result_numel):
+        var coords = List[Int]()
+        var temp_i = i
+        for j in range(len(target_shape)):
+            var stride = 1
+            for k in range(j + 1, len(target_shape)):
+                stride *= target_shape[k]
+            var coord = temp_i // stride
+            coords.append(coord)
+            temp_i = temp_i % stride
+
+        var src_idx = 0
+        for j in range(len(target_shape)):
+            src_idx += coords[j] * broadcast_strides[j]
+
+        # Copy value using typed pointer -- zero bitcasts
+        dst_ptr[i] = src_ptr[src_idx]
+
+    return result^
+
+
+# ============================================================================
+# Layer 2: AnyTensor dispatch for broadcast_to
+# ============================================================================
+
+
+fn _broadcast_to_dispatch[
+    dtype: DType
+](tensor: AnyTensor, target_shape: List[Int]) raises -> AnyTensor:
+    """Dispatch broadcast_to to typed core."""
+    return _broadcast_to_typed[dtype](
+        tensor.as_tensor[dtype](), target_shape
+    ).as_any()
+
+
 fn broadcast_to(tensor: AnyTensor, target_shape: List[Int]) raises -> AnyTensor:
     """Broadcast tensor to target shape.
 
@@ -1286,53 +1528,176 @@ fn broadcast_to(tensor: AnyTensor, target_shape: List[Int]) raises -> AnyTensor:
             var b = broadcast_to(a, target)  # Shape (4, 3)
     ```
     """
-    from shared.base.broadcasting import (
-        are_shapes_broadcastable,
-        compute_broadcast_strides,
-    )
+    var ordinal = dtype_to_ordinal(tensor.dtype())
 
+    if ordinal == DTYPE_FLOAT16:
+        return _broadcast_to_dispatch[DType.float16](tensor, target_shape)
+    elif ordinal == DTYPE_FLOAT32:
+        return _broadcast_to_dispatch[DType.float32](tensor, target_shape)
+    elif ordinal == DTYPE_FLOAT64:
+        return _broadcast_to_dispatch[DType.float64](tensor, target_shape)
+    elif ordinal == DTYPE_INT8:
+        return _broadcast_to_dispatch[DType.int8](tensor, target_shape)
+    elif ordinal == DTYPE_INT16:
+        return _broadcast_to_dispatch[DType.int16](tensor, target_shape)
+    elif ordinal == DTYPE_INT32:
+        return _broadcast_to_dispatch[DType.int32](tensor, target_shape)
+    elif ordinal == DTYPE_INT64:
+        return _broadcast_to_dispatch[DType.int64](tensor, target_shape)
+    elif ordinal == DTYPE_UINT8:
+        return _broadcast_to_dispatch[DType.uint8](tensor, target_shape)
+    elif ordinal == DTYPE_UINT16:
+        return _broadcast_to_dispatch[DType.uint16](tensor, target_shape)
+    elif ordinal == DTYPE_UINT32:
+        return _broadcast_to_dispatch[DType.uint32](tensor, target_shape)
+    elif ordinal == DTYPE_UINT64:
+        return _broadcast_to_dispatch[DType.uint64](tensor, target_shape)
+    else:
+        raise Error("broadcast_to: unsupported dtype")
+
+fn broadcast_to[dt: DType](
+    tensor: Tensor[dt], target_shape: List[Int]
+) raises -> Tensor[dt]:
+    """Broadcast tensor to target shape (typed overload).
+
+    Parameters:
+        dt: Compile-time dtype parameter.
+
+    Args:
+        tensor: Input typed tensor.
+        target_shape: Shape to broadcast to.
+
+    Returns:
+        A new Tensor[dt] broadcast to the target shape.
+    """
+    return _broadcast_to_typed[dt](tensor, target_shape)
+
+
+# ============================================================================
+# Layer 3 (Core): Native Tensor[dtype] permute implementation
+# ============================================================================
+
+
+fn _validate_permute_dims(dims: List[Int], ndim: Int) raises:
+    """Validate dims is a valid permutation of [0..ndim-1].
+
+    Args:
+        dims: Permutation to validate.
+        ndim: Number of dimensions expected.
+
+    Raises:
+        Error: If dims is not a valid permutation.
+    """
+    if len(dims) != ndim:
+        raise Error(
+            "permute: dims length "
+            + String(len(dims))
+            + " must equal tensor ndim "
+            + String(ndim)
+        )
+
+    var seen = List[Bool]()
+    for _ in range(ndim):
+        seen.append(False)
+
+    for i in range(ndim):
+        var d = dims[i]
+        if d < 0 or d >= ndim:
+            raise Error(
+                "permute: dimension "
+                + String(d)
+                + " out of range [0, "
+                + String(ndim)
+                + ")"
+            )
+        if seen[d]:
+            raise Error(
+                "permute: dimension " + String(d) + " appears multiple times"
+            )
+        seen[d] = True
+
+
+fn _permute_typed[
+    dtype: DType
+](tensor: Tensor[dtype], dims: List[Int]) raises -> Tensor[dtype]:
+    """Permute tensor dimensions (native Tensor[dtype] core).
+
+    Zero dtype branches, zero bitcasts.
+
+    Parameters:
+        dtype: Compile-time dtype parameter.
+
+    Args:
+        tensor: Input typed tensor.
+        dims: Permutation of dimensions.
+
+    Returns:
+        Tensor with permuted dimensions.
+    """
     var shape = tensor.shape()
+    var ndim = len(shape)
 
-    # Cannot reduce number of dimensions (target must have >= dims than source).
-    # Note: are_shapes_broadcastable also enforces this guard, but we raise a
-    # descriptive Error here for better caller UX.
-    if len(target_shape) < len(shape):
-        raise Error("broadcast_to: cannot broadcast to fewer dimensions")
+    _validate_permute_dims(dims, ndim)
 
-    # Check if broadcast is valid
-    if not are_shapes_broadcastable(shape, target_shape):
-        raise Error("broadcast_to: shapes are not broadcast-compatible")
-
-    # Compute broadcast strides
-    var broadcast_strides = compute_broadcast_strides(shape, target_shape)
+    # Compute new shape
+    var new_shape = List[Int]()
+    for i in range(ndim):
+        new_shape.append(shape[dims[i]])
 
     # Create result tensor
-    var result = AnyTensor(target_shape, tensor.dtype())
+    var result = Tensor[dtype](new_shape)
     var result_numel = result.numel()
 
-    # Fill result using broadcast strides
+    var src_ptr = tensor._data
+    var dst_ptr = result._data
+
+    # Fill result by permuting coordinates
     for i in range(result_numel):
         # Compute coordinates in result tensor
-        var coords = List[Int]()
+        var result_coords = List[Int]()
         var temp_i = i
-        for j in range(len(target_shape)):
+        for j in range(ndim):
             var stride = 1
-            for k in range(j + 1, len(target_shape)):
-                stride *= target_shape[k]
+            for k in range(j + 1, ndim):
+                stride *= new_shape[k]
             var coord = temp_i // stride
-            coords.append(coord)
+            result_coords.append(coord)
             temp_i = temp_i % stride
 
-        # Compute source index using broadcast strides
-        var src_idx = 0
-        for j in range(len(target_shape)):
-            src_idx += coords[j] * broadcast_strides[j]
+        # Compute source coordinates by inverse permutation
+        var src_coords = List[Int]()
+        for _ in range(ndim):
+            src_coords.append(0)
 
-        # Copy value
-        var val = tensor._get_float64(src_idx)
-        result._set_float64(i, val)
+        for j in range(ndim):
+            src_coords[dims[j]] = result_coords[j]
+
+        # Compute source index
+        var src_idx = 0
+        for j in range(ndim):
+            var src_stride = 1
+            for k in range(j + 1, ndim):
+                src_stride *= shape[k]
+            src_idx += src_coords[j] * src_stride
+
+        # Copy value using typed pointer -- zero bitcasts
+        dst_ptr[i] = src_ptr[src_idx]
 
     return result^
+
+
+# ============================================================================
+# Layer 2: AnyTensor dispatch for permute
+# ============================================================================
+
+
+fn _permute_dispatch[
+    dtype: DType
+](tensor: AnyTensor, dims: List[Int]) raises -> AnyTensor:
+    """Dispatch permute to typed core."""
+    return _permute_typed[dtype](
+        tensor.as_tensor[dtype](), dims
+    ).as_any()
 
 
 fn permute(tensor: AnyTensor, dims: List[Int]) raises -> AnyTensor:
@@ -1358,86 +1723,51 @@ fn permute(tensor: AnyTensor, dims: List[Int]) raises -> AnyTensor:
             var b = permute(a, perm)  # Shape (4, 2, 3)
     ```
     """
-    var shape = tensor.shape()
-    var ndim = len(shape)
+    var ordinal = dtype_to_ordinal(tensor.dtype())
 
-    # Validate dims is correct length
-    if len(dims) != ndim:
-        raise Error(
-            "permute: dims length "
-            + String(len(dims))
-            + " must equal tensor ndim "
-            + String(ndim)
-        )
+    if ordinal == DTYPE_FLOAT16:
+        return _permute_dispatch[DType.float16](tensor, dims)
+    elif ordinal == DTYPE_FLOAT32:
+        return _permute_dispatch[DType.float32](tensor, dims)
+    elif ordinal == DTYPE_FLOAT64:
+        return _permute_dispatch[DType.float64](tensor, dims)
+    elif ordinal == DTYPE_INT8:
+        return _permute_dispatch[DType.int8](tensor, dims)
+    elif ordinal == DTYPE_INT16:
+        return _permute_dispatch[DType.int16](tensor, dims)
+    elif ordinal == DTYPE_INT32:
+        return _permute_dispatch[DType.int32](tensor, dims)
+    elif ordinal == DTYPE_INT64:
+        return _permute_dispatch[DType.int64](tensor, dims)
+    elif ordinal == DTYPE_UINT8:
+        return _permute_dispatch[DType.uint8](tensor, dims)
+    elif ordinal == DTYPE_UINT16:
+        return _permute_dispatch[DType.uint16](tensor, dims)
+    elif ordinal == DTYPE_UINT32:
+        return _permute_dispatch[DType.uint32](tensor, dims)
+    elif ordinal == DTYPE_UINT64:
+        return _permute_dispatch[DType.uint64](tensor, dims)
+    else:
+        raise Error("permute: unsupported dtype")
 
-    # Validate dims is a permutation of [0..ndim-1]
-    var seen = List[Bool]()
-    for _ in range(ndim):
-        seen.append(False)
+fn permute[dt: DType](tensor: Tensor[dt], dims: List[Int]) raises -> Tensor[dt]:
+    """Permute tensor dimensions (typed overload).
 
-    for i in range(ndim):
-        var d = dims[i]
-        if d < 0 or d >= ndim:
-            raise Error(
-                "permute: dimension "
-                + String(d)
-                + " out of range [0, "
-                + String(ndim)
-                + ")"
-            )
-        if seen[d]:
-            raise Error(
-                "permute: dimension " + String(d) + " appears multiple times"
-            )
-        seen[d] = True
+    Parameters:
+        dt: Compile-time dtype parameter.
 
-    # Compute new shape
-    var new_shape = List[Int]()
-    for i in range(ndim):
-        new_shape.append(shape[dims[i]])
+    Args:
+        tensor: Input typed tensor.
+        dims: Permutation of dimensions.
 
-    # Create result tensor
-    var result = AnyTensor(new_shape, tensor.dtype())
-    var result_numel = result.numel()
-
-    # Fill result by permuting coordinates
-    for i in range(result_numel):
-        # Compute coordinates in result tensor
-        var result_coords = List[Int]()
-        var temp_i = i
-        for j in range(ndim):
-            var stride = 1
-            for k in range(j + 1, ndim):
-                stride *= new_shape[k]
-            var coord = temp_i // stride
-            result_coords.append(coord)
-            temp_i = temp_i % stride
-
-        # Compute source coordinates by inverse permutation
-        var src_coords = List[Int]()
-        for _ in range(ndim):
-            src_coords.append(0)  # Initialize
-
-        for j in range(ndim):
-            src_coords[dims[j]] = result_coords[j]
-
-        # Compute source index
-        var src_idx = 0
-        for j in range(ndim):
-            var src_stride = 1
-            for k in range(j + 1, ndim):
-                src_stride *= shape[k]
-            src_idx += src_coords[j] * src_stride
-
-        # Copy value
-        var val = tensor._get_float64(src_idx)
-        result._set_float64(i, val)
-
-    return result^
+    Returns:
+        A new Tensor[dt] with permuted dimensions.
+    """
+    return _permute_typed[dt](tensor, dims)
 
 
 # ============================================================================
-# Typed Tensor[dtype] overloads — wrap AnyTensor versions via as_any/as_tensor
+# Typed Tensor[dtype] overloads — delegate to typed cores directly
 # ============================================================================
 
 
@@ -1453,7 +1783,7 @@ fn reshape_typed[dt: DType](
     Returns:
         A new Tensor[dt] with the given shape.
     """
-    return reshape(tensor.as_any(), new_shape).as_tensor[dt]()
+    return _reshape_typed[dt](tensor, new_shape)
 
 
 fn squeeze_typed[dt: DType](
@@ -1468,7 +1798,29 @@ fn squeeze_typed[dt: DType](
     Returns:
         A new Tensor[dt] with size-1 dimensions removed.
     """
-    return squeeze(tensor.as_any(), axis).as_tensor[dt]()
+    # Compute the squeezed shape, then delegate to typed reshape
+    var old_shape = tensor.shape()
+    var ndim = len(old_shape)
+
+    if axis != -999:
+        var actual_axis = axis if axis >= 0 else ndim + axis
+        if actual_axis < 0 or actual_axis >= ndim:
+            raise Error("squeeze: dimension out of range")
+        if old_shape[actual_axis] != 1:
+            raise Error("squeeze: cannot squeeze dimension that is not size 1")
+        var new_shape = List[Int]()
+        for i in range(ndim):
+            if i != actual_axis:
+                new_shape.append(old_shape[i])
+        return _reshape_typed[dt](tensor, new_shape)
+    else:
+        var new_shape = List[Int]()
+        for i in range(ndim):
+            if old_shape[i] != 1:
+                new_shape.append(old_shape[i])
+        if len(new_shape) == ndim:
+            return _reshape_typed[dt](tensor, old_shape)
+        return _reshape_typed[dt](tensor, new_shape)
 
 
 fn unsqueeze_typed[dt: DType](tensor: Tensor[dt], axis: Int) raises -> Tensor[dt]:
@@ -1481,7 +1833,21 @@ fn unsqueeze_typed[dt: DType](tensor: Tensor[dt], axis: Int) raises -> Tensor[dt
     Returns:
         A new Tensor[dt] with an added size-1 dimension.
     """
-    return unsqueeze(tensor.as_any(), axis).as_tensor[dt]()
+    var old_shape = tensor.shape()
+    var ndim = len(old_shape)
+    var new_ndim = ndim + 1
+    var actual_axis = axis if axis >= 0 else new_ndim + axis
+    if actual_axis < 0 or actual_axis > ndim:
+        raise Error("unsqueeze: dimension out of range")
+    var new_shape = List[Int]()
+    var j = 0
+    for i in range(new_ndim):
+        if i == actual_axis:
+            new_shape.append(1)
+        else:
+            new_shape.append(old_shape[j])
+            j += 1
+    return _reshape_typed[dt](tensor, new_shape)
 
 
 fn expand_dims_typed[dt: DType](
@@ -1498,7 +1864,7 @@ fn expand_dims_typed[dt: DType](
     Returns:
         A new Tensor[dt] with an added size-1 dimension.
     """
-    return expand_dims(tensor.as_any(), axis).as_tensor[dt]()
+    return unsqueeze_typed[dt](tensor, axis)
 
 
 fn flatten_typed[dt: DType](tensor: Tensor[dt]) raises -> Tensor[dt]:
@@ -1510,7 +1876,9 @@ fn flatten_typed[dt: DType](tensor: Tensor[dt]) raises -> Tensor[dt]:
     Returns:
         A new 1D Tensor[dt] with all elements in row-major order.
     """
-    return flatten(tensor.as_any()).as_tensor[dt]()
+    var shape_1d = List[Int]()
+    shape_1d.append(tensor.numel())
+    return _reshape_typed[dt](tensor, shape_1d)
 
 
 fn broadcast_to_typed[dt: DType](
@@ -1525,4 +1893,19 @@ fn broadcast_to_typed[dt: DType](
     Returns:
         A new Tensor[dt] broadcast to the target shape.
     """
-    return broadcast_to(tensor.as_any(), target_shape).as_tensor[dt]()
+    return _broadcast_to_typed[dt](tensor, target_shape)
+
+
+fn permute_typed[dt: DType](
+    tensor: Tensor[dt], dims: List[Int]
+) raises -> Tensor[dt]:
+    """Permute tensor dimensions (typed version).
+
+    Args:
+        tensor: Input typed tensor.
+        dims: Permutation of dimensions.
+
+    Returns:
+        A new Tensor[dt] with permuted dimensions.
+    """
+    return _permute_typed[dt](tensor, dims)

--- a/shared/core/strassen.mojo
+++ b/shared/core/strassen.mojo
@@ -1,12 +1,30 @@
 """Strassen's Algorithm for Fast Matrix Multiplication.
 
-Implements Strassen's divide-and-conquer algorithm reducing O(n³) to O(n^2.807)
+Implements Strassen's divide-and-conquer algorithm reducing O(n^3) to O(n^2.807)
 by performing 7 multiplications instead of 8.
+
+Architecture: Tensor[dtype] typed core eliminates all dtype branches/bitcasts.
+AnyTensor entry point dispatches to typed core via ordinal-based table.
 """
 
 from .any_tensor import AnyTensor, zeros
 from .arithmetic import add, subtract
 from .matmul import matmul_tiled
+from shared.tensor.tensor import Tensor
+from shared.base.dtype_ordinal import (
+    dtype_to_ordinal,
+    DTYPE_FLOAT16,
+    DTYPE_FLOAT32,
+    DTYPE_FLOAT64,
+    DTYPE_INT8,
+    DTYPE_INT16,
+    DTYPE_INT32,
+    DTYPE_INT64,
+    DTYPE_UINT8,
+    DTYPE_UINT16,
+    DTYPE_UINT32,
+    DTYPE_UINT64,
+)
 
 comptime STRASSEN_ENABLED: Bool = True
 comptime STRASSEN_THRESHOLD: Int = 512
@@ -22,8 +40,123 @@ fn next_power_of_2(n: Int) -> Int:
     return power
 
 
+# ============================================================================
+# Layer 3 (Core): Native Tensor[dtype] Strassen Implementation
+# ============================================================================
+
+
+fn _extract_quadrants_typed[
+    dtype: DType
+](
+    src: Tensor[dtype], n: Int, n_half: Int
+) raises -> Tuple[
+    Tensor[dtype],
+    Tensor[dtype],
+    Tensor[dtype],
+    Tensor[dtype],
+]:
+    """Extract four quadrants from a square matrix (typed core).
+
+    Parameters:
+        dtype: Compile-time dtype parameter.
+
+    Args:
+        src: Source matrix of shape (n, n).
+        n: Full dimension.
+        n_half: Half dimension (n // 2).
+
+    Returns:
+        Tuple of (top-left, top-right, bottom-left, bottom-right) quadrants.
+    """
+    var q_shape = List[Int]()
+    q_shape.append(n_half)
+    q_shape.append(n_half)
+
+    var q11 = Tensor[dtype](q_shape)
+    var q12 = Tensor[dtype](q_shape)
+    var q21 = Tensor[dtype](q_shape)
+    var q22 = Tensor[dtype](q_shape)
+
+    var src_ptr = src._data
+    var q11_ptr = q11._data
+    var q12_ptr = q12._data
+    var q21_ptr = q21._data
+    var q22_ptr = q22._data
+
+    for i in range(n_half):
+        for j in range(n_half):
+            q11_ptr.store(i * n_half + j, src_ptr.load(i * n + j))
+            q12_ptr.store(i * n_half + j, src_ptr.load(i * n + (j + n_half)))
+            q21_ptr.store(i * n_half + j, src_ptr.load((i + n_half) * n + j))
+            q22_ptr.store(
+                i * n_half + j,
+                src_ptr.load((i + n_half) * n + (j + n_half)),
+            )
+
+    return (q11^, q12^, q21^, q22^)
+
+
+fn _combine_quadrants_typed[
+    dtype: DType
+](
+    c11: Tensor[dtype],
+    c12: Tensor[dtype],
+    c21: Tensor[dtype],
+    c22: Tensor[dtype],
+    n: Int,
+    n_half: Int,
+) raises -> Tensor[dtype]:
+    """Combine four quadrants into a full matrix (typed core).
+
+    Parameters:
+        dtype: Compile-time dtype parameter.
+
+    Args:
+        c11: Top-left quadrant.
+        c12: Top-right quadrant.
+        c21: Bottom-left quadrant.
+        c22: Bottom-right quadrant.
+        n: Full dimension.
+        n_half: Half dimension.
+
+    Returns:
+        Combined matrix of shape (n, n).
+    """
+    var c_shape = List[Int]()
+    c_shape.append(n)
+    c_shape.append(n)
+    var result = Tensor[dtype](c_shape)
+
+    var c_ptr = result._data
+    var c11_ptr = c11._data
+    var c12_ptr = c12._data
+    var c21_ptr = c21._data
+    var c22_ptr = c22._data
+
+    for i in range(n_half):
+        for j in range(n_half):
+            c_ptr.store(i * n + j, c11_ptr.load(i * n_half + j))
+            c_ptr.store(
+                i * n + (j + n_half), c12_ptr.load(i * n_half + j)
+            )
+            c_ptr.store(
+                (i + n_half) * n + j, c21_ptr.load(i * n_half + j)
+            )
+            c_ptr.store(
+                (i + n_half) * n + (j + n_half),
+                c22_ptr.load(i * n_half + j),
+            )
+
+    return result^
+
+
 fn _strassen_recursive(A: AnyTensor, B: AnyTensor) raises -> AnyTensor:
-    """Recursive core of Strassen's algorithm using 7 products."""
+    """Recursive core of Strassen's algorithm using 7 products.
+
+    Note: This remains on AnyTensor because the recursive calls use
+    arithmetic add/subtract which operate on AnyTensor. The quadrant
+    extraction/combination uses typed cores to eliminate bitcasts.
+    """
     var shape = A.shape()
     var n = shape[0]
 
@@ -37,82 +170,53 @@ fn _strassen_recursive(A: AnyTensor, B: AnyTensor) raises -> AnyTensor:
 
     var n_half = n // 2
 
-    # Extract quadrants
-    var A11_shape = List[Int]()
-    A11_shape.append(n_half)
-    A11_shape.append(n_half)
-    var A11 = AnyTensor(A11_shape, A.dtype())
+    # Extract quadrants using typed core (zero bitcasts)
+    var ordinal = dtype_to_ordinal(A.dtype())
+    var A11: AnyTensor
+    var A12: AnyTensor
+    var A21: AnyTensor
+    var A22: AnyTensor
+    var B11: AnyTensor
+    var B12: AnyTensor
+    var B21: AnyTensor
+    var B22: AnyTensor
 
-    var A12 = AnyTensor(A11_shape, A.dtype())
-    var A21 = AnyTensor(A11_shape, A.dtype())
-    var A22 = AnyTensor(A11_shape, A.dtype())
-
-    var B11 = AnyTensor(A11_shape, B.dtype())
-    var B12 = AnyTensor(A11_shape, B.dtype())
-    var B21 = AnyTensor(A11_shape, B.dtype())
-    var B22 = AnyTensor(A11_shape, B.dtype())
-
-    # Extract A quadrants
-    if A.dtype() == DType.float32:
-        var a_ptr = A._data.bitcast[Float32]()
-        var a11_ptr = A11._data.bitcast[Float32]()
-        var a12_ptr = A12._data.bitcast[Float32]()
-        var a21_ptr = A21._data.bitcast[Float32]()
-        var a22_ptr = A22._data.bitcast[Float32]()
-
-        for i in range(n_half):
-            for j in range(n_half):
-                a11_ptr.store(i * n_half + j, a_ptr.load(i * n + j))
-                a12_ptr.store(i * n_half + j, a_ptr.load(i * n + (j + n_half)))
-                a21_ptr.store(i * n_half + j, a_ptr.load((i + n_half) * n + j))
-                a22_ptr.store(
-                    i * n_half + j, a_ptr.load((i + n_half) * n + (j + n_half))
-                )
-
-        var b_ptr = B._data.bitcast[Float32]()
-        var b11_ptr = B11._data.bitcast[Float32]()
-        var b12_ptr = B12._data.bitcast[Float32]()
-        var b21_ptr = B21._data.bitcast[Float32]()
-        var b22_ptr = B22._data.bitcast[Float32]()
-
-        for i in range(n_half):
-            for j in range(n_half):
-                b11_ptr.store(i * n_half + j, b_ptr.load(i * n + j))
-                b12_ptr.store(i * n_half + j, b_ptr.load(i * n + (j + n_half)))
-                b21_ptr.store(i * n_half + j, b_ptr.load((i + n_half) * n + j))
-                b22_ptr.store(
-                    i * n_half + j, b_ptr.load((i + n_half) * n + (j + n_half))
-                )
+    if ordinal == DTYPE_FLOAT32:
+        var a_typed = A.as_tensor[DType.float32]()
+        var b_typed = B.as_tensor[DType.float32]()
+        var a_quads = _extract_quadrants_typed[DType.float32](
+            a_typed, n, n_half
+        )
+        var b_quads = _extract_quadrants_typed[DType.float32](
+            b_typed, n, n_half
+        )
+        A11 = a_quads[0].as_any()
+        A12 = a_quads[1].as_any()
+        A21 = a_quads[2].as_any()
+        A22 = a_quads[3].as_any()
+        B11 = b_quads[0].as_any()
+        B12 = b_quads[1].as_any()
+        B21 = b_quads[2].as_any()
+        B22 = b_quads[3].as_any()
+    elif ordinal == DTYPE_FLOAT64:
+        var a_typed = A.as_tensor[DType.float64]()
+        var b_typed = B.as_tensor[DType.float64]()
+        var a_quads = _extract_quadrants_typed[DType.float64](
+            a_typed, n, n_half
+        )
+        var b_quads = _extract_quadrants_typed[DType.float64](
+            b_typed, n, n_half
+        )
+        A11 = a_quads[0].as_any()
+        A12 = a_quads[1].as_any()
+        A21 = a_quads[2].as_any()
+        A22 = a_quads[3].as_any()
+        B11 = b_quads[0].as_any()
+        B12 = b_quads[1].as_any()
+        B21 = b_quads[2].as_any()
+        B22 = b_quads[3].as_any()
     else:
-        var a_ptr = A._data.bitcast[Float64]()
-        var a11_ptr = A11._data.bitcast[Float64]()
-        var a12_ptr = A12._data.bitcast[Float64]()
-        var a21_ptr = A21._data.bitcast[Float64]()
-        var a22_ptr = A22._data.bitcast[Float64]()
-
-        for i in range(n_half):
-            for j in range(n_half):
-                a11_ptr.store(i * n_half + j, a_ptr.load(i * n + j))
-                a12_ptr.store(i * n_half + j, a_ptr.load(i * n + (j + n_half)))
-                a21_ptr.store(i * n_half + j, a_ptr.load((i + n_half) * n + j))
-                a22_ptr.store(
-                    i * n_half + j, a_ptr.load((i + n_half) * n + (j + n_half))
-                )
-
-        var b_ptr = B._data.bitcast[Float64]()
-        var b11_ptr = B11._data.bitcast[Float64]()
-        var b12_ptr = B12._data.bitcast[Float64]()
-        var b21_ptr = B21._data.bitcast[Float64]()
-        var b22_ptr = B22._data.bitcast[Float64]()
-
-        for i in range(n_half):
-            for j in range(n_half):
-                b11_ptr.store(i * n_half + j, b_ptr.load(i * n + j))
-                b12_ptr.store(i * n_half + j, b_ptr.load(i * n + (j + n_half)))
-                b21_ptr.store(i * n_half + j, b_ptr.load((i + n_half) * n + j))
-                b22_ptr.store(
-                    i * n_half + j, b_ptr.load((i + n_half) * n + (j + n_half))
-                )
+        raise Error("strassen: only float32/float64 supported")
 
     # Compute 7 products
     var sum_a1 = add(A11, A22)
@@ -151,46 +255,51 @@ fn _strassen_recursive(A: AnyTensor, B: AnyTensor) raises -> AnyTensor:
     var C22_temp = add(C22, M3)
     C22 = add(C22_temp, M6)
 
-    # Combine quadrants
-    var c_shape = List[Int]()
-    c_shape.append(n)
-    c_shape.append(n)
-    var C = AnyTensor(c_shape, A.dtype())
-
-    if A.dtype() == DType.float32:
-        var c_ptr = C._data.bitcast[Float32]()
-        var c11_ptr = C11._data.bitcast[Float32]()
-        var c12_ptr = C12._data.bitcast[Float32]()
-        var c21_ptr = C21._data.bitcast[Float32]()
-        var c22_ptr = C22._data.bitcast[Float32]()
-
-        for i in range(n_half):
-            for j in range(n_half):
-                c_ptr.store(i * n + j, c11_ptr.load(i * n_half + j))
-                c_ptr.store(i * n + (j + n_half), c12_ptr.load(i * n_half + j))
-                c_ptr.store((i + n_half) * n + j, c21_ptr.load(i * n_half + j))
-                c_ptr.store(
-                    (i + n_half) * n + (j + n_half),
-                    c22_ptr.load(i * n_half + j),
-                )
+    # Combine quadrants using typed core (zero bitcasts)
+    if ordinal == DTYPE_FLOAT32:
+        return _combine_quadrants_typed[DType.float32](
+            C11.as_tensor[DType.float32](),
+            C12.as_tensor[DType.float32](),
+            C21.as_tensor[DType.float32](),
+            C22.as_tensor[DType.float32](),
+            n,
+            n_half,
+        ).as_any()
+    elif ordinal == DTYPE_FLOAT64:
+        return _combine_quadrants_typed[DType.float64](
+            C11.as_tensor[DType.float64](),
+            C12.as_tensor[DType.float64](),
+            C21.as_tensor[DType.float64](),
+            C22.as_tensor[DType.float64](),
+            n,
+            n_half,
+        ).as_any()
     else:
-        var c_ptr = C._data.bitcast[Float64]()
-        var c11_ptr = C11._data.bitcast[Float64]()
-        var c12_ptr = C12._data.bitcast[Float64]()
-        var c21_ptr = C21._data.bitcast[Float64]()
-        var c22_ptr = C22._data.bitcast[Float64]()
+        raise Error("strassen: only float32/float64 supported")
 
-        for i in range(n_half):
-            for j in range(n_half):
-                c_ptr.store(i * n + j, c11_ptr.load(i * n_half + j))
-                c_ptr.store(i * n + (j + n_half), c12_ptr.load(i * n_half + j))
-                c_ptr.store((i + n_half) * n + j, c21_ptr.load(i * n_half + j))
-                c_ptr.store(
-                    (i + n_half) * n + (j + n_half),
-                    c22_ptr.load(i * n_half + j),
-                )
 
-    return C^
+fn _matmul_strassen_copy_result[
+    dtype: DType
+](src: AnyTensor, mut dst: AnyTensor, m: Int, n: Int) raises:
+    """Copy Strassen result using typed pointers (zero bitcasts).
+
+    Parameters:
+        dtype: Compile-time dtype parameter.
+
+    Args:
+        src: Source result from Strassen.
+        dst: Destination tensor.
+        m: Number of rows.
+        n: Number of columns.
+    """
+    var src_typed = src.as_tensor[dtype]()
+    var dst_typed = dst.as_tensor[dtype]()
+    var src_ptr = src_typed._data
+    var dst_ptr = dst_typed._data
+    for i in range(m):
+        for j in range(n):
+            var idx = i * n + j
+            dst_ptr.store(idx, src_ptr.load(idx))
 
 
 fn matmul_strassen(A: AnyTensor, B: AnyTensor, mut C: AnyTensor) raises:
@@ -241,18 +350,11 @@ fn matmul_strassen(A: AnyTensor, B: AnyTensor, mut C: AnyTensor) raises:
     # For square matrices above threshold, use Strassen
     var C_result = _strassen_recursive(A, B)
 
-    # Copy result
-    if C.dtype() == DType.float32:
-        var src_ptr = C_result._data.bitcast[Float32]()
-        var dst_ptr = C._data.bitcast[Float32]()
-        for i in range(M):
-            for j in range(N):
-                var idx = i * N + j
-                dst_ptr.store(idx, src_ptr.load(idx))
+    # Copy result using typed core (zero bitcasts)
+    var ordinal = dtype_to_ordinal(C.dtype())
+    if ordinal == DTYPE_FLOAT32:
+        _matmul_strassen_copy_result[DType.float32](C_result, C, M, N)
+    elif ordinal == DTYPE_FLOAT64:
+        _matmul_strassen_copy_result[DType.float64](C_result, C, M, N)
     else:
-        var src_ptr = C_result._data.bitcast[Float64]()
-        var dst_ptr = C._data.bitcast[Float64]()
-        for i in range(M):
-            for j in range(N):
-                var idx = i * N + j
-                dst_ptr.store(idx, src_ptr.load(idx))
+        raise Error("matmul_strassen: only float32/float64 supported")


### PR DESCRIPTION
## Summary
- Shape ops (reshape, flatten, squeeze, unsqueeze, permute, as_contiguous, broadcast_to) get `Tensor[dtype]` typed cores with zero bitcasts and ordinal-based AnyTensor dispatch
- Comparison ops (equal, not_equal, less, less_equal, greater, greater_equal) rewritten with individual typed cores per op, eliminating per-op dispatch boilerplate
- Normalization forward (batch_norm2d, layer_norm) get typed entry points
- Loss forward (cross_entropy, mse, bce, smooth_l1, kl_divergence) get typed entry points with full parameter forwarding
- Numerical safety (has_nan, has_inf, count_nan, count_inf, tensor_min, tensor_max, l2_norm) dispatch to typed cores using compile-time `@parameter` guards
- Strassen matmul quadrant extraction/combination uses typed cores (eliminates 34 bitcasts)
- Collection ops (concatenate/stack/split) stay on AnyTensor (they use `List[AnyTensor]`)
- Backward/gradient functions stay on AnyTensor

## Test plan
- [ ] `just package` compiles (zero new errors in modified files; pre-existing AnyTensor conversion errors unchanged)
- [ ] `just test-mojo` all tests pass

Closes #4998

🤖 Generated with [Claude Code](https://claude.com/claude-code)