### PR TITLE
chore: update to hephaestus plugin and rename hook to /learn

### DIFF
--- a/.claude/hooks/learn-trigger.py
+++ b/.claude/hooks/learn-trigger.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Hook script triggered on SessionEnd to prompt for retrospective.
+Hook script triggered on SessionEnd to prompt for /learn.
 
 Receives JSON input with:
 - session_id: Session identifier
@@ -47,10 +47,10 @@ def main():
         # Error reading transcript, exit silently
         sys.exit(0)
 
-    # Output message prompting retrospective
+    # Output message prompting /learn
     output = {
         "systemMessage": (
-            "Session ending. Consider running /retrospective to capture learnings "
+            "Session ending. Consider running /learn to capture learnings "
             "from this session. Would you like to save your learnings to the "
             "skills marketplace before ending?"
         )

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/retrospective-trigger.py\"",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/learn-trigger.py\"",
             "timeout": 120,
             "once": true
           }
@@ -14,7 +14,7 @@
     ]
   },
   "enabledPlugins": {
-    "skills-registry-commands@ProjectMnemosyne": true,
+    "hephaestus@ProjectHephaestus": true,
     "safety-net@cc-marketplace": true
   }
 }


### PR DESCRIPTION
## Summary
- Enable `hephaestus@ProjectHephaestus` plugin (replaces stale `skills-registry-commands@ProjectMnemosyne`)
- Rename `retrospective-trigger.py` to `learn-trigger.py` (matches `/learn` command rename)
- Update hook content to reference `/learn` instead of `/retrospective`

## Test plan
- [ ] Verify `.claude/settings.json` contains `hephaestus@ProjectHephaestus: true`
- [ ] Verify hook file renamed to `learn-trigger.py`
- [ ] No stale `/retrospective` references in `.claude/`
- [ ] Start a Claude Code session and confirm `/hephaestus:advise` is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)