### PR TITLE
ci: add str truncation test verification to CI

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -265,6 +265,9 @@ jobs:
           # Consider refactoring by moving layer-specific tests to tests/shared/core/layers/
           # or similar subdirectory. See Issue #4359 for discussion of auto-discovery patterns
           # and the constraints of the pattern field (no true glob support).
+          # Coverage: test_extensor_*.mojo includes str truncation tests (issue #4040):
+          #   test_extensor_str.mojo, test_extensor_int_str.mojo,
+          #   test_extensor_multidim_int_str.mojo, test_extensor_slicing_view_strides.mojo
           - name: "Core Utilities"
             path: "tests/shared/core"
             pattern: "test_utilities.mojo test_utility*.mojo test_utils*.mojo test_validation*.mojo test_integration*.mojo test_inplace_simd.mojo test_lazy_expression.mojo test_memory_pool_part*.mojo test_constants.mojo test_extensor_*.mojo test_setitem_view_part*.mojo test_memory_leaks*.mojo test_initializers_*.mojo test_layers*.mojo test_linear*.mojo test_conv*.mojo test_normalization*.mojo test_dropout_part*.mojo test_module.mojo test_composed_op*.mojo test_hash.mojo test_sequential.mojo"


### PR DESCRIPTION
## Summary

- Verified that the str truncation tests (`test_extensor_str.mojo`, `test_extensor_int_str.mojo`, `test_extensor_multidim_int_str.mojo`) are already covered by the `test_extensor_*.mojo` wildcard pattern in the "Core Utilities" test group of the comprehensive-tests CI workflow
- Added explicit documentation comment in the workflow file to make this coverage relationship discoverable for future maintainers

## Changes Made

Added a 3-line comment block in `.github/workflows/comprehensive-tests.yml` above the "Core Utilities" test group entry that lists the specific str truncation test files matched by `test_extensor_*.mojo`, referencing issue #4040.

## Verification

- `python3 scripts/validate_test_coverage.py` passes (exit code 0) -- all test files remain covered
- YAML syntax validated
- Pre-commit hooks pass

Closes #4040

## Test plan

- [ ] CI comprehensive tests workflow runs successfully
- [ ] `validate-test-coverage` job confirms all tests are covered
- [ ] The "Core Utilities" test group runs the str truncation test files