### PR TITLE
feat(tensor): add copy() utility function for AnyTensor

### DIFF
--- a/shared/tensor/any_tensor.mojo
+++ b/shared/tensor/any_tensor.mojo
@@ -4790,6 +4790,31 @@ fn calculate_max_batch_size(
 # ============================================================================
 
 
+fn copy(tensor: AnyTensor) raises -> AnyTensor:
+    """Create an independent deep copy of the tensor.
+
+    This is a convenience wrapper around the AnyTensor.clone() method,
+    following NumPy naming conventions. The returned tensor has its own
+    independent memory; modifications to it do not affect the original.
+
+    Args:
+        tensor: The tensor to copy.
+
+    Returns:
+        A new AnyTensor that is a deep copy of the input.
+
+    Raises:
+        Error: If memory allocation fails.
+
+    Example:
+        ```mojo
+        var x = ones([3, 4], DType.float32)
+        var y = copy(x)  # Independent deep copy
+        ```
+    """
+    return tensor.clone()
+
+
 fn clone(tensor: AnyTensor) raises -> AnyTensor:
     """Create a clone of the tensor.
 

--- a/tests/shared/core/test_utility.mojo
+++ b/tests/shared/core/test_utility.mojo
@@ -5,7 +5,7 @@ and helper methods like numel, dim, size, stride, is_contiguous.
 """
 
 # Import AnyTensor and operations
-from shared.tensor.any_tensor import AnyTensor, zeros, ones, full, arange, clone, item, diff
+from shared.tensor.any_tensor import AnyTensor, zeros, ones, full, arange, copy, clone, item, diff
 from shared.core import as_contiguous, transpose_view
 
 # Import test helpers
@@ -29,15 +29,20 @@ from tests.shared.conftest import (
 
 
 fn test_copy_independence() raises:
-    """Test that copy creates independent tensor."""
+    """Test that copy() creates an independent deep copy."""
     var shape = List[Int]()
     shape.append(5)
     var a = full(shape, 3.0, DType.float32)
-    var b = clone(a)
+    var b = copy(a)
 
-    # Check that clone creates a copy with same values
-    assert_value_at(b, 0, 3.0, 1e-6, "Clone should have same value")
-    assert_value_at(b, 4, 3.0, 1e-6, "Clone should have same value at end")
+    # Check that copy creates a tensor with same values
+    assert_value_at(b, 0, 3.0, 1e-6, "Copy should have same value")
+    assert_value_at(b, 4, 3.0, 1e-6, "Copy should have same value at end")
+
+    # Verify independence: modifying copy doesn't affect original
+    b.set(0, Float64(99.0))
+    assert_almost_equal(b._get_float64(0), 99.0, 1e-6, "Copy should be modified")
+    assert_value_at(a, 0, 3.0, 1e-6, "Original should be unchanged after copy modification")
 
 
 fn test_clone_identical() raises:


### PR DESCRIPTION
## Summary
- Add module-level `copy()` function as NumPy-style alias for `clone()`, completing the copy/clone API (NumPy + PyTorch conventions)
- Strengthen `test_copy_independence` to verify data independence by mutating the copy and asserting the original is unchanged

Closes #2722

## Context

Most utility methods listed in #2722 (clone, item, tolist, __setitem__, __len__, __int__, __float__, __str__, __repr__, __hash__, diff, contiguous) were already implemented. The missing piece was the NumPy-style `copy()` function.

**Key finding**: A naive `copy()` method on AnyTensor would conflict with Mojo's built-in `Copyable.copy()` (which performs a shallow refcount-increment copy). The module-level function delegates to `clone()` to ensure a true deep copy with independent memory.

## Files Modified
| File | Changes |
|------|---------|
| `shared/tensor/any_tensor.mojo` | Added `copy()` module-level function |
| `tests/shared/core/test_utility.mojo` | Updated import, test uses `copy()` with mutation-based independence verification |

## Test plan
- [x] `just test-group "tests/shared/core" "test_utility.mojo"` — all 60 tests pass
- [x] Full `tests/shared/core` suite — 241/247 pass (6 pre-existing failures unrelated to this PR)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)