### PR TITLE
chore: clean up stale agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ examples/*/inference
 test_*
 !tests/**
 .worktrees/
+.claude/worktrees/
 .issue_implementer/
 
 # Training artifacts


### PR DESCRIPTION
## Summary

- Ran `git worktree prune` to clean stale worktree references
- Added `.claude/worktrees/` to `.gitignore` to prevent agent worktree directories from being tracked

The `.claude/worktrees/agent-*` directories referenced in the issue no longer exist (already cleaned up), but the `.gitignore` entry ensures they won't be accidentally committed in the future.

Closes #5105

## Test plan

- [x] Verified `.claude/worktrees/` is now in `.gitignore`
- [x] Ran `git worktree prune` to clean stale references
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)