### PR TITLE
docs: add .env.example for environment variable documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,46 @@
+# ProjectOdyssey Environment Variables
+# Copy this file to .env and customize for your system:
+#   cp .env.example .env
+#
+# Most variables have sensible defaults and are optional.
+# See CLAUDE.md "Environment Setup" for more details.
+
+# ---------------------------------------------------------------------------
+# Container user/group mapping (used by docker-compose.yml and justfile)
+# ---------------------------------------------------------------------------
+# These control the UID/GID inside Podman containers so that files created
+# in the container have correct ownership on the host filesystem.
+# Default: auto-detected via `id -u` / `id -g` in the justfile.
+# Set explicitly if auto-detection does not match your host user.
+USER_ID=1000
+GROUP_ID=1000
+
+# ---------------------------------------------------------------------------
+# Native vs Podman execution (used by justfile)
+# ---------------------------------------------------------------------------
+# When set to "1", justfile recipes run commands directly on the host
+# instead of inside a Podman container.  Leave unset (or empty) to use
+# the default Podman-based execution.
+# NATIVE=1
+
+# ---------------------------------------------------------------------------
+# Mojo runtime logging (used by shared/utils/logging.mojo)
+# ---------------------------------------------------------------------------
+# Controls the log verbosity for ML Odyssey Mojo code.
+# Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL (case-insensitive)
+# Default: unset (no log filtering)
+# ML_ODYSSEY_LOG_LEVEL=INFO
+
+# ---------------------------------------------------------------------------
+# Script debugging (used by scripts/analyze_issues.py, scripts/plan_issues.py)
+# ---------------------------------------------------------------------------
+# When set, Python automation scripts emit DEBUG-level output.
+# DEBUG=1
+
+# ---------------------------------------------------------------------------
+# GitHub API token (used by scripts/merge_prs.py, scripts/get_stats.py)
+# ---------------------------------------------------------------------------
+# Required only for scripts that call the GitHub API directly.
+# The `gh` CLI uses its own auth (`gh auth login`), so most workflows
+# do not need this variable.
+# GITHUB_TOKEN=ghp_...

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ training_*.txt
 *_weights/
 checkpoints/
 
+# Environment files
+.env
+
 # Editor files
 *.swp
 .coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,6 +424,16 @@ This project uses Pixi for environment management:
 # Mojo is the primary language target for future implementations
 ```
 
+**Environment Variables**: Copy `.env.example` to `.env` and customize for your system:
+
+```bash
+cp .env.example .env
+```
+
+See `.env.example` for all available variables (container user mapping, native vs Podman
+execution, log levels, etc.). The justfile auto-detects most values, so `.env` is optional
+for typical setups.
+
 **GLIBC Constraint**: CI runners use Ubuntu with GLIBC 2.35 (Mojo requires 2.32+). Any
 native binaries built locally must be compatible with this version to avoid CI failures.
 If you're unable to run tests locally due to GLIBC version mismatch, see the


### PR DESCRIPTION
## Summary

- Create `.env.example` documenting all environment variables used by `docker-compose.yml`, `justfile`, and application code
- Add `.env` to `.gitignore` to prevent committing actual secrets/values
- Reference `.env.example` in CLAUDE.md's Environment Setup section

## Variables Documented

| Variable | Source | Purpose |
|----------|--------|---------|
| `USER_ID` / `GROUP_ID` | docker-compose.yml, justfile | Container UID/GID mapping |
| `NATIVE` | justfile | Run recipes on host instead of Podman |
| `ML_ODYSSEY_LOG_LEVEL` | shared/utils/logging.mojo | Mojo runtime log verbosity |
| `DEBUG` | scripts/*.py | Python script debug output |
| `GITHUB_TOKEN` | scripts/merge_prs.py, get_stats.py | GitHub API access |

## Test plan

- [ ] Verify `cp .env.example .env && just podman-up` works for a new contributor
- [ ] Verify `.env` is gitignored (not tracked)
- [ ] Verify all environment variables from docker-compose.yml are documented

Closes #5053

🤖 Generated with [Claude Code](https://claude.com/claude-code)