### PR TITLE
fix: correct ${HOME} volume path resolution in docker-compose.yml

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,7 @@
 # Run 'id -u' and 'id -g' to check your host values
 USER_ID=1000
 GROUP_ID=1000
+
+# Container username and home directory
+# Must match the USER_NAME ARG in the Dockerfile (default: dev)
+USER_NAME=dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,21 +9,22 @@ services:
       args:
         USER_ID: ${USER_ID}
         GROUP_ID: ${GROUP_ID}
+        USER_NAME: ${USER_NAME:-dev}
     image: projectodyssey:dev
     volumes:
       - .:/workspace:Z
       - workspace-pixi:/workspace/.pixi
-      - pixi-cache:/home/dev/.pixi
-      - pre-commit-cache:/home/dev/.cache/pre-commit
-      - ${HOME}/.gitconfig:/home/dev/.gitconfig:ro
+      - pixi-cache:/home/${USER_NAME:-dev}/.pixi
+      - pre-commit-cache:/home/${USER_NAME:-dev}/.cache/pre-commit
+      - ${HOME}/.gitconfig:/home/${USER_NAME:-dev}/.gitconfig:ro
     entrypoint: ["/usr/local/bin/entrypoint.sh"]
     environment:
-      - HOME=/home/dev
+      - HOME=/home/${USER_NAME:-dev}
       - USER_ID=${USER_ID}
       - GROUP_ID=${GROUP_ID}
       - ENVIRONMENT=development
       - TERM=xterm-256color
-      - PIXI_HOME=/home/dev/.pixi
+      - PIXI_HOME=/home/${USER_NAME:-dev}/.pixi
     working_dir: /workspace
     stdin_open: true
     tty: true
@@ -41,19 +42,20 @@ services:
       args:
         USER_ID: ${USER_ID}
         GROUP_ID: ${GROUP_ID}
+        USER_NAME: ${USER_NAME:-dev}
     image: projectodyssey:ci
     volumes:
       - .:/workspace
       - workspace-pixi:/workspace/.pixi
-      - pixi-cache:/home/dev/.pixi
+      - pixi-cache:/home/${USER_NAME:-dev}/.pixi
     entrypoint: ["/usr/local/bin/entrypoint.sh"]
     environment:
-      - HOME=/home/dev
+      - HOME=/home/${USER_NAME:-dev}
       - USER_ID=${USER_ID}
       - GROUP_ID=${GROUP_ID}
       - ENVIRONMENT=ci
       - CI=true
-      - PIXI_HOME=/home/dev/.pixi
+      - PIXI_HOME=/home/${USER_NAME:-dev}/.pixi
     working_dir: /workspace
 
   # Production environment
@@ -66,15 +68,16 @@ services:
       args:
         USER_ID: ${USER_ID}
         GROUP_ID: ${GROUP_ID}
+        USER_NAME: ${USER_NAME:-dev}
     image: projectodyssey:prod
     volumes:
       - .:/workspace:ro
     environment:
-      - HOME=/home/dev
+      - HOME=/home/${USER_NAME:-dev}
       - USER_ID=${USER_ID}
       - GROUP_ID=${GROUP_ID}
       - ENVIRONMENT=production
-      - PIXI_HOME=/home/dev/.pixi
+      - PIXI_HOME=/home/${USER_NAME:-dev}/.pixi
     working_dir: /workspace
 
 volumes:


### PR DESCRIPTION
## Summary

- Replace all hardcoded `/home/dev` container-side paths in `docker-compose.yml` with `${USER_NAME:-dev}` so volume mounts and environment variables stay consistent with the Dockerfile's `USER_NAME` build arg
- Pass `USER_NAME` as a build arg to all three service targets (dev, ci, prod) to keep the Dockerfile and compose file in sync
- Add `USER_NAME=dev` to `.env` so the container username is configurable alongside `USER_ID`/`GROUP_ID`

## Test plan

- [ ] Run `podman compose config` (or `docker compose config`) and verify all volume mount targets resolve to `/home/dev/...` with default `.env`
- [ ] Change `USER_NAME=testuser` in `.env`, run `podman compose config`, and verify paths resolve to `/home/testuser/...`
- [ ] Run `just podman-up` and verify pixi cache is mounted at the correct container path (`/home/dev/.pixi`)
- [ ] Verify `${HOME}/.gitconfig` on the host side still resolves to the host user's gitconfig

Closes #4912

Generated with [Claude Code](https://claude.com/claude-code)