### PR TITLE
Split Data CI group into 6 sub-groups in matrix

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -282,9 +282,24 @@ jobs:
           # ---- All data subsystems (formats/datasets/samplers/transforms/loaders) ----
           # NOTE: Data test JIT crashes mitigated by targeted submodule imports (#5103).
           # See docs/dev/mojo-jit-crash-workaround.md for details.
-          - name: "Data"
+          - name: "Data Core"
             path: "tests/shared/data"
-            pattern: "test_*.mojo datasets/test_*.mojo samplers/test_*.mojo transforms/test_*.mojo loaders/test_*.mojo formats/test_*.mojo"
+            pattern: "test_*.mojo"
+          - name: "Data Datasets"
+            path: "tests/shared/data/datasets"
+            pattern: "test_*.mojo"
+          - name: "Data Loaders"
+            path: "tests/shared/data/loaders"
+            pattern: "test_*.mojo"
+          - name: "Data Transforms"
+            path: "tests/shared/data/transforms"
+            pattern: "test_*.mojo"
+          - name: "Data Samplers"
+            path: "tests/shared/data/samplers"
+            pattern: "test_*.mojo"
+          - name: "Data Formats"
+            path: "tests/shared/data/formats"
+            pattern: "test_*.mojo"
           # ---- Autograd engine + shared benchmarking helpers ----
           # Kept as separate entries (not merged under tests/shared parent path)
           # to avoid silent pass-with-0-tests if a subdirectory is empty/renamed.


### PR DESCRIPTION
## Summary

- Replace the single monolithic `"Data"` CI matrix entry with 6 dedicated sub-group entries: **Data Core**, **Data Datasets**, **Data Loaders**, **Data Transforms**, **Data Samplers**, **Data Formats**
- Each sub-group uses `test_*.mojo` wildcard at its leaf path — new test files are auto-discovered without manual list updates
- All 52 data test files remain covered (13+8+5+18+6+2) with zero overlap between groups

Closes #4458

## Test plan

- [x] `python scripts/validate_test_coverage.py` exits 0
- [x] `just pre-commit-all` — all hooks pass (Validate Test Coverage, Check YAML, etc.)
- [x] Manual verification: 52 files across 6 groups, no overlaps
- [ ] CI: 6 separate `Data *` matrix jobs appear in GitHub Actions
- [ ] CI: `validate-test-coverage` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)