### PR TITLE
fix: resolve 4 runtime bugs (#5065, #5066, #5067, #5069)

### DIFF
--- a/shared/core/conv.mojo
+++ b/shared/core/conv.mojo
@@ -624,7 +624,7 @@ fn _conv2d_backward_kernel[
                         + ih * in_width
                         + iw
                     )
-                    grad_input[grad_in_idx] = Float32(grad_sum)
+                    grad_input._set_float64(grad_in_idx, Float64(grad_sum))
 
     # Compute grad_kernel
     # For each kernel position, sum input * grad_output over all valid positions
@@ -688,7 +688,7 @@ fn _conv2d_backward_kernel[
                         + kh * kW
                         + kw
                     )
-                    grad_kernel[grad_k_idx] = Float32(grad_sum)
+                    grad_kernel._set_float64(grad_k_idx, Float64(grad_sum))
 
     # Compute grad_bias: sum over batch, height, width
     var grad_bias_shape = List[Int]()
@@ -712,7 +712,7 @@ fn _conv2d_backward_kernel[
                     ]()[grad_out_idx]
                     bias_grad_sum += grad_out_val
 
-        grad_bias[oc] = Float32(bias_grad_sum)
+        grad_bias._set_float64(oc, Float64(bias_grad_sum))
 
     return GradientTriple(grad_input^, grad_kernel^, grad_bias^)
 

--- a/shared/core/pooling.mojo
+++ b/shared/core/pooling.mojo
@@ -128,7 +128,7 @@ fn maxpool2d(
                         var in_w_end = in_w_start + kernel_size
 
                         # Find maximum in window
-                        var max_val = Float32(-1e9)  # Very small initial value
+                        var max_val = Float32(-65504.0)  # Very small initial value
 
                         for kh in range(kernel_size):
                             for kw in range(kernel_size):
@@ -175,7 +175,7 @@ fn maxpool2d(
                         var in_w_end = in_w_start + kernel_size
 
                         # Find maximum in window
-                        var max_val = Float32(-1e9)  # Very small initial value
+                        var max_val = Float32(-65504.0)  # Very small initial value
 
                         for kh in range(kernel_size):
                             for kw in range(kernel_size):
@@ -237,7 +237,7 @@ fn _maxpool2d_optimized(
     var row_max_size = in_height * out_width
     var row_max = List[Float32]()
     for _ in range(row_max_size):
-        row_max.append(Float32(-1e9))
+        row_max.append(Float32(-65504.0))
 
     for b in range(batch):
         for c in range(channels):
@@ -246,7 +246,7 @@ fn _maxpool2d_optimized(
                 for ow in range(out_width):
                     # Window starts at w_start = ow * stride - padding
                     var w_start = ow * stride - padding
-                    var row_max_val = Float32(-1e9)
+                    var row_max_val = Float32(-65504.0)
 
                     for kw in range(kernel_size):
                         var iw = w_start + kw
@@ -268,7 +268,7 @@ fn _maxpool2d_optimized(
                 var h_start = oh * stride - padding
 
                 for ow in range(out_width):
-                    var max_val = Float32(-1e9)
+                    var max_val = Float32(-65504.0)
 
                     for kh in range(kernel_size):
                         var ih = h_start + kh
@@ -559,7 +559,7 @@ fn maxpool2d_backward(
                     var in_w_start = ow * actual_stride - padding
 
                     # Find the position of maximum value in the window
-                    var max_val = Float32(-1e9)
+                    var max_val = Float32(-65504.0)
                     var max_h = -1
                     var max_w = -1
 

--- a/shared/tensor/any_tensor.mojo
+++ b/shared/tensor/any_tensor.mojo
@@ -1373,7 +1373,7 @@ struct AnyTensor(
             # Copy each row contiguously
             var src_offset = starts[0] * stride_numel * dtype_size
             for i in range(result_shape[0]):
-                var src_addr = src_ptr + src_offset + i * stride_numel * dtype_size
+                var src_addr = src_ptr + src_offset + i * steps[0] * stride_numel * dtype_size
                 var dst_addr = dst_ptr + i * stride_numel * dtype_size
                 # memcpy semantics: copy stride_numel elements
                 for b in range(stride_numel * dtype_size):

--- a/tests/shared/core/test_extensor_int_str.mojo
+++ b/tests/shared/core/test_extensor_int_str.mojo
@@ -74,10 +74,10 @@ fn test_str_uint32() raises:
 
 fn test_str_uint64() raises:
     """Test __str__ for uint64 tensor."""
-    var t = full([3], Float64(18446744073709551615), DType.uint64)
+    var t = full([3], Float64(9007199254740992), DType.uint64)
     var s = String(t)
     assert_true(s.startswith("AnyTensor(["))
-    assert_true("18446744073709551615" in s)
+    assert_true("9007199254740992" in s)
     assert_true("dtype=uint64" in s)
 
 


### PR DESCRIPTION
## Summary

- **#5065**: uint64 `__str__` test uses Float64-unrepresentable value (2^64-1) — changed to 2^53
- **#5066**: Multidim slice fast-path doesn't multiply by `steps[0]` — rows were copied consecutively instead of with step stride
- **#5067**: conv2d backward uses `Float32()` casts losing precision — changed to `_set_float64()`
- **#5069**: Max pooling initializes with `Float32(-1e9)` overflowing float16 — changed to `Float32(-65504.0)`

Closes #5065
Closes #5066
Closes #5067
Closes #5069

## Test plan

- [x] `test_extensor_int_str.mojo` — uint64 value within Float64 precision
- [x] Slice step fix verified against test expectations (`sliced[4]` should be `8`)
- [x] Conv2d gradient: `_set_float64` preserves full precision for gradient checking
- [x] Pooling: `-65504.0` is within float16 range and valid for float32/float64
- [ ] CI: Comprehensive Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)