### PR TITLE
Consolidate dependency declarations with pixi.toml as single source of truth

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -225,6 +225,26 @@ jobs:
           python scripts/audit_shared_links.py
 
   # ============================================================================
+  # Dependency Sync Validation - pixi.toml is single source of truth
+  # ============================================================================
+  validate-dep-sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    name: "Dependency Sync Validation"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: '3.11'
+
+      - name: Validate dependency consistency
+        run: python scripts/check_dep_sync.py
+
+  # ============================================================================
   # Comprehensive Mojo Test Suite - Parallelized by Test Group
   # ============================================================================
   test-mojo-comprehensive:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,7 +13,7 @@ on:
     paths:
       - 'pixi.toml'
       - 'requirements.txt'
-      - 'tools/requirements.txt'
+      - 'requirements-dev.txt'
       - 'pyproject.toml'
       - '.github/dependabot.yml'
   schedule:
@@ -220,7 +220,7 @@ jobs:
           FILES_SCANNED=0
           VULN_COUNT=0
 
-          for file in requirements.txt tools/requirements.txt; do
+          for file in requirements.txt requirements-dev.txt; do
             if [ -f "$file" ]; then
               echo "### $file" >> safety-report.md
               echo "" >> safety-report.md
@@ -248,7 +248,7 @@ jobs:
           echo "## pip-audit Scan Results" > pip-audit-report.md
           echo "" >> pip-audit-report.md
 
-          pip install -r requirements.txt -r tools/requirements.txt 2>/dev/null || true
+          pip install -r requirements.txt -r requirements-dev.txt 2>/dev/null || true
 
           if pip-audit --format json --output pip-audit.json 2>/dev/null; then
             echo "✅ No vulnerabilities found" >> pip-audit-report.md
@@ -347,7 +347,7 @@ jobs:
 
       - name: Check licenses
         run: |
-          pip install -r requirements.txt -r tools/requirements.txt 2>/dev/null || true
+          pip install -r requirements.txt -r requirements-dev.txt 2>/dev/null || true
 
           echo "## License Audit Report" > license-report.md
           echo "" >> license-report.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ ENV PIXI_VERSION=0.65.0
 RUN curl -fsSL https://pixi.sh/install.sh | PIXI_VERSION=${PIXI_VERSION} bash
 
 # Copy dependency manifests first for layer caching
+# Note: requirements*.txt are auto-generated lockfiles from pixi.toml (see scripts/sync_requirements.py)
 COPY --chown=${USER_NAME}:${USER_NAME} pixi.toml pixi.lock pyproject.toml requirements.txt requirements-dev.txt .pre-commit-config.yaml ./
 
 # Install project dependencies (cached unless manifests change)

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -30,6 +30,7 @@ COPY pixi.toml pixi.lock ./
 RUN pixi install --frozen
 
 # Copy source code
+# Note: requirements*.txt are auto-generated lockfiles from pixi.toml (see scripts/sync_requirements.py)
 COPY shared/ ./shared/
 COPY tests/ ./tests/
 COPY pyproject.toml requirements.txt requirements-dev.txt ./

--- a/pixi.lock
+++ b/pixi.lock
@@ -12,9 +12,15 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.12.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.6.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/backports-datetime-fromisoformat-2.0.3-py314hdafbbf9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backrefs-6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bandit-1.9.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.3.0-pyhcf101f3_1.conda
@@ -27,7 +33,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py314h4a8dc5f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.6-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.2.1-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.5-py314h67df5f8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.3-py314hd8ed1ab_101.conda
@@ -35,13 +41,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dparse-0.6.4-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flask-3.1.3-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ghp-import-2.1.0-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.46-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.17-pyhd8ed1ab_0.conda
@@ -50,6 +62,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
@@ -78,11 +91,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lychee-0.22.0-he64ecbb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.10.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py314h67df5f8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/marshmallow-4.2.2-pyhcf101f3_0.conda
       - conda: https://conda.modular.com/max/noarch/mblack-26.1.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mergedeep-1.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-1.6.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-get-deps-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-material-9.7.6-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-material-extensions-1.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.modular.com/max/linux-64/mojo-0.26.1.0-release.conda
       - conda: https://conda.modular.com/max/linux-64/mojo-compiler-0.26.1.0-release.conda
       - conda: https://conda.modular.com/max/noarch/mojo-python-0.26.1.0-release.conda
@@ -95,10 +115,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbstripout-0.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nltk-3.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py314h2b28147_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/paginate-0.5.7-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.9.0.2-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
@@ -110,17 +132,21 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-hooks-4.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prettytable-3.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py314h0f05182_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-9.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py314h2e6c369_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygithub-2.8.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pymdown-extensions-10.21-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pynacl-1.6.2-py314h1594a91_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-5.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-timeout-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_101_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.2.0-pyhcf101f3_0.conda
@@ -129,27 +155,36 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-librt-0.8.1-py314h0f05182_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py314h67df5f8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyyaml-env-tag-1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2026.2.28-py314h5bd0f2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py314h2e6c369_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py314h0f05182_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.14.14-h40fa522_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/safety-3.7.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/safety-schemas-0.0.16-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stevedore-5.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tenacity-9.1.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.14.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py314h5bd0f2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.24.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20250915-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
@@ -158,6 +193,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py314h9891dd4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.2.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/watchdog-6.0.0-py314h9e666f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.6-pyhcf101f3_0.conda
@@ -180,6 +216,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.12.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
@@ -188,8 +225,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.6.9-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/backports-datetime-fromisoformat-2.0.3-py314hdafbbf9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backrefs-6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bandit-1.9.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.3.0-pyhcf101f3_1.conda
@@ -207,7 +247,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py314h4a8dc5f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.6-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.2.1-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py314h97ea11e_4.conda
@@ -223,7 +263,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dparse-0.6.4-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flask-3.1.3-pyhcf101f3_1.conda
@@ -237,6 +279,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonttools-4.62.0-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.2-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ghp-import-2.1.0-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.46-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
@@ -260,6 +303,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.0.0-pyhcf101f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
@@ -336,14 +380,21 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.43-h711ed8c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lychee-0.22.0-he64ecbb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.10.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py314h67df5f8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/marshmallow-4.2.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.10.8-py314hdafbbf9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.8-py314h1194b4b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.modular.com/max/noarch/mblack-26.1.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mergedeep-1.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-1.6.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-get-deps-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-material-9.7.6-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-material-extensions-1.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.modular.com/max/linux-64/mojo-0.26.1.0-release.conda
       - conda: https://conda.modular.com/max/linux-64/mojo-compiler-0.26.1.0-release.conda
       - conda: https://conda.modular.com/max/noarch/mojo-python-0.26.1.0-release.conda
@@ -358,6 +409,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbstripout-0.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nltk-3.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py314h2b28147_0.conda
@@ -366,6 +418,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/paginate-0.5.7-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.3.3-py314ha0b5721_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.9.0.2-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
@@ -389,19 +442,23 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-9.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py314h2e6c369_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygithub-2.8.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pymdown-extensions-10.21-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pynacl-1.6.2-py314h1594a91_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.10.2-py314h3987850_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-5.2.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-timeout-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_101_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.2.0-pyhcf101f3_0.conda
@@ -413,11 +470,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.1.post1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py314h67df5f8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyyaml-env-tag-1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.10.2-pl5321h16c4a6b_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2026.2.28-py314h5bd0f2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
@@ -427,11 +486,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py314h0f05182_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.14.14-h40fa522_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/safety-3.7.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/safety-schemas-0.0.16-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py314hf07bd8e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-2.1.0-pyha191276_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
@@ -439,14 +501,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.6-py314hc02f841_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stevedore-5.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tenacity-9.1.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.14.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py314h5bd0f2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.24.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20250915-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
@@ -458,6 +523,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.2.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/watchdog-6.0.0-py314h9e666f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-25.10.0-pyhd8ed1ab_0.conda
@@ -531,6 +597,18 @@ packages:
   purls: []
   size: 584660
   timestamp: 1768327524772
+- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
+  sha256: cc9fbc50d4ee7ee04e49ee119243e6f1765750f0fd0b4d270d5ef35461b643b1
+  md5: 52be5139047efadaeeb19c6a5103f92a
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/annotated-doc?source=hash-mapping
+  size: 14222
+  timestamp: 1762868213144
 - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
   sha256: e0ea1ba78fbb64f17062601edda82097fcf815012cf52bb704150a2668110d48
   md5: 2934f256a8acfe48f6ebb4fce6cde29c
@@ -643,6 +721,19 @@ packages:
   - pkg:pypi/attrs?source=compressed-mapping
   size: 64927
   timestamp: 1773935801332
+- conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.6.9-pyhd8ed1ab_0.conda
+  sha256: 4b42b6d075eebde1a9155b28457ee49cfc95c8b57dbf36936c244fc95dbc91dd
+  md5: 93ab741be30f5d5169e2ccfd32705ffa
+  depends:
+  - cryptography
+  - python >=3.10
+  - requests
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/authlib?source=hash-mapping
+  size: 148124
+  timestamp: 1772444659494
 - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
   sha256: a14a9ad02101aab25570543a59c5193043b73dc311a25650134ed9e6cb691770
   md5: f1976ce927373500cc19d3c0b2c85177
@@ -657,6 +748,17 @@ packages:
   - pkg:pypi/babel?source=compressed-mapping
   size: 7684321
   timestamp: 1772555330347
+- conda: https://conda.anaconda.org/conda-forge/linux-64/backports-datetime-fromisoformat-2.0.3-py314hdafbbf9_1.conda
+  sha256: 2380143b4687eca799e1597e56033dcc7676c44257a0512bb4bd2911aa363677
+  md5: e3584f55d48fb92f6cb7c87273c2e28b
+  depends:
+  - python >=3.14.0rc2,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 7426
+  timestamp: 1755765970318
 - conda: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
   noarch: generic
   sha256: c31ab719d256bc6f89926131e88ecd0f0c5d003fe8481852c6424f4ec6c7eb29
@@ -667,6 +769,17 @@ packages:
   purls: []
   size: 7514
   timestamp: 1767044983590
+- conda: https://conda.anaconda.org/conda-forge/noarch/backrefs-6.2-pyhd8ed1ab_0.conda
+  sha256: ea22e1ae38622c7872a41708a248ef0b1917ca3d91a0672995a0c8cbfc85c04e
+  md5: d78c9304d873002ca50e65c33ed6ff0e
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/backrefs?source=hash-mapping
+  size: 144933
+  timestamp: 1771286293210
 - conda: https://conda.anaconda.org/conda-forge/noarch/bandit-1.9.4-pyhd8ed1ab_0.conda
   sha256: ac84f32020800be62b325c6c315ceb511427f1bf664fc12110290b721e449d2a
   md5: f99ecbb2c98d7a47685ace879f754601
@@ -893,19 +1006,18 @@ packages:
   - pkg:pypi/charset-normalizer?source=compressed-mapping
   size: 58510
   timestamp: 1773660086450
-- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
-  sha256: 38cfe1ee75b21a8361c8824f5544c3866f303af1762693a178266d7f198e8715
-  md5: ea8a6c3256897cc31263de9f455e25d9
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.2.1-pyh707e725_0.conda
+  sha256: 8aee789c82d8fdd997840c952a586db63c6890b00e88c4fb6e80a38edd5f51c0
+  md5: 94b550b8d3a614dbd326af798c7dfb40
   depends:
-  - python >=3.10
   - __unix
-  - python
+  - python >=3.10
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/click?source=hash-mapping
-  size: 97676
-  timestamp: 1764518652276
+  size: 87749
+  timestamp: 1747811451319
 - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
   sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
   md5: 962b9857ee8e7018c22f2776ffa0b2d7
@@ -1103,6 +1215,19 @@ packages:
   purls: []
   size: 71809
   timestamp: 1765193127016
+- conda: https://conda.anaconda.org/conda-forge/noarch/dparse-0.6.4-pyhff2d567_0.conda
+  sha256: 566e97ef8c7676b458493e3946207683cda76b741a201928f411c59902524a22
+  md5: 5d6dff2b4879b872a1cd9044d88f004d
+  depends:
+  - packaging
+  - python >=3.9
+  - tomli
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/dparse?source=hash-mapping
+  size: 22268
+  timestamp: 1731180466651
 - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
   sha256: ee6cf346d017d954255bbcbdb424cddea4d14e4ed7e9813e429db1d795d01144
   md5: 8e662bd460bda79b1ea39194e3c4c9ab
@@ -1114,6 +1239,17 @@ packages:
   - pkg:pypi/exceptiongroup?source=hash-mapping
   size: 21333
   timestamp: 1763918099466
+- conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
+  sha256: 1acc6a420efc5b64c384c1f35f49129966f8a12c93b4bb2bdc30079e5dc9d8a8
+  md5: a57b4be42619213a94f31d2c69c5dda7
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/execnet?source=hash-mapping
+  size: 39499
+  timestamp: 1762974150770
 - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
   sha256: 210c8165a58fdbf16e626aac93cc4c14dbd551a01d1516be5ecad795d2422cad
   md5: ff9efb7f7469aed3c4a8106ffa29593c
@@ -1262,6 +1398,18 @@ packages:
   purls: []
   size: 174292
   timestamp: 1772757205296
+- conda: https://conda.anaconda.org/conda-forge/noarch/ghp-import-2.1.0-pyhd8ed1ab_2.conda
+  sha256: 40fdf5a9d5cc7a3503cd0c33e1b90b1e6eab251aaaa74e6b965417d089809a15
+  md5: 93f742fe078a7b34c29a182958d4d765
+  depends:
+  - python >=3.9
+  - python-dateutil >=2.8.1
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/ghp-import?source=hash-mapping
+  size: 16538
+  timestamp: 1734344477841
 - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
   sha256: dbbec21a369872c8ebe23cb9a3b9d63638479ee30face165aa0fccc96e93eec3
   md5: 7c14f3706e099f8fcd47af2d494616cc
@@ -1598,6 +1746,18 @@ packages:
   - pkg:pypi/jinja2?source=compressed-mapping
   size: 120685
   timestamp: 1764517220861
+- conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.3-pyhd8ed1ab_0.conda
+  sha256: 301539229d7be6420c084490b8145583291123f0ce6b92f56be5948a2c83a379
+  md5: 615de2a4d97af50c350e5cf160149e77
+  depends:
+  - python >=3.10
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/joblib?source=hash-mapping
+  size: 226448
+  timestamp: 1765794135253
 - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.13.0-pyhd8ed1ab_0.conda
   sha256: ba03ca5a6db38d9f48bd30172e8c512dea7a686a5c7701c6fcdb7b3023dae2ad
   md5: 8d5f66ebf832c4ce28d5c37a0e76605c
@@ -2623,6 +2783,19 @@ packages:
   purls: []
   size: 5907664
   timestamp: 1765062488326
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.10.2-pyhcf101f3_0.conda
+  sha256: 20e0892592a3e7c683e3d66df704a9425d731486a97c34fc56af4da1106b2b6b
+  md5: ba0a9221ce1063f31692c07370d062f3
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/markdown?source=compressed-mapping
+  size: 85893
+  timestamp: 1770694658918
 - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
   sha256: 7b1da4b5c40385791dbc3cc85ceea9fad5da680a27d5d3cb8bfaa185e304a89e
   md5: 5b5203189eb668f042ac2b0826244964
@@ -2651,6 +2824,19 @@ packages:
   - pkg:pypi/markupsafe?source=hash-mapping
   size: 27424
   timestamp: 1772445227915
+- conda: https://conda.anaconda.org/conda-forge/noarch/marshmallow-4.2.2-pyhcf101f3_0.conda
+  sha256: a618b134778c19b0eb4e2a8b8f0966b44ecead95390dd3145ae28571ecfc1b2b
+  md5: 8c560fab8cd41ff0fa0226036e6afc88
+  depends:
+  - python >=3.10
+  - backports-datetime-fromisoformat
+  - typing_extensions
+  - python
+  license: MIT AND BSD-3-Clause
+  purls:
+  - pkg:pypi/marshmallow?source=hash-mapping
+  size: 98003
+  timestamp: 1770232168942
 - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.10.8-py314hdafbbf9_0.conda
   sha256: 0c9417291ada8df3415ad13d52db38707adaba42584246264294e0faaaa54f77
   md5: 8286e3966eac286d5ac7c7a4afbac812
