### PR TITLE
feat(tensor): add __bool__ implementation to AnyTensor

### DIFF
--- a/shared/tensor/tensor.mojo
+++ b/shared/tensor/tensor.mojo
@@ -360,6 +360,56 @@ struct Tensor[dtype: DType = DType.float32](
         return self._shape[0]
 
     # ------------------------------------------------------------------
+    # Scalar extraction
+    # ------------------------------------------------------------------
+
+    fn item(self) raises -> Scalar[Self.dtype]:
+        """Extract the value from a single-element tensor.
+
+        Returns:
+            The scalar value as Scalar[Self.dtype].
+
+        Raises:
+            Error: If tensor has more than one element.
+
+        Example:
+            ```mojo
+            var t = Tensor[DType.float32]([1])
+            t[0] = 42.0
+            var val = t.item()  # Returns Scalar[DType.float32](42.0)
+            ```
+        """
+        if self._numel != 1:
+            raise Error(
+                "item() requires single-element tensor, got "
+                + String(self._numel)
+                + " elements"
+            )
+        return self._data[0]
+
+    fn __bool__(self) raises -> Bool:
+        """Return the boolean value of a single-element tensor.
+
+        Follows PyTorch/NumPy convention: a single-element tensor can be
+        used in boolean context. Returns True if the value is non-zero.
+
+        Returns:
+            True if the single element is non-zero, False otherwise.
+
+        Raises:
+            Error: If tensor has more than one element.
+
+        Example:
+            ```mojo
+            var t = Tensor[DType.float32]([1])
+            t[0] = 5.0
+            if t:  # True
+                print("non-zero")
+            ```
+        """
+        return self.item().__bool__()
+
+    # ------------------------------------------------------------------
     # Query methods
     # ------------------------------------------------------------------
 

--- a/tests/shared/tensor/test_tensor_element_access.mojo
+++ b/tests/shared/tensor/test_tensor_element_access.mojo
@@ -13,6 +13,8 @@ Tests cover:
 - __str__ output format
 - __len__ returns first dimension
 - 1D tensor correctness
+- item() single-element extraction and multi-element error
+- __bool__ truthiness for zero/non-zero and multi-element error
 """
 
 from testing import assert_true, assert_almost_equal
@@ -99,6 +101,67 @@ fn test_tensor_getitem_float64_typed() raises:
     print("PASS: test_tensor_getitem_float64_typed")
 
 
+fn test_tensor_item_single_element() raises:
+    """Verify item() extracts value from single-element tensor."""
+    var t = Tensor[DType.float32]([1])
+    t[0] = Scalar[DType.float32](42.0)
+    var val = t.item()
+    assert_almost_equal(Float32(val), Float32(42.0), atol=1e-6)
+    print("PASS: test_tensor_item_single_element")
+
+
+fn test_tensor_item_raises_multi_element() raises:
+    """Verify item() raises for multi-element tensor."""
+    var t = Tensor[DType.float32]([5])
+    var error_raised = False
+    try:
+        var val = t.item()
+        _ = val
+    except e:
+        error_raised = True
+        var error_msg = String(e)
+        if "single" not in error_msg.lower():
+            raise Error(
+                "Error message should mention single-element requirement"
+            )
+    if not error_raised:
+        raise Error("item() on multi-element tensor should raise error")
+    print("PASS: test_tensor_item_raises_multi_element")
+
+
+fn test_tensor_bool_single_element() raises:
+    """__bool__ on single-element tensor returns correct truthiness."""
+    var t_zero = Tensor[DType.float32]([1])
+    t_zero[0] = Scalar[DType.float32](0.0)
+    var t_nonzero = Tensor[DType.float32]([1])
+    t_nonzero[0] = Scalar[DType.float32](5.0)
+
+    if t_zero:
+        raise Error("Zero tensor should be falsy")
+    if not t_nonzero:
+        raise Error("Non-zero tensor should be truthy")
+    print("PASS: test_tensor_bool_single_element")
+
+
+fn test_tensor_bool_raises_multi_element() raises:
+    """__bool__ raises for multi-element tensor."""
+    var t = Tensor[DType.float32]([5])
+    var error_raised = False
+    try:
+        var val = t.__bool__()
+        _ = val
+    except e:
+        error_raised = True
+        var error_msg = String(e)
+        if "single" not in error_msg.lower():
+            raise Error(
+                "Error message should mention single-element requirement"
+            )
+    if not error_raised:
+        raise Error("__bool__ on multi-element tensor should raise error")
+    print("PASS: test_tensor_bool_raises_multi_element")
+
+
 fn main() raises:
     test_tensor_float32_creation()
     test_tensor_float64_creation()
@@ -109,4 +172,8 @@ fn main() raises:
     test_tensor_str_output()
     test_tensor_len()
     test_tensor_1d()
-    print("All 9 tensor element access tests passed!")
+    test_tensor_item_single_element()
+    test_tensor_item_raises_multi_element()
+    test_tensor_bool_single_element()
+    test_tensor_bool_raises_multi_element()
+    print("All 13 tensor element access tests passed!")


### PR DESCRIPTION
## Summary

- Add `item()` and `__bool__()` methods to the parametric `Tensor[dtype]` struct, matching the existing `AnyTensor` API
- `__bool__` follows PyTorch/NumPy convention: single-element tensors evaluate to `True` if non-zero, `False` if zero; multi-element tensors raise an error
- Add 4 new tests covering `item()` extraction, `item()` error on multi-element, `__bool__` truthiness, and `__bool__` error on multi-element tensors

Closes #3271

## Test plan

- [x] `test_tensor_item_single_element` -- verifies `item()` returns correct typed scalar value
- [x] `test_tensor_item_raises_multi_element` -- verifies `item()` raises error for tensors with >1 element
- [x] `test_tensor_bool_single_element` -- verifies zero tensor is falsy and non-zero tensor is truthy
- [x] `test_tensor_bool_raises_multi_element` -- verifies `__bool__` raises error for tensors with >1 element
- [x] All 13 `test_tensor_element_access.mojo` tests pass (9 existing + 4 new)
- [x] All existing `test_utility.mojo` AnyTensor tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)