### PR TITLE
test(validation): add confusion matrix integration test

### DIFF
--- a/shared/training/loops/validation_loop.mojo
+++ b/shared/training/loops/validation_loop.mojo
@@ -80,6 +80,44 @@ fn validate(
     Raises:
             Error: If validation fails.
     """
+    var confusion_matrix = ConfusionMatrix(num_classes=num_classes)
+    return _validate_impl(
+        model_forward,
+        compute_loss,
+        val_loader,
+        confusion_matrix,
+        compute_accuracy,
+        compute_confusion,
+        num_classes,
+    )
+
+
+fn _validate_impl(
+    model_forward: fn (AnyTensor) raises -> AnyTensor,
+    compute_loss: fn (AnyTensor, AnyTensor) raises -> AnyTensor,
+    mut val_loader: DataLoader,
+    mut confusion_matrix: ConfusionMatrix,
+    compute_accuracy: Bool = True,
+    compute_confusion: Bool = False,
+    num_classes: Int = 10,
+) raises -> Float64:
+    """Run validation loop with caller-provided confusion matrix.
+
+    Args:
+            model_forward: Forward pass function.
+            compute_loss: Loss computation function.
+            val_loader: Validation data loader.
+            confusion_matrix: Confusion matrix to update (caller retains access).
+            compute_accuracy: Whether to compute accuracy.
+            compute_confusion: Whether to compute confusion matrix.
+            num_classes: Number of classes (for confusion matrix).
+
+    Returns:
+            Average validation loss.
+
+    Raises:
+            Error: If validation fails.
+    """
     print("\nRunning validation...")
 
     var total_loss = Float64(0.0)
@@ -88,7 +126,6 @@ fn validate(
     # Setup metrics
     var accuracy_metric = AccuracyMetric()
     var loss_tracker = LossTracker(window_size=100)
-    var confusion_matrix = ConfusionMatrix(num_classes=num_classes)
 
     # Reset dataloader
     val_loader.reset()
@@ -158,37 +195,47 @@ struct ValidationLoop:
     - Metric aggregation
     - Subset validation support
     - Memory-efficient evaluation
+    - Confusion matrix tracking (when compute_confusion=True)
     """
 
     var compute_accuracy: Bool
     var compute_confusion: Bool
     var num_classes: Int
+    var confusion_matrix: ConfusionMatrix
+    """Confusion matrix populated during run() when compute_confusion=True."""
 
     fn __init__(
         out self,
         compute_accuracy: Bool = True,
         compute_confusion: Bool = False,
         num_classes: Int = 10,
-    ):
+    ) raises:
         """Initialize validation loop.
 
         Args:
             compute_accuracy: Whether to compute accuracy.
             compute_confusion: Whether to compute confusion matrix.
             num_classes: Number of classes (for confusion matrix).
+
+        Raises:
+            Error: If confusion matrix initialization fails.
         """
         self.compute_accuracy = compute_accuracy
         self.compute_confusion = compute_confusion
         self.num_classes = num_classes
+        self.confusion_matrix = ConfusionMatrix(num_classes=num_classes)
 
     fn run(
-        self,
+        mut self,
         model_forward: fn (AnyTensor) raises -> AnyTensor,
         compute_loss: fn (AnyTensor, AnyTensor) raises -> AnyTensor,
         mut val_loader: DataLoader,
         mut metrics: TrainingMetrics,
     ) raises -> Float64:
         """Run validation loop.
+
+        After this call, self.confusion_matrix contains the accumulated
+        counts when compute_confusion=True.
 
         Args:
             model_forward: Forward pass function.
@@ -202,10 +249,14 @@ struct ValidationLoop:
         Raises:
             Error: If validation fails.
         """