@@ -2733,6 +2919,17 @@ packages:
   - pkg:pypi/mdurl?source=hash-mapping
   size: 14465
   timestamp: 1733255681319
+- conda: https://conda.anaconda.org/conda-forge/noarch/mergedeep-1.3.4-pyhd8ed1ab_1.conda
+  sha256: e5b555fd638334a253d83df14e3c913ef8ce10100090e17fd6fb8e752d36f95d
+  md5: d9a8fc1f01deae61735c88ec242e855c
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/mergedeep?source=hash-mapping
+  size: 11676
+  timestamp: 1734157119152
 - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.0-pyhcf101f3_0.conda
   sha256: d3fb4beb5e0a52b6cc33852c558e077e1bfe44df1159eb98332d69a264b14bae
   md5: b11e360fc4de2b0035fc8aaa74f17fd6
@@ -2746,6 +2943,84 @@ packages:
   - pkg:pypi/mistune?source=hash-mapping
   size: 74250
   timestamp: 1766504456031
+- conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-1.6.1-pyhd8ed1ab_1.conda
+  sha256: 902d2e251f9a7ffa7d86a3e62be5b2395e28614bd4dbe5f50acf921fd64a8c35
+  md5: 14661160be39d78f2b210f2cc2766059
+  depends:
+  - click >=7.0,<8.3.0a0
+  - colorama >=0.4
+  - ghp-import >=1.0
+  - importlib-metadata >=4.4
+  - jinja2 >=2.11.1
+  - markdown >=3.3.6
+  - markupsafe >=2.0.1
+  - mergedeep >=1.3.4
+  - mkdocs-get-deps >=0.2.0
+  - packaging >=20.5
+  - pathspec >=0.11.1
+  - python >=3.9
+  - pyyaml >=5.1
+  - pyyaml-env-tag >=0.1
+  - watchdog >=2.0
+  constrains:
+  - babel >=2.9.0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/mkdocs?source=hash-mapping
+  size: 3524754
+  timestamp: 1734344673481
+- conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-get-deps-0.2.2-pyhd8ed1ab_0.conda
+  sha256: fad4463b52def6214f64dfb918ad77ec4feb4c5d1072838dcf693dab860fde52
+  md5: 4e396e96b60a1f616da1f0e5fceae543
+  depends:
+  - importlib-metadata >=4.3
+  - mergedeep >=1.3.4
+  - platformdirs >=2.2.0
+  - python >=3.10
+  - pyyaml >=5.1
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/mkdocs-get-deps?source=hash-mapping
+  size: 15572
+  timestamp: 1773570672864
+- conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-material-9.7.6-pyhcf101f3_0.conda
+  sha256: af3b6eead849d8de1fced264d5125f9f3191999ff1f45e5846459af025465e3b
+  md5: 18b0913b53bb4c636c06e0b4557f3f1e
+  depends:
+  - python >=3.10
+  - jinja2 >=3.1
+  - markdown >=3.2
+  - mkdocs >=1.6
+  - mkdocs-material-extensions >=1.3
+  - pygments >=2.16
+  - pymdown-extensions >=10.2
+  - babel >=2.10
+  - colorama >=0.4
+  - paginate >=0.5
+  - backrefs >=5.7.post1
+  - requests >=2.30
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/mkdocs-material?source=hash-mapping
+  size: 4800762
+  timestamp: 1773953779495
+- conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-material-extensions-1.3.1-pyhd8ed1ab_1.conda
+  sha256: f62955d40926770ab65cc54f7db5fde6c073a3ba36a0787a7a5767017da50aa3
+  md5: de8af4000a4872e16fb784c649679c8e
+  depends:
+  - python >=3.9
+  constrains:
+  - mkdocs-material >=5.0.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/mkdocs-material-extensions?source=hash-mapping
+  size: 16122
+  timestamp: 1734641109286
 - conda: https://conda.modular.com/max/linux-64/mojo-0.26.1.0-release.conda
   sha256: e945e8fbff0fdd2064ea193b26fb4ba95ab782367cfd2a2c4522350066434494
   depends:
@@ -2927,6 +3202,22 @@ packages:
   - pkg:pypi/nest-asyncio?source=hash-mapping
   size: 11543
   timestamp: 1733325673691
+- conda: https://conda.anaconda.org/conda-forge/noarch/nltk-3.9.4-pyhcf101f3_0.conda
+  sha256: c872b1659fe016fc8592f2271bb2f805d511f4266503388e48aff5e836c1fec6
+  md5: b7062c4781765a9e0b10403550a771c0
+  depends:
+  - python >=3.10
+  - click
+  - joblib
+  - regex >=2021.8.3
+  - tqdm
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/nltk?source=hash-mapping
+  size: 1161578
+  timestamp: 1774340885455
 - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
   sha256: 4fa40e3e13fc6ea0a93f67dfc76c96190afd7ea4ffc1bac2612d954b42cdc3ee
   md5: eb52d14a901e23c39e9e7b4a1a5c015f
@@ -3037,6 +3328,17 @@ packages:
   - pkg:pypi/packaging?source=compressed-mapping
   size: 72010
   timestamp: 1769093650580
+- conda: https://conda.anaconda.org/conda-forge/noarch/paginate-0.5.7-pyhd8ed1ab_1.conda
+  sha256: f6fef1b43b0d3d92476e1870c08d7b9c229aebab9a0556b073a5e1641cf453bd
+  md5: c3f35453097faf911fd3f6023fc2ab24
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/paginate?source=hash-mapping
+  size: 18865
+  timestamp: 1734618649164
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.3.3-py314ha0b5721_2.conda
   sha256: 0a86a582b906d9cfd4d2c59180898fe9d714b55eea7ced71630a1fedae206c62
   md5: fe3a5c8be07a7b82058bdeb39d33d93b
@@ -3365,6 +3667,17 @@ packages:
   - pkg:pypi/pure-eval?source=hash-mapping
   size: 16668
   timestamp: 1733569518868
+- conda: https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-9.0.0-pyhd8ed1ab_1.conda
+  sha256: 6d8f03c13d085a569fde931892cded813474acbef2e03381a1a87f420c7da035
+  md5: 46830ee16925d5ed250850503b5dc3a8
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/py-cpuinfo?source=hash-mapping
+  size: 25766
+  timestamp: 1733236452235
 - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
   sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
   md5: 12c566707c80111f9799308d9e265aef
@@ -3456,6 +3769,19 @@ packages:
   - pkg:pypi/pyjwt?source=hash-mapping
   size: 32247
   timestamp: 1773482160904
+- conda: https://conda.anaconda.org/conda-forge/noarch/pymdown-extensions-10.21-pyhd8ed1ab_0.conda
+  sha256: 9e852e0fddcbb41b22c4d6331786c8b34bd183f27f5a42773528dc7eab702625
+  md5: 4eee223c7f0598e74f5fde2a20bfb80e
+  depends:
+  - markdown >=3.6
+  - python >=3.10
+  - pyyaml
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pymdown-extensions?source=compressed-mapping
+  size: 171999
+  timestamp: 1773922214762
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pynacl-1.6.2-py314h1594a91_1.conda
   sha256: f2d22140c77652c5cc63e2d5828c303de3a2a55a0f6cf2a0768c49d781154619
   md5: 77fdae6293e45ed38efbc84370b8389e
@@ -3544,6 +3870,19 @@ packages:
   - pkg:pypi/pytest?source=hash-mapping
   size: 294852
   timestamp: 1762354779909
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-5.2.3-pyhd8ed1ab_0.conda
+  sha256: 2f2229415a6e5387c1faaedf442ea8c07471cb2bf5ad1007b9cfb83ea85ca29a
+  md5: 0e7294ed4af8b833fcd2c101d647c3da
+  depends:
+  - py-cpuinfo
+  - pytest >=8.1
+  - python >=3.10
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pytest-benchmark?source=hash-mapping
+  size: 43976
+  timestamp: 1762716480208
 - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.3.0-pyhd8ed1ab_0.conda
   sha256: 5ba3e0955e473234fcc38cb4f0d893135710ec85ccb1dffdd73d9b213e99e8fb
   md5: 50d191b852fccb4bf9ab7b59b030c99d
