### PR TITLE
feat(ci): add per-file JIT crash retry for Mojo 0.26.1

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -380,6 +380,10 @@ jobs:
 
           # Use justfile to run test group
           # The justfile handles all the complexity of test discovery and execution
+          # Note: just test-group uses scripts/test-with-retry.sh for JIT crash resilience.
+          # Individual test files are retried once on "execution crashed" (Mojo JIT fault).
+          # Real test failures (assertion errors, compile errors) are NOT retried.
+          # See: docs/adr/ADR-014-jit-crash-retry-mitigation.md
           if just test-group "${{ matrix.test-group.path }}" "${{ matrix.test-group.pattern }}"; then
             test_result="passed"
             exit_code=0

--- a/docs/adr/ADR-014-jit-crash-retry-mitigation.md
+++ b/docs/adr/ADR-014-jit-crash-retry-mitigation.md
@@ -1,0 +1,162 @@
+# ADR-014: JIT Crash Retry Mitigation
+
+**Status**: Accepted
+
+**Date**: 2026-03-25
+
+**Issue Reference**: [Issue #5108](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5108)
+
+**Decision Owner**: Development Team
+
+## Executive Summary
+
+Non-deterministic `libKGENCompilerRTShared.so` JIT crashes in Mojo 0.26.1 cause ~40-60% of CI
+runs to fail despite no bugs in test code. Since this is an upstream compiler bug
+([modular/modular#6187](https://github.com/modular/modular/issues/6187)), we add a per-file
+retry mechanism that retries only on JIT crash signatures, never on real test failures.
+
+## Context
+
+### Problem Statement
+
+The Mojo 0.26.1 JIT compiler intermittently crashes with the signature:
+
+```text
+#0 libKGENCompilerRTShared.so+0x3cb78b
+#1 libKGENCompilerRTShared.so+0x3c93c6
+#2 libKGENCompilerRTShared.so+0x3cc397
+#3 libc.so.6+0x45330
+#4 <JIT-compiled code at random address>
+/workspace/.pixi/envs/default/bin/mojo: error: execution crashed
+```
+
+The crash is non-deterministic: different test files crash on different runs with no code changes.
+The same test file may pass or crash depending on ASLR, memory layout, and JIT cache state.
+
+### What Has Already Been Done
+
+| Approach | Result |
+|----------|--------|
+| Targeted submodule imports (ADR-009 era) | Reduced frequency but didn't eliminate |
+| ADR-009 file splitting | No longer needed (bitcast UAF resolved) |
+| `@always_inline` on helpers | Made things worse (reverted) |
+| `continue-on-error: true` | Removed -- was masking real failures |
+
+### Constraints
+
+- Mojo 0.26.1 upstream bug -- cannot fix without Mojo upgrade
+- Must not mask real test failures (assertion errors, compile errors)
+- CI must remain a reliable signal for code quality
+
+## Decision
+
+Add a per-file retry wrapper (`scripts/test-with-retry.sh`) that detects JIT crashes by
+checking for `execution crashed` in test output and retries the file once. Real test failures
+are never retried.
+
+### Solution Overview
+
+**Layer 1 -- Per-file retry in `scripts/test-with-retry.sh`**:
+
+- Runs `pixi run mojo --Werror -I "$REPO_ROOT" -I . "$test_file"` capturing output
+- If test fails AND output contains `execution crashed` -> retry once
+- If test fails without `execution crashed` -> fail immediately (exit 1)
+- If retry also crashes -> report as persistent JIT crash (exit 2)
+- Exit 0 on pass (first attempt or retry)
+
+**Layer 2 -- Justfile integration**:
+
+- `_test-group-inner` and `_test-mojo-inner` call the retry wrapper instead of `pixi run mojo`
+  directly
+- JIT crash count tracked separately in test summary output
+- Failed tests annotated with `(JIT crash)` when applicable
+
+### Technical Details
+
+**Detection marker**: `execution crashed` -- the exact string Mojo 0.26.1 prints on JIT fault.
+
+**MAX_RETRIES=1**: One retry is sufficient. Two consecutive JIT crashes on the same file
+indicates a harder problem (possibly a real compilation issue). Configurable via
+`TEST_WITH_RETRY_MAX` environment variable.
+
+**Exit codes**:
+
+| Code | Meaning | Retried? |
+|------|---------|----------|
+| 0 | Test passed | First attempt or after retry |
+| 1 | Real test failure | Never |
+| 2 | JIT crash persisted | Yes, once |
+
+## Rationale
+
+### Key Factors
+
+1. **Correctness**: Real test failures are never masked or retried
+2. **Simplicity**: Single bash script, no dependencies beyond coreutils
+3. **Transparency**: Retry attempts are logged clearly in CI output
+4. **Minimal blast radius**: Only affects the test execution path, no workflow structure changes
+
+### Why Not Workflow-Level Retry?
+
+GitHub Actions `continue-on-error` or step-level retry would retry the entire test group
+(dozens of files), wasting CI minutes. Per-file retry is surgical: only the crashed file
+is re-executed, and only once.
+
+### Why MAX_RETRIES=1?
+
+JIT crashes are transient. If a file crashes twice consecutively, it's likely a deterministic
+issue (e.g., a file that always overflows the JIT buffer). Retrying more than once wastes CI
+time without improving pass rates.
+
+## Consequences
+
+### Positive
+
+- Reduces CI failure rate from ~40-60% to <5% (expected)
+- Real test failures still block the workflow immediately
+- Clear audit trail: JIT crash retries are logged with distinct messaging
+- No structural changes to CI workflow
+
+### Negative
+
+- Slightly longer CI time for files that crash (one retry adds ~30s per file)
+- Retry mechanism adds a layer of indirection in test execution
+
+### Neutral
+
+- Test coverage unchanged
+- No changes to test code or imports
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `scripts/test-with-retry.sh` | New -- core retry logic |
+| `justfile` | `_test-group-inner` and `_test-mojo-inner` use retry wrapper |
+| `.github/workflows/comprehensive-tests.yml` | Comment documenting retry mechanism |
+| `docs/dev/mojo-jit-crash-workaround.md` | Added retry mitigation section |
+| `tests/smoke/test_retry_script.py` | Smoke tests for retry behavior |
+
+## References
+
+- [Issue #5108](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5108) -- JIT crash comprehensive tracking
+- [modular/modular#6187](https://github.com/modular/modular/issues/6187) -- Upstream Mojo bug
+- [ADR-009](ADR-009-heap-corruption-workaround.md) -- Heap corruption workaround (resolved)
+- [docs/dev/mojo-jit-crash-workaround.md](../../docs/dev/mojo-jit-crash-workaround.md) -- Import-explosion variant
+
+---
+
+## Document Metadata
+
+- **Location**: `/docs/adr/ADR-014-jit-crash-retry-mitigation.md`
+- **Status**: Accepted
+- **Review Frequency**: When Mojo is upgraded past 0.26.1
+- **Next Review**: After Mojo upgrade (see #4913)
+- **Supersedes**: None
+- **Superseded By**: Mojo upgrade (when available)
+
+## Revision History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-03-25 | Claude Code | Initial ADR documenting retry mitigation |

--- a/docs/dev/mojo-jit-crash-workaround.md
+++ b/docs/dev/mojo-jit-crash-workaround.md
@@ -3,8 +3,9 @@
 **Tracking**: Issue #3330, follow-up from #3120
 
 **Status**: The ADR-009 heap corruption workaround is **RESOLVED** (2026-03-20, bitcast UAF fix).
-No retry logic or `continue-on-error` masking exists in CI. All test failures are immediately
-visible. The test file splitting workaround from ADR-009 is no longer necessary.
+The test file splitting workaround from ADR-009 is no longer necessary. A per-file JIT crash
+retry mechanism was added (2026-03-25, ADR-014) to mitigate the remaining upstream JIT crash.
+Real test failures are never retried — only `execution crashed` (JIT fault) triggers a retry.
 
 The JIT crash described in this document (`libKGENCompilerRTShared.so`) is a separate upstream
 Mojo 0.26.1 compiler bug that is mitigated by targeted submodule imports (see below).
@@ -151,8 +152,38 @@ higher memory pressure than a single test file produces. The targeted import fix
 the correct defensive measure -- it reduces compilation footprint by ~95% per test file,
 which lowers the probability of hitting the JIT buffer overflow regardless of environment.
 
+## Per-File Retry Mitigation (2026-03-25)
+
+Despite targeted imports reducing JIT crash frequency, the crash still occurs non-deterministically
+in CI (~40-60% of runs have at least one crash). Since this is an upstream Mojo 0.26.1 compiler
+bug ([modular/modular#6187](https://github.com/modular/modular/issues/6187)), we added a per-file
+retry mechanism that detects JIT crashes and retries the affected test file once.
+
+**How it works**:
+
+- `scripts/test-with-retry.sh` wraps each `pixi run mojo` invocation
+- If the test exits non-zero AND output contains `execution crashed`, retry once
+- If the test exits non-zero without `execution crashed`, fail immediately (real test failure)
+- If the retry also crashes, report as JIT crash failure (exit code 2)
+- The justfile `_test-group-inner` and `_test-mojo-inner` recipes call this wrapper
+
+**Key property**: Real test failures (assertion errors, compile errors) are **never retried**.
+Only the JIT crash signature triggers a retry.
+
+**Exit codes from `scripts/test-with-retry.sh`**:
+
+| Code | Meaning |
+|------|---------|
+| 0 | Test passed (first attempt or after retry) |
+| 1 | Real test failure (not retried) |
+| 2 | JIT crash persisted after retry |
+
+See [ADR-014](../adr/ADR-014-jit-crash-retry-mitigation.md) for the full decision record.
+
 ## References
 
+- [Issue #5108](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5108) -- JIT crash comprehensive tracking
 - [Issue #3330](https://github.com/HomericIntelligence/ProjectOdyssey/issues/3330) -- Document JIT crash workaround
 - [Issue #3120](https://github.com/HomericIntelligence/ProjectOdyssey/issues/3120) -- Core Loss test crashes (follow-up context)
 - [ADR-009](../adr/ADR-009-heap-corruption-workaround.md) -- Heap corruption workaround (resolved 2026-03-20)
+- [ADR-014](../adr/ADR-014-jit-crash-retry-mitigation.md) -- JIT crash retry mitigation

--- a/justfile
+++ b/justfile
@@ -575,6 +575,7 @@ _test-group-inner path pattern:
     test_count=0
     passed_count=0
     failed_count=0
+    jit_crash_count=0
     failed_tests=""
 
     echo "=================================================="
@@ -614,39 +615,21 @@ _test-group-inner path pattern:
     fi
 
     # Run each test file (with JIT crash retry — see #5104)
-    MAX_JIT_RETRIES=1
     for test_file in $test_files; do
         if [ -f "$test_file" ]; then
             echo ""
             echo "Running: $test_file"
             test_count=$((test_count + 1))
 
-            attempt=0
-            test_passed=false
-            while [ $attempt -le $MAX_JIT_RETRIES ]; do
-                output=$(pixi run mojo --Werror -I "$REPO_ROOT" -I . "$test_file" 2>&1) && {
-                    test_passed=true
-                    break
-                }
-                # Check if failure was a JIT crash (not an assertion failure)
-                if echo "$output" | grep -qi "execution crashed\|SIGABRT\|SIGSEGV\|libKGEN"; then
-                    attempt=$((attempt + 1))
-                    if [ $attempt -le $MAX_JIT_RETRIES ]; then
-                        echo "⚠️  JIT crash detected, retrying ($attempt/$MAX_JIT_RETRIES)..."
-                    fi
-                else
-                    # Real test failure (assertion, compilation, etc.) — don't retry
-                    echo "$output"
-                    break
-                fi
-            done
-
-            if $test_passed; then
-                echo "✅ PASSED: $test_file"
+            retry_result=0
+            bash "$REPO_ROOT/scripts/test-with-retry.sh" "$REPO_ROOT" "$test_file" || retry_result=$?
+            if [ $retry_result -eq 0 ]; then
                 passed_count=$((passed_count + 1))
+            elif [ $retry_result -eq 2 ]; then
+                failed_count=$((failed_count + 1))
+                jit_crash_count=$((jit_crash_count + 1))
+                failed_tests="$failed_tests\n  - $test_file (JIT crash)"
             else
-                echo "$output"
-                echo "❌ FAILED: $test_file"
                 failed_count=$((failed_count + 1))
                 failed_tests="$failed_tests\n  - $test_file"
             fi
@@ -660,6 +643,9 @@ _test-group-inner path pattern:
     echo "Total: $test_count tests"
     echo "Passed: $passed_count tests"
     echo "Failed: $failed_count tests"
+    if [ $jit_crash_count -gt 0 ]; then
+        echo "JIT crash retries: $jit_crash_count (persistent crashes after retry)"
+    fi
 
     # Guard against no tests being run (beyond initial empty check)
     if [ $test_count -eq 0 ]; then
@@ -713,8 +699,9 @@ _test-mojo-inner:
         fi
         if [ -f "$test_file" ]; then
             echo "Testing: $test_file"
-            if ! pixi run mojo --Werror -I "$REPO_ROOT" -I . "$test_file"; then
-                echo "❌ FAILED: $test_file"
+            retry_result=0
+            bash "$REPO_ROOT/scripts/test-with-retry.sh" "$REPO_ROOT" "$test_file" || retry_result=$?
+            if [ $retry_result -ne 0 ]; then
                 failed=1
             fi
         fi

--- a/scripts/test-with-retry.sh
+++ b/scripts/test-with-retry.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# test-with-retry.sh — Run a single Mojo test file with JIT crash retry logic.
+#
+# Usage: bash scripts/test-with-retry.sh <REPO_ROOT> <test_file>
+#
+# Exit codes:
+#   0 — test passed (on first attempt or after retry)
+#   1 — test failed with a real failure (assertion error, compile error) — NOT retried
+#   2 — test crashed with JIT fault on both attempts (persisted after retry)
+#
+# The retry targets ONLY the Mojo 0.26.1 JIT crash signature ("execution crashed"
+# from libKGENCompilerRTShared.so). Real test failures are never retried.
+#
+# See: docs/adr/ADR-014-jit-crash-retry-mitigation.md
+# See: https://github.com/modular/modular/issues/6187
+
+set -o pipefail
+
+REPO_ROOT="${1:?Usage: test-with-retry.sh <REPO_ROOT> <test_file>}"
+TEST_FILE="${2:?Usage: test-with-retry.sh <REPO_ROOT> <test_file>}"
+MAX_RETRIES="${TEST_WITH_RETRY_MAX:-1}"
+JIT_CRASH_MARKER="execution crashed"
+
+run_test() {
+    local output_file
+    output_file=$(mktemp)
+    local exit_code=0
+
+    pixi run mojo --Werror -I "$REPO_ROOT" -I . "$TEST_FILE" 2>&1 | tee "$output_file" || exit_code=${PIPESTATUS[0]}
+
+    # If tee succeeded but mojo failed, capture the mojo exit code
+    if [ $exit_code -eq 0 ]; then
+        # Re-check via PIPESTATUS — tee masks the mojo exit code in some shells.
+        # The `set -o pipefail` above makes $? reflect the leftmost non-zero.
+        exit_code=$?
+    fi
+
+    OUTPUT=$(cat "$output_file")
+    rm -f "$output_file"
+    return $exit_code
+}
+
+# --- Attempt 1 ---
+OUTPUT=""
+run_test
+RESULT=$?
+
+if [ $RESULT -eq 0 ]; then
+    echo "✅ PASSED: $TEST_FILE"
+    exit 0
+fi
+
+# Check if the failure is a JIT crash (not a real test failure)
+if echo "$OUTPUT" | grep -q "$JIT_CRASH_MARKER"; then
+    echo "⚠️  JIT crash detected in $TEST_FILE — retrying (attempt 2/$((MAX_RETRIES + 1)))..."
+else
+    # Real test failure — do NOT retry
+    echo "❌ FAILED: $TEST_FILE"
+    exit 1
+fi
+
+# --- Retry loop ---
+attempt=2
+while [ $((attempt - 1)) -le "$MAX_RETRIES" ]; do
+    OUTPUT=""
+    run_test
+    RESULT=$?
+
+    if [ $RESULT -eq 0 ]; then
+        echo "✅ PASSED on retry (attempt $attempt): $TEST_FILE"
+        exit 0
+    fi
+
+    if echo "$OUTPUT" | grep -q "$JIT_CRASH_MARKER"; then
+        if [ $attempt -le "$MAX_RETRIES" ]; then
+            echo "⚠️  JIT crash persisted — retrying (attempt $((attempt + 1))/$((MAX_RETRIES + 1)))..."
+        fi
+    else
+        # Retry produced a real failure — report as real failure
+        echo "❌ FAILED: $TEST_FILE"
+        exit 1
+    fi
+
+    attempt=$((attempt + 1))
+done
+
+echo "❌ FAILED (JIT crash persisted after $((MAX_RETRIES + 1)) attempts): $TEST_FILE"
+exit 2

--- a/tests/smoke/test_retry_script.py
+++ b/tests/smoke/test_retry_script.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Smoke tests for scripts/test-with-retry.sh.
+
+Validates the JIT crash retry logic by simulating different failure modes
+using mock test scripts instead of real Mojo tests:
+  1. Passing test → exit 0, no retry
+  2. Real test failure (no "execution crashed") → exit 1, no retry
+  3. Persistent JIT crash → exit 2, retried once then fails
+  4. Transient JIT crash (crash then pass) → exit 0, retried once then passes
+"""
+
+import os
+import subprocess
+import stat
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+RETRY_SCRIPT = REPO_ROOT / "scripts" / "test-with-retry.sh"
+
+
+@pytest.fixture(scope="module")
+def retry_script_exists() -> Path:
+    """Ensure the retry script exists and is executable."""
+    assert RETRY_SCRIPT.exists(), f"test-with-retry.sh not found at {RETRY_SCRIPT}"
+    assert os.access(RETRY_SCRIPT, os.X_OK), "test-with-retry.sh is not executable"
+    return RETRY_SCRIPT
+
+
+def _make_mock_mojo(tmp_path: Path, name: str, script_content: str) -> Path:
+    """Create a mock 'pixi' wrapper that simulates mojo test behavior.
+
+    The retry script invokes `pixi run mojo --Werror -I ... -I . <file>`.
+    We override PATH so that our mock `pixi` script runs instead.
+    """
+    mock_pixi = tmp_path / "pixi"
+    mock_pixi.write_text(textwrap.dedent(script_content))
+    mock_pixi.chmod(mock_pixi.stat().st_mode | stat.S_IEXEC)
+    return mock_pixi
+
+
+def _run_retry(
+    tmp_path: Path,
+    mock_script_content: str,
+    test_file: str = "fake_test.mojo",
+    max_retries: int = 1,
+) -> subprocess.CompletedProcess:
+    """Run test-with-retry.sh with a mock pixi on PATH."""
+    _make_mock_mojo(tmp_path, "pixi", mock_script_content)
+
+    env = os.environ.copy()
+    # Prepend tmp_path so our mock pixi is found first
+    env["PATH"] = str(tmp_path) + ":" + env.get("PATH", "")
+    env["TEST_WITH_RETRY_MAX"] = str(max_retries)
+
+    result = subprocess.run(
+        ["bash", str(RETRY_SCRIPT), str(REPO_ROOT), test_file],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    return result
+
+
+class TestRetryScriptExists:
+    """Verify the retry script is present and well-formed."""
+
+    def test_script_exists(self, retry_script_exists: Path) -> None:
+        """test-with-retry.sh must exist at scripts/test-with-retry.sh."""
+        assert retry_script_exists.exists()
+
+    def test_script_has_shebang(self, retry_script_exists: Path) -> None:
+        """Script must have a proper bash shebang line."""
+        first_line = retry_script_exists.read_text().split("\n")[0]
+        assert first_line.startswith("#!/"), "Missing shebang line"
+        assert "bash" in first_line, "Shebang should reference bash"
+
+
+class TestRetryBehavior:
+    """Validate retry logic for different failure modes."""
+
+    def test_passing_test_exits_zero(self, tmp_path: Path, retry_script_exists: Path) -> None:
+        """A passing test should exit 0 with no retry."""
+        mock = """\
+        #!/usr/bin/env bash
+        echo "test_example ... PASS"
+        exit 0
+        """
+        result = _run_retry(tmp_path, mock)
+        assert result.returncode == 0
+        assert "PASSED" in result.stdout
+        assert "retry" not in result.stdout.lower() or "PASSED on retry" not in result.stdout
+
+    def test_real_failure_exits_one_no_retry(self, tmp_path: Path, retry_script_exists: Path) -> None:
+        """A real test failure (no 'execution crashed') should exit 1, never retry."""
+        mock = """\
+        #!/usr/bin/env bash
+        echo "test_example ... FAIL: assertion failed"
+        exit 1
+        """
+        result = _run_retry(tmp_path, mock)
+        assert result.returncode == 1
+        assert "FAILED" in result.stdout
+        # Should NOT contain retry messaging
+        assert "retrying" not in result.stdout.lower()
+
+    def test_persistent_jit_crash_exits_two(self, tmp_path: Path, retry_script_exists: Path) -> None:
+        """Persistent JIT crash (both attempts crash) should exit 2."""
+        mock = """\
+        #!/usr/bin/env bash
+        echo "execution crashed"
+        exit 1
+        """
+        result = _run_retry(tmp_path, mock)
+        assert result.returncode == 2
+        assert "JIT crash" in result.stdout.lower() or "jit crash" in result.stdout.lower()
+
+    def test_transient_jit_crash_passes_on_retry(self, tmp_path: Path, retry_script_exists: Path) -> None:
+        """Transient JIT crash (crash first, pass on retry) should exit 0."""
+        # Use a state file to track attempts
+        state_file = tmp_path / "attempt_counter"
+        state_file.write_text("0")
+        mock = f"""\
+        #!/usr/bin/env bash
+        STATE="{state_file}"
+        COUNT=$(cat "$STATE")
+        COUNT=$((COUNT + 1))
+        echo "$COUNT" > "$STATE"
+        if [ "$COUNT" -eq 1 ]; then
+            echo "execution crashed"
+            exit 1
+        else
+            echo "test_example ... PASS"
+            exit 0
+        fi
+        """
+        result = _run_retry(tmp_path, mock)
+        assert result.returncode == 0
+        assert "retry" in result.stdout.lower()
+
+    def test_jit_crash_then_real_failure(self, tmp_path: Path, retry_script_exists: Path) -> None:
+        """JIT crash on first attempt, real failure on retry → exit 1."""
+        state_file = tmp_path / "attempt_counter"
+        state_file.write_text("0")
+        mock = f"""\
+        #!/usr/bin/env bash
+        STATE="{state_file}"
+        COUNT=$(cat "$STATE")
+        COUNT=$((COUNT + 1))
+        echo "$COUNT" > "$STATE"
+        if [ "$COUNT" -eq 1 ]; then
+            echo "execution crashed"
+            exit 1
+        else
+            echo "test_example ... FAIL: assertion failed at line 42"
+            exit 1
+        fi
+        """
+        result = _run_retry(tmp_path, mock)
+        assert result.returncode == 1
+        assert "FAILED" in result.stdout


### PR DESCRIPTION
## Summary

- Add `scripts/test-with-retry.sh` that wraps each Mojo test file execution with JIT crash detection and retry logic
- Integrate the retry wrapper into justfile `_test-group-inner` and `_test-mojo-inner` recipes
- Only retries on `execution crashed` (JIT fault signature) — real test failures are never retried
- Exit codes: 0 (pass), 1 (real failure), 2 (JIT crash persisted after retry)

Closes #5108

## Changes Made

| File | Change |
|------|--------|
| `scripts/test-with-retry.sh` | New — per-file retry logic with JIT crash detection |
| `justfile` | Both test runners use retry wrapper instead of direct `pixi run mojo` |
| `.github/workflows/comprehensive-tests.yml` | Comment documenting retry mechanism |
| `docs/adr/ADR-014-jit-crash-retry-mitigation.md` | ADR documenting the decision |
| `docs/dev/mojo-jit-crash-workaround.md` | Updated with retry mitigation section |
| `tests/smoke/test_retry_script.py` | 7 smoke tests validating all retry behavior modes |

## Test plan

- [x] 7 smoke tests pass (`pixi run pytest tests/smoke/test_retry_script.py -v`)
- [x] All 33 existing smoke tests still pass
- [x] All pre-commit hooks pass
- [ ] CI Comprehensive Tests workflow passes with retry in effect
- [ ] Monitor 5+ CI runs to verify crash rate reduction from ~40-60% to <5%

🤖 Generated with [Claude Code](https://claude.com/claude-code)