### PR TITLE
fix(security): add non-root user to Dockerfile.ci stages

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -7,10 +7,9 @@
 FROM mcr.microsoft.com/mirror/docker/library/ubuntu:24.04 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV PATH="/root/.pixi/bin:$PATH"
 ENV PIXI_VERSION=0.65.0
 
-# Install system dependencies
+# Install system dependencies (as root)
 RUN apt-get update && apt-get install -y \
     curl \
     git \
@@ -18,22 +17,37 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /build
+# Create non-root user (matches main Dockerfile pattern)
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+ARG USER_NAME=dev
+
+RUN groupadd -g ${GROUP_ID} ${USER_NAME} 2>/dev/null || \
+    groupmod -n ${USER_NAME} $(getent group ${GROUP_ID} | cut -d: -f1) && \
+    useradd -m -u ${USER_ID} -g ${GROUP_ID} -s /bin/bash ${USER_NAME} 2>/dev/null || \
+    usermod -l ${USER_NAME} -d /home/${USER_NAME} -m $(id -nu ${USER_ID} 2>/dev/null || echo nobody)
+
+ENV HOME=/home/${USER_NAME}
+ENV PATH="${HOME}/.pixi/bin:$PATH"
+
+# Switch to non-root user for pixi install and build
+USER ${USER_NAME}
+WORKDIR /home/${USER_NAME}/build
 
 # Install Pixi (pinned version for reproducible builds)
 RUN curl -fsSL https://pixi.sh/install.sh | PIXI_VERSION=${PIXI_VERSION} bash
 
 # Copy dependency files first (better layer caching)
-COPY pixi.toml pixi.lock ./
+COPY --chown=${USER_NAME}:${USER_NAME} pixi.toml pixi.lock ./
 
 # Install dependencies (this is the slow step - cached if pixi.toml unchanged)
 RUN pixi install --frozen
 
 # Copy source code
 # Note: requirements*.txt are auto-generated lockfiles from pixi.toml (see scripts/sync_requirements.py)
-COPY shared/ ./shared/
-COPY tests/ ./tests/
-COPY pyproject.toml requirements.txt requirements-dev.txt ./
+COPY --chown=${USER_NAME}:${USER_NAME} shared/ ./shared/
+COPY --chown=${USER_NAME}:${USER_NAME} tests/ ./tests/
+COPY --chown=${USER_NAME}:${USER_NAME} pyproject.toml requirements.txt requirements-dev.txt ./
 
 # ==============================================================================
 # Stage 2: Runtime - Minimal image for running tests/inference
@@ -41,31 +55,45 @@ COPY pyproject.toml requirements.txt requirements-dev.txt ./
 FROM mcr.microsoft.com/mirror/docker/library/ubuntu:24.04 AS runtime
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV PATH="/root/.pixi/bin:$PATH"
-ENV PYTHONPATH=/app
 ENV PIXI_VERSION=0.65.0
 
-# Install minimal runtime dependencies
+# Install minimal runtime dependencies (as root)
 RUN apt-get update && apt-get install -y \
     curl \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
+# Create non-root user (new FROM requires its own user creation)
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+ARG USER_NAME=dev
+
+RUN groupadd -g ${GROUP_ID} ${USER_NAME} 2>/dev/null || \
+    groupmod -n ${USER_NAME} $(getent group ${GROUP_ID} | cut -d: -f1) && \
+    useradd -m -u ${USER_ID} -g ${GROUP_ID} -s /bin/bash ${USER_NAME} 2>/dev/null || \
+    usermod -l ${USER_NAME} -d /home/${USER_NAME} -m $(id -nu ${USER_ID} 2>/dev/null || echo nobody)
+
+ENV HOME=/home/${USER_NAME}
+ENV PATH="${HOME}/.pixi/bin:$PATH"
+ENV PYTHONPATH=/app
+
+# Switch to non-root user
+USER ${USER_NAME}
 WORKDIR /app
 
 # Install Pixi (pinned version for reproducible builds)
 RUN curl -fsSL https://pixi.sh/install.sh | PIXI_VERSION=${PIXI_VERSION} bash
 
 # Copy dependency files
-COPY pixi.toml pixi.lock ./
+COPY --chown=${USER_NAME}:${USER_NAME} pixi.toml pixi.lock ./
 
 # Install runtime dependencies only
 RUN pixi install --frozen
 
 # Copy built artifacts and source
-COPY --from=builder /build/shared/ ./shared/
-COPY --from=builder /build/tests/ ./tests/
-COPY pyproject.toml requirements.txt ./
+COPY --chown=${USER_NAME}:${USER_NAME} --from=builder /home/dev/build/shared/ ./shared/
+COPY --chown=${USER_NAME}:${USER_NAME} --from=builder /home/dev/build/tests/ ./tests/
+COPY --chown=${USER_NAME}:${USER_NAME} pyproject.toml requirements.txt ./
 
 # Default command runs tests
 CMD ["pixi", "run", "mojo", "test", "-I", ".", "tests/"]