-        var val_loss = validate(
+        # Reset confusion matrix for this run
+        self.confusion_matrix.reset()
+
+        var val_loss = _validate_impl(
             model_forward,
             compute_loss,
             val_loader,
+            self.confusion_matrix,
             self.compute_accuracy,
             self.compute_confusion,
             self.num_classes,

--- a/shared/training/trainer.mojo
+++ b/shared/training/trainer.mojo
@@ -69,11 +69,14 @@ struct BaseTrainer(Trainer):
     var validation_loop: ValidationLoop
     var is_training: Bool
 
-    fn __init__(out self, config: TrainerConfig):
+    fn __init__(out self, config: TrainerConfig) raises:
         """Initialize base trainer.
 
         Args:
             config: Trainer configuration.
+
+        Raises:
+            Error: If validation loop initialization fails.
         """
         self.config = config.copy()
         self.metrics = TrainingMetrics()
@@ -424,7 +427,7 @@ struct BaseTrainer(Trainer):
         self.is_training = False
 
 
-fn create_trainer(config: TrainerConfig) -> BaseTrainer:
+fn create_trainer(config: TrainerConfig) raises -> BaseTrainer:
     """Create a base trainer with given configuration.
 
     Args:
@@ -432,15 +435,21 @@ fn create_trainer(config: TrainerConfig) -> BaseTrainer:
 
     Returns:
             Initialized BaseTrainer.
+
+    Raises:
+            Error: If trainer initialization fails.
     """
     return BaseTrainer(config)
 
 
-fn create_default_trainer() -> BaseTrainer:
+fn create_default_trainer() raises -> BaseTrainer:
     """Create a trainer with default configuration.
 
     Returns:
             BaseTrainer with default config.
+
+    Raises:
+            Error: If trainer initialization fails.
     """
     var config = TrainerConfig()
     return BaseTrainer(config)

--- a/tests/shared/training/test_validation_loop.mojo
+++ b/tests/shared/training/test_validation_loop.mojo
@@ -485,6 +485,90 @@ fn test_confusion_matrix_all_wrong() raises:
 
 
 # ============================================================================
+# Helper: identity forward (returns input unchanged for controlled logits)
+# ============================================================================
+
+
+fn identity_forward(data: AnyTensor) raises -> AnyTensor:
+    """Identity forward: returns the input data unchanged.
+
+    Used to control predictions via crafted input logits.
+    """
+    return data
+
+
+# ============================================================================
+# ValidationLoop Confusion Matrix Integration Test (Issue #3185)
+# ============================================================================
+
+
+fn test_validation_loop_confusion_matrix_integration() raises:
+    """Integration test: ValidationLoop populates confusion matrix with correct counts.
+
+    Constructs ValidationLoop(compute_confusion=True, num_classes=2), runs
+    validation with crafted 2-column logit data and known int32 labels,
+    then inspects vloop.confusion_matrix to verify exact cell counts.
+
+    Fixture (single batch of 4 samples):
+        Data (logits):  [[1.0, 0.0], [0.0, 1.0], [0.0, 1.0], [1.0, 0.0]]
+        -> argmax:      [0, 1, 1, 0]
+        Labels:         [0, 1, 0, 1]
+
+    Expected confusion matrix (row=true, col=pred):
+            pred=0  pred=1
+    true=0    1       1    (TN=1, FP=1)
+    true=1    1       1    (FN=1, TP=1)
+
+    Closes #3185.
+    """
+    var vloop = ValidationLoop(
+        compute_confusion=True, compute_accuracy=False, num_classes=2
+    )
+
+    # Construct data: 4 samples, 2 logit columns
+    var n_samples = 4
+    var data_shape = List[Int]()
+    data_shape.append(n_samples)
+    data_shape.append(2)
+    var data = AnyTensor(data_shape, DType.float32)
+    # Row 0: [1.0, 0.0] -> argmax=0
+    data._data.bitcast[Float32]()[0] = Float32(1.0)
+    data._data.bitcast[Float32]()[1] = Float32(0.0)
+    # Row 1: [0.0, 1.0] -> argmax=1
+    data._data.bitcast[Float32]()[2] = Float32(0.0)
+    data._data.bitcast[Float32]()[3] = Float32(1.0)
+    # Row 2: [0.0, 1.0] -> argmax=1
+    data._data.bitcast[Float32]()[4] = Float32(0.0)
+    data._data.bitcast[Float32]()[5] = Float32(1.0)
+    # Row 3: [1.0, 0.0] -> argmax=0
+    data._data.bitcast[Float32]()[6] = Float32(1.0)
+    data._data.bitcast[Float32]()[7] = Float32(0.0)
+
+    var labels_shape = List[Int]()
+    labels_shape.append(n_samples)
+    var labels = AnyTensor(labels_shape, DType.int32)
+    labels._data.bitcast[Int32]()[0] = Int32(0)
+    labels._data.bitcast[Int32]()[1] = Int32(1)
+    labels._data.bitcast[Int32]()[2] = Int32(0)
+    labels._data.bitcast[Int32]()[3] = Int32(1)
+
+    var loader = DataLoader(data^, labels^, batch_size=4)
+    var metrics = TrainingMetrics()
+
+    # Run validation through ValidationLoop (the full integration path)
+    _ = vloop.run(identity_forward, simple_loss, loader, metrics)
+
+    # Inspect the confusion matrix stored on ValidationLoop
+    var raw = vloop.confusion_matrix.normalize(mode="none")
+    # Matrix layout: raw[row*2 + col] where row=true, col=pred
+    assert_equal_int(Int(raw._data.bitcast[Float64]()[0]), 1)  # [0,0] TN=1
+    assert_equal_int(Int(raw._data.bitcast[Float64]()[1]), 1)  # [0,1] FP=1
+    assert_equal_int(Int(raw._data.bitcast[Float64]()[2]), 1)  # [1,0] FN=1
+    assert_equal_int(Int(raw._data.bitcast[Float64]()[3]), 1)  # [1,1] TP=1
+    print("  test_validation_loop_confusion_matrix_integration: PASSED")
+
+
+# ============================================================================
 # Test Main
 # ============================================================================
 
@@ -524,5 +608,6 @@ fn main() raises:
     test_confusion_matrix_binary_counts()
     test_confusion_matrix_all_correct()
     test_confusion_matrix_all_wrong()
+    test_validation_loop_confusion_matrix_integration()
 
     print("\nAll validation loop tests passed!")


### PR DESCRIPTION
## Summary

- Expose `ConfusionMatrix` as a field on `ValidationLoop` so callers can inspect counts after `run()`
- Add `test_validation_loop_confusion_matrix_integration` that constructs `ValidationLoop(compute_confusion=True, num_classes=2)`, runs validation with known binary predictions, and asserts exact TN/FP/FN/TP counts
- Extract `_validate_impl()` to accept caller-provided confusion matrix (backwards-compatible `validate()` wrapper preserved)

## Changes Made

- `shared/training/loops/validation_loop.mojo`: Add `confusion_matrix` field to `ValidationLoop`, extract `_validate_impl()`, change `run()` to `mut self`
- `shared/training/trainer.mojo`: Add `raises` to `BaseTrainer.__init__` and factory functions (required by `ValidationLoop.__init__` now raising)
- `tests/shared/training/test_validation_loop.mojo`: Add `identity_forward` helper and `test_validation_loop_confusion_matrix_integration` integration test

## Test plan

- [x] `test_validation_loop_confusion_matrix_integration` verifies exact cell counts (TN=1, FP=1, FN=1, TP=1) after running through the full `ValidationLoop.run()` integration path
- [x] All existing validation loop tests pass
- [x] `validate()` standalone function tests pass (backwards compatible)
- [x] Package builds successfully (`just package`)
- [x] All pre-commit hooks pass

Closes #3185

🤖 Generated with [Claude Code](https://claude.com/claude-code)