@@ -3571,6 +3910,21 @@ packages:
   - pkg:pypi/pytest-timeout?source=hash-mapping
   size: 20137
   timestamp: 1746533140824
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
+  sha256: b7b58a5be090883198411337b99afb6404127809c3d1c9f96e99b59f36177a96
+  md5: 8375cfbda7c57fbceeda18229be10417
+  depends:
+  - execnet >=2.1
+  - pytest >=7.0.0
+  - python >=3.9
+  constrains:
+  - psutil >=3.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pytest-xdist?source=hash-mapping
+  size: 39300
+  timestamp: 1751452761594
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_101_cp314.conda
   build_number: 101
   sha256: cb0628c5f1732f889f53a877484da98f5a0e0f47326622671396fb4f2b0cd6bd
@@ -3722,6 +4076,18 @@ packages:
   - pkg:pypi/pyyaml?source=compressed-mapping
   size: 202391
   timestamp: 1770223462836
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyyaml-env-tag-1.1-pyhd8ed1ab_0.conda
+  sha256: 69ab63bd45587406ae911811fc4d4c1bf972d643fa57a009de7c01ac978c4edd
+  md5: e8e53c4150a1bba3b160eacf9d53a51b
+  depends:
+  - python >=3.9
+  - pyyaml
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml-env-tag?source=hash-mapping
+  size: 11137
+  timestamp: 1747237061448
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
   noarch: python
   sha256: be66c1f85c3b48137200d62c12d918f4f8ad329423daef04fed292818efd3c28
@@ -3852,6 +4218,20 @@ packages:
   - pkg:pypi/referencing?source=hash-mapping
   size: 51788
   timestamp: 1760379115194
+- conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2026.2.28-py314h5bd0f2a_0.conda
+  sha256: e085e336f1446f5263a3ec9747df8c719b6996753901181add50dc4fdd8bb2e8
+  md5: 3c8b6a8c4d0ff5a264e9831eac4941f4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: Apache-2.0 AND CNRI-Python
+  license_family: PSF
+  purls:
+  - pkg:pypi/regex?source=hash-mapping
+  size: 411924
+  timestamp: 1772255161535
 - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
   sha256: 7813c38b79ae549504b2c57b3f33394cea4f2ad083f0994d2045c2e24cb538c5
   md5: c65df89a0b2e321045a9e01d1337b182
@@ -3980,6 +4360,53 @@ packages:
   - pkg:pypi/ruff?source=hash-mapping
   size: 9131490
   timestamp: 1769520999080
+- conda: https://conda.anaconda.org/conda-forge/noarch/safety-3.7.0-pyhcf101f3_0.conda
+  sha256: ef58a7f263b0c8dae61d26dbbb347f99953c9ca4ad3236c4dbd9cc53f378a474
+  md5: a09a0a5795851fa82267a6aabb694cd1
+  depends:
+  - authlib >=1.2.0
+  - click >=8.0.2
+  - dparse >=0.6.4
+  - filelock >=3.16.1,<4.0
+  - httpx <1.0
+  - jinja2 >=3.1.0
+  - marshmallow >=3.15.0
+  - nltk >=3.9
+  - packaging >=21.0
+  - pydantic >=2.6.0
+  - python >=3.10
+  - requests
+  - ruamel.yaml >=0.17.21
+  - safety-schemas ==0.0.16
+  - tenacity >=8.1.0
+  - tomli
+  - tomlkit
+  - typer >=0.16.0
+  - typing_extensions >=4.7.1
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/safety?source=hash-mapping
+  size: 295210
+  timestamp: 1762520587416
+- conda: https://conda.anaconda.org/conda-forge/noarch/safety-schemas-0.0.16-pyhcf101f3_0.conda
+  sha256: c042de377158b7fc88517c0265e7df9afa601fddcc3f39a6b533856f94ec0940
+  md5: 36f531ea4d928c5d3c2086f5e7938bb4
+  depends:
+  - dparse >=0.6.4
+  - ruamel.yaml >=0.17.21
+  - packaging >=21.0
+  - pydantic >=2.6.0
+  - python >=3.10
+  - typing_extensions >=4.7.1
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/safety-schemas?source=hash-mapping
+  size: 55732
+  timestamp: 1758147880904
 - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py314hf07bd8e_0.conda
   sha256: 1ae427836d7979779c9005388a05993a3addabcc66c4422694639a4272d7d972
   md5: d0510124f87c75403090e220db1e9d41
@@ -4056,6 +4483,17 @@ packages:
   - pkg:pypi/setuptools?source=compressed-mapping
   size: 639697
   timestamp: 1773074868565
+- conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+  sha256: 1d6534df8e7924d9087bd388fbac5bd868c5bf8971c36885f9f016da0657d22b
+  md5: 83ea3a2ddb7a75c1b09cea582aa4f106
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/shellingham?source=hash-mapping
+  size: 15018
+  timestamp: 1762858315311
 - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
   md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -4147,6 +4585,18 @@ packages:
   - pkg:pypi/stevedore?source=hash-mapping
   size: 36179
   timestamp: 1771653640360
+- conda: https://conda.anaconda.org/conda-forge/noarch/tenacity-9.1.4-pyhcf101f3_0.conda
+  sha256: 32e75900d6a094ffe4290a8c9f1fa15744d9da8ff617aba4acaa0f057a065c34
+  md5: 043f0599dc8aa023369deacdb5ac24eb
+  depends:
+  - python >=3.10
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/tenacity?source=hash-mapping
+  size: 31404
+  timestamp: 1770510172846
 - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
   sha256: 6b6727a13d1ca6a23de5e6686500d0669081a117736a87c8abf444d60c1e40eb
   md5: 17b43cee5cc84969529d5d0b0309b2cb
@@ -4212,6 +4662,17 @@ packages:
   - pkg:pypi/tomli?source=compressed-mapping
   size: 21453
   timestamp: 1768146676791
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.14.0-pyha770c72_0.conda
+  sha256: b35082091c8efd084e51bc3a4a2d3b07897eff232aaf58cbc0f959b6291a6a93
+  md5: 385dca77a8b0ec6fa9b92cb62d09b43b
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/tomlkit?source=compressed-mapping
+  size: 39224
+  timestamp: 1768476626454
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py314h5bd0f2a_0.conda
   sha256: b8f9f9ae508d79c9c697eb01b6a8d2ed4bc1899370f44aa6497c8abbd15988ea
   md5: e35f08043f54d26a1be93fdbf90d30c3
@@ -4249,6 +4710,22 @@ packages:
   - pkg:pypi/traitlets?source=hash-mapping
   size: 110051
   timestamp: 1733367480074
+- conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.24.0-pyhcf101f3_0.conda
+  sha256: e1116d08e6a55b2b42a090130c268f75211ad8e6a8e7749e977924de3864d487
+  md5: 10870929f587540c5802cd9b071cba5c
+  depends:
+  - annotated-doc >=0.0.2
+  - click >=8.2.1
+  - python >=3.10
+  - rich >=12.3.0
+  - shellingham >=1.3.0
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/typer?source=hash-mapping
+  size: 117860
+  timestamp: 1771292312899
 - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20250915-pyhd8ed1ab_1.conda
   sha256: ba565f80b5dc5d88f34587b391f21807efd54099516f11beae5cb29a7925fd3d
   md5: 0fcb42ddc8e8ba6f906274108e6d891d
@@ -4385,6 +4862,19 @@ packages:
   - pkg:pypi/virtualenv?source=compressed-mapping
   size: 4647775
   timestamp: 1773133660203
+- conda: https://conda.anaconda.org/conda-forge/linux-64/watchdog-6.0.0-py314h9e666f3_3.conda
+  sha256: 19605181aa56af8aeef977ec99614194420c96e929eaad2c1d858e5fcb16414c
+  md5: d0003e6427d81d247aa5ef84ba814d47
+  depends:
+  - python
+  - pyyaml >=3.10
+  - python_abi 3.14.* *_cp314
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/watchdog?source=hash-mapping
+  size: 162474
+  timestamp: 1772608179138
 - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
   sha256: ea374d57a8fcda281a0a89af0ee49a2c2e99cc4ac97cf2e2db7064e74e764bdb
   md5: 996583ea9c796e5b915f7d7580b51ea6

