### PR TITLE
feat: integrate hephaestus and fix CI secret scanning

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,12 +42,21 @@ jobs:
           fetch-depth: 0  # Required: full history needed for gitleaks git-log mode (do not remove, see #3316)
 
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.9
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: --exit-code=1
-          config: .gitleaks.toml
+        run: |
+          # Pinned to v8.30.0 — update hash when upgrading version (see #3316)
+          wget -q https://github.com/gitleaks/gitleaks/releases/download/v8.30.0/gitleaks_8.30.0_linux_x64.tar.gz
+          # Verify integrity before execution — SHA256 from https://github.com/gitleaks/gitleaks/releases/download/v8.30.0/gitleaks_8.30.0_checksums.txt
+          echo "79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e  gitleaks_8.30.0_linux_x64.tar.gz" | sha256sum --check
+          tar -xzf gitleaks_8.30.0_linux_x64.tar.gz
+          chmod +x gitleaks
+
+          if [ -f .gitleaks.toml ]; then
+            echo "Using .gitleaks.toml configuration"
+            ./gitleaks detect --source=. --config=.gitleaks.toml --verbose --exit-code=1
+          else
+            echo "No .gitleaks.toml found, using default configuration"
+            ./gitleaks detect --source=. --verbose --exit-code=1
+          fi
 
   # ============================================================================
   # SAST Scanning


### PR DESCRIPTION
## Summary

- **Integrate Hephaestus**: Replace local utilities with `hephaestus` package imports, consolidating shared ML infrastructure
- **Parametric Tensor Architecture**: Implement `Tensor[dtype]` parametric struct, `AnyTensor` runtime-typed tensor, `TensorLike` trait, and native typed operations (ADR-012)
- **Layer Parameterization**: Migrate all layers and traits to use the new dual-type tensor system
- **CI Containerization**: Migrate from Docker to Podman for all container operations
- **Fix CI Secret Scanning**: Replace paid `gitleaks-action@v2.3.9` (requires `GITLEAKS_LICENSE` for org repos) with free CLI binary (gitleaks v8.30.0, SHA256-verified)

## Test plan

- [x] 14/14 security workflow smoke and regression tests pass locally
- [x] All pre-commit hooks pass (including gitleaks `--no-git` guard)
- [ ] CI `secret-scan` job passes without `GITLEAKS_LICENSE` secret
- [ ] CI build and test jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)