@@ -75,9 +103,12 @@ CMD ["pixi", "run", "mojo", "test", "-I", ".", "tests/"]
 # ==============================================================================
 FROM runtime AS ci
 
+# Re-declare ARG (does not persist across FROM)
+ARG USER_NAME=dev
+
 # Copy additional test dependencies
-COPY requirements-dev.txt ./
-COPY .pre-commit-config.yaml ./
+COPY --chown=${USER_NAME}:${USER_NAME} requirements-dev.txt ./
+COPY --chown=${USER_NAME}:${USER_NAME} .pre-commit-config.yaml ./
 
 # Install pre-commit hooks
 RUN pixi run pre-commit install --install-hooks || true

--- a/tests/foundation/test_dockerfile_nonroot_user.py
+++ b/tests/foundation/test_dockerfile_nonroot_user.py
@@ -1,0 +1,61 @@
+"""Static regression tests asserting Dockerfiles use non-root users.
+
+Guards against re-introduction of root-only stages in Dockerfiles.
+All runtime, CI, and production stages must drop root privileges
+to reduce blast radius if the container is compromised.
+
+Follow-up from #5037.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[2]
+DOCKERFILES = [REPO_ROOT / "Dockerfile", REPO_ROOT / "Dockerfile.ci"]
+
+
+@pytest.mark.parametrize("dockerfile", DOCKERFILES, ids=["Dockerfile", "Dockerfile.ci"])
+class TestNonRootUser:
+    """Assert Dockerfiles create and switch to a non-root user."""
+
+    def test_user_directive_present(self, dockerfile: Path) -> None:
+        """Assert at least one USER directive exists.
+
+        Args:
+            dockerfile: Path to the Dockerfile under test.
+        """
+        content = dockerfile.read_text()
+        match = re.search(r"^USER\s+", content, re.MULTILINE)
+        assert match is not None, (
+            f"No USER directive found in {dockerfile.name}. "
+            "All Dockerfiles must drop root privileges with a USER directive."
+        )
+
+    def test_no_root_path_in_env(self, dockerfile: Path) -> None:
+        """Assert PATH does not reference /root/.pixi.
+
+        Args:
+            dockerfile: Path to the Dockerfile under test.
+        """
+        content = dockerfile.read_text()
+        root_path_refs = re.findall(r'ENV\s+PATH="/root/\.pixi', content)
+        assert len(root_path_refs) == 0, (
+            f"Found {len(root_path_refs)} reference(s) to /root/.pixi in "
+            f"PATH in {dockerfile.name}. Use a non-root user home directory "
+            "instead (e.g., /home/dev/.pixi)."
+        )
+
+    def test_user_creation_exists(self, dockerfile: Path) -> None:
+        """Assert a non-root user is created (useradd or adduser).
+
+        Args:
+            dockerfile: Path to the Dockerfile under test.
+        """
+        content = dockerfile.read_text()
+        has_useradd = "useradd" in content
+        has_adduser = "adduser" in content
+        assert has_useradd or has_adduser, (
+            f"No user creation command (useradd/adduser) found in {dockerfile.name}. A non-root user must be created."
+        )


### PR DESCRIPTION
## Summary

- Add non-root `dev` user (UID/GID 1000) to all `Dockerfile.ci` stages, mirroring the main `Dockerfile` pattern
- Replace `/root/.pixi` PATH references with `/home/dev/.pixi` across builder and runtime stages
- Use `--chown` on all `COPY` directives so application files are owned by the non-root user
- Add regression tests (`test_dockerfile_nonroot_user.py`) guarding against reintroduction of root-only stages

Closes #5037

## Changes Made

**`Dockerfile.ci`**:
- **Builder stage**: Create `dev` user with idempotent `groupadd/useradd` pattern, switch to non-root before pixi install, use `--chown` on COPYs
- **Runtime stage**: Same user creation (separate `FROM` requires its own), `USER dev` before pixi and app code
- **CI stage**: Inherits `USER` from runtime parent, re-declares `ARG USER_NAME` for `--chown`
- **Production stage**: Inherits `USER` from runtime parent, no changes needed

**`tests/foundation/test_dockerfile_nonroot_user.py`** (new):
- `test_user_directive_present` — asserts `USER` directive exists in both Dockerfiles
- `test_no_root_path_in_env` — asserts no `ENV PATH="/root/.pixi` references
- `test_user_creation_exists` — asserts `useradd`/`adduser` commands exist

## Test plan

- [x] All 6 new non-root user tests pass for both `Dockerfile` and `Dockerfile.ci`
- [x] All 12 existing Dockerfile regression tests still pass (pixi pin, cargo-free, just pin)
- [x] Pre-commit hooks pass (ruff, mypy, bandit, markdownlint, etc.)
- [ ] CI container-publish workflow builds all 4 targets successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)