--- a/pixi.toml
+++ b/pixi.toml
@@ -6,27 +6,48 @@ version = "0.1.0"
 
 
 [dependencies]
+# Language runtime
 mojo = "==0.26.1"
-pre-commit = ">=3.5.0"
-prettytable = ">=3.17.0,<4"
+
+# Testing
 pytest = ">=8.1.0,<9"
 pytest-cov = ">=6.0.0,<7"
 pytest-timeout = ">=2.1.0,<3"
-pygithub = ">=2.8.1,<3"
-jsonschema = ">=4.0"
+pytest-xdist = ">=3.0.0,<4"
+pytest-benchmark = ">=5.0.0,<6"
+
+# Code quality
 ruff = ">=0.14.7,<0.16"
 bandit = ">=1.7.5"
-numpy = ">=2.3.5,<3"
-lychee = ">=0.22.0,<0.23"
-pip = ">=25.3,<26"
 mypy = ">=1.19.1,<2"
-nbstripout = ">=0.7.1"            # tracked to keep in sync with .pre-commit-config.yaml (Issue #4030)
-pre-commit-hooks = ">=4.5.0,<4.6"  # pinned to match .pre-commit-config.yaml rev (Issue #4030)
 types-PyYAML = ">=6.0"
+safety = ">=3.0.0,<4"
+
+# Pre-commit
+pre-commit = ">=3.5.0"
+pre-commit-hooks = ">=4.5.0,<4.6"  # pinned to match .pre-commit-config.yaml rev (Issue #4030)
+nbstripout = ">=0.7.1"            # tracked to keep in sync with .pre-commit-config.yaml (Issue #4030)
+
+# Documentation
+mkdocs = ">=1.6.0,<2"
+mkdocs-material = ">=9.0.0,<10"
+
+# Core libraries
+numpy = ">=2.3.5,<3"
+jinja2 = ">=3.1.0,<4"
+pyyaml = ">=6.0.0,<7"
+click = ">=8.0.0,<9"
 tqdm = ">=4.67.0,<5"
+flask = ">=3.0.0,<4"
+
+# Utilities
+prettytable = ">=3.17.0,<4"
+pygithub = ">=2.8.1,<3"
+jsonschema = ">=4.0"
 nbformat = ">=5.10.0,<6"
 nbconvert = ">=7.16.0,<8"
-flask = ">=3.0.0,<4"
+lychee = ">=0.22.0,<0.23"
+pip = ">=25.3,<26"
 just = "*"
 pydantic = ">=2.12.5,<3"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+# Dependencies are managed in pixi.toml (single source of truth).
+# This file provides project metadata and tool configuration only.
+
 [build-system]
 requires = ["setuptools>=65.0", "wheel"]
 build-backend = "setuptools.build_meta"
@@ -13,29 +16,10 @@ authors = [
     {name = "Micah Villmow", email = "4211002+mvillmow@users.noreply.github.com"}
 ]
 
-dependencies = [
-    "pytest>=7.0.0",
-    "pytest-cov>=4.0.0",
-    "pytest-timeout>=2.1.0",
-    "pytest-xdist>=3.0.0",
-]
-
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["scripts*"]
 exclude = ["tests*", "notes*", "agents*", "papers*", "docs*", "logs*"]
-
-[project.optional-dependencies]
-dev = [
-    "pre-commit>=3.0.0",
-    "safety>=2.0.0",
-    "bandit>=1.7.0",
-    "mkdocs>=1.5.0",
-    "mkdocs-material>=9.0.0",
-    "pytest-benchmark>=4.0.0",
-    "ruff>=0.1.0",
-    "mypy>=1.0.0",
-]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,18 +1,12 @@
-# Development dependencies
-# Pin exact versions for reproducibility
-# Update via Dependabot PRs
+# AUTO-GENERATED from pixi.toml — do not edit manually.
+# Regenerate with: python scripts/sync_requirements.py
+# These files exist for pip-only contexts (Docker, CI fallback).
+
 -r requirements.txt
 
-# Pre-commit hooks
-pre-commit==4.5.1
-
-# Security scanning
-safety==3.7.0
-bandit==1.9.4
-
-# Documentation
-mkdocs==1.6.1
-mkdocs-material==9.7.6
-
-# Benchmarking
-pytest-benchmark==5.2.3
+pre-commit==4.5.1  # Pre-commit hooks
+safety==3.7.0  # Security scanning
+bandit==1.9.4  # Security scanning
+mkdocs==1.6.1  # Documentation
+mkdocs-material==9.7.6  # Documentation
+pytest-benchmark==5.2.3  # Benchmarking

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,23 +1,13 @@
-# Core testing dependencies
-# Pin exact versions for reproducibility
-# Update via Dependabot PRs
+# AUTO-GENERATED from pixi.toml — do not edit manually.
+# Regenerate with: python scripts/sync_requirements.py
+# These files exist for pip-only contexts (Docker, CI fallback).
 
 pytest==8.4.2
 pytest-cov==6.3.0
 pytest-timeout==2.4.0
 pytest-xdist==3.8.0
-
-# Code quality
-ruff==0.15.7
-
-# Type checking
+ruff==0.14.14
 mypy==1.19.1
-
-# Template engine (paper scaffolding, code generation)
-jinja2==3.1.6
-
-# YAML parsing (configuration)
-pyyaml==6.0.3
-
-# CLI framework (command-line tools)
-click==8.3.1
+jinja2==3.1.6  # Template engine (paper scaffolding, code generation)
+pyyaml==6.0.3  # YAML parsing (configuration)
+click==8.2.1  # CLI framework (command-line tools)

