### PR TITLE
fix(tests): fix linear matmul constraint and packaging imports

### DIFF
--- a/tests/shared/core/layers/test_linear_struct.mojo
+++ b/tests/shared/core/layers/test_linear_struct.mojo
@@ -96,10 +96,9 @@ fn test_linear_struct_forward_single_sample() raises:
     bias_data[0] = 0.0
     bias_data[1] = 0.0
 
-    # Create input: [1, 2, 3]
-    var input_shape: List[Int] = [3]
-    var input = zeros_like(zeros(input_shape, DType.float32))
-    # Need to properly initialize the input
+    # Create input: [[1, 2, 3]] (2D: batch=1, features=3)
+    # AnyTensor.__matmul__ requires 2D inputs
+    var input_shape: List[Int] = [1, 3]
     var input_val = ones(input_shape, DType.float32)
     var input_data = input_val._data.bitcast[Float32]()
     input_data[0] = 1.0
@@ -109,9 +108,10 @@ fn test_linear_struct_forward_single_sample() raises:
     # Forward pass
     var output = input_val @ layer.weight + layer.bias
 
-    # Check output shape
+    # Check output shape: (1, 2)
     var output_shape = output.shape()
-    assert_equal(output_shape[0], 2)
+    assert_equal(output_shape[0], 1)
+    assert_equal(output_shape[1], 2)
 
     # Check values: [1*1 + 2*0 + 3*0, 1*0 + 2*1 + 3*0] = [1, 2]
     var output_data = output._data.bitcast[Float32]()

--- a/tests/shared/integration/test_packaging.mojo
+++ b/tests/shared/integration/test_packaging.mojo
@@ -93,8 +93,10 @@ fn test_layer_root_level_imports() raises:
     # Core module trait
     from shared import Module
 
-    # Core tensors and creation functions (AnyTensor + Tensor alias)
-    from shared import AnyTensor, Tensor, zeros, ones, randn
+    # Core tensors and creation functions
+    # AnyTensor is NOT re-exported from shared (avoids circular imports)
+    from shared.tensor.any_tensor import AnyTensor, zeros, ones, randn
+    from shared.tensor.tensor import Tensor
 
     # Training schedulers
     from shared import StepLR, CosineAnnealingLR


### PR DESCRIPTION
## Summary

- Fixes `test_linear_struct.mojo`: reshape 1D input `[3]` to 2D `[1, 3]` for `__matmul__` which requires 2D x 2D
- Fixes `test_packaging.mojo`: import `AnyTensor/Tensor/zeros/ones/randn` from `shared.tensor.any_tensor` and `shared.tensor.tensor` (not from `shared`, which intentionally doesn't re-export them to avoid circular imports)

## Related Issues Filed

The remaining runtime failures have been filed as GitHub issues for deeper investigation:

- #5065 — `AnyTensor.__str__` assertion failure for uint64/int64 types
- #5066 — Multidim slice-with-step produces wrong values
- #5067 — conv2d gradient check fails numerically
- #5068 — test_training_loop.mojo execution crash (segfault)
- #5069 — AlexNet float16 max pooling produces NaN/Inf
- #5070 — VGG16 end-to-end test execution crash (segfault)

## Test plan

- [x] `test_linear_struct.mojo` — input reshaped to 2D to match `__matmul__` contract
- [x] `test_packaging.mojo` — imports updated to direct paths
- [ ] CI: Comprehensive Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)