--- a/scripts/check_dep_sync.py
+++ b/scripts/check_dep_sync.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Validate dependency consistency across project configuration files.
+
+Checks:
+1. Every package in requirements*.txt has a corresponding entry in pixi.toml.
+2. Pinned versions in requirements*.txt fall within pixi.toml range constraints.
+3. pyproject.toml does not declare [project.dependencies] or
+   [project.optional-dependencies].
+
+Usage:
+    python scripts/check_dep_sync.py
+    python scripts/check_dep_sync.py --repo-root /path/to/repo
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, NamedTuple, Optional, Tuple
+
+
+class VersionRange(NamedTuple):
+    """A single version constraint (operator + version)."""
+
+    op: str
+    version: Tuple[int, ...]
+
+
+def parse_version(v: str) -> Tuple[int, ...]:
+    """Parse a dotted version string into a tuple of ints."""
+    return tuple(int(x) for x in v.split("."))
+
+
+def parse_pixi_constraints(spec: str) -> List[VersionRange]:
+    """Parse a pixi.toml version spec like ``>=1.2.0,<2`` into constraints."""
+    constraints: List[VersionRange] = []
+    # Remove surrounding quotes
+    spec = spec.strip().strip('"').strip("'")
+    for part in spec.split(","):
+        part = part.strip()
+        match = re.match(r"(>=|<=|>|<|==|!=|~=)(.+)", part)
+        if match:
+            op, ver = match.group(1), match.group(2)
+            constraints.append(VersionRange(op=op, version=parse_version(ver)))
+    return constraints
+
+
+def version_satisfies(version: Tuple[int, ...], constraints: List[VersionRange]) -> bool:
+    """Check if *version* satisfies all *constraints*."""
+    for c in constraints:
+        # Pad shorter tuple with zeros for comparison
+        v = version + (0,) * max(0, len(c.version) - len(version))
+        cv = c.version + (0,) * max(0, len(version) - len(c.version))
+        if c.op == ">=" and not (v >= cv):
+            return False
+        if c.op == "<=" and not (v <= cv):
+            return False
+        if c.op == ">" and not (v > cv):
+            return False
+        if c.op == "<" and not (v < cv):
+            return False
+        if c.op == "==" and not (v == cv):
+            return False
+        if c.op == "!=" and (v == cv):
+            return False
+    return True
+
+
+def parse_pixi_toml(path: Path) -> Dict[str, str]:
+    """Extract package name → version spec from pixi.toml [dependencies]."""
+    deps: Dict[str, str] = {}
+    in_deps = False
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("[dependencies]"):
+            in_deps = True
+            continue
+        if stripped.startswith("[") and in_deps:
+            in_deps = False
+            continue
+        if in_deps and "=" in stripped and not stripped.startswith("#"):
+            # Handle inline comments
+            line_no_comment = stripped.split("#")[0].strip()
+            match = re.match(r'(\S+)\s*=\s*"([^"]+)"', line_no_comment)
+            if match:
+                deps[match.group(1)] = match.group(2)
+    return deps
+
+
+def parse_requirements(path: Path) -> Dict[str, str]:
+    """Extract package name → pinned version from a requirements file."""
+    pins: Dict[str, str] = {}
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or stripped.startswith("-r"):
+            continue
+        # Strip inline comments
+        stripped = stripped.split("#")[0].strip()
+        match = re.match(r"([a-zA-Z0-9_-]+)==(.+)", stripped)
+        if match:
+            pins[match.group(1).lower()] = match.group(2)
+    return pins
+
+
+def check_pyproject_no_deps(path: Path) -> List[str]:
+    """Return errors if pyproject.toml still declares dependencies."""
+    errors: List[str] = []
+    text = path.read_text()
+    if re.search(r"^\[project\.dependencies\]", text, re.MULTILINE):
+        errors.append("pyproject.toml contains [project.dependencies] — remove it")
+    if re.search(r"^\[project\].*?^dependencies\s*=", text, re.MULTILINE | re.DOTALL):
+        # Check for inline dependencies in [project] section
+        in_project = False
+        for line in text.splitlines():
+            if line.strip() == "[project]":
+                in_project = True
+            elif line.strip().startswith("[") and line.strip() != "[project]":
+                in_project = False
+            elif in_project and line.strip().startswith("dependencies"):
+                errors.append(
+                    "pyproject.toml [project] section contains 'dependencies' — "
+                    "remove it (deps are managed in pixi.toml)"
+                )
+                break
+    if "[project.optional-dependencies]" in text:
+        errors.append("pyproject.toml contains [project.optional-dependencies] — remove it")
+    return errors
+
+
+def check_dep_sync(repo_root: Optional[Path] = None) -> List[str]:
+    """Run all dependency consistency checks.
+
+    Returns:
+        List of error messages (empty means all checks passed).
+    """
+    if repo_root is None:
+        repo_root = Path(__file__).resolve().parent.parent
+    errors: List[str] = []
+
+    pixi_path = repo_root / "pixi.toml"
+    pyproject_path = repo_root / "pyproject.toml"
+
+    if not pixi_path.exists():
+        errors.append("pixi.toml not found")
+        return errors
+
+    pixi_deps = parse_pixi_toml(pixi_path)
+    # Normalize pixi package names to lowercase
+    pixi_deps_lower = {k.lower(): v for k, v in pixi_deps.items()}
+
+    # Check requirements files
+    for req_file in ["requirements.txt", "requirements-dev.txt"]:
+        req_path = repo_root / req_file
+        if not req_path.exists():
+            continue
+        pins = parse_requirements(req_path)
+        for pkg, pinned_ver in pins.items():
+            if pkg not in pixi_deps_lower:
+                errors.append(f"{req_file}: {pkg}=={pinned_ver} has no matching entry in pixi.toml")
+                continue
+            constraints = parse_pixi_constraints(pixi_deps_lower[pkg])
+            if constraints:
+                ver_tuple = parse_version(pinned_ver)
+                if not version_satisfies(ver_tuple, constraints):
+                    errors.append(
+                        f"{req_file}: {pkg}=={pinned_ver} falls outside pixi.toml constraint {pixi_deps_lower[pkg]}"
+                    )
+
+    # Check pyproject.toml
+    if pyproject_path.exists():
+        errors.extend(check_pyproject_no_deps(pyproject_path))
+
+    return errors
+
+
+def main() -> None:
+    """Entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root directory (default: auto-detect).",
+    )
+    args = parser.parse_args()
+
+    errors = check_dep_sync(args.repo_root)
+    if errors:
+        print("Dependency sync check FAILED:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        sys.exit(1)
+    else:
+        print("OK: all dependency declarations are consistent")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync_requirements.py
+++ b/scripts/sync_requirements.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Synchronize requirements*.txt from pixi.toml resolved versions.
+
+Reads pixi.lock (via ``pixi list --json``) and regenerates
+``requirements.txt`` and ``requirements-dev.txt`` with exact pins
+matching the pixi-resolved versions.
+
+Usage:
+    python scripts/sync_requirements.py
+    python scripts/sync_requirements.py --check  # verify files are up-to-date
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+# Header written at the top of every generated requirements file.
+GENERATED_HEADER = """\
+# AUTO-GENERATED from pixi.toml — do not edit manually.
+# Regenerate with: python scripts/sync_requirements.py
+# These files exist for pip-only contexts (Docker, CI fallback).
+"""
+
+# Packages that belong in requirements.txt (core runtime/testing).
+CORE_PACKAGES: List[str] = [
+    "pytest",
+    "pytest-cov",
+    "pytest-timeout",
+    "pytest-xdist",
+    "ruff",
+    "mypy",
+    "jinja2",
+    "pyyaml",
+    "click",
+]
+
+# Additional packages in requirements-dev.txt (dev-only tooling).
+DEV_PACKAGES: List[str] = [
+    "pre-commit",
+    "safety",
+    "bandit",
+    "mkdocs",
+    "mkdocs-material",
+    "pytest-benchmark",
+]
+
+
+def get_pixi_packages() -> Dict[str, str]:
+    """Return a mapping of {package_name: version} from ``pixi list --json``."""
+    result = subprocess.run(
+        ["pixi", "list", "--json"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"Error running pixi list --json: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    data = json.loads(result.stdout)
+    return {pkg["name"]: pkg["version"] for pkg in data}
+
+
+def generate_requirements(
+    packages: List[str],
+    resolved: Dict[str, str],
+    *,
+    include_base: Optional[str] = None,
+    section_comments: Optional[Dict[str, str]] = None,
+) -> str:
+    """Build a requirements file string with exact pins from resolved versions.
+
+    Args:
+        packages: Package names to include.
+        resolved: Mapping of package name to resolved version.
+        include_base: Optional ``-r <file>`` line to include at the top.
+        section_comments: Optional mapping of package name to inline comment.
+
+    Returns:
+        The full file content as a string.
+    """
+    if section_comments is None:
+        section_comments = {}
+
+    lines: List[str] = [GENERATED_HEADER]
+    if include_base:
+        lines.append(include_base)
+        lines.append("")
+
+    for pkg in packages:
+        version = resolved.get(pkg)
+        if version is None:
+            print(
+                f"Warning: {pkg} not found in pixi environment, skipping",
+                file=sys.stderr,
+            )
+            continue
+        comment = section_comments.get(pkg, "")
+        suffix = f"  {comment}" if comment else ""
+        lines.append(f"{pkg}=={version}{suffix}")
+
+    # Ensure trailing newline
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_requirements(repo_root: Path, resolved: Dict[str, str]) -> List[Path]:
+    """Write requirements.txt and requirements-dev.txt under *repo_root*.
+
+    Returns:
+        List of paths written.
+    """
+    core_comments: Dict[str, str] = {
+        "jinja2": "# Template engine (paper scaffolding, code generation)",
+        "pyyaml": "# YAML parsing (configuration)",
+        "click": "# CLI framework (command-line tools)",
+    }
+    dev_comments: Dict[str, str] = {
+        "pre-commit": "# Pre-commit hooks",
+        "safety": "# Security scanning",
+        "bandit": "# Security scanning",
+        "mkdocs": "# Documentation",
+        "mkdocs-material": "# Documentation",
+        "pytest-benchmark": "# Benchmarking",
+    }
+
+    req_txt = generate_requirements(
+        CORE_PACKAGES,
+        resolved,
+        section_comments=core_comments,
+    )
+    req_dev_txt = generate_requirements(
+        DEV_PACKAGES,
+        resolved,
+        include_base="-r requirements.txt",
+        section_comments=dev_comments,
+    )
+
+    paths: List[Path] = []
+    for name, content in [
+        ("requirements.txt", req_txt),
+        ("requirements-dev.txt", req_dev_txt),
+    ]:
+        path = repo_root / name
+        path.write_text(content)
+        paths.append(path)
+        print(f"Wrote {path}")
+    return paths
+
+
+def check_requirements(repo_root: Path, resolved: Dict[str, str]) -> bool:
+    """Return True if existing requirements files match what would be generated."""
+    core_comments: Dict[str, str] = {
+        "jinja2": "# Template engine (paper scaffolding, code generation)",
+        "pyyaml": "# YAML parsing (configuration)",
+        "click": "# CLI framework (command-line tools)",
+    }
+    dev_comments: Dict[str, str] = {
+        "pre-commit": "# Pre-commit hooks",
+        "safety": "# Security scanning",
+        "bandit": "# Security scanning",
+        "mkdocs": "# Documentation",
+        "mkdocs-material": "# Documentation",
+        "pytest-benchmark": "# Benchmarking",
+    }
+
+    expected = {
+        "requirements.txt": generate_requirements(
+            CORE_PACKAGES,
+            resolved,
+            section_comments=core_comments,
+        ),
+        "requirements-dev.txt": generate_requirements(
+            DEV_PACKAGES,
+            resolved,
+            include_base="-r requirements.txt",
+            section_comments=dev_comments,
+        ),
+    }
+
+    ok = True
+    for name, expected_content in expected.items():
+        path = repo_root / name
+        if not path.exists():
+            print(f"FAIL: {name} does not exist", file=sys.stderr)
+            ok = False
+            continue
+        actual = path.read_text()
+        if actual != expected_content:
+            print(
+                f"FAIL: {name} is out of date — regenerate with: python scripts/sync_requirements.py",
+                file=sys.stderr,
+            )
+            ok = False
+    return ok
+
+
+def main() -> None:
+    """Entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify requirements files are up-to-date (exit 1 if not).",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root directory (default: auto-detect).",
+    )
+    args = parser.parse_args()
+
+    repo_root = args.repo_root or Path(__file__).resolve().parent.parent
+    resolved = get_pixi_packages()
+
+    if args.check:
+        if check_requirements(repo_root, resolved):
+            print("OK: requirements files are up-to-date")
+        else:
+            sys.exit(1)
+    else:
+        write_requirements(repo_root, resolved)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/test_check_dep_sync.py
+++ b/tests/scripts/test_check_dep_sync.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check_dep_sync.py — dependency consistency validation."""
+
+import importlib.util
+import textwrap
+from pathlib import Path
+
+
+# Load module from file path (scripts/ has no __init__.py)
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_spec = importlib.util.spec_from_file_location("check_dep_sync", _PROJECT_ROOT / "scripts" / "check_dep_sync.py")
+_mod = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+
+check_dep_sync = _mod.check_dep_sync
+check_pyproject_no_deps = _mod.check_pyproject_no_deps
+parse_pixi_constraints = _mod.parse_pixi_constraints
+parse_pixi_toml = _mod.parse_pixi_toml
+parse_requirements = _mod.parse_requirements
+parse_version = _mod.parse_version
+version_satisfies = _mod.version_satisfies
+
+
+# ---------------------------------------------------------------------------
+# Version parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseVersion:
+    def test_simple(self) -> None:
+        assert parse_version("1.2.3") == (1, 2, 3)
+
+    def test_two_parts(self) -> None:
+        assert parse_version("3.0") == (3, 0)
+
+    def test_single(self) -> None:
+        assert parse_version("5") == (5,)
+
+
+# ---------------------------------------------------------------------------
+# Constraint parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParsePixiConstraints:
+    def test_range(self) -> None:
+        result = parse_pixi_constraints(">=1.2.0,<2")
+        assert len(result) == 2
+        assert result[0].op == ">="
+        assert result[0].version == (1, 2, 0)
+        assert result[1].op == "<"
+        assert result[1].version == (2,)
+
+    def test_exact(self) -> None:
+        result = parse_pixi_constraints("==0.26.1")
+        assert len(result) == 1
+        assert result[0].op == "=="
+
+    def test_with_quotes(self) -> None:
+        result = parse_pixi_constraints('">=3.0.0,<4"')
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# Version satisfies
+# ---------------------------------------------------------------------------
+
+
+class TestVersionSatisfies:
+    def test_in_range(self) -> None:
+        constraints = parse_pixi_constraints(">=1.0.0,<2")
+        assert version_satisfies((1, 5, 0), constraints)
+
+    def test_below_range(self) -> None:
+        constraints = parse_pixi_constraints(">=1.0.0,<2")
+        assert not version_satisfies((0, 9, 0), constraints)
+
+    def test_above_range(self) -> None:
+        constraints = parse_pixi_constraints(">=1.0.0,<2")
+        assert not version_satisfies((2, 0, 0), constraints)
+
+    def test_exact_lower(self) -> None:
+        constraints = parse_pixi_constraints(">=1.0.0,<2")
+        assert version_satisfies((1, 0, 0), constraints)
+
+    def test_exact_upper_excluded(self) -> None:
+        constraints = parse_pixi_constraints(">=1.0.0,<2")
+        assert not version_satisfies((2, 0, 0), constraints)
+
+    def test_floor_only(self) -> None:
+        constraints = parse_pixi_constraints(">=1.7.5")
+        assert version_satisfies((1, 9, 4), constraints)
+        assert not version_satisfies((1, 7, 4), constraints)
+
+
+# ---------------------------------------------------------------------------
+# pixi.toml parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParsePixiToml:
+    def test_basic(self, tmp_path: Path) -> None:
+        pixi = tmp_path / "pixi.toml"
+        pixi.write_text(
+            textwrap.dedent("""\
+            [workspace]
+            name = "test"
+
+            [dependencies]
+            pytest = ">=8.0,<9"
+            ruff = ">=0.14.7,<0.16"
+
+            [feature.notebook.dependencies]
+            jupyterlab = ">=4.3.0,<5"
+        """)
+        )
+        deps = parse_pixi_toml(pixi)
+        assert "pytest" in deps
+        assert deps["pytest"] == ">=8.0,<9"
+        assert "ruff" in deps
+        # Feature dependencies should NOT be included
+        assert "jupyterlab" not in deps
+
+    def test_inline_comments(self, tmp_path: Path) -> None:
+        pixi = tmp_path / "pixi.toml"
+        pixi.write_text(
+            textwrap.dedent("""\
+            [dependencies]
+            nbstripout = ">=0.7.1"  # tracked for sync
+        """)
+        )
+        deps = parse_pixi_toml(pixi)
+        assert deps["nbstripout"] == ">=0.7.1"
+
+
+# ---------------------------------------------------------------------------
+# requirements.txt parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseRequirements:
+    def test_basic(self, tmp_path: Path) -> None:
+        req = tmp_path / "requirements.txt"
+        req.write_text(
+            textwrap.dedent("""\
+            # comment
+            pytest==8.4.2
+            ruff==0.14.14
+            -r other.txt
+        """)
+        )
+        pins = parse_requirements(req)
+        assert pins == {"pytest": "8.4.2", "ruff": "0.14.14"}
+
+    def test_with_inline_comment(self, tmp_path: Path) -> None:
+        req = tmp_path / "requirements.txt"
+        req.write_text("click==8.2.1  # CLI framework\n")
+        pins = parse_requirements(req)
+        assert pins == {"click": "8.2.1"}
+
+
+# ---------------------------------------------------------------------------
+# pyproject.toml checks
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPyprojectNoDeps:
+    def test_clean(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            textwrap.dedent("""\
+            [build-system]
+            requires = ["setuptools"]
+
+            [project]
+            name = "test"
+            version = "1.0"
+
+            [tool.pytest.ini_options]
+            testpaths = ["tests"]
+        """)
+        )
+        assert check_pyproject_no_deps(pyproject) == []
+
+    def test_has_dependencies(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            textwrap.dedent("""\
+            [project]
+            name = "test"
+            version = "1.0"
+            dependencies = ["pytest>=7.0"]
+        """)
+        )
+        errors = check_pyproject_no_deps(pyproject)
+        assert len(errors) > 0
+        assert "dependencies" in errors[0]
+
+    def test_has_optional_dependencies(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            textwrap.dedent("""\
+            [project]
+            name = "test"
+
+            [project.optional-dependencies]
+            dev = ["ruff>=0.1.0"]
+        """)
+        )
+        errors = check_pyproject_no_deps(pyproject)
+        assert len(errors) > 0
+        assert "optional-dependencies" in errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Integration: check_dep_sync
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDepSync:
+    def _create_repo(self, tmp_path: Path) -> None:
+        """Create a minimal consistent repo structure."""
+        pixi = tmp_path / "pixi.toml"
+        pixi.write_text(
+            textwrap.dedent("""\
+            [dependencies]
+            pytest = ">=8.0,<9"
+            ruff = ">=0.14.0,<0.16"
+        """)
+        )
+        req = tmp_path / "requirements.txt"
+        req.write_text("pytest==8.4.2\nruff==0.14.14\n")
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            textwrap.dedent("""\
+            [project]
+            name = "test"
+            version = "1.0"
+
+            [tool.pytest.ini_options]
+            testpaths = ["tests"]
+        """)
+        )
+
+    def test_all_consistent(self, tmp_path: Path) -> None:
+        self._create_repo(tmp_path)
+        errors = check_dep_sync(tmp_path)
+        assert errors == []
+
+    def test_missing_package_in_pixi(self, tmp_path: Path) -> None:
+        self._create_repo(tmp_path)
+        req = tmp_path / "requirements.txt"
+        req.write_text("pytest==8.4.2\nruff==0.14.14\nmissing-pkg==1.0.0\n")
+        errors = check_dep_sync(tmp_path)
+        assert any("missing-pkg" in e for e in errors)
+
+    def test_version_outside_range(self, tmp_path: Path) -> None:
+        self._create_repo(tmp_path)
+        req = tmp_path / "requirements.txt"
+        req.write_text("pytest==7.0.0\nruff==0.14.14\n")
+        errors = check_dep_sync(tmp_path)
+        assert any("pytest" in e and "outside" in e for e in errors)
+
+    def test_pyproject_with_deps(self, tmp_path: Path) -> None:
+        self._create_repo(tmp_path)
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            textwrap.dedent("""\
+            [project]
+            name = "test"
+            dependencies = ["pytest>=7.0"]
+        """)
+        )
+        errors = check_dep_sync(tmp_path)
+        assert any("dependencies" in e for e in errors)
+
+    def test_no_pixi_toml(self, tmp_path: Path) -> None:
+        errors = check_dep_sync(tmp_path)
+        assert any("pixi.toml not found" in e for e in errors)

--- a/tests/scripts/test_sync_requirements.py
+++ b/tests/scripts/test_sync_requirements.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Tests for scripts/sync_requirements.py — requirements file generation."""
+
+import importlib.util
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+# Load module from file path (scripts/ has no __init__.py)
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_spec = importlib.util.spec_from_file_location("sync_requirements", _PROJECT_ROOT / "scripts" / "sync_requirements.py")
+_mod = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+
+CORE_PACKAGES = _mod.CORE_PACKAGES
+DEV_PACKAGES = _mod.DEV_PACKAGES
+GENERATED_HEADER = _mod.GENERATED_HEADER
+check_requirements = _mod.check_requirements
+generate_requirements = _mod.generate_requirements
+write_requirements = _mod.write_requirements
+
+
+SAMPLE_RESOLVED: Dict[str, str] = {
+    "pytest": "8.4.2",
+    "pytest-cov": "6.3.0",
+    "pytest-timeout": "2.4.0",
+    "pytest-xdist": "3.8.0",
+    "ruff": "0.14.14",
+    "mypy": "1.19.1",
+    "jinja2": "3.1.6",
+    "pyyaml": "6.0.3",
+    "click": "8.2.1",
+    "pre-commit": "4.5.1",
+    "safety": "3.7.0",
+    "bandit": "1.9.4",
+    "mkdocs": "1.6.1",
+    "mkdocs-material": "9.7.6",
+    "pytest-benchmark": "5.2.3",
+}
+
+
+class TestGenerateRequirements:
+    def test_has_header(self) -> None:
+        content = generate_requirements(["pytest"], SAMPLE_RESOLVED)
+        assert content.startswith(GENERATED_HEADER)
+
+    def test_pins_exact_versions(self) -> None:
+        content = generate_requirements(["pytest", "ruff"], SAMPLE_RESOLVED)
+        assert "pytest==8.4.2" in content
+        assert "ruff==0.14.14" in content
+
+    def test_include_base(self) -> None:
+        content = generate_requirements(["pre-commit"], SAMPLE_RESOLVED, include_base="-r requirements.txt")
+        assert "-r requirements.txt" in content
+
+    def test_section_comments(self) -> None:
+        content = generate_requirements(
+            ["click"],
+            SAMPLE_RESOLVED,
+            section_comments={"click": "# CLI"},
+        )
+        assert "click==8.2.1  # CLI" in content
+
+    def test_missing_package_skipped(self, capsys: pytest.CaptureFixture[str]) -> None:
+        content = generate_requirements(["nonexistent"], SAMPLE_RESOLVED)
+        assert "nonexistent" not in content
+        captured = capsys.readouterr()
+        assert "nonexistent" in captured.err
+
+    def test_trailing_newline(self) -> None:
+        content = generate_requirements(["pytest"], SAMPLE_RESOLVED)
+        assert content.endswith("\n")
+
+
+class TestWriteRequirements:
+    def test_creates_both_files(self, tmp_path: Path) -> None:
+        paths = write_requirements(tmp_path, SAMPLE_RESOLVED)
+        assert len(paths) == 2
+        assert (tmp_path / "requirements.txt").exists()
+        assert (tmp_path / "requirements-dev.txt").exists()
+
+    def test_core_packages_in_requirements(self, tmp_path: Path) -> None:
+        write_requirements(tmp_path, SAMPLE_RESOLVED)
+        content = (tmp_path / "requirements.txt").read_text()
+        for pkg in CORE_PACKAGES:
+            if pkg in SAMPLE_RESOLVED:
+                assert f"{pkg}==" in content
+
+    def test_dev_packages_in_requirements_dev(self, tmp_path: Path) -> None:
+        write_requirements(tmp_path, SAMPLE_RESOLVED)
+        content = (tmp_path / "requirements-dev.txt").read_text()
+        for pkg in DEV_PACKAGES:
+            if pkg in SAMPLE_RESOLVED:
+                assert f"{pkg}==" in content
+
+    def test_dev_includes_base(self, tmp_path: Path) -> None:
+        write_requirements(tmp_path, SAMPLE_RESOLVED)
+        content = (tmp_path / "requirements-dev.txt").read_text()
+        assert "-r requirements.txt" in content
+
+
+class TestCheckRequirements:
+    def test_up_to_date(self, tmp_path: Path) -> None:
+        write_requirements(tmp_path, SAMPLE_RESOLVED)
+        assert check_requirements(tmp_path, SAMPLE_RESOLVED) is True
+
+    def test_out_of_date(self, tmp_path: Path) -> None:
+        write_requirements(tmp_path, SAMPLE_RESOLVED)
+        # Tamper with file
+        req = tmp_path / "requirements.txt"
+        req.write_text("pytest==0.0.0\n")
+        assert check_requirements(tmp_path, SAMPLE_RESOLVED) is False
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        assert check_requirements(tmp_path, SAMPLE_RESOLVED) is False


### PR DESCRIPTION
## Summary
- Makes `pixi.toml` the single source of truth for all Python dependency declarations
- Removes duplicate `[project.dependencies]` and `[project.optional-dependencies]` from `pyproject.toml`
- Adds missing packages to `pixi.toml`: pytest-xdist, safety, mkdocs, mkdocs-material, pytest-benchmark, jinja2, pyyaml, click
- Regenerates `requirements.txt` and `requirements-dev.txt` as auto-generated lockfiles with exact pins from pixi
- Adds `scripts/sync_requirements.py` (generation) and `scripts/check_dep_sync.py` (CI guardrail)
- Fixes `security.yml` ghost reference to non-existent `tools/requirements.txt`
- Adds CI job `validate-dep-sync` to catch dependency drift on every PR

Closes #4907

## Test plan
- [x] 37 new unit tests covering version parsing, constraint validation, requirements generation, and pyproject checks
- [x] `check_dep_sync.py` validates consistency against live repo — passes
- [x] `sync_requirements.py --check` confirms generated files are up-to-date
- [x] All pre-commit hooks pass (ruff, mypy, bandit, yaml, markdown)
- [ ] CI: comprehensive-tests, security, pre-commit workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)