### PR TITLE
fix(mojo-0263): root cause fix all CI failures — closure migration + Writable trait

### DIFF
--- a/shared/tensor/any_tensor.mojo
+++ b/shared/tensor/any_tensor.mojo
@@ -43,6 +43,7 @@ from std.collections import List
 from std.memory import UnsafePointer, memset_zero, alloc, bitcast
 from std.math import ceildiv
 from std.hashlib.hasher import Hasher
+from std.io import Writer
 from shared.base.memory_pool import pooled_alloc, pooled_free
 from .tensor import Tensor
 from .tensor_traits import TensorLike
@@ -3507,6 +3508,22 @@ struct AnyTensor(
                 result += String(self._get_float64(i))
         result += "])"
         return result
+
+    def write_to[W: Writer](self, mut writer: W):
+        """Write the string representation to a Writer (required for Writable trait).
+
+        This method is called when using `String(tensor)` or `print(tensor)` to convert
+        the tensor to a string representation. It delegates to `__str__()` for the
+        actual formatting logic.
+
+        Parameters:
+            W: The writer type conforming to the Writer trait.
+
+        Args:
+            writer: The writer to write the string representation to.
+        """
+        var s = self.__str__()
+        writer.write(s)
 
     def __hash__[H: Hasher](self, mut hasher: H):
         """Compute hash based on shape, dtype, and data.

--- a/shared/tensor/any_tensor.mojo
+++ b/shared/tensor/any_tensor.mojo
@@ -3525,6 +3525,22 @@ struct AnyTensor(
         var s = self.__str__()
         writer.write(s)
 
+    def write_repr_to[W: Writer](self, mut writer: W):
+        """Write the repr representation to a Writer (required for Writable trait).
+
+        This method is called when using `repr(tensor)` to get the detailed
+        debugging representation. It delegates to `__repr__()` for the actual
+        formatting logic.
+
+        Parameters:
+            W: The writer type conforming to the Writer trait.
+
+        Args:
+            writer: The writer to write the repr representation to.
+        """
+        var s = self.__repr__()
+        writer.write(s)
+
     def __hash__[H: Hasher](self, mut hasher: H):
         """Compute hash based on shape, dtype, and data.
 

--- a/shared/tensor/tensor.mojo
+++ b/shared/tensor/tensor.mojo
@@ -21,6 +21,7 @@ Example:
 
 from std.collections import List
 from std.memory import UnsafePointer, memset_zero, alloc
+from std.io import Writer
 from shared.base.memory_pool import pooled_alloc, pooled_free
 from shared.tensor.tensor_traits import TensorLike
 from .any_tensor import AnyTensor
@@ -558,6 +559,22 @@ struct Tensor[dtype: DType = DType.float32](
                     result += "?"
         result += "], dtype=" + String(Self.dtype) + ")"
         return result
+
+    def write_to[W: Writer](self, mut writer: W):
+        """Write the string representation to a Writer (required for Writable trait).
+
+        This method is called when using `String(tensor)` or `print(tensor)` to convert
+        the tensor to a string representation. It delegates to `__str__()` for the
+        actual formatting logic.
+
+        Parameters:
+            W: The writer type conforming to the Writer trait.
+
+        Args:
+            writer: The writer to write the string representation to.
+        """
+        var s = self.__str__()
+        writer.write(s)
 
     def __repr__(self) -> String:
         """Detailed representation for debugging.

--- a/shared/tensor/tensor.mojo
+++ b/shared/tensor/tensor.mojo
@@ -576,6 +576,22 @@ struct Tensor[dtype: DType = DType.float32](
         var s = self.__str__()
         writer.write(s)
 
+    def write_repr_to[W: Writer](self, mut writer: W):
+        """Write the repr representation to a Writer (required for Writable trait).
+
+        This method is called when using `repr(tensor)` to get the detailed
+        debugging representation. It delegates to `__repr__()` for the actual
+        formatting logic.
+
+        Parameters:
+            W: The writer type conforming to the Writer trait.
+
+        Args:
+            writer: The writer to write the repr representation to.
+        """
+        var s = self.__repr__()
+        writer.write(s)
+
     def __repr__(self) -> String:
         """Detailed representation for debugging.
 

--- a/shared/training/__init__.mojo
+++ b/shared/training/__init__.mojo
@@ -530,6 +530,7 @@ struct CrossEntropyLoss(Loss, Movable):
 
 # Training script utilities (Issue #3034)
 from shared.training.script_runner import (
+    StepFn,
     TrainingCallbacks,
     run_epoch_with_batches,
     print_training_header,

--- a/shared/training/precision_config.mojo
+++ b/shared/training/precision_config.mojo
@@ -22,6 +22,7 @@ See examples/mixed_precision_training.mojo for complete usage
 """
 
 from std.sys import is_defined
+from std.io import Writer
 
 from shared.tensor.any_tensor import AnyTensor, full, zeros
 from shared.core.dtype_cast import cast_tensor
@@ -99,6 +100,22 @@ struct PrecisionMode(Copyable, ImplicitlyCopyable, Movable, Writable):
             return "fp8"
         else:
             return "unknown"
+
+    def write_to[W: Writer](self, mut writer: W):
+        """Write the string representation to a Writer (required for Writable trait).
+
+        This method is called when using `String(mode)` or `print(mode)` to convert
+        the precision mode to a string representation. It delegates to `__str__()` for
+        the actual formatting logic.
+
+        Parameters:
+            W: The writer type conforming to the Writer trait.
+
+        Args:
+            writer: The writer to write the string representation to.
+        """
+        var s = self.__str__()
+        writer.write(s)
 
 
 struct PrecisionConfig(Copyable, Movable):

--- a/shared/training/precision_config.mojo
+++ b/shared/training/precision_config.mojo
@@ -117,6 +117,22 @@ struct PrecisionMode(Copyable, ImplicitlyCopyable, Movable, Writable):
         var s = self.__str__()
         writer.write(s)
 
+    def write_repr_to[W: Writer](self, mut writer: W):
+        """Write the repr representation to a Writer (required for Writable trait).
+
+        This method is called when using `repr(mode)` to get the debugging
+        representation. Delegates to `__str__()` since PrecisionMode has no
+        separate repr format.
+
+        Parameters:
+            W: The writer type conforming to the Writer trait.
+
+        Args:
+            writer: The writer to write the repr representation to.
+        """
+        var s = self.__str__()
+        writer.write(s)
+
 
 struct PrecisionConfig(Copyable, Movable):
     """Central configuration for multi-precision training.

--- a/shared/training/script_runner.mojo
+++ b/shared/training/script_runner.mojo
@@ -32,6 +32,32 @@ from shared.tensor.any_tensor import AnyTensor
 from shared.training.trainer_interface import DataLoader
 
 
+trait StepFn(Copyable, Movable):
+    """Trait for training step functions used by run_epoch_with_batches.
+
+    Implementors accept input and target tensors and return a scalar loss tensor.
+    Use this trait (with a @fieldwise_init struct) instead of bare closures
+    when calling run_epoch_with_batches, because inner def closures are
+    nonescaping in Mojo 0.26.3+.
+
+    Example:
+        ```mojo
+        @fieldwise_init
+        struct MyStep(StepFn):
+            def __call__(
+                self, inputs: AnyTensor, targets: AnyTensor
+            ) raises -> AnyTensor:
+                return inputs  # replace with real forward+loss
+        var loss = run_epoch_with_batches(loader, callbacks, MyStep())
+        ```
+    """
+
+    def __call__(
+        self, inputs: AnyTensor, targets: AnyTensor
+    ) raises -> AnyTensor:
+        ...
+
+
 struct TrainingCallbacks(Copyable, Movable):
     """Callbacks for training loop events.
 
@@ -98,6 +124,42 @@ def run_epoch_with_batches(
         loader: DataLoader providing batches.
         callbacks: Training callbacks for progress reporting.
         step_fn: Function to execute a single training step, returning loss.
+
+    Returns:
+        Average loss for the epoch.
+    """
+    loader.reset()
+    var total_loss = Float64(0.0)
+    var num_batches = Int(0)
+
+    while loader.has_next():
+        var batch = loader.next()
+        var loss = step_fn(batch.data, batch.labels)
+        var loss_val = loss._get_float32(0)
+        total_loss += Float64(loss_val)
+        num_batches += 1
+        callbacks.on_batch_end(0, num_batches, Float32(loss_val))
+
+    if num_batches > 0:
+        return Float32(total_loss / Float64(num_batches))
+    return Float32(0.0)
+
+
+def run_epoch_with_batches[S: StepFn](
+    mut loader: DataLoader,
+    callbacks: TrainingCallbacks,
+    step_fn: S,
+) raises -> Float32:
+    """Run one training epoch with batch processing (trait-parameterized overload).
+
+    This overload accepts any type implementing StepFn, which avoids the
+    nonescaping-closure restriction on bare def function arguments in
+    Mojo 0.26.3+.
+
+    Args:
+        loader: DataLoader providing batches.
+        callbacks: Training callbacks for progress reporting.
+        step_fn: A value implementing StepFn (e.g. a @fieldwise_init struct).
 
     Returns:
         Average loss for the epoch.

--- a/tests/core/types/test_mxfp4_block.mojo
+++ b/tests/core/types/test_mxfp4_block.mojo
@@ -60,8 +60,11 @@ def test_mxfp4_block_creation_range() raises:
     for i in range(32):
         var expected = Float32(i) * 0.1
         var error = abs(decoded[i] - expected)
-        # E2M1 precision is limited, allow larger tolerance
-        assert_true(error < 0.5, "Value " + String(i) + " error too large")
+        # E2M1 precision is limited, allow larger tolerance.
+        # Use <= 0.5: values equidistant between two E2M1 codes (e.g., 2.5
+        # falls exactly between 2.0 and 3.0 in scaled space) produce error
+        # of exactly 0.5, which is valid quantization behavior.
+        assert_true(error <= 0.5, "Value " + String(i) + " error too large")
 
 
 def test_mxfp4_block_size_validation() raises:

--- a/tests/shared/core/test_activations.mojo
+++ b/tests/shared/core/test_activations.mojo
@@ -30,6 +30,8 @@ from shared.core.activation import (
 )
 from shared.testing import (
     check_gradient,
+    NumericalForward,
+    NumericalBackward,
 )
 from tests.shared.conftest import (
     assert_almost_equal,
@@ -143,6 +145,18 @@ def test_relu_non_negativity() raises:
         assert_true(val >= 0.0)
 
 
+@fieldwise_init
+struct _ReluFwd(NumericalForward):
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        return relu(x)
+
+
+@fieldwise_init
+struct _ReluBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        return relu_backward(grad, x)
+
+
 def test_relu_backward() raises:
     """Test ReLU gradient with numerical validation."""
     var shape = List[Int]()
@@ -155,22 +169,12 @@ def test_relu_backward() raises:
     x.set(2, Float32(0.5))
     x.set(3, Float32(2.0))
 
-    # Forward function wrapper
-    def forward(x: AnyTensor) raises unified {read} -> AnyTensor:
-        return relu(x)
-
     var y = relu(x)
     var grad_out = ones_like(y)
 
-    # Backward function wrapper
-    def backward_wrapper(
-        grad: AnyTensor, x: AnyTensor
-    ) raises unified {read} -> AnyTensor:
-        return relu_backward(grad, x)
-
     # Use numerical gradient checking (gold standard)
     # Note: rtol=1e-3 is appropriate for float32 finite differences
-    check_gradient(forward, backward_wrapper, x, grad_out, rtol=1e-3, atol=1e-6)
+    check_gradient(_ReluFwd(), _ReluBwd(), x, grad_out, rtol=1e-3, atol=1e-6)
 
 
 def test_relu_shape() raises:
@@ -288,6 +292,18 @@ def test_leaky_relu_custom_alpha() raises:
     )
 
 
+@fieldwise_init
+struct _LeakyReluFwd(NumericalForward):
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        return leaky_relu(x, alpha=0.1)
+
+
+@fieldwise_init
+struct _LeakyReluBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        return leaky_relu_backward(grad, x, alpha=0.1)
+
+
 def test_leaky_relu_backward() raises:
     """Test Leaky ReLU gradient with numerical validation."""
     var shape = List[Int]()
@@ -297,21 +313,11 @@ def test_leaky_relu_backward() raises:
     x.set(0, Float32(-1.0))
     x.set(1, Float32(1.0))
 
-    # Forward function wrapper
-    def forward(x: AnyTensor) raises unified {read} -> AnyTensor:
-        return leaky_relu(x, alpha=0.1)
-
     var y = leaky_relu(x, alpha=0.1)
     var grad_out = ones_like(y)
 
-    # Use numerical gradient checking (gold standard)
-    def backward_wrapper(
-        grad: AnyTensor, x: AnyTensor
-    ) raises unified {read} -> AnyTensor:
-        return leaky_relu_backward(grad, x, alpha=0.1)
-
     # Note: rtol=1e-3 is appropriate for float32 finite differences
-    check_gradient(forward, backward_wrapper, x, grad_out, rtol=1e-3, atol=1e-6)
+    check_gradient(_LeakyReluFwd(), _LeakyReluBwd(), x, grad_out, rtol=1e-3, atol=1e-6)
 
 
 def test_prelu_basic() raises:
@@ -408,6 +414,23 @@ def test_prelu_elementwise_alpha() raises:
     )
 
 
+@fieldwise_init
+struct _PreluFwd(NumericalForward):
+    var alpha: AnyTensor
+
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        return prelu(x, self.alpha)
+
+
+@fieldwise_init
+struct _PreluBwd(NumericalBackward):
+    var alpha: AnyTensor
+
+    def __call__(self, grad: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        var result = prelu_backward(grad, x, self.alpha)
+        return result.grad_a
+
+
 def test_prelu_backward() raises:
     """Test PReLU gradient with numerical validation."""
     var shape = List[Int]()
@@ -421,20 +444,11 @@ def test_prelu_backward() raises:
     alpha.set(0, Float32(0.5))
     alpha.set(1, Float32(0.5))
 
-    # Forward function wrapper
-    def forward(x: AnyTensor) raises unified {read} -> AnyTensor:
-        return prelu(x, alpha)
-
     var y = prelu(x, alpha)
     var grad_out = ones_like(y)
 
-    # Validate gradient w.r.t. input using numerical checking
-    def backward_input(grad: AnyTensor, x: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = prelu_backward(grad, x, alpha)
-        return result.grad_a
-
     # Note: rtol=1e-3 is appropriate for float32 finite differences
-    check_gradient(forward, backward_input, x, grad_out, rtol=1e-3, atol=1e-6)
+    check_gradient(_PreluFwd(alpha), _PreluBwd(alpha), x, grad_out, rtol=1e-3, atol=1e-6)
 
 
 def test_sigmoid_basic() raises:
@@ -460,6 +474,19 @@ def test_sigmoid_basic() raises:
     )
 
 
+@fieldwise_init
+struct _SigmoidFwd(NumericalForward):
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        return sigmoid(x)
+
+
+@fieldwise_init
+struct _SigmoidBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        var out = sigmoid(x)
+        return sigmoid_backward(grad, out)
+
+
 def test_sigmoid_backward() raises:
     """Test sigmoid gradient with numerical validation."""
     var shape = List[Int]()
@@ -471,21 +498,12 @@ def test_sigmoid_backward() raises:
     x.set(1, Float32(0.0))
     x.set(2, Float32(1.0))
 
-    # Forward function wrapper
-    def forward(x: AnyTensor) raises unified {read} -> AnyTensor:
-        return sigmoid(x)
-
     var y = sigmoid(x)
     var grad_out = ones_like(y)
 
-    # Note: sigmoid_backward takes output y, not input x
-    def backward_fn(grad: AnyTensor, x: AnyTensor) raises unified {read} -> AnyTensor:
-        var out = sigmoid(x)  # Recompute output inside wrapper
-        return sigmoid_backward(grad, out)
-
     # Use numerical gradient checking (gold standard)
     # Note: rtol=1e-3 is appropriate for float32 finite differences
-    check_gradient(forward, backward_fn, x, grad_out, rtol=1e-3, atol=1e-6)
+    check_gradient(_SigmoidFwd(), _SigmoidBwd(), x, grad_out, rtol=1e-3, atol=1e-6)
 
 
 def test_sigmoid_range() raises:
@@ -613,6 +631,19 @@ def test_tanh_values() raises:
     )
 
 
+@fieldwise_init
+struct _TanhFwd(NumericalForward):
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        return tanh(x)
+
+
+@fieldwise_init
+struct _TanhBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        var out = tanh(x)
+        return tanh_backward(grad, out)
+
+
 def test_tanh_backward() raises:
     """Test tanh gradient with numerical validation."""
     var shape = List[Int]()
@@ -624,21 +655,12 @@ def test_tanh_backward() raises:
     x.set(1, Float32(0.0))
     x.set(2, Float32(1.0))
 
-    # Forward function wrapper
-    def forward(x: AnyTensor) raises unified {read} -> AnyTensor:
-        return tanh(x)
-
     var y = tanh(x)
     var grad_out = ones_like(y)
 
-    # Note: tanh_backward takes output y, not input x
-    def backward_fn(grad: AnyTensor, x: AnyTensor) raises unified {read} -> AnyTensor:
-        var out = tanh(x)  # Recompute output inside wrapper
-        return tanh_backward(grad, out)
-
     # Use numerical gradient checking (gold standard)
     # Note: rtol=1e-3 is appropriate for float32 finite differences
-    check_gradient(forward, backward_fn, x, grad_out, rtol=1e-3, atol=1e-6)
+    check_gradient(_TanhFwd(), _TanhBwd(), x, grad_out, rtol=1e-3, atol=1e-6)
 
 
 def test_tanh_range() raises:
@@ -764,6 +786,19 @@ def test_softmax_numerical_stability() raises:
     assert_true(y._data.bitcast[Float32]()[1] > y._data.bitcast[Float32]()[0])
 
 
+@fieldwise_init
+struct _SoftmaxFwd(NumericalForward):
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        return softmax(x, axis=1)
+
+
+@fieldwise_init
+struct _SoftmaxBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        var out = softmax(x, axis=1)
+        return softmax_backward(grad, out, axis=1)
+
+
 def test_softmax_backward() raises:
     """Test softmax gradient with numerical validation."""
     var shape = List[Int]()
@@ -779,23 +814,14 @@ def test_softmax_backward() raises:
     x.set(4, Float32(0.5))
     x.set(5, Float32(1.5))
 
-    # Forward function wrapper
-    def forward(x: AnyTensor) raises unified {read} -> AnyTensor:
-        return softmax(x, axis=1)
-
     var y = softmax(x, axis=1)
     var grad_out = ones_like(y)
-
-    # Note: softmax_backward takes output y, not input x
-    def backward_fn(grad: AnyTensor, x: AnyTensor) raises unified {read} -> AnyTensor:
-        var out = softmax(x, axis=1)  # Recompute output inside wrapper
-        return softmax_backward(grad, out, axis=1)
 
     # Use numerical gradient checking (gold standard)
     # Note: rtol=1e-3, atol=5e-4 is needed for float32 softmax gradients
     # Softmax involves exp() and division which amplify numerical errors,
     # especially at the edges of the distribution
-    check_gradient(forward, backward_fn, x, grad_out, rtol=1e-3, atol=5e-4)
+    check_gradient(_SoftmaxFwd(), _SoftmaxBwd(), x, grad_out, rtol=1e-3, atol=5e-4)
 
 
 def test_gelu_basic() raises:
@@ -943,6 +969,18 @@ def test_gelu_float16() raises:
     assert_almost_equal(val_0, Float32(0.0), tolerance=0.01)
 
 
+@fieldwise_init
+struct _GeluFwd(NumericalForward):
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        return gelu(x, approximate=False)
+
+
+@fieldwise_init
+struct _GeluBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        return gelu_backward(grad, x, approximate=False)
+
+
 def test_gelu_backward_gradient() raises:
     """Test GELU backward with numerical gradient checking."""
     var shape = List[Int]()
@@ -954,19 +992,11 @@ def test_gelu_backward_gradient() raises:
     x.set(1, Float32(0.0))
     x.set(2, Float32(0.5))
 
-    # Forward function wrapper
-    def forward(x: AnyTensor) raises unified {read} -> AnyTensor:
-        return gelu(x, approximate=False)
-
     var y = gelu(x, approximate=False)
     var grad_out = ones_like(y)
 
-    # Backward function wrapper
-    def backward_fn(grad: AnyTensor, x: AnyTensor) raises unified {read} -> AnyTensor:
-        return gelu_backward(grad, x, approximate=False)
-
     # Use numerical gradient checking (gold standard)
-    check_gradient(forward, backward_fn, x, grad_out, rtol=1e-3, atol=1e-6)
+    check_gradient(_GeluFwd(), _GeluBwd(), x, grad_out, rtol=1e-3, atol=1e-6)
 
 
 def test_swish_basic() raises:
@@ -1001,6 +1031,18 @@ def test_swish_positive() raises:
     )
 
 
+@fieldwise_init
+struct _SwishFwd(NumericalForward):
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        return swish(x)
+
+
+@fieldwise_init
+struct _SwishBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        return swish_backward(grad, x)
+
+
 def test_swish_backward_gradient() raises:
     """Test Swish backward with numerical gradient checking."""
     var shape = List[Int]()
@@ -1012,19 +1054,11 @@ def test_swish_backward_gradient() raises:
     x.set(1, Float32(0.0))
     x.set(2, Float32(0.5))
 
-    # Forward function wrapper
-    def forward(x: AnyTensor) raises unified {read} -> AnyTensor:
-        return swish(x)
-
     var y = swish(x)
     var grad_out = ones_like(y)
 
-    # Backward function wrapper
-    def backward_fn(grad: AnyTensor, x: AnyTensor) raises unified {read} -> AnyTensor:
-        return swish_backward(grad, x)
-
     # Use numerical gradient checking (gold standard)
-    check_gradient(forward, backward_fn, x, grad_out, rtol=1e-3, atol=1e-6)
+    check_gradient(_SwishFwd(), _SwishBwd(), x, grad_out, rtol=1e-3, atol=1e-6)
 
 
 def test_mish_basic() raises:
@@ -1058,6 +1092,18 @@ def test_mish_shape() raises:
     assert_equal(y.shape()[2], 4)
 
 
+@fieldwise_init
+struct _MishFwd(NumericalForward):
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        return mish(x)
+
+
+@fieldwise_init
+struct _MishBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        return mish_backward(grad, x)
+
+
 def test_mish_backward_gradient() raises:
     """Test Mish backward with numerical gradient checking."""
     var shape = List[Int]()
@@ -1069,19 +1115,11 @@ def test_mish_backward_gradient() raises:
     x.set(1, Float32(0.0))
     x.set(2, Float32(0.5))
 
-    # Forward function wrapper
-    def forward(x: AnyTensor) raises unified {read} -> AnyTensor:
-        return mish(x)
-
     var y = mish(x)
     var grad_out = ones_like(y)
 
-    # Backward function wrapper
-    def backward_fn(grad: AnyTensor, x: AnyTensor) raises unified {read} -> AnyTensor:
-        return mish_backward(grad, x)
-
     # Use numerical gradient checking (gold standard)
-    check_gradient(forward, backward_fn, x, grad_out, rtol=1e-3, atol=1e-6)
+    check_gradient(_MishFwd(), _MishBwd(), x, grad_out, rtol=1e-3, atol=1e-6)
 
 
 def test_elu_basic() raises:
@@ -1110,6 +1148,18 @@ def test_elu_basic() raises:
     )
 
 
+@fieldwise_init
+struct _EluFwd(NumericalForward):
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        return elu(x, alpha=1.0)
+
+
+@fieldwise_init
+struct _EluBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        return elu_backward(grad, x, alpha=1.0)
+
+
 def test_elu_backward() raises:
     """Test ELU gradient with numerical validation."""
     var shape = List[Int]()
@@ -1120,20 +1170,12 @@ def test_elu_backward() raises:
     x.set(1, Float32(0.0))
     x.set(2, Float32(1.0))
 
-    # Forward function wrapper
-    def forward(x: AnyTensor) raises unified {read} -> AnyTensor:
-        return elu(x, alpha=1.0)
-
     var y = elu(x, alpha=1.0)
     var grad_out = ones_like(y)
 
-    # Note: elu_backward takes x, y, and alpha
-    def backward_fn(grad: AnyTensor, x: AnyTensor) raises unified {read} -> AnyTensor:
-        return elu_backward(grad, x, alpha=1.0)
-
     # Use numerical gradient checking (gold standard)
     # Note: rtol=1e-3 is appropriate for float32 finite differences
-    check_gradient(forward, backward_fn, x, grad_out, rtol=1e-3, atol=1e-6)
+    check_gradient(_EluFwd(), _EluBwd(), x, grad_out, rtol=1e-3, atol=1e-6)
 
 
 def test_integration_forward_backward() raises:

--- a/tests/shared/core/test_arithmetic_backward.mojo
+++ b/tests/shared/core/test_arithmetic_backward.mojo
@@ -36,6 +36,8 @@ from shared.core.arithmetic import (
 from shared.testing import (
     check_gradient,
     compute_numerical_gradient,
+    NumericalForward,
+    NumericalBackward,
 )
 
 
@@ -460,6 +462,23 @@ def test_divide_broadcast() raises:
         )
 
 
+@fieldwise_init
+struct _AddFwd(NumericalForward):
+    var b: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return add(inp, self.b)
+
+
+@fieldwise_init
+struct _AddBwd(NumericalBackward):
+    var b: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var grads = add_backward(grad_out, inp, self.b)
+        return grads.grad_a
+
+
 def test_add_backward_gradient() raises:
     """Test add_backward with numerical gradient checking.
 
@@ -476,17 +495,27 @@ def test_add_backward_gradient() raises:
         a.set(i, Float32(Float32(i) * 0.1 - 1.2))
         b.set(i, Float32(Float32(i) * 0.15 - 0.8))
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return add(inp, b)
-
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = add_backward(grad_out, inp, b)
-        return grads.grad_a
-
-    var output = forward(a)
+    var output = add(a, b)
     var grad_output = ones_like(output)
 
-    check_gradient(forward, backward, a, grad_output, rtol=5e-3, atol=1e-5)
+    check_gradient(_AddFwd(b), _AddBwd(b), a, grad_output, rtol=5e-3, atol=1e-5)
+
+
+@fieldwise_init
+struct _SubtractFwd(NumericalForward):
+    var b: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return subtract(inp, self.b)
+
+
+@fieldwise_init
+struct _SubtractBwd(NumericalBackward):
+    var b: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var grads = subtract_backward(grad_out, inp, self.b)
+        return grads.grad_a
 
 
 def test_subtract_backward_gradient() raises:
@@ -503,17 +532,27 @@ def test_subtract_backward_gradient() raises:
         a.set(i, Float32(Float32(i) * 0.1 + 0.5))
         b.set(i, Float32(Float32(i) * 0.2 - 1.5))
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return subtract(inp, b)
-
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = subtract_backward(grad_out, inp, b)
-        return grads.grad_a
-
-    var output = forward(a)
+    var output = subtract(a, b)
     var grad_output = ones_like(output)
 
-    check_gradient(forward, backward, a, grad_output, rtol=5e-3, atol=1e-5)
+    check_gradient(_SubtractFwd(b), _SubtractBwd(b), a, grad_output, rtol=5e-3, atol=1e-5)
+
+
+@fieldwise_init
+struct _MultiplyFwd(NumericalForward):
+    var b: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return multiply(inp, self.b)
+
+
+@fieldwise_init
+struct _MultiplyBwd(NumericalBackward):
+    var b: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var grads = multiply_backward(grad_out, inp, self.b)
+        return grads.grad_a
 
 
 def test_multiply_backward_gradient() raises:
@@ -531,17 +570,27 @@ def test_multiply_backward_gradient() raises:
         a.set(i, Float32(Float32(i) * 0.1 + 0.1))
         b.set(i, Float32(Float32(i) * 0.15 + 0.2))
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return multiply(inp, b)
-
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = multiply_backward(grad_out, inp, b)
-        return grads.grad_a
-
-    var output = forward(a)
+    var output = multiply(a, b)
     var grad_output = ones_like(output)
 
-    check_gradient(forward, backward, a, grad_output, rtol=5e-3, atol=1e-5)
+    check_gradient(_MultiplyFwd(b), _MultiplyBwd(b), a, grad_output, rtol=5e-3, atol=1e-5)
+
+
+@fieldwise_init
+struct _DivideFwd(NumericalForward):
+    var b: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return divide(inp, self.b)
+
+
+@fieldwise_init
+struct _DivideBwd(NumericalBackward):
+    var b: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var grads = divide_backward(grad_out, inp, self.b)
+        return grads.grad_a
 
 
 def test_divide_backward_gradient() raises:
@@ -559,17 +608,27 @@ def test_divide_backward_gradient() raises:
         a.set(i, Float32(Float32(i) * 0.2 + 0.5))
         b.set(i, Float32(Float32(i) * 0.1 + 1.0))  # Ensure b > 0
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return divide(inp, b)
-
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = divide_backward(grad_out, inp, b)
-        return grads.grad_a
-
-    var output = forward(a)
+    var output = divide(a, b)
     var grad_output = ones_like(output)
 
-    check_gradient(forward, backward, a, grad_output, rtol=1e-2, atol=1e-5)
+    check_gradient(_DivideFwd(b), _DivideBwd(b), a, grad_output, rtol=1e-2, atol=1e-5)
+
+
+@fieldwise_init
+struct _AddFwdB(NumericalForward):
+    var a: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return add(self.a, inp)
+
+
+@fieldwise_init
+struct _AddBwdB(NumericalBackward):
+    var a: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var grads = add_backward(grad_out, self.a, inp)
+        return grads.grad_b
 
 
 def test_add_backward_b_gradient() raises:
@@ -586,17 +645,27 @@ def test_add_backward_b_gradient() raises:
         a.set(i, Float32(Float32(i) * 0.1 - 0.5))
         b.set(i, Float32(Float32(i) * 0.12 + 0.3))
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return add(a, inp)
-
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = add_backward(grad_out, a, inp)
-        return grads.grad_b
-
-    var output = forward(b)
+    var output = add(a, b)
     var grad_output = ones_like(output)
 
-    check_gradient(forward, backward, b, grad_output, rtol=5e-3, atol=1e-5)
+    check_gradient(_AddFwdB(a), _AddBwdB(a), b, grad_output, rtol=5e-3, atol=1e-5)
+
+
+@fieldwise_init
+struct _SubtractFwdB(NumericalForward):
+    var a: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return subtract(self.a, inp)
+
+
+@fieldwise_init
+struct _SubtractBwdB(NumericalBackward):
+    var a: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var grads = subtract_backward(grad_out, self.a, inp)
+        return grads.grad_b
 
 
 def test_subtract_backward_b_gradient() raises:
@@ -613,17 +682,27 @@ def test_subtract_backward_b_gradient() raises:
         a.set(i, Float32(Float32(i) * 0.15 + 0.2))
         b.set(i, Float32(Float32(i) * 0.1 - 1.0))
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return subtract(a, inp)
-
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = subtract_backward(grad_out, a, inp)
-        return grads.grad_b
-
-    var output = forward(b)
+    var output = subtract(a, b)
     var grad_output = ones_like(output)
 
-    check_gradient(forward, backward, b, grad_output, rtol=5e-3, atol=1e-5)
+    check_gradient(_SubtractFwdB(a), _SubtractBwdB(a), b, grad_output, rtol=5e-3, atol=1e-5)
+
+
+@fieldwise_init
+struct _MultiplyFwdB(NumericalForward):
+    var a: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return multiply(self.a, inp)
+
+
+@fieldwise_init
+struct _MultiplyBwdB(NumericalBackward):
+    var a: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var grads = multiply_backward(grad_out, self.a, inp)
+        return grads.grad_b
 
 
 def test_multiply_backward_b_gradient() raises:
@@ -640,17 +719,27 @@ def test_multiply_backward_b_gradient() raises:
         a.set(i, Float32(Float32(i) * 0.2 + 0.1))
         b.set(i, Float32(Float32(i) * 0.15 + 0.15))
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return multiply(a, inp)
-
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = multiply_backward(grad_out, a, inp)
-        return grads.grad_b
-
-    var output = forward(b)
+    var output = multiply(a, b)
     var grad_output = ones_like(output)
 
-    check_gradient(forward, backward, b, grad_output, rtol=1e-2, atol=1e-5)
+    check_gradient(_MultiplyFwdB(a), _MultiplyBwdB(a), b, grad_output, rtol=1e-2, atol=1e-5)
+
+
+@fieldwise_init
+struct _DivideFwdB(NumericalForward):
+    var a: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return divide(self.a, inp)
+
+
+@fieldwise_init
+struct _DivideBwdB(NumericalBackward):
+    var a: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var grads = divide_backward(grad_out, self.a, inp)
+        return grads.grad_b
 
 
 def test_divide_backward_b_gradient() raises:
@@ -667,17 +756,10 @@ def test_divide_backward_b_gradient() raises:
         a.set(i, Float32(Float32(i) * 0.2 + 0.5))
         b.set(i, Float32(Float32(i) * 0.1 + 1.5))  # b > 0
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return divide(a, inp)
-
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = divide_backward(grad_out, a, inp)
-        return grads.grad_b
-
-    var output = forward(b)
+    var output = divide(a, b)
     var grad_output = ones_like(output)
 
-    check_gradient(forward, backward, b, grad_output, rtol=1e-2, atol=1e-5)
+    check_gradient(_DivideFwdB(a), _DivideBwdB(a), b, grad_output, rtol=1e-2, atol=1e-5)
 
 
 def test_add_backward_broadcast_gradient() raises:

--- a/tests/shared/core/test_arithmetic_backward.mojo
+++ b/tests/shared/core/test_arithmetic_backward.mojo
@@ -762,6 +762,57 @@ def test_divide_backward_b_gradient() raises:
     check_gradient(_DivideFwdB(a), _DivideBwdB(a), b, grad_output, rtol=1e-2, atol=1e-5)
 
 
+@fieldwise_init
+struct _AddBroadcastFwd(NumericalForward):
+    var a: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return add(self.a, inp)
+
+
+@fieldwise_init
+struct _AddBroadcastBwd(NumericalBackward):
+    var a: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var grads = add_backward(grad_out, self.a, inp)
+        return grads.grad_b
+
+
+@fieldwise_init
+struct _MultiplyBroadcastFwd(NumericalForward):
+    var a: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return multiply(self.a, inp)
+
+
+@fieldwise_init
+struct _MultiplyBroadcastBwd(NumericalBackward):
+    var a: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var grads = multiply_backward(grad_out, self.a, inp)
+        return grads.grad_b
+
+
+@fieldwise_init
+struct _DivideBroadcastFwd(NumericalForward):
+    var a: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return divide(self.a, inp)
+
+
+@fieldwise_init
+struct _DivideBroadcastBwd(NumericalBackward):
+    var a: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var grads = divide_backward(grad_out, self.a, inp)
+        return grads.grad_b
+
+
 def test_add_backward_broadcast_gradient() raises:
     """Test add_backward with broadcasting and numerical gradient checking.
 
@@ -780,17 +831,10 @@ def test_add_backward_broadcast_gradient() raises:
     for i in range(3):
         b.set(i, Float32(Float32(i) * 0.15 - 0.3))
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return add(a, inp)
-
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = add_backward(grad_out, a, inp)
-        return grads.grad_b
-
-    var output = forward(b)
+    var output = add(a, b)
     var grad_output = ones_like(output)
 
-    check_gradient(forward, backward, b, grad_output, rtol=5e-3, atol=1e-5)
+    check_gradient(_AddBroadcastFwd(a), _AddBroadcastBwd(a), b, grad_output, rtol=5e-3, atol=1e-5)
 
 
 def test_multiply_backward_broadcast_gradient() raises:
@@ -811,17 +855,10 @@ def test_multiply_backward_broadcast_gradient() raises:
     for i in range(3):
         b.set(i, Float32(Float32(i) * 0.2 + 0.2))
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return multiply(a, inp)
-
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = multiply_backward(grad_out, a, inp)
-        return grads.grad_b
-
-    var output = forward(b)
+    var output = multiply(a, b)
     var grad_output = ones_like(output)
 
-    check_gradient(forward, backward, b, grad_output, rtol=5e-3, atol=1e-5)
+    check_gradient(_MultiplyBroadcastFwd(a), _MultiplyBroadcastBwd(a), b, grad_output, rtol=5e-3, atol=1e-5)
 
 
 def test_divide_backward_broadcast_gradient() raises:
@@ -842,17 +879,10 @@ def test_divide_backward_broadcast_gradient() raises:
     for i in range(3):
         b.set(i, Float32(Float32(i) * 0.1 + 1.0))  # b > 0
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return divide(a, inp)
-
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = divide_backward(grad_out, a, inp)
-        return grads.grad_b
-
-    var output = forward(b)
+    var output = divide(a, b)
     var grad_output = ones_like(output)
 
-    check_gradient(forward, backward, b, grad_output, rtol=5e-3, atol=1e-5)
+    check_gradient(_DivideBroadcastFwd(a), _DivideBroadcastBwd(a), b, grad_output, rtol=5e-3, atol=1e-5)
 
 
 def main() raises:

--- a/tests/shared/core/test_backward_conv_padding.mojo
+++ b/tests/shared/core/test_backward_conv_padding.mojo
@@ -14,7 +14,25 @@ from tests.shared.conftest import (
 )
 from shared.tensor.any_tensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.conv import conv2d, conv2d_backward
-from shared.testing import check_gradient
+from shared.testing import check_gradient, NumericalForward, NumericalBackward
+
+
+@fieldwise_init
+struct _Conv2dInpPad1Fwd(NumericalForward):
+    var kernel: AnyTensor
+    var bias: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return conv2d(inp, self.kernel, self.bias, stride=1, padding=1)
+
+
+@fieldwise_init
+struct _Conv2dInpPad1Bwd(NumericalBackward):
+    var kernel: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var grads = conv2d_backward(grad_out, inp, self.kernel, stride=1, padding=1)
+        return grads.grad_input
 
 
 def test_conv2d_backward_grad_input_padding1() raises:
@@ -51,22 +69,33 @@ def test_conv2d_backward_grad_input_padding1() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward_input(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return conv2d(inp, kernel, bias, stride=1, padding=1)
-
-    def backward_input(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = conv2d_backward(grad_out, inp, kernel, stride=1, padding=1)
-        return grads.grad_input
-
     # Non-uniform grad_output: avoids pathological cancellation at boundaries
-    var output = forward_input(x)
+    var output = conv2d(x, kernel, bias, stride=1, padding=1)
     var grad_output = zeros_like(output)
     for i in range(16):
         grad_output.set(i, Float32(i % 4) * Float32(0.25) - Float32(0.3))
 
     check_gradient(
-        forward_input, backward_input, x, grad_output, rtol=1e-2, atol=1e-2
+        _Conv2dInpPad1Fwd(kernel, bias), _Conv2dInpPad1Bwd(kernel), x, grad_output, rtol=1e-2, atol=1e-2
     )
+
+
+@fieldwise_init
+struct _Conv2dWgtPad1Fwd(NumericalForward):
+    var x: AnyTensor
+    var bias: AnyTensor
+
+    def __call__(self, k: AnyTensor) raises -> AnyTensor:
+        return conv2d(self.x, k, self.bias, stride=1, padding=1)
+
+
+@fieldwise_init
+struct _Conv2dWgtPad1Bwd(NumericalBackward):
+    var x: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, k: AnyTensor) raises -> AnyTensor:
+        var grads = conv2d_backward(grad_out, self.x, k, stride=1, padding=1)
+        return grads.grad_weights
 
 
 def test_conv2d_backward_grad_weights_padding1() raises:
@@ -103,27 +132,38 @@ def test_conv2d_backward_grad_weights_padding1() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward_weights(k: AnyTensor) raises unified {read} -> AnyTensor:
-        return conv2d(x, k, bias, stride=1, padding=1)
-
-    def backward_weights(grad_out: AnyTensor, k: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = conv2d_backward(grad_out, x, k, stride=1, padding=1)
-        return grads.grad_weights
-
     # Non-uniform grad_output
-    var output = forward_weights(kernel)
+    var output = conv2d(x, kernel, bias, stride=1, padding=1)
     var grad_output = zeros_like(output)
     for i in range(16):
         grad_output.set(i, Float32(i % 4) * Float32(0.25) - Float32(0.3))
 
     check_gradient(
-        forward_weights,
-        backward_weights,
+        _Conv2dWgtPad1Fwd(x, bias),
+        _Conv2dWgtPad1Bwd(x),
         kernel,
         grad_output,
         rtol=1e-2,
         atol=1e-2,
     )
+
+
+@fieldwise_init
+struct _Conv2dInpPad2Fwd(NumericalForward):
+    var kernel: AnyTensor
+    var bias: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return conv2d(inp, self.kernel, self.bias, stride=1, padding=2)
+
+
+@fieldwise_init
+struct _Conv2dInpPad2Bwd(NumericalBackward):
+    var kernel: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var grads = conv2d_backward(grad_out, inp, self.kernel, stride=1, padding=2)
+        return grads.grad_input
 
 
 def test_conv2d_backward_grad_input_padding2() raises:
@@ -161,22 +201,33 @@ def test_conv2d_backward_grad_input_padding2() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward_input(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return conv2d(inp, kernel, bias, stride=1, padding=2)
-
-    def backward_input(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = conv2d_backward(grad_out, inp, kernel, stride=1, padding=2)
-        return grads.grad_input
-
     # Non-uniform grad_output over (1,1,7,7) = 49 elements
-    var output = forward_input(x)
+    var output = conv2d(x, kernel, bias, stride=1, padding=2)
     var grad_output = zeros_like(output)
     for i in range(49):
         grad_output.set(i, Float32(i % 4) * Float32(0.25) - Float32(0.3))
 
     check_gradient(
-        forward_input, backward_input, x, grad_output, rtol=1e-2, atol=1e-2
+        _Conv2dInpPad2Fwd(kernel, bias), _Conv2dInpPad2Bwd(kernel), x, grad_output, rtol=1e-2, atol=1e-2
     )
+
+
+@fieldwise_init
+struct _Conv2dWgtPad2Fwd(NumericalForward):
+    var x: AnyTensor
+    var bias: AnyTensor
+
+    def __call__(self, k: AnyTensor) raises -> AnyTensor:
+        return conv2d(self.x, k, self.bias, stride=1, padding=2)
+
+
+@fieldwise_init
+struct _Conv2dWgtPad2Bwd(NumericalBackward):
+    var x: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, k: AnyTensor) raises -> AnyTensor:
+        var grads = conv2d_backward(grad_out, self.x, k, stride=1, padding=2)
+        return grads.grad_weights
 
 
 def test_conv2d_backward_grad_weights_padding2() raises:
@@ -214,22 +265,15 @@ def test_conv2d_backward_grad_weights_padding2() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward_weights(k: AnyTensor) raises unified {read} -> AnyTensor:
-        return conv2d(x, k, bias, stride=1, padding=2)
-
-    def backward_weights(grad_out: AnyTensor, k: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = conv2d_backward(grad_out, x, k, stride=1, padding=2)
-        return grads.grad_weights
-
     # Non-uniform grad_output over (1,1,7,7) = 49 elements
-    var output = forward_weights(kernel)
+    var output = conv2d(x, kernel, bias, stride=1, padding=2)
     var grad_output = zeros_like(output)
     for i in range(49):
         grad_output.set(i, Float32(i % 4) * Float32(0.25) - Float32(0.3))
 
     check_gradient(
-        forward_weights,
-        backward_weights,
+        _Conv2dWgtPad2Fwd(x, bias),
+        _Conv2dWgtPad2Bwd(x),
         kernel,
         grad_output,
         rtol=1e-2,

--- a/tests/shared/core/test_backward_conv_pool.mojo
+++ b/tests/shared/core/test_backward_conv_pool.mojo
@@ -15,7 +15,7 @@ from shared.core.pooling import (
     avgpool2d,
     avgpool2d_backward,
 )
-from shared.testing import check_gradient
+from shared.testing import check_gradient, NumericalForward, NumericalBackward
 
 
 # ============================================================================
@@ -138,6 +138,24 @@ def test_conv2d_backward_with_stride() raises:
     assert_equal(gi_shape[3], 8)
 
 
+@fieldwise_init
+struct _Conv2dInpFwd(NumericalForward):
+    var kernel: AnyTensor
+    var bias: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return conv2d(inp, self.kernel, self.bias, stride=1, padding=0)
+
+
+@fieldwise_init
+struct _Conv2dInpBwd(NumericalBackward):
+    var kernel: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var grads = conv2d_backward(grad_out, inp, self.kernel, stride=1, padding=0)
+        return grads.grad_input
+
+
 def test_conv2d_backward_grad_input_numerical() raises:
     """Test conv2d_backward grad_input values via numerical gradient checking.
 
@@ -146,18 +164,29 @@ def test_conv2d_backward_grad_input_numerical() raises:
     """
     var (x, kernel, bias) = _make_test_conv2d_tensors()
 
-    def forward_input(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return conv2d(inp, kernel, bias, stride=1, padding=0)
-
-    def backward_input(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = conv2d_backward(grad_out, inp, kernel, stride=1, padding=0)
-        return grads.grad_input
-
-    var output = forward_input(x)
+    var output = conv2d(x, kernel, bias, stride=1, padding=0)
     var grad_output = ones_like(output)
     check_gradient(
-        forward_input, backward_input, x, grad_output, rtol=1e-2, atol=1e-2
+        _Conv2dInpFwd(kernel, bias), _Conv2dInpBwd(kernel), x, grad_output, rtol=1e-2, atol=1e-2
     )
+
+
+@fieldwise_init
+struct _Conv2dWgtFwd(NumericalForward):
+    var x: AnyTensor
+    var bias: AnyTensor
+
+    def __call__(self, k: AnyTensor) raises -> AnyTensor:
+        return conv2d(self.x, k, self.bias, stride=1, padding=0)
+
+
+@fieldwise_init
+struct _Conv2dWgtBwd(NumericalBackward):
+    var x: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, k: AnyTensor) raises -> AnyTensor:
+        var grads = conv2d_backward(grad_out, self.x, k, stride=1, padding=0)
+        return grads.grad_weights
 
 
 def test_conv2d_backward_grad_weights_numerical() raises:
@@ -168,19 +197,11 @@ def test_conv2d_backward_grad_weights_numerical() raises:
     """
     var (x, kernel, bias) = _make_test_conv2d_tensors()
 
-    # Treat kernel as the variable being perturbed; x is held fixed
-    def forward_weights(k: AnyTensor) raises unified {read} -> AnyTensor:
-        return conv2d(x, k, bias, stride=1, padding=0)
-
-    def backward_weights(grad_out: AnyTensor, k: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = conv2d_backward(grad_out, x, k, stride=1, padding=0)
-        return grads.grad_weights
-
-    var output = forward_weights(kernel)
+    var output = conv2d(x, kernel, bias, stride=1, padding=0)
     var grad_output = ones_like(output)
     check_gradient(
-        forward_weights,
-        backward_weights,
+        _Conv2dWgtFwd(x, bias),
+        _Conv2dWgtBwd(x),
         kernel,
         grad_output,
         rtol=1e-2,
@@ -294,6 +315,24 @@ def test_avgpool2d_backward_gradient_distribution() raises:
     )
 
 
+@fieldwise_init
+struct _Conv2dFwd(NumericalForward):
+    var kernel: AnyTensor
+    var bias: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return conv2d(inp, self.kernel, self.bias, stride=1, padding=0)
+
+
+@fieldwise_init
+struct _Conv2dBwd(NumericalBackward):
+    var kernel: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var grads = conv2d_backward(grad_out, inp, self.kernel, stride=1, padding=0)
+        return grads.grad_input
+
+
 def test_conv2d_backward_gradient() raises:
     """Test conv2d backward with numerical gradient checking."""
     var input_shape = List[Int]()
@@ -318,16 +357,21 @@ def test_conv2d_backward_gradient() raises:
     bias_shape.append(2)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return conv2d(inp, kernel, bias, stride=1, padding=0)
-
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = conv2d_backward(grad_out, inp, kernel, stride=1, padding=0)
-        return grads.grad_input
-
-    var output = forward(x)
+    var output = conv2d(x, kernel, bias, stride=1, padding=0)
     var grad_output = ones_like(output)
-    check_gradient(forward, backward, x, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(_Conv2dFwd(kernel, bias), _Conv2dBwd(kernel), x, grad_output, rtol=1e-2, atol=1e-2)
+
+
+@fieldwise_init
+struct _MaxPool2dFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return maxpool2d(inp, kernel_size=2, stride=2, padding=0)
+
+
+@fieldwise_init
+struct _MaxPool2dBwd(NumericalBackward):
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return maxpool2d_backward(grad_out, inp, kernel_size=2, stride=2, padding=0)
 
 
 def test_maxpool2d_backward_gradient() raises:
@@ -341,17 +385,21 @@ def test_maxpool2d_backward_gradient() raises:
     for i in range(1 * 2 * 4 * 4):
         x.set(i, Float64(Float32(i) * 0.1 - 1.6))
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return maxpool2d(inp, kernel_size=2, stride=2, padding=0)
-
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return maxpool2d_backward(
-            grad_out, inp, kernel_size=2, stride=2, padding=0
-        )
-
-    var output = forward(x)
+    var output = maxpool2d(x, kernel_size=2, stride=2, padding=0)
     var grad_output = ones_like(output)
-    check_gradient(forward, backward, x, grad_output, rtol=1e-3, atol=5e-4)
+    check_gradient(_MaxPool2dFwd(), _MaxPool2dBwd(), x, grad_output, rtol=1e-3, atol=5e-4)
+
+
+@fieldwise_init
+struct _AvgPool2dFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return avgpool2d(inp, kernel_size=2, stride=2, padding=0)
+
+
+@fieldwise_init
+struct _AvgPool2dBwd(NumericalBackward):
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return avgpool2d_backward(grad_out, inp, kernel_size=2, stride=2, padding=0)
 
 
 def test_avgpool2d_backward_gradient() raises:
@@ -365,17 +413,9 @@ def test_avgpool2d_backward_gradient() raises:
     for i in range(1 * 2 * 4 * 4):
         x.set(i, Float64(Float32(i) * 0.1 - 1.6))
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return avgpool2d(inp, kernel_size=2, stride=2, padding=0)
-
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return avgpool2d_backward(
-            grad_out, inp, kernel_size=2, stride=2, padding=0
-        )
-
-    var output = forward(x)
+    var output = avgpool2d(x, kernel_size=2, stride=2, padding=0)
     var grad_output = ones_like(output)
-    check_gradient(forward, backward, x, grad_output, rtol=1e-3, atol=5e-4)
+    check_gradient(_AvgPool2dFwd(), _AvgPool2dBwd(), x, grad_output, rtol=1e-3, atol=5e-4)
 
 
 def main() raises:

--- a/tests/shared/core/test_backward_linear.mojo
+++ b/tests/shared/core/test_backward_linear.mojo
@@ -12,6 +12,8 @@ from shared.tensor.any_tensor import AnyTensor, zeros, ones, ones_like
 from shared.core.linear import linear, linear_backward
 from shared.testing import (
     check_gradient,
+    NumericalForward,
+    NumericalBackward,
 )
 
 
@@ -119,6 +121,24 @@ def test_linear_backward_batch() raises:
     assert_equal(grads.grad_bias.shape()[0], out_features)
 
 
+@fieldwise_init
+struct _LinearFwd(NumericalForward):
+    var weights: AnyTensor
+    var bias: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return linear(inp, self.weights, self.bias)
+
+
+@fieldwise_init
+struct _LinearBwd(NumericalBackward):
+    var weights: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var grads = linear_backward(grad_out, inp, self.weights)
+        return grads.grad_input
+
+
 def test_linear_backward_gradient() raises:
     """Test linear backward with numerical gradient checking."""
     var batch = 2
@@ -147,21 +167,15 @@ def test_linear_backward_gradient() raises:
     weights.set(4, Float64(-0.2))
     weights.set(5, Float64(0.5))
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var bias_shape = List[Int]()
-        bias_shape.append(out_features)
-        var bias = zeros(bias_shape, DType.float32)
-        bias.set(0, Float64(0.3))
-        bias.set(1, Float64(-0.2))
-        return linear(inp, weights, bias)
+    var bias_shape = List[Int]()
+    bias_shape.append(out_features)
+    var bias = zeros(bias_shape, DType.float32)
+    bias.set(0, Float64(0.3))
+    bias.set(1, Float64(-0.2))
 
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = linear_backward(grad_out, inp, weights)
-        return grads.grad_input
-
-    var output = forward(x)
+    var output = linear(x, weights, bias)
     var grad_output = ones_like(output)
-    check_gradient(forward, backward, x, grad_output, rtol=1e-3, atol=5e-4)
+    check_gradient(_LinearFwd(weights, bias), _LinearBwd(weights), x, grad_output, rtol=1e-3, atol=5e-4)
 
 
 def main() raises:

--- a/tests/shared/core/test_backward_losses.mojo
+++ b/tests/shared/core/test_backward_losses.mojo
@@ -17,7 +17,7 @@ from shared.core.loss import (
     mean_squared_error,
     mean_squared_error_backward,
 )
-from shared.testing import check_gradient
+from shared.testing import check_gradient, NumericalForward, NumericalBackward
 
 
 def test_cross_entropy_backward_shapes() raises:
@@ -152,6 +152,22 @@ def test_mean_squared_error_backward_zero_diff() raises:
         )
 
 
+@fieldwise_init
+struct _CEFwd(NumericalForward):
+    var targets: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return cross_entropy(inp, self.targets)
+
+
+@fieldwise_init
+struct _CEBwd(NumericalBackward):
+    var targets: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return cross_entropy_backward(grad_out, inp, self.targets)
+
+
 def test_cross_entropy_backward_gradient() raises:
     """Test cross-entropy backward with numerical gradient checking."""
     var batch = 2
@@ -175,15 +191,25 @@ def test_cross_entropy_backward_gradient() raises:
     targets.set(0, Float64(1.0))
     targets.set(4, Float64(1.0))
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return cross_entropy(inp, targets)
-
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return cross_entropy_backward(grad_out, inp, targets)
-
-    var loss = forward(logits)
+    var loss = cross_entropy(logits, targets)
     var grad_output = ones_like(loss)
-    check_gradient(forward, backward, logits, grad_output, rtol=1e-3, atol=1e-3)
+    check_gradient(_CEFwd(targets), _CEBwd(targets), logits, grad_output, rtol=1e-3, atol=1e-3)
+
+
+@fieldwise_init
+struct _BCEBLFwd(NumericalForward):
+    var targets: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return binary_cross_entropy(inp, self.targets)
+
+
+@fieldwise_init
+struct _BCEBLBwd(NumericalBackward):
+    var targets: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return binary_cross_entropy_backward(grad_out, inp, self.targets)
 
 
 def test_binary_cross_entropy_backward_gradient() raises:
@@ -212,17 +238,27 @@ def test_binary_cross_entropy_backward_gradient() raises:
     targets.set(6, Float64(0.0))
     targets.set(7, Float64(1.0))
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return binary_cross_entropy(inp, targets)
-
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return binary_cross_entropy_backward(grad_out, inp, targets)
-
-    var loss = forward(predictions)
+    var loss = binary_cross_entropy(predictions, targets)
     var grad_output = ones_like(loss)
     check_gradient(
-        forward, backward, predictions, grad_output, rtol=1e-3, atol=1e-6
+        _BCEBLFwd(targets), _BCEBLBwd(targets), predictions, grad_output, rtol=1e-3, atol=1e-6
     )
+
+
+@fieldwise_init
+struct _MSEBLFwd(NumericalForward):
+    var targets: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return mean_squared_error(inp, self.targets)
+
+
+@fieldwise_init
+struct _MSEBLBwd(NumericalBackward):
+    var targets: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return mean_squared_error_backward(grad_out, inp, self.targets)
 
 
 def test_mean_squared_error_backward_gradient() raises:
@@ -261,16 +297,10 @@ def test_mean_squared_error_backward_gradient() raises:
     targets.set(10, Float64(0.0))
     targets.set(11, Float64(0.6))
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return mean_squared_error(inp, targets)
-
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return mean_squared_error_backward(grad_out, inp, targets)
-
-    var loss = forward(predictions)
+    var loss = mean_squared_error(predictions, targets)
     var grad_output = ones_like(loss)
     check_gradient(
-        forward, backward, predictions, grad_output, rtol=1e-3, atol=1e-6
+        _MSEBLFwd(targets), _MSEBLBwd(targets), predictions, grad_output, rtol=1e-3, atol=1e-6
     )
 
 

--- a/tests/shared/core/test_conv.mojo
+++ b/tests/shared/core/test_conv.mojo
@@ -28,7 +28,36 @@ from shared.core.conv import (
 from shared.testing import (
     compute_numerical_gradient,
     assert_gradients_close,
+    NumericalForward,
 )
+
+
+@fieldwise_init
+struct _ConvInputFwd(NumericalForward):
+    var kernel: AnyTensor
+    var stride: Int
+    var padding: Int
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        var out = conv2d_no_bias(inp, self.kernel, self.stride, self.padding)
+        var reduced = out
+        while reduced.dim() > 0:
+            reduced = reduce_sum(reduced, axis=0, keepdims=False)
+        return reduced
+
+
+@fieldwise_init
+struct _ConvKernelFwd(NumericalForward):
+    var x: AnyTensor
+    var stride: Int
+    var padding: Int
+
+    def __call__(self, k: AnyTensor) raises -> AnyTensor:
+        var out = conv2d_no_bias(self.x, k, self.stride, self.padding)
+        var reduced = out
+        while reduced.dim() > 0:
+            reduced = reduce_sum(reduced, axis=0, keepdims=False)
+        return reduced
 from shared.core.reduction import sum as reduce_sum
 from shared.tensor.any_tensor import AnyTensor, zeros, ones, full
 
@@ -1040,15 +1069,8 @@ def test_conv2d_backward_gradient_input() raises:
     var analytical_grad = result.grad_input
 
     # Numerical gradient: forward_fn sums conv output (equivalent to ones grad_output)
-    def forward_for_input(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var out = conv2d_no_bias(inp, kernel, stride, padding)
-        var reduced = out
-        while reduced.dim() > 0:
-            reduced = reduce_sum(reduced, axis=0, keepdims=False)
-        return reduced
-
     var numerical_grad = compute_numerical_gradient(
-        forward_for_input, x, epsilon=3e-4
+        _ConvInputFwd(kernel, stride, padding), x, epsilon=3e-4
     )
 
     assert_gradients_close(
@@ -1100,15 +1122,8 @@ def test_conv2d_backward_gradient_kernel() raises:
     var analytical_grad = result.grad_weights
 
     # Numerical gradient: forward_fn sums conv output (equivalent to ones grad_output)
-    def forward_for_kernel(k: AnyTensor) raises unified {read} -> AnyTensor:
-        var out = conv2d_no_bias(x, k, stride, padding)
-        var reduced = out
-        while reduced.dim() > 0:
-            reduced = reduce_sum(reduced, axis=0, keepdims=False)
-        return reduced
-
     var numerical_grad = compute_numerical_gradient(
-        forward_for_kernel, kernel, epsilon=3e-4
+        _ConvKernelFwd(x, stride, padding), kernel, epsilon=3e-4
     )
 
     assert_gradients_close(
@@ -1166,15 +1181,8 @@ def test_conv2d_backward_gradient_input_with_padding() raises:
     var result = conv2d_backward(grad_output, x, kernel, stride, padding)
     var analytical_grad = result.grad_input
 
-    def forward_for_input_p1(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var out = conv2d_no_bias(inp, kernel, stride, padding)
-        var reduced = out
-        while reduced.dim() > 0:
-            reduced = reduce_sum(reduced, axis=0, keepdims=False)
-        return reduced
-
     var numerical_grad = compute_numerical_gradient(
-        forward_for_input_p1, x, epsilon=3e-4
+        _ConvInputFwd(kernel, stride, padding), x, epsilon=3e-4
     )
 
     assert_gradients_close(
@@ -1192,15 +1200,8 @@ def test_conv2d_backward_gradient_input_with_padding() raises:
     result = conv2d_backward(grad_output, x, kernel, stride, padding)
     analytical_grad = result.grad_input
 
-    def forward_for_input_p2(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var out = conv2d_no_bias(inp, kernel, stride, padding)
-        var reduced = out
-        while reduced.dim() > 0:
-            reduced = reduce_sum(reduced, axis=0, keepdims=False)
-        return reduced
-
     numerical_grad = compute_numerical_gradient(
-        forward_for_input_p2, x, epsilon=3e-4
+        _ConvInputFwd(kernel, stride, padding), x, epsilon=3e-4
     )
 
     assert_gradients_close(
@@ -1253,15 +1254,8 @@ def test_conv2d_backward_gradient_kernel_with_padding() raises:
     var result = conv2d_backward(grad_output, x, kernel, stride, padding)
     var analytical_grad = result.grad_weights
 
-    def forward_for_kernel_p1(k: AnyTensor) raises unified {read} -> AnyTensor:
-        var out = conv2d_no_bias(x, k, stride, padding)
-        var reduced = out
-        while reduced.dim() > 0:
-            reduced = reduce_sum(reduced, axis=0, keepdims=False)
-        return reduced
-
     var numerical_grad = compute_numerical_gradient(
-        forward_for_kernel_p1, kernel, epsilon=3e-4
+        _ConvKernelFwd(x, stride, padding), kernel, epsilon=3e-4
     )
 
     assert_gradients_close(
@@ -1279,15 +1273,8 @@ def test_conv2d_backward_gradient_kernel_with_padding() raises:
     result = conv2d_backward(grad_output, x, kernel, stride, padding)
     analytical_grad = result.grad_weights
 
-    def forward_for_kernel_p2(k: AnyTensor) raises unified {read} -> AnyTensor:
-        var out = conv2d_no_bias(x, k, stride, padding)
-        var reduced = out
-        while reduced.dim() > 0:
-            reduced = reduce_sum(reduced, axis=0, keepdims=False)
-        return reduced
-
     numerical_grad = compute_numerical_gradient(
-        forward_for_kernel_p2, kernel, epsilon=3e-4
+        _ConvKernelFwd(x, stride, padding), kernel, epsilon=3e-4
     )
 
     assert_gradients_close(

--- a/tests/shared/core/test_depthwise_conv_grad_check.mojo
+++ b/tests/shared/core/test_depthwise_conv_grad_check.mojo
@@ -12,7 +12,51 @@ from tests.shared.conftest import (
 )
 from shared.tensor.any_tensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.conv import depthwise_conv2d, depthwise_conv2d_backward
-from shared.testing import check_gradient
+from shared.testing import check_gradient, NumericalForward, NumericalBackward
+
+
+@fieldwise_init
+struct _DepthwiseInputFwd(NumericalForward):
+    var kernel: AnyTensor
+    var bias: AnyTensor
+    var stride: Int
+    var padding: Int
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return depthwise_conv2d(inp, self.kernel, self.bias, stride=self.stride, padding=self.padding)
+
+
+@fieldwise_init
+struct _DepthwiseInputBwd(NumericalBackward):
+    var kernel: AnyTensor
+    var stride: Int
+    var padding: Int
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var grads = depthwise_conv2d_backward(grad_out, inp, self.kernel, stride=self.stride, padding=self.padding)
+        return grads.grad_input
+
+
+@fieldwise_init
+struct _DepthwiseWeightsFwd(NumericalForward):
+    var x: AnyTensor
+    var bias: AnyTensor
+    var stride: Int
+    var padding: Int
+
+    def __call__(self, k: AnyTensor) raises -> AnyTensor:
+        return depthwise_conv2d(self.x, k, self.bias, stride=self.stride, padding=self.padding)
+
+
+@fieldwise_init
+struct _DepthwiseWeightsBwd(NumericalBackward):
+    var x: AnyTensor
+    var stride: Int
+    var padding: Int
+
+    def __call__(self, grad_out: AnyTensor, k: AnyTensor) raises -> AnyTensor:
+        var grads = depthwise_conv2d_backward(grad_out, self.x, k, stride=self.stride, padding=self.padding)
+        return grads.grad_weights
 
 
 def test_depthwise_conv2d_backward_shapes() raises:
@@ -91,19 +135,12 @@ def test_depthwise_conv2d_backward_stride1_padding0_grad_input() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward_input(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return depthwise_conv2d(inp, kernel, bias, stride=1, padding=0)
-
-    def backward_input(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = depthwise_conv2d_backward(grad_out, inp, kernel, stride=1, padding=0)
-        return grads.grad_input
-
-    var output = forward_input(x)
+    var output = _DepthwiseInputFwd(kernel, bias, 1, 0)(x)
     var grad_output = zeros_like(output)
     for i in range(output.numel()):
         grad_output.set(i, Float32(Float32(i % 4) * 0.25 - 0.3))
 
-    check_gradient(forward_input, backward_input, x, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(_DepthwiseInputFwd(kernel, bias, 1, 0), _DepthwiseInputBwd(kernel, 1, 0), x, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def test_depthwise_conv2d_backward_stride2_grad_input() raises:
@@ -135,19 +172,12 @@ def test_depthwise_conv2d_backward_stride2_grad_input() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward_input(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return depthwise_conv2d(inp, kernel, bias, stride=2, padding=0)
-
-    def backward_input(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = depthwise_conv2d_backward(grad_out, inp, kernel, stride=2, padding=0)
-        return grads.grad_input
-
-    var output = forward_input(x)
+    var output = _DepthwiseInputFwd(kernel, bias, 2, 0)(x)
     var grad_output = zeros_like(output)
     for i in range(output.numel()):
         grad_output.set(i, Float32(Float32(i % 4) * 0.25 - 0.3))
 
-    check_gradient(forward_input, backward_input, x, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(_DepthwiseInputFwd(kernel, bias, 2, 0), _DepthwiseInputBwd(kernel, 2, 0), x, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def test_depthwise_conv2d_backward_padding1_grad_input() raises:
@@ -179,19 +209,12 @@ def test_depthwise_conv2d_backward_padding1_grad_input() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward_input(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return depthwise_conv2d(inp, kernel, bias, stride=1, padding=1)
-
-    def backward_input(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = depthwise_conv2d_backward(grad_out, inp, kernel, stride=1, padding=1)
-        return grads.grad_input
-
-    var output = forward_input(x)
+    var output = _DepthwiseInputFwd(kernel, bias, 1, 1)(x)
     var grad_output = zeros_like(output)
     for i in range(output.numel()):
         grad_output.set(i, Float32(Float32(i % 4) * 0.25 - 0.3))
 
-    check_gradient(forward_input, backward_input, x, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(_DepthwiseInputFwd(kernel, bias, 1, 1), _DepthwiseInputBwd(kernel, 1, 1), x, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def test_depthwise_conv2d_backward_multichannel_grad_input() raises:
@@ -224,19 +247,12 @@ def test_depthwise_conv2d_backward_multichannel_grad_input() raises:
     bias_shape.append(channels)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward_input(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return depthwise_conv2d(inp, kernel, bias, stride=1, padding=0)
-
-    def backward_input(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = depthwise_conv2d_backward(grad_out, inp, kernel, stride=1, padding=0)
-        return grads.grad_input
-
-    var output = forward_input(x)
+    var output = _DepthwiseInputFwd(kernel, bias, 1, 0)(x)
     var grad_output = zeros_like(output)
     for i in range(output.numel()):
         grad_output.set(i, Float32(Float32(i % 4) * 0.25 - 0.3))
 
-    check_gradient(forward_input, backward_input, x, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(_DepthwiseInputFwd(kernel, bias, 1, 0), _DepthwiseInputBwd(kernel, 1, 0), x, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def test_depthwise_conv2d_backward_grad_weights_numerical() raises:
@@ -269,19 +285,12 @@ def test_depthwise_conv2d_backward_grad_weights_numerical() raises:
     var bias = zeros(bias_shape, DType.float32)
 
     # Perturb kernel, hold x fixed
-    def forward_weights(k: AnyTensor) raises unified {read} -> AnyTensor:
-        return depthwise_conv2d(x, k, bias, stride=1, padding=0)
-
-    def backward_weights(grad_out: AnyTensor, k: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = depthwise_conv2d_backward(grad_out, x, k, stride=1, padding=0)
-        return grads.grad_weights
-
-    var output = forward_weights(kernel)
+    var output = _DepthwiseWeightsFwd(x, bias, 1, 0)(kernel)
     var grad_output = zeros_like(output)
     for i in range(output.numel()):
         grad_output.set(i, Float32(Float32(i % 4) * 0.25 - 0.3))
 
-    check_gradient(forward_weights, backward_weights, kernel, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(_DepthwiseWeightsFwd(x, bias, 1, 0), _DepthwiseWeightsBwd(x, 1, 0), kernel, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def test_depthwise_conv2d_backward_grad_bias_value() raises:
@@ -367,19 +376,12 @@ def test_depthwise_conv2d_backward_grad_weights_multichannel() raises:
     bias_shape.append(channels)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward_weights(k: AnyTensor) raises unified {read} -> AnyTensor:
-        return depthwise_conv2d(x, k, bias, stride=1, padding=0)
-
-    def backward_weights(grad_out: AnyTensor, k: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = depthwise_conv2d_backward(grad_out, x, k, stride=1, padding=0)
-        return grads.grad_weights
-
-    var output = forward_weights(kernel)
+    var output = _DepthwiseWeightsFwd(x, bias, 1, 0)(kernel)
     var grad_output = zeros_like(output)
     for i in range(output.numel()):
         grad_output.set(i, Float32(Float32(i % 4) * 0.25 - 0.3))
 
-    check_gradient(forward_weights, backward_weights, kernel, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(_DepthwiseWeightsFwd(x, bias, 1, 0), _DepthwiseWeightsBwd(x, 1, 0), kernel, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def test_depthwise_conv2d_backward_full_gradient_pipeline() raises:

--- a/tests/shared/core/test_dropout.mojo
+++ b/tests/shared/core/test_dropout.mojo
@@ -30,7 +30,7 @@ from shared.core.dropout import (
     dropout_backward,
     dropout2d_backward,
 )
-from shared.testing import check_gradient
+from shared.testing import check_gradient, NumericalForward, NumericalBackward
 
 
 def test_dropout_shapes() raises:
@@ -211,6 +211,30 @@ def test_dropout_backward_gradient_flow() raises:
             assert_almost_equal(grad_val, Float32(0.0), tolerance=1e-5)
 
 
+@fieldwise_init
+struct _DropoutFwd(NumericalForward):
+    var mask: AnyTensor
+    var p: Float32
+
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        from shared.core.arithmetic import multiply
+        from shared.tensor.any_tensor import full_like
+
+        var masked = multiply(x, self.mask)
+        var scale = 1.0 / (1.0 - self.p)
+        var scale_tensor = full_like(x, scale)
+        return multiply(masked, scale_tensor)
+
+
+@fieldwise_init
+struct _DropoutBwd(NumericalBackward):
+    var mask: AnyTensor
+    var p: Float32
+
+    def __call__(self, grad: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        return dropout_backward(grad, self.mask, p=self.p)
+
+
 def test_dropout_backward_gradient() raises:
     """Test dropout_backward with numerical gradient checking."""
     var shape = List[Int]()
@@ -233,26 +257,9 @@ def test_dropout_backward_gradient() raises:
     var grad_out = ones_like(output)
     var p = 0.3
 
-    # Forward function wrapper - manually apply the SAME mask
-    # This makes the function deterministic for gradient checking
-    def forward(x: AnyTensor) raises unified {read} -> AnyTensor:
-        # Apply the same mask that was generated initially
-        from shared.core.arithmetic import multiply
-        from shared.tensor.any_tensor import full_like
-
-        var masked = multiply(x, mask)
-        var scale = 1.0 / (1.0 - p)
-        var scale_tensor = full_like(x, scale)
-        return multiply(masked, scale_tensor)
-
-    # Backward function wrapper - use the same stored mask
-    def backward(grad: AnyTensor, x: AnyTensor) raises unified {read} -> AnyTensor:
-        # Use the mask from forward pass to ensure consistency
-        return dropout_backward(grad, mask, p=p)
-
     # Use numerical gradient checking (gold standard)
     # Note: Using relaxed tolerances due to Float32 precision limits
-    check_gradient(forward, backward, x, grad_out, rtol=2e-3, atol=1e-5)
+    check_gradient(_DropoutFwd(mask, p), _DropoutBwd(mask, p), x, grad_out, rtol=2e-3, atol=1e-5)
 
 
 def test_dropout2d_shapes() raises:

--- a/tests/shared/core/test_dropout.mojo
+++ b/tests/shared/core/test_dropout.mojo
@@ -214,14 +214,14 @@ def test_dropout_backward_gradient_flow() raises:
 @fieldwise_init
 struct _DropoutFwd(NumericalForward):
     var mask: AnyTensor
-    var p: Float32
+    var p: Float64
 
     def __call__(self, x: AnyTensor) raises -> AnyTensor:
         from shared.core.arithmetic import multiply
         from shared.tensor.any_tensor import full_like
 
         var masked = multiply(x, self.mask)
-        var scale = 1.0 / (1.0 - self.p)
+        var scale = Float64(1.0) / (Float64(1.0) - self.p)
         var scale_tensor = full_like(x, scale)
         return multiply(masked, scale_tensor)
 
@@ -229,7 +229,7 @@ struct _DropoutFwd(NumericalForward):
 @fieldwise_init
 struct _DropoutBwd(NumericalBackward):
     var mask: AnyTensor
-    var p: Float32
+    var p: Float64
 
     def __call__(self, grad: AnyTensor, x: AnyTensor) raises -> AnyTensor:
         return dropout_backward(grad, self.mask, p=self.p)
@@ -362,6 +362,30 @@ def test_dropout2d_backward_shapes() raises:
     assert_equal(grad_input.shape()[3], 8)
 
 
+@fieldwise_init
+struct _Dropout2dFwd(NumericalForward):
+    var mask: AnyTensor
+    var p: Float64
+
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        from shared.core.arithmetic import multiply
+        from shared.tensor.any_tensor import full_like
+
+        var masked = multiply(x, self.mask)
+        var scale = Float64(1.0) / (Float64(1.0) - self.p)
+        var scale_tensor = full_like(x, scale)
+        return multiply(masked, scale_tensor)
+
+
+@fieldwise_init
+struct _Dropout2dBwd(NumericalBackward):
+    var mask: AnyTensor
+    var p: Float64
+
+    def __call__(self, grad: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        return dropout2d_backward(grad, self.mask, p=self.p)
+
+
 def test_dropout2d_backward_gradient() raises:
     """Test dropout2d_backward with numerical gradient checking."""
     var shape = List[Int]()
@@ -384,27 +408,10 @@ def test_dropout2d_backward_gradient() raises:
     var grad_out = ones_like(output)
     var p = 0.2
 
-    # Forward function wrapper - manually apply the SAME mask
-    # This makes the function deterministic for gradient checking
-    def forward(x: AnyTensor) raises unified {read} -> AnyTensor:
-        # Apply the same mask that was generated initially
-        from shared.core.arithmetic import multiply
-        from shared.tensor.any_tensor import full_like
-
-        var masked = multiply(x, mask)
-        var scale = 1.0 / (1.0 - p)
-        var scale_tensor = full_like(x, scale)
-        return multiply(masked, scale_tensor)
-
-    # Backward function wrapper - use stored mask instead of regenerating
-    def backward(grad: AnyTensor, x: AnyTensor) raises unified {read} -> AnyTensor:
-        # Use the mask from forward pass to ensure consistency
-        return dropout2d_backward(grad, mask, p=p)
-
     # Use numerical gradient checking (gold standard)
     # Note: Using relaxed tolerances due to Float32 precision limits
     # Dropout2d uses larger tensors, requiring more relaxed tolerances
-    check_gradient(forward, backward, x, grad_out, rtol=1e-2, atol=1e-3)
+    check_gradient(_Dropout2dFwd(mask, p), _Dropout2dBwd(mask, p), x, grad_out, rtol=1e-2, atol=1e-3)
 
 
 def main() raises:

--- a/tests/shared/core/test_elementwise.mojo
+++ b/tests/shared/core/test_elementwise.mojo
@@ -48,8 +48,116 @@ from shared.core.elementwise import (
     sin_backward,
     cos_backward,
 )
-from shared.testing import check_gradient
+from shared.testing import check_gradient, NumericalForward, NumericalBackward
 from std.math import sqrt as math_sqrt, pi
+
+
+@fieldwise_init
+struct _AbsFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return abs(inp)
+
+
+@fieldwise_init
+struct _AbsBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return abs_backward(grad, inp)
+
+
+@fieldwise_init
+struct _ExpFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return exp(inp)
+
+
+@fieldwise_init
+struct _ExpBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return exp_backward(grad, inp)
+
+
+@fieldwise_init
+struct _LogFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return log(inp)
+
+
+@fieldwise_init
+struct _LogBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return log_backward(grad, inp)
+
+
+@fieldwise_init
+struct _Log10Fwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return log10(inp)
+
+
+@fieldwise_init
+struct _Log10Bwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return log10_backward(grad, inp)
+
+
+@fieldwise_init
+struct _Log2Fwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return log2(inp)
+
+
+@fieldwise_init
+struct _Log2Bwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return log2_backward(grad, inp)
+
+
+@fieldwise_init
+struct _SqrtFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return sqrt(inp)
+
+
+@fieldwise_init
+struct _SqrtBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return sqrt_backward(grad, inp)
+
+
+@fieldwise_init
+struct _SinFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return sin(inp)
+
+
+@fieldwise_init
+struct _SinBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return sin_backward(grad, inp)
+
+
+@fieldwise_init
+struct _CosFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return cos(inp)
+
+
+@fieldwise_init
+struct _CosBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return cos_backward(grad, inp)
+
+
+@fieldwise_init
+struct _ClipFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return clip(inp, min_val=-1.0, max_val=1.0)
+
+
+@fieldwise_init
+struct _ClipBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return clip_backward(grad, inp, min_val=-1.0, max_val=1.0)
 
 
 def test_abs_shapes() raises:
@@ -132,19 +240,11 @@ def test_abs_backward_gradient() raises:
     x.set(1, Float32(0.2))
     x.set(2, Float32(1.5))
 
-    # Forward function wrapper
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return abs(inp)
-
     var y = abs(x)
     var grad_out = ones_like(y)
 
-    # Backward function wrapper
-    def backward_fn(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-        return abs_backward(grad, inp)
-
     # Use numerical gradient checking (gold standard)
-    check_gradient(forward, backward_fn, x, grad_out, rtol=1e-3, atol=1e-6)
+    check_gradient(_AbsFwd(), _AbsBwd(), x, grad_out, rtol=1e-3, atol=1e-6)
 
 
 def test_sign_values() raises:
@@ -295,19 +395,11 @@ def test_exp_backward_gradient() raises:
     x.set(1, Float32(0.0))
     x.set(2, Float32(0.5))
 
-    # Forward function wrapper
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return exp(inp)
-
     var y = exp(x)
     var grad_out = ones_like(y)
 
-    # Backward function wrapper
-    def backward_fn(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-        return exp_backward(grad, inp)
-
     # Use numerical gradient checking (gold standard)
-    check_gradient(forward, backward_fn, x, grad_out, rtol=1e-3, atol=1e-6)
+    check_gradient(_ExpFwd(), _ExpBwd(), x, grad_out, rtol=1e-3, atol=1e-6)
 
 
 def test_log_shapes() raises:
@@ -379,19 +471,11 @@ def test_log_backward_gradient() raises:
     x.set(1, Float32(1.0))
     x.set(2, Float32(2.0))
 
-    # Forward function wrapper
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return log(inp)
-
     var y = log(x)
     var grad_out = ones_like(y)
 
-    # Backward function wrapper
-    def backward_fn(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-        return log_backward(grad, inp)
-
     # Use numerical gradient checking (gold standard)
-    check_gradient(forward, backward_fn, x, grad_out, rtol=1e-3, atol=1e-6)
+    check_gradient(_LogFwd(), _LogBwd(), x, grad_out, rtol=1e-3, atol=1e-6)
 
 
 def test_log10_values() raises:
@@ -429,19 +513,11 @@ def test_log10_backward_gradient() raises:
     x.set(1, Float32(1.0))
     x.set(2, Float32(2.0))
 
-    # Forward function wrapper
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return log10(inp)
-
     var y = log10(x)
     var grad_out = ones_like(y)
 
-    # Backward function wrapper
-    def backward_fn(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-        return log10_backward(grad, inp)
-
     # Use numerical gradient checking (gold standard)
-    check_gradient(forward, backward_fn, x, grad_out, rtol=5e-3, atol=1e-5)
+    check_gradient(_Log10Fwd(), _Log10Bwd(), x, grad_out, rtol=5e-3, atol=1e-5)
 
 
 def test_log2_values() raises:
@@ -479,19 +555,11 @@ def test_log2_backward_gradient() raises:
     x.set(1, Float32(1.0))
     x.set(2, Float32(2.0))
 
-    # Forward function wrapper
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return log2(inp)
-
     var y = log2(x)
     var grad_out = ones_like(y)
 
-    # Backward function wrapper
-    def backward_fn(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-        return log2_backward(grad, inp)
-
     # Use numerical gradient checking (gold standard)
-    check_gradient(forward, backward_fn, x, grad_out, rtol=5e-3, atol=1e-5)
+    check_gradient(_Log2Fwd(), _Log2Bwd(), x, grad_out, rtol=5e-3, atol=1e-5)
 
 
 def test_sqrt_shapes() raises:
@@ -568,19 +636,11 @@ def test_sqrt_backward_gradient() raises:
     x.set(1, Float32(1.0))
     x.set(2, Float32(2.0))
 
-    # Forward function wrapper
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return sqrt(inp)
-
     var y = sqrt(x)
     var grad_out = ones_like(y)
 
-    # Backward function wrapper
-    def backward_fn(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-        return sqrt_backward(grad, inp)
-
     # Use numerical gradient checking (gold standard)
-    check_gradient(forward, backward_fn, x, grad_out, rtol=5e-3, atol=1e-5)
+    check_gradient(_SqrtFwd(), _SqrtBwd(), x, grad_out, rtol=5e-3, atol=1e-5)
 
 
 def test_sin_values() raises:
@@ -668,19 +728,11 @@ def test_sin_backward_gradient() raises:
     x.set(1, Float32(0.0))
     x.set(2, Float32(0.5))
 
-    # Forward function wrapper
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return sin(inp)
-
     var y = sin(x)
     var grad_out = ones_like(y)
 
-    # Backward function wrapper
-    def backward_fn(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-        return sin_backward(grad, inp)
-
     # Use numerical gradient checking (gold standard)
-    check_gradient(forward, backward_fn, x, grad_out, rtol=1e-3, atol=1e-6)
+    check_gradient(_SinFwd(), _SinBwd(), x, grad_out, rtol=1e-3, atol=1e-6)
 
 
 def test_cos_backward() raises:
@@ -720,19 +772,11 @@ def test_cos_backward_gradient() raises:
     x.set(1, Float32(0.0))
     x.set(2, Float32(0.5))
 
-    # Forward function wrapper
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return cos(inp)
-
     var y = cos(x)
     var grad_out = ones_like(y)
 
-    # Backward function wrapper
-    def backward_fn(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-        return cos_backward(grad, inp)
-
     # Use numerical gradient checking (gold standard)
-    check_gradient(forward, backward_fn, x, grad_out, rtol=1e-3, atol=1e-6)
+    check_gradient(_CosFwd(), _CosBwd(), x, grad_out, rtol=1e-3, atol=1e-6)
 
 
 def test_clip_shapes() raises:
@@ -824,19 +868,11 @@ def test_clip_backward_gradient() raises:
     x.set(1, Float32(0.0))
     x.set(2, Float32(0.5))
 
-    # Forward function wrapper
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return clip(inp, min_val=-1.0, max_val=1.0)
-
     var y = clip(x, min_val=-1.0, max_val=1.0)
     var grad_out = ones_like(y)
 
-    # Backward function wrapper
-    def backward_fn(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-        return clip_backward(grad, inp, min_val=-1.0, max_val=1.0)
-
     # Use numerical gradient checking (gold standard)
-    check_gradient(forward, backward_fn, x, grad_out, rtol=1e-3, atol=1e-6)
+    check_gradient(_ClipFwd(), _ClipBwd(), x, grad_out, rtol=1e-3, atol=1e-6)
 
 
 def test_ceil_values() raises:

--- a/tests/shared/core/test_gradient_checking_basic.mojo
+++ b/tests/shared/core/test_gradient_checking_basic.mojo
@@ -9,7 +9,7 @@ corruption bug that occurs after ~15 cumulative tests. See ADR-009.
 """
 
 from tests.shared.conftest import assert_true
-from shared.testing import check_gradients
+from shared.testing import check_gradients, NumericalForward, NumericalBackward
 from shared.tensor.any_tensor import AnyTensor, zeros, ones, full
 from shared.core.activation import (
     relu,
@@ -27,6 +27,79 @@ from shared.core.arithmetic import (
 )
 
 
+# ---- ReLU (no captures) ----
+
+@fieldwise_init
+struct _ReluFwd(NumericalForward):
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        return relu(x)
+
+@fieldwise_init
+struct _ReluBwd(NumericalBackward):
+    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        return relu_backward(grad_out, x)
+
+
+# ---- Sigmoid (no captures) ----
+
+@fieldwise_init
+struct _SigmoidFwd(NumericalForward):
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        return sigmoid(x)
+
+@fieldwise_init
+struct _SigmoidBwd(NumericalBackward):
+    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        var output = sigmoid(x)
+        return sigmoid_backward(grad_out, output)
+
+
+# ---- Tanh (no captures) ----
+
+@fieldwise_init
+struct _TanhFwd(NumericalForward):
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        return tanh(x)
+
+@fieldwise_init
+struct _TanhBwd(NumericalBackward):
+    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        var output = tanh(x)
+        return tanh_backward(grad_out, output)
+
+
+# ---- Add (captures input_b) ----
+
+@fieldwise_init
+struct _AddFwd(NumericalForward):
+    var input_b: AnyTensor
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        return add(x, self.input_b)
+
+@fieldwise_init
+struct _AddBwd(NumericalBackward):
+    var input_b: AnyTensor
+    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        var grads = add_backward(grad_out, x, self.input_b)
+        return grads.grad_a
+
+
+# ---- Multiply (captures input_b) ----
+
+@fieldwise_init
+struct _MultiplyFwd(NumericalForward):
+    var input_b: AnyTensor
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        return multiply(x, self.input_b)
+
+@fieldwise_init
+struct _MultiplyBwd(NumericalBackward):
+    var input_b: AnyTensor
+    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        var grads = multiply_backward(grad_out, x, self.input_b)
+        return grads.grad_a
+
+
 def test_relu_gradient() raises:
     """Test ReLU backward pass using gradient checking."""
     var shape = List[Int]()
@@ -34,13 +107,7 @@ def test_relu_gradient() raises:
     shape.append(4)
     var input = full(shape, 2.0, DType.float32)
 
-    def forward(x: AnyTensor) raises -> AnyTensor:
-        return relu(x)
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        return relu_backward(grad_out, x)
-
-    var passed = check_gradients(forward, backward, input)
+    var passed = check_gradients(_ReluFwd(), _ReluBwd(), input)
     assert_true(passed, "ReLU gradient check failed")
 
 
@@ -51,13 +118,7 @@ def test_relu_negative_inputs() raises:
     shape.append(4)
     var input = full(shape, -2.0, DType.float32)
 
-    def forward(x: AnyTensor) raises -> AnyTensor:
-        return relu(x)
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        return relu_backward(grad_out, x)
-
-    var passed = check_gradients(forward, backward, input)
+    var passed = check_gradients(_ReluFwd(), _ReluBwd(), input)
     assert_true(passed, "ReLU gradient check failed for negative inputs")
 
 
@@ -82,13 +143,7 @@ def test_relu_mixed_inputs() raises:
     input._set_float64(10, 0.1)
     input._set_float64(11, -0.1)
 
-    def forward(x: AnyTensor) raises -> AnyTensor:
-        return relu(x)
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        return relu_backward(grad_out, x)
-
-    var passed = check_gradients(forward, backward, input)
+    var passed = check_gradients(_ReluFwd(), _ReluBwd(), input)
     assert_true(passed, "ReLU gradient check failed for mixed inputs")
 
 
@@ -99,14 +154,7 @@ def test_sigmoid_gradient() raises:
     shape.append(4)
     var input = full(shape, 0.5, DType.float32)
 
-    def forward(x: AnyTensor) raises -> AnyTensor:
-        return sigmoid(x)
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        var output = sigmoid(x)
-        return sigmoid_backward(grad_out, output)
-
-    var passed = check_gradients(forward, backward, input)
+    var passed = check_gradients(_SigmoidFwd(), _SigmoidBwd(), input)
     assert_true(passed, "Sigmoid gradient check failed")
 
 
@@ -117,14 +165,7 @@ def test_tanh_gradient() raises:
     shape.append(4)
     var input = full(shape, 0.5, DType.float32)
 
-    def forward(x: AnyTensor) raises -> AnyTensor:
-        return tanh(x)
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        var output = tanh(x)
-        return tanh_backward(grad_out, output)
-
-    var passed = check_gradients(forward, backward, input)
+    var passed = check_gradients(_TanhFwd(), _TanhBwd(), input)
     assert_true(passed, "Tanh gradient check failed")
 
 
@@ -136,14 +177,7 @@ def test_add_gradient() raises:
     var input_a = ones(shape, DType.float32)
     var input_b = ones(shape, DType.float32)
 
-    def forward(x: AnyTensor) raises -> AnyTensor:
-        return add(x, input_b)
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        var grads = add_backward(grad_out, x, input_b)
-        return grads.grad_a
-
-    var passed = check_gradients(forward, backward, input_a)
+    var passed = check_gradients(_AddFwd(input_b), _AddBwd(input_b), input_a)
     assert_true(passed, "Add gradient check failed")
 
 
@@ -155,14 +189,7 @@ def test_multiply_gradient() raises:
     var input_a = full(shape, 2.0, DType.float32)
     var input_b = full(shape, 3.0, DType.float32)
 
-    def forward(x: AnyTensor) raises -> AnyTensor:
-        return multiply(x, input_b)
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        var grads = multiply_backward(grad_out, x, input_b)
-        return grads.grad_a
-
-    var passed = check_gradients(forward, backward, input_a)
+    var passed = check_gradients(_MultiplyFwd(input_b), _MultiplyBwd(input_b), input_a)
     assert_true(passed, "Multiply gradient check failed")
 
 
@@ -173,13 +200,7 @@ def test_gradient_at_zero() raises:
     shape.append(2)
     var input = full(shape, 0.01, DType.float32)
 
-    def forward(x: AnyTensor) raises -> AnyTensor:
-        return relu(x)
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        return relu_backward(grad_out, x)
-
-    var passed = check_gradients(forward, backward, input)
+    var passed = check_gradients(_ReluFwd(), _ReluBwd(), input)
     assert_true(passed, "Gradient near zero check failed")
 
 
@@ -190,13 +211,7 @@ def test_gradient_small_tensor() raises:
     shape.append(1)
     var input = full(shape, 2.0, DType.float32)
 
-    def forward(x: AnyTensor) raises -> AnyTensor:
-        return relu(x)
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        return relu_backward(grad_out, x)
-
-    var passed = check_gradients(forward, backward, input)
+    var passed = check_gradients(_ReluFwd(), _ReluBwd(), input)
     assert_true(passed, "Small tensor gradient check failed")
 
 

--- a/tests/shared/core/test_gradient_checking_batch_norm.mojo
+++ b/tests/shared/core/test_gradient_checking_batch_norm.mojo
@@ -16,12 +16,60 @@ Note: Split from test_gradient_checking.mojo due to Mojo 0.26.1 heap
 corruption bug that occurs after ~15 cumulative tests. See ADR-009.
 """
 
-from shared.testing.gradient_checker import check_gradient
+from shared.testing.gradient_checker import check_gradient, NumericalForward, NumericalBackward
 from shared.testing.assertions import assert_true
 from shared.tensor.any_tensor import AnyTensor, zeros, ones
 from shared.core.normalization import batch_norm2d, batch_norm2d_backward
 from shared.core.arithmetic import multiply
 from shared.core.reduction import sum as reduce_sum
+
+
+# ---- Batch norm input gradient (captures gamma, beta, running_mean, running_var) ----
+
+@fieldwise_init
+struct _BatchNormInputFwd(NumericalForward):
+    var gamma: AnyTensor
+    var beta: AnyTensor
+    var running_mean: AnyTensor
+    var running_var: AnyTensor
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        var result = batch_norm2d(x, self.gamma, self.beta, self.running_mean, self.running_var, training=True)
+        return result[0]
+
+@fieldwise_init
+struct _BatchNormInputBwd(NumericalBackward):
+    var gamma: AnyTensor
+    var running_mean: AnyTensor
+    var running_var: AnyTensor
+    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        var result = batch_norm2d_backward(
+            grad_out, x, self.gamma, self.running_mean, self.running_var, training=True
+        )
+        return result[0]
+
+
+# ---- Batch norm gamma gradient (captures input, beta, running_mean, running_var) ----
+
+@fieldwise_init
+struct _BatchNormGammaFwd(NumericalForward):
+    var input: AnyTensor
+    var beta: AnyTensor
+    var running_mean: AnyTensor
+    var running_var: AnyTensor
+    def __call__(self, g: AnyTensor) raises -> AnyTensor:
+        var result = batch_norm2d(self.input, g, self.beta, self.running_mean, self.running_var, training=True)
+        return result[0]
+
+@fieldwise_init
+struct _BatchNormGammaBwd(NumericalBackward):
+    var input: AnyTensor
+    var running_mean: AnyTensor
+    var running_var: AnyTensor
+    def __call__(self, grad_out: AnyTensor, g: AnyTensor) raises -> AnyTensor:
+        var result = batch_norm2d_backward(
+            grad_out, self.input, g, self.running_mean, self.running_var, training=True
+        )
+        return result[1]
 
 
 def _make_non_uniform_grad_output(output: AnyTensor) raises -> AnyTensor:
@@ -72,21 +120,13 @@ def test_batch_norm_gradient_batch_size_1() raises:
     var running_var = ones(mean_shape, DType.float32)
 
     # Compute forward to get output shape for grad_output
-    def forward(x: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = batch_norm2d(x, gamma, beta, running_mean, running_var, training=True)
-        return result[0]
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = batch_norm2d_backward(
-            grad_out, x, gamma, running_mean, running_var, training=True
-        )
-        return result[0]
-
-    var output = forward(input)
+    var fwd = _BatchNormInputFwd(gamma, beta, running_mean, running_var)
+    var bwd = _BatchNormInputBwd(gamma, running_mean, running_var)
+    var output = fwd(input)
     var grad_output = _make_non_uniform_grad_output(output)
 
     # Use check_gradient which accepts custom grad_output
-    check_gradient(forward, backward, input, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(fwd, bwd, input, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def test_batch_norm_gradient_batch_size_2() raises:
@@ -111,20 +151,12 @@ def test_batch_norm_gradient_batch_size_2() raises:
     var running_mean = zeros(mean_shape, DType.float32)
     var running_var = ones(mean_shape, DType.float32)
 
-    def forward(x: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = batch_norm2d(x, gamma, beta, running_mean, running_var, training=True)
-        return result[0]
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = batch_norm2d_backward(
-            grad_out, x, gamma, running_mean, running_var, training=True
-        )
-        return result[0]
-
-    var output = forward(input)
+    var fwd = _BatchNormInputFwd(gamma, beta, running_mean, running_var)
+    var bwd = _BatchNormInputBwd(gamma, running_mean, running_var)
+    var output = fwd(input)
     var grad_output = _make_non_uniform_grad_output(output)
 
-    check_gradient(forward, backward, input, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(fwd, bwd, input, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def test_batch_norm_gradient_batch_size_4() raises:
@@ -149,20 +181,12 @@ def test_batch_norm_gradient_batch_size_4() raises:
     var running_mean = zeros(mean_shape, DType.float32)
     var running_var = ones(mean_shape, DType.float32)
 
-    def forward(x: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = batch_norm2d(x, gamma, beta, running_mean, running_var, training=True)
-        return result[0]
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = batch_norm2d_backward(
-            grad_out, x, gamma, running_mean, running_var, training=True
-        )
-        return result[0]
-
-    var output = forward(input)
+    var fwd = _BatchNormInputFwd(gamma, beta, running_mean, running_var)
+    var bwd = _BatchNormInputBwd(gamma, running_mean, running_var)
+    var output = fwd(input)
     var grad_output = _make_non_uniform_grad_output(output)
 
-    check_gradient(forward, backward, input, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(fwd, bwd, input, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def test_batch_norm_gamma_gradient_batch_size_2() raises:
@@ -187,20 +211,12 @@ def test_batch_norm_gamma_gradient_batch_size_2() raises:
     var running_mean = zeros(mean_shape, DType.float32)
     var running_var = ones(mean_shape, DType.float32)
 
-    def forward(g: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = batch_norm2d(input, g, beta, running_mean, running_var, training=True)
-        return result[0]
-
-    def backward(grad_out: AnyTensor, g: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = batch_norm2d_backward(
-            grad_out, input, g, running_mean, running_var, training=True
-        )
-        return result[1]
-
-    var output = forward(gamma)
+    var fwd = _BatchNormGammaFwd(input, beta, running_mean, running_var)
+    var bwd = _BatchNormGammaBwd(input, running_mean, running_var)
+    var output = fwd(gamma)
     var grad_output = _make_non_uniform_grad_output(output)
 
-    check_gradient(forward, backward, gamma, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(fwd, bwd, gamma, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def main() raises:

--- a/tests/shared/core/test_gradient_checking_conv2d.mojo
+++ b/tests/shared/core/test_gradient_checking_conv2d.mojo
@@ -25,7 +25,71 @@ References:
 
 from shared.core.conv import conv2d, conv2d_backward
 from shared.tensor.any_tensor import AnyTensor, zeros, zeros_like
-from shared.testing.gradient_checker import check_gradient
+from shared.testing.gradient_checker import check_gradient, NumericalForward, NumericalBackward
+
+
+# ---- Conv2d: perturb input (captures kernel, bias, stride, padding) ----
+
+@fieldwise_init
+struct _Conv2dInputFwd(NumericalForward):
+    var kernel: AnyTensor
+    var bias: AnyTensor
+    var stride: Int
+    var padding: Int
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return conv2d(inp, self.kernel, self.bias, stride=self.stride, padding=self.padding)
+
+@fieldwise_init
+struct _Conv2dInputBwd(NumericalBackward):
+    var kernel: AnyTensor
+    var stride: Int
+    var padding: Int
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var result = conv2d_backward(grad_out, inp, self.kernel, stride=self.stride, padding=self.padding)
+        return result.grad_input
+
+
+# ---- Conv2d: perturb kernel/weights (captures x, bias, stride, padding) ----
+
+@fieldwise_init
+struct _Conv2dKernelFwd(NumericalForward):
+    var x: AnyTensor
+    var bias: AnyTensor
+    var stride: Int
+    var padding: Int
+    def __call__(self, k: AnyTensor) raises -> AnyTensor:
+        return conv2d(self.x, k, self.bias, stride=self.stride, padding=self.padding)
+
+@fieldwise_init
+struct _Conv2dKernelBwd(NumericalBackward):
+    var x: AnyTensor
+    var stride: Int
+    var padding: Int
+    def __call__(self, grad_out: AnyTensor, k: AnyTensor) raises -> AnyTensor:
+        var result = conv2d_backward(grad_out, self.x, k, stride=self.stride, padding=self.padding)
+        return result.grad_weights
+
+
+# ---- Conv2d: perturb bias (captures x, kernel, stride, padding) ----
+
+@fieldwise_init
+struct _Conv2dBiasFwd(NumericalForward):
+    var x: AnyTensor
+    var kernel: AnyTensor
+    var stride: Int
+    var padding: Int
+    def __call__(self, b: AnyTensor) raises -> AnyTensor:
+        return conv2d(self.x, self.kernel, b, stride=self.stride, padding=self.padding)
+
+@fieldwise_init
+struct _Conv2dBiasBwd(NumericalBackward):
+    var x: AnyTensor
+    var kernel: AnyTensor
+    var stride: Int
+    var padding: Int
+    def __call__(self, grad_out: AnyTensor, b: AnyTensor) raises -> AnyTensor:
+        var result = conv2d_backward(grad_out, self.x, self.kernel, stride=self.stride, padding=self.padding)
+        return result.grad_bias
 
 
 def _make_ones_grad_output(output: AnyTensor) raises -> AnyTensor:
@@ -60,16 +124,11 @@ def test_conv2d_same_padding_grad_input() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return conv2d(inp, kernel, bias, stride=1, padding=1)
-
-    def backward_fn(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = conv2d_backward(grad_out, inp, kernel, stride=1, padding=1)
-        return result.grad_input
-
-    var output = forward(x)
+    var fwd = _Conv2dInputFwd(kernel, bias, 1, 1)
+    var bwd = _Conv2dInputBwd(kernel, 1, 1)
+    var output = fwd(x)
     var grad_output = _make_ones_grad_output(output)
-    check_gradient(forward, backward_fn, x, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(fwd, bwd, x, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def test_conv2d_same_padding_grad_weights() raises:
@@ -96,16 +155,11 @@ def test_conv2d_same_padding_grad_weights() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward(k: AnyTensor) raises unified {read} -> AnyTensor:
-        return conv2d(x, k, bias, stride=1, padding=1)
-
-    def backward_fn(grad_out: AnyTensor, k: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = conv2d_backward(grad_out, x, k, stride=1, padding=1)
-        return result.grad_weights
-
-    var output = forward(kernel)
+    var fwd = _Conv2dKernelFwd(x, bias, 1, 1)
+    var bwd = _Conv2dKernelBwd(x, 1, 1)
+    var output = fwd(kernel)
     var grad_output = _make_ones_grad_output(output)
-    check_gradient(forward, backward_fn, kernel, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(fwd, bwd, kernel, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def test_conv2d_same_padding_grad_bias() raises:
@@ -132,16 +186,11 @@ def test_conv2d_same_padding_grad_bias() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward(b: AnyTensor) raises unified {read} -> AnyTensor:
-        return conv2d(x, kernel, b, stride=1, padding=1)
-
-    def backward_fn(grad_out: AnyTensor, b: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = conv2d_backward(grad_out, x, kernel, stride=1, padding=1)
-        return result.grad_bias
-
-    var output = forward(bias)
+    var fwd = _Conv2dBiasFwd(x, kernel, 1, 1)
+    var bwd = _Conv2dBiasBwd(x, kernel, 1, 1)
+    var output = fwd(bias)
     var grad_output = _make_ones_grad_output(output)
-    check_gradient(forward, backward_fn, bias, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(fwd, bwd, bias, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def test_conv2d_strided_grad_input() raises:
@@ -168,16 +217,11 @@ def test_conv2d_strided_grad_input() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return conv2d(inp, kernel, bias, stride=2, padding=0)
-
-    def backward_fn(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = conv2d_backward(grad_out, inp, kernel, stride=2, padding=0)
-        return result.grad_input
-
-    var output = forward(x)
+    var fwd = _Conv2dInputFwd(kernel, bias, 2, 0)
+    var bwd = _Conv2dInputBwd(kernel, 2, 0)
+    var output = fwd(x)
     var grad_output = _make_ones_grad_output(output)
-    check_gradient(forward, backward_fn, x, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(fwd, bwd, x, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def test_conv2d_strided_grad_weights() raises:
@@ -204,16 +248,11 @@ def test_conv2d_strided_grad_weights() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward(k: AnyTensor) raises unified {read} -> AnyTensor:
-        return conv2d(x, k, bias, stride=2, padding=0)
-
-    def backward_fn(grad_out: AnyTensor, k: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = conv2d_backward(grad_out, x, k, stride=2, padding=0)
-        return result.grad_weights
-
-    var output = forward(kernel)
+    var fwd = _Conv2dKernelFwd(x, bias, 2, 0)
+    var bwd = _Conv2dKernelBwd(x, 2, 0)
+    var output = fwd(kernel)
     var grad_output = _make_ones_grad_output(output)
-    check_gradient(forward, backward_fn, kernel, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(fwd, bwd, kernel, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def test_conv2d_strided_grad_bias() raises:
@@ -240,16 +279,11 @@ def test_conv2d_strided_grad_bias() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward(b: AnyTensor) raises unified {read} -> AnyTensor:
-        return conv2d(x, kernel, b, stride=2, padding=0)
-
-    def backward_fn(grad_out: AnyTensor, b: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = conv2d_backward(grad_out, x, kernel, stride=2, padding=0)
-        return result.grad_bias
-
-    var output = forward(bias)
+    var fwd = _Conv2dBiasFwd(x, kernel, 2, 0)
+    var bwd = _Conv2dBiasBwd(x, kernel, 2, 0)
+    var output = fwd(bias)
     var grad_output = _make_ones_grad_output(output)
-    check_gradient(forward, backward_fn, bias, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(fwd, bwd, bias, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def test_conv2d_multichannel_grad_input() raises:
@@ -276,16 +310,11 @@ def test_conv2d_multichannel_grad_input() raises:
     bias_shape.append(3)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return conv2d(inp, kernel, bias, stride=1, padding=1)
-
-    def backward_fn(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = conv2d_backward(grad_out, inp, kernel, stride=1, padding=1)
-        return result.grad_input
-
-    var output = forward(x)
+    var fwd = _Conv2dInputFwd(kernel, bias, 1, 1)
+    var bwd = _Conv2dInputBwd(kernel, 1, 1)
+    var output = fwd(x)
     var grad_output = _make_ones_grad_output(output)
-    check_gradient(forward, backward_fn, x, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(fwd, bwd, x, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def test_conv2d_multichannel_grad_weights() raises:
@@ -312,16 +341,11 @@ def test_conv2d_multichannel_grad_weights() raises:
     bias_shape.append(3)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward(k: AnyTensor) raises unified {read} -> AnyTensor:
-        return conv2d(x, k, bias, stride=1, padding=1)
-
-    def backward_fn(grad_out: AnyTensor, k: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = conv2d_backward(grad_out, x, k, stride=1, padding=1)
-        return result.grad_weights
-
-    var output = forward(kernel)
+    var fwd = _Conv2dKernelFwd(x, bias, 1, 1)
+    var bwd = _Conv2dKernelBwd(x, 1, 1)
+    var output = fwd(kernel)
     var grad_output = _make_ones_grad_output(output)
-    check_gradient(forward, backward_fn, kernel, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(fwd, bwd, kernel, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def test_conv2d_multichannel_grad_bias() raises:
@@ -348,16 +372,11 @@ def test_conv2d_multichannel_grad_bias() raises:
     bias_shape.append(3)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward(b: AnyTensor) raises unified {read} -> AnyTensor:
-        return conv2d(x, kernel, b, stride=1, padding=1)
-
-    def backward_fn(grad_out: AnyTensor, b: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = conv2d_backward(grad_out, x, kernel, stride=1, padding=1)
-        return result.grad_bias
-
-    var output = forward(bias)
+    var fwd = _Conv2dBiasFwd(x, kernel, 1, 1)
+    var bwd = _Conv2dBiasBwd(x, kernel, 1, 1)
+    var output = fwd(bias)
     var grad_output = _make_ones_grad_output(output)
-    check_gradient(forward, backward_fn, bias, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(fwd, bwd, bias, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def main() raises:

--- a/tests/shared/core/test_gradient_checking_depthwise_conv2d.mojo
+++ b/tests/shared/core/test_gradient_checking_depthwise_conv2d.mojo
@@ -12,9 +12,73 @@ Note: Split from test_gradient_checking.mojo due to Mojo 0.26.1 heap
 corruption bug that occurs after ~15 cumulative tests. See ADR-009.
 """
 
-from shared.testing.gradient_checker import check_gradient
+from shared.testing.gradient_checker import check_gradient, NumericalForward, NumericalBackward
 from shared.tensor.any_tensor import AnyTensor, zeros, zeros_like
 from shared.core.conv import depthwise_conv2d, depthwise_conv2d_backward
+
+
+# ---- Depthwise conv2d: perturb kernel (captures input, bias, stride, padding) ----
+
+@fieldwise_init
+struct _DepthwiseConv2dKernelFwd(NumericalForward):
+    var input: AnyTensor
+    var bias: AnyTensor
+    var stride: Int
+    var padding: Int
+    def __call__(self, k: AnyTensor) raises -> AnyTensor:
+        return depthwise_conv2d(self.input, k, self.bias, stride=self.stride, padding=self.padding)
+
+@fieldwise_init
+struct _DepthwiseConv2dKernelBwd(NumericalBackward):
+    var input: AnyTensor
+    var stride: Int
+    var padding: Int
+    def __call__(self, grad_out: AnyTensor, k: AnyTensor) raises -> AnyTensor:
+        var result = depthwise_conv2d_backward(grad_out, self.input, k, stride=self.stride, padding=self.padding)
+        return result.grad_weights
+
+
+# ---- Depthwise conv2d: perturb bias (captures input, kernel, stride, padding) ----
+
+@fieldwise_init
+struct _DepthwiseConv2dBiasFwd(NumericalForward):
+    var input: AnyTensor
+    var kernel: AnyTensor
+    var stride: Int
+    var padding: Int
+    def __call__(self, b: AnyTensor) raises -> AnyTensor:
+        return depthwise_conv2d(self.input, self.kernel, b, stride=self.stride, padding=self.padding)
+
+@fieldwise_init
+struct _DepthwiseConv2dBiasBwd(NumericalBackward):
+    var input: AnyTensor
+    var kernel: AnyTensor
+    var stride: Int
+    var padding: Int
+    def __call__(self, grad_out: AnyTensor, b: AnyTensor) raises -> AnyTensor:
+        var result = depthwise_conv2d_backward(grad_out, self.input, self.kernel, stride=self.stride, padding=self.padding)
+        return result.grad_bias
+
+
+# ---- Depthwise conv2d: perturb input (captures kernel, bias, stride, padding) ----
+
+@fieldwise_init
+struct _DepthwiseConv2dInputFwd(NumericalForward):
+    var kernel: AnyTensor
+    var bias: AnyTensor
+    var stride: Int
+    var padding: Int
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        return depthwise_conv2d(x, self.kernel, self.bias, stride=self.stride, padding=self.padding)
+
+@fieldwise_init
+struct _DepthwiseConv2dInputBwd(NumericalBackward):
+    var kernel: AnyTensor
+    var stride: Int
+    var padding: Int
+    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        var result = depthwise_conv2d_backward(grad_out, x, self.kernel, stride=self.stride, padding=self.padding)
+        return result.grad_input
 
 
 def _make_ones_grad_output(output: AnyTensor) raises -> AnyTensor:
@@ -49,16 +113,11 @@ def test_depthwise_conv2d_gradient_kernel_basic() raises:
     bias_shape.append(2)  # channels
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward(k: AnyTensor) raises unified {read} -> AnyTensor:
-        return depthwise_conv2d(input, k, bias, stride=1, padding=1)
-
-    def backward(grad_out: AnyTensor, k: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = depthwise_conv2d_backward(grad_out, input, k, stride=1, padding=1)
-        return result.grad_weights
-
-    var output = forward(kernel)
+    var fwd = _DepthwiseConv2dKernelFwd(input, bias, 1, 1)
+    var bwd = _DepthwiseConv2dKernelBwd(input, 1, 1)
+    var output = fwd(kernel)
     var grad_output = _make_ones_grad_output(output)
-    check_gradient(forward, backward, kernel, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(fwd, bwd, kernel, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def test_depthwise_conv2d_gradient_bias_basic() raises:
@@ -85,16 +144,11 @@ def test_depthwise_conv2d_gradient_bias_basic() raises:
     bias_shape.append(2)  # channels
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward(b: AnyTensor) raises unified {read} -> AnyTensor:
-        return depthwise_conv2d(input, kernel, b, stride=1, padding=1)
-
-    def backward(grad_out: AnyTensor, b: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = depthwise_conv2d_backward(grad_out, input, kernel, stride=1, padding=1)
-        return result.grad_bias
-
-    var output = forward(bias)
+    var fwd = _DepthwiseConv2dBiasFwd(input, kernel, 1, 1)
+    var bwd = _DepthwiseConv2dBiasBwd(input, kernel, 1, 1)
+    var output = fwd(bias)
     var grad_output = _make_ones_grad_output(output)
-    check_gradient(forward, backward, bias, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(fwd, bwd, bias, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def test_depthwise_conv2d_gradient_input_basic() raises:
@@ -121,16 +175,11 @@ def test_depthwise_conv2d_gradient_input_basic() raises:
     bias_shape.append(2)  # channels
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward(x: AnyTensor) raises unified {read} -> AnyTensor:
-        return depthwise_conv2d(x, kernel, bias, stride=1, padding=1)
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = depthwise_conv2d_backward(grad_out, x, kernel, stride=1, padding=1)
-        return result.grad_input
-
-    var output = forward(input)
+    var fwd = _DepthwiseConv2dInputFwd(kernel, bias, 1, 1)
+    var bwd = _DepthwiseConv2dInputBwd(kernel, 1, 1)
+    var output = fwd(input)
     var grad_output = _make_ones_grad_output(output)
-    check_gradient(forward, backward, input, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(fwd, bwd, input, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def test_depthwise_conv2d_gradient_kernel_strided() raises:
@@ -157,16 +206,11 @@ def test_depthwise_conv2d_gradient_kernel_strided() raises:
     bias_shape.append(2)  # channels
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward(k: AnyTensor) raises unified {read} -> AnyTensor:
-        return depthwise_conv2d(input, k, bias, stride=2, padding=1)
-
-    def backward(grad_out: AnyTensor, k: AnyTensor) raises unified {read} -> AnyTensor:
-        var result = depthwise_conv2d_backward(grad_out, input, k, stride=2, padding=1)
-        return result.grad_weights
-
-    var output = forward(kernel)
+    var fwd = _DepthwiseConv2dKernelFwd(input, bias, 2, 1)
+    var bwd = _DepthwiseConv2dKernelBwd(input, 2, 1)
+    var output = fwd(kernel)
     var grad_output = _make_ones_grad_output(output)
-    check_gradient(forward, backward, kernel, grad_output, rtol=1e-2, atol=1e-2)
+    check_gradient(fwd, bwd, kernel, grad_output, rtol=1e-2, atol=1e-2)
 
 
 def main() raises:

--- a/tests/shared/core/test_gradient_checking_dtype.mojo
+++ b/tests/shared/core/test_gradient_checking_dtype.mojo
@@ -9,7 +9,7 @@ corruption bug that occurs after ~15 cumulative tests. See ADR-009.
 """
 
 from tests.shared.conftest import assert_true
-from shared.testing import check_gradients
+from shared.testing import check_gradients, NumericalForward, NumericalBackward
 from shared.tensor.any_tensor import AnyTensor, zeros, ones, full
 from shared.core.activation import (
     relu,
@@ -24,6 +24,97 @@ from shared.core.loss import cross_entropy, cross_entropy_backward
 from shared.training.precision_config import PrecisionConfig
 
 
+# ---- Composite relu+multiply (captures input_b) ----
+
+@fieldwise_init
+struct _CompositeReluMulFwd(NumericalForward):
+    var input_b: AnyTensor
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        var mul_result = multiply(x, self.input_b)
+        return relu(mul_result)
+
+@fieldwise_init
+struct _CompositeReluMulBwd(NumericalBackward):
+    var input_b: AnyTensor
+    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        var mul_result = multiply(x, self.input_b)
+        var grad_relu = relu_backward(grad_out, mul_result)
+        var grads = multiply_backward(grad_relu, x, self.input_b)
+        return grads.grad_a
+
+
+# ---- Linear (captures weights, bias) ----
+
+@fieldwise_init
+struct _LinearFwd(NumericalForward):
+    var weights: AnyTensor
+    var bias: AnyTensor
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        return linear(x, self.weights, self.bias)
+
+@fieldwise_init
+struct _LinearBwd(NumericalBackward):
+    var weights: AnyTensor
+    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        var grads = linear_backward(grad_out, x, self.weights)
+        return grads.grad_input
+
+
+# ---- Conv2D FP32 no padding (captures kernel, bias) ----
+
+@fieldwise_init
+struct _Conv2dNoPadFwd(NumericalForward):
+    var kernel: AnyTensor
+    var bias: AnyTensor
+    var stride: Int
+    var padding: Int
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        return conv2d(x, self.kernel, self.bias, stride=self.stride, padding=self.padding)
+
+@fieldwise_init
+struct _Conv2dNoPadBwd(NumericalBackward):
+    var kernel: AnyTensor
+    var stride: Int
+    var padding: Int
+    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        var grads = conv2d_backward(grad_out, x, self.kernel, stride=self.stride, padding=self.padding)
+        return grads.grad_input
+
+
+# ---- Conv2D FP16 forward with move (captures kernel, bias) ----
+
+@fieldwise_init
+struct _Conv2dFp16Fwd(NumericalForward):
+    var kernel: AnyTensor
+    var bias: AnyTensor
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        var result = conv2d(x, self.kernel, self.bias, stride=1, padding=0)
+        # Conv computes in FP32 for numerical stability
+        return result^
+
+@fieldwise_init
+struct _Conv2dFp16Bwd(NumericalBackward):
+    var kernel: AnyTensor
+    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        var grads = conv2d_backward(grad_out, x, self.kernel, stride=1, padding=0)
+        return grads.grad_input
+
+
+# ---- Cross entropy (captures labels) ----
+
+@fieldwise_init
+struct _CrossEntropyFwd(NumericalForward):
+    var labels: AnyTensor
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        return cross_entropy(x, self.labels)
+
+@fieldwise_init
+struct _CrossEntropyBwd(NumericalBackward):
+    var labels: AnyTensor
+    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        return cross_entropy_backward(grad_out, x, self.labels)
+
+
 def test_composite_relu_multiply() raises:
     """Test gradient through composite operation: multiply -> relu."""
     var shape = List[Int]()
@@ -32,17 +123,7 @@ def test_composite_relu_multiply() raises:
     var input_a = full(shape, 2.0, DType.float32)
     var input_b = full(shape, 3.0, DType.float32)
 
-    def forward(x: AnyTensor) raises -> AnyTensor:
-        var mul_result = multiply(x, input_b)
-        return relu(mul_result)
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        var mul_result = multiply(x, input_b)
-        var grad_relu = relu_backward(grad_out, mul_result)
-        var grads = multiply_backward(grad_relu, x, input_b)
-        return grads.grad_a
-
-    var passed = check_gradients(forward, backward, input_a)
+    var passed = check_gradients(_CompositeReluMulFwd(input_b), _CompositeReluMulBwd(input_b), input_a)
     assert_true(passed, "Composite gradient check failed")
 
 
@@ -62,14 +143,7 @@ def test_linear_gradient_fp32() raises:
     bias_shape.append(3)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward(x: AnyTensor) raises -> AnyTensor:
-        return linear(x, weights, bias)
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        var grads = linear_backward(grad_out, x, weights)
-        return grads.grad_input
-
-    var passed = check_gradients(forward, backward,
+    var passed = check_gradients(_LinearFwd(weights, bias), _LinearBwd(weights),
         input, epsilon=1e-5, tolerance=3e-3
     )
     assert_true(passed, "Linear FP32 gradient check failed")
@@ -93,14 +167,7 @@ def test_linear_gradient_fp16() raises:
     bias_shape.append(3)
     var bias = config.cast_to_compute(zeros(bias_shape, DType.float32))
 
-    def forward(x: AnyTensor) raises -> AnyTensor:
-        return linear(x, weights, bias)
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        var grads = linear_backward(grad_out, x, weights)
-        return grads.grad_input
-
-    var passed = check_gradients(forward, backward,
+    var passed = check_gradients(_LinearFwd(weights, bias), _LinearBwd(weights),
         input, epsilon=1e-2, tolerance=2e-1
     )
     assert_true(passed, "Linear FP16 gradient check failed")
@@ -126,14 +193,7 @@ def test_conv2d_gradient_fp32() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward(x: AnyTensor) raises -> AnyTensor:
-        return conv2d(x, kernel, bias, stride=1, padding=0)
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        var grads = conv2d_backward(grad_out, x, kernel, stride=1, padding=0)
-        return grads.grad_input
-
-    var passed = check_gradients(forward, backward,
+    var passed = check_gradients(_Conv2dNoPadFwd(kernel, bias, 1, 0), _Conv2dNoPadBwd(kernel, 1, 0),
         input, epsilon=1e-5, tolerance=1e-2
     )
     assert_true(passed, "Conv2D FP32 gradient check failed")
@@ -160,17 +220,10 @@ def test_conv2d_grad_3x3_same_padding() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward(x: AnyTensor) raises -> AnyTensor:
-        return conv2d(x, kernel, bias, stride=1, padding=1)
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        var grads = conv2d_backward(grad_out, x, kernel, stride=1, padding=1)
-        return grads.grad_input
-
     # Looser tolerance for same-padding conv2d: boundary padding introduces
     # additional numerical error in finite-difference gradient estimation.
     # TODO: investigate proper numerical stability fix (see GitHub issue)
-    var passed = check_gradients(forward, backward,
+    var passed = check_gradients(_Conv2dNoPadFwd(kernel, bias, 1, 1), _Conv2dNoPadBwd(kernel, 1, 1),
         input, epsilon=1e-4, tolerance=5e-2
     )
     assert_true(passed, "Conv2D 3x3 same-padding gradient check failed")
@@ -196,14 +249,7 @@ def test_conv2d_grad_3x3_strided() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward(x: AnyTensor) raises -> AnyTensor:
-        return conv2d(x, kernel, bias, stride=2, padding=0)
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        var grads = conv2d_backward(grad_out, x, kernel, stride=2, padding=0)
-        return grads.grad_input
-
-    var passed = check_gradients(forward, backward,
+    var passed = check_gradients(_Conv2dNoPadFwd(kernel, bias, 2, 0), _Conv2dNoPadBwd(kernel, 2, 0),
         input, epsilon=1e-5, tolerance=1e-2
     )
     assert_true(passed, "Conv2D 3x3 strided gradient check failed")
@@ -230,16 +276,9 @@ def test_conv2d_grad_multichannel() raises:
     bias_shape.append(3)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward(x: AnyTensor) raises -> AnyTensor:
-        return conv2d(x, kernel, bias, stride=1, padding=0)
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        var grads = conv2d_backward(grad_out, x, kernel, stride=1, padding=0)
-        return grads.grad_input
-
     # Multi-channel conv2d accumulates FP errors across channels.
     # TODO: investigate proper numerical stability fix (see GitHub issue)
-    var passed = check_gradients(forward, backward,
+    var passed = check_gradients(_Conv2dNoPadFwd(kernel, bias, 1, 0), _Conv2dNoPadBwd(kernel, 1, 0),
         input, epsilon=1e-4, tolerance=5e-2
     )
     assert_true(passed, "Conv2D multi-channel gradient check failed")
@@ -262,13 +301,7 @@ def test_cross_entropy_gradient_fp32() raises:
     var labels = zeros(labels_shape, DType.float32)
     labels._set_float64(0, 1.0)
 
-    def forward(x: AnyTensor) raises -> AnyTensor:
-        return cross_entropy(x, labels)
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        return cross_entropy_backward(grad_out, x, labels)
-
-    var passed = check_gradients(forward, backward,
+    var passed = check_gradients(_CrossEntropyFwd(labels), _CrossEntropyBwd(labels),
         logits, epsilon=1e-5, tolerance=1e-2
     )
     assert_true(passed, "CrossEntropy FP32 gradient check failed")
@@ -305,18 +338,9 @@ def test_conv2d_gradient_fp16() raises:
     bias_shape.append(1)
     var bias = zeros(bias_shape, DType.float32)
 
-    def forward(x: AnyTensor) raises -> AnyTensor:
-        var result = conv2d(x, kernel, bias, stride=1, padding=0)
-        # Conv computes in FP32 for numerical stability
-        return result^
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        var grads = conv2d_backward(grad_out, x, kernel, stride=1, padding=0)
-        return grads.grad_input
-
     # This tests FP32 compute with the understanding that mixed-precision
     # training keeps conv operations in FP32 for stability
-    var passed = check_gradients(forward, backward,
+    var passed = check_gradients(_Conv2dFp16Fwd(kernel, bias), _Conv2dFp16Bwd(kernel),
         input, epsilon=1e-5, tolerance=1e-2
     )
     assert_true(passed, "Conv2D FP16 gradient check failed")
@@ -350,14 +374,8 @@ def test_cross_entropy_gradient_fp16() raises:
     labels_fp32._set_float64(0, 1.0)  # Sample 0: class 0
     var labels = config.cast_to_compute(labels_fp32)
 
-    def forward(x: AnyTensor) raises -> AnyTensor:
-        return cross_entropy(x, labels)
-
-    def backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        return cross_entropy_backward(grad_out, x, labels)
-
     # FP16 with relaxed tolerance for exp/log operations
-    var passed = check_gradients(forward, backward,
+    var passed = check_gradients(_CrossEntropyFwd(labels), _CrossEntropyBwd(labels),
         logits, epsilon=1e-2, tolerance=2e-1
     )
     assert_true(passed, "CrossEntropy FP16 gradient check failed")

--- a/tests/shared/core/test_gradient_validation.mojo
+++ b/tests/shared/core/test_gradient_validation.mojo
@@ -20,11 +20,99 @@ from shared.core.conv import conv2d, conv2d_backward
 from shared.core.linear import linear, linear_backward
 from shared.tensor.any_tensor import AnyTensor, full, zeros
 from shared.core.initializers import kaiming_uniform
-from shared.testing.gradient_checker import check_gradients
+from shared.testing.gradient_checker import check_gradients, NumericalForward, NumericalBackward
 from shared.testing.special_values import (
     create_seeded_random_tensor,
 )
 from shared.testing.assertions import assert_true
+
+
+# ---- ReLU (no captures) ----
+
+@fieldwise_init
+struct _ReluFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return relu(inp)
+
+@fieldwise_init
+struct _ReluBwd(NumericalBackward):
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return relu_backward(grad_out, inp)
+
+
+# ---- Sigmoid (no captures) ----
+
+@fieldwise_init
+struct _SigmoidFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return sigmoid(inp)
+
+@fieldwise_init
+struct _SigmoidBwd(NumericalBackward):
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var output = sigmoid(inp)  # Compute sigmoid(x) first
+        return sigmoid_backward(grad_out, output)
+
+
+# ---- Tanh (no captures) ----
+
+@fieldwise_init
+struct _TanhFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return tanh(inp)
+
+@fieldwise_init
+struct _TanhBwd(NumericalBackward):
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var output = tanh(inp)  # Compute tanh(x) first
+        return tanh_backward(grad_out, output)
+
+
+# ---- GELU (no captures) ----
+
+@fieldwise_init
+struct _GeluFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return gelu(inp)
+
+@fieldwise_init
+struct _GeluBwd(NumericalBackward):
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return gelu_backward(grad_out, inp)
+
+
+# ---- Conv2D input gradient (captures kernel, bias) ----
+
+@fieldwise_init
+struct _Conv2dInputFwd(NumericalForward):
+    var kernel: AnyTensor
+    var bias: AnyTensor
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return conv2d(inp, self.kernel, self.bias, stride=1, padding=1)
+
+@fieldwise_init
+struct _Conv2dInputBwd(NumericalBackward):
+    var kernel: AnyTensor
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var result = conv2d_backward(grad_out, inp, self.kernel, stride=1, padding=1)
+        return result.grad_input
+
+
+# ---- Linear input gradient (captures weights, bias) ----
+
+@fieldwise_init
+struct _LinearFwd(NumericalForward):
+    var weights: AnyTensor
+    var bias: AnyTensor
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return linear(inp, self.weights, self.bias)
+
+@fieldwise_init
+struct _LinearBwd(NumericalBackward):
+    var weights: AnyTensor
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var result = linear_backward(grad_out, inp, self.weights)
+        return result.grad_input
 
 
 # ============================================================================
@@ -38,15 +126,7 @@ def test_relu_gradient_positive_values() raises:
         [2, 3], DType.float32, seed=42, low=0.1, high=2.0
     )
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return relu(inp)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises unified {read} -> AnyTensor:
-        return relu_backward(grad_out, inp)
-
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_ReluFwd(), _ReluBwd(),
         x, epsilon=1e-5, tolerance=1e-2
     )
     assert_true(passed, "ReLU gradient check failed for positive values")
@@ -58,15 +138,7 @@ def test_relu_gradient_negative_values() raises:
         [2, 3], DType.float32, seed=123, low=-2.0, high=-0.1
     )
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return relu(inp)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises unified {read} -> AnyTensor:
-        return relu_backward(grad_out, inp)
-
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_ReluFwd(), _ReluBwd(),
         x, epsilon=1e-5, tolerance=1e-2
     )
     assert_true(passed, "ReLU gradient check failed for negative values")
@@ -78,15 +150,7 @@ def test_relu_gradient_mixed_values() raises:
         [2, 3], DType.float32, seed=999, low=-1.0, high=1.0
     )
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return relu(inp)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises unified {read} -> AnyTensor:
-        return relu_backward(grad_out, inp)
-
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_ReluFwd(), _ReluBwd(),
         x, epsilon=1e-5, tolerance=1e-2
     )
     assert_true(passed, "ReLU gradient check failed for mixed values")
@@ -103,15 +167,7 @@ def test_relu_gradient_near_zero() raises:
         [2, 3], DType.float32, seed=555, low=-0.01, high=0.01
     )
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return relu(inp)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises unified {read} -> AnyTensor:
-        return relu_backward(grad_out, inp)
-
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_ReluFwd(), _ReluBwd(),
         x, epsilon=1e-5, tolerance=1e-2
     )
     assert_true(passed, "ReLU gradient check failed near zero")
@@ -128,16 +184,8 @@ def test_relu_gradient_large_values() raises:
         [2, 3], DType.float32, seed=42, low=10.0, high=20.0
     )
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return relu(inp)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises unified {read} -> AnyTensor:
-        return relu_backward(grad_out, inp)
-
     # Use wider tolerance (5%) for large values due to numerical precision
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_ReluFwd(), _ReluBwd(),
         x, epsilon=1e-5, tolerance=0.05
     )
     assert_true(passed, "ReLU gradient check failed for large values")
@@ -157,16 +205,7 @@ def test_sigmoid_gradient_normal_range() raises:
         [2, 3], DType.float32, seed=42, low=-2.0, high=2.0
     )
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return sigmoid(inp)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises unified {read} -> AnyTensor:
-        var output = sigmoid(inp)  # Compute sigmoid(x) first
-        return sigmoid_backward(grad_out, output)
-
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_SigmoidFwd(), _SigmoidBwd(),
         x, epsilon=1e-5, tolerance=1e-2
     )
     assert_true(passed, "Sigmoid gradient check failed")
@@ -183,17 +222,8 @@ def test_sigmoid_gradient_saturation_positive() raises:
     shape.append(3)
     var x = full(shape, 10.0, DType.float32)
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return sigmoid(inp)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises unified {read} -> AnyTensor:
-        var output = sigmoid(inp)  # Compute sigmoid(x) first
-        return sigmoid_backward(grad_out, output)
-
     # Use tighter tolerance for near-zero gradients
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_SigmoidFwd(), _SigmoidBwd(),
         x, epsilon=1e-4, tolerance=1e-3
     )
     assert_true(passed, "Sigmoid gradient check failed in positive saturation")
@@ -210,17 +240,8 @@ def test_sigmoid_gradient_saturation_negative() raises:
     shape.append(3)
     var x = full(shape, -10.0, DType.float32)
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return sigmoid(inp)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises unified {read} -> AnyTensor:
-        var output = sigmoid(inp)  # Compute sigmoid(x) first
-        return sigmoid_backward(grad_out, output)
-
     # Use tighter tolerance for near-zero gradients
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_SigmoidFwd(), _SigmoidBwd(),
         x, epsilon=1e-4, tolerance=1e-3
     )
     assert_true(passed, "Sigmoid gradient check failed in negative saturation")
@@ -240,16 +261,7 @@ def test_tanh_gradient() raises:
         [2, 3], DType.float32, seed=42, low=-2.0, high=2.0
     )
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return tanh(inp)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises unified {read} -> AnyTensor:
-        var output = tanh(inp)  # Compute tanh(x) first
-        return tanh_backward(grad_out, output)
-
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_TanhFwd(), _TanhBwd(),
         x, epsilon=1e-5, tolerance=1e-2
     )
     assert_true(passed, "Tanh gradient check failed")
@@ -264,15 +276,7 @@ def test_gelu_gradient() raises:
         [2, 3], DType.float32, seed=42, low=-2.0, high=2.0
     )
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return gelu(inp)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises unified {read} -> AnyTensor:
-        return gelu_backward(grad_out, inp)
-
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_GeluFwd(), _GeluBwd(),
         x, epsilon=1e-5, tolerance=1e-2
     )
     assert_true(passed, "GELU gradient check failed")
@@ -314,17 +318,8 @@ def test_conv2d_gradient_input() raises:
     input_shape.append(8)
     var x = create_seeded_random_tensor(input_shape, DType.float32, seed=42)
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return conv2d(inp, kernel, bias, stride=1, padding=1)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises unified {read} -> AnyTensor:
-        var result = conv2d_backward(grad_out, inp, kernel, stride=1, padding=1)
-        return result.grad_input
-
     # Use slightly larger epsilon for conv (more complex operation)
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_Conv2dInputFwd(kernel, bias), _Conv2dInputBwd(kernel),
         x, epsilon=1e-4, tolerance=1e-2
     )
     assert_true(passed, "Conv2D input gradient check failed")
@@ -357,17 +352,8 @@ def test_linear_gradient_input() raises:
     input_shape.append(in_features)
     var x = create_seeded_random_tensor(input_shape, DType.float32, seed=42)
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return linear(inp, weights, bias)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises unified {read} -> AnyTensor:
-        var result = linear_backward(grad_out, inp, weights)
-        return result.grad_input
-
     # Wider tolerance (1.5%) for matrix operations
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_LinearFwd(weights, bias), _LinearBwd(weights),
         x, epsilon=1e-5, tolerance=0.015
     )
     assert_true(passed, "Linear input gradient check failed")

--- a/tests/shared/core/test_gradient_validation_activations.mojo
+++ b/tests/shared/core/test_gradient_validation_activations.mojo
@@ -21,9 +21,36 @@ References:
 from shared.core.activation import relu, sigmoid
 from shared.core.activation import relu_backward, sigmoid_backward
 from shared.tensor.any_tensor import AnyTensor, full
-from shared.testing.gradient_checker import check_gradients
+from shared.testing.gradient_checker import check_gradients, NumericalForward, NumericalBackward
 from shared.testing.special_values import create_seeded_random_tensor
 from shared.testing.assertions import assert_true
+
+
+# ---- ReLU (no captures) ----
+
+@fieldwise_init
+struct _ReluFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return relu(inp)
+
+@fieldwise_init
+struct _ReluBwd(NumericalBackward):
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return relu_backward(grad_out, inp)
+
+
+# ---- Sigmoid (no captures) ----
+
+@fieldwise_init
+struct _SigmoidFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return sigmoid(inp)
+
+@fieldwise_init
+struct _SigmoidBwd(NumericalBackward):
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var output = sigmoid(inp)  # Compute sigmoid(x) first
+        return sigmoid_backward(grad_out, output)
 
 
 def test_relu_gradient_positive_values() raises:
@@ -32,15 +59,7 @@ def test_relu_gradient_positive_values() raises:
         [2, 3], DType.float32, seed=42, low=0.1, high=2.0
     )
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return relu(inp)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises -> AnyTensor:
-        return relu_backward(grad_out, inp)
-
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_ReluFwd(), _ReluBwd(),
         x, epsilon=1e-5, tolerance=1e-2
     )
     assert_true(passed, "ReLU gradient check failed for positive values")
@@ -52,15 +71,7 @@ def test_relu_gradient_negative_values() raises:
         [2, 3], DType.float32, seed=123, low=-2.0, high=-0.1
     )
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return relu(inp)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises -> AnyTensor:
-        return relu_backward(grad_out, inp)
-
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_ReluFwd(), _ReluBwd(),
         x, epsilon=1e-5, tolerance=1e-2
     )
     assert_true(passed, "ReLU gradient check failed for negative values")
@@ -72,15 +83,7 @@ def test_relu_gradient_mixed_values() raises:
         [2, 3], DType.float32, seed=999, low=-1.0, high=1.0
     )
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return relu(inp)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises -> AnyTensor:
-        return relu_backward(grad_out, inp)
-
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_ReluFwd(), _ReluBwd(),
         x, epsilon=1e-5, tolerance=1e-2
     )
     assert_true(passed, "ReLU gradient check failed for mixed values")
@@ -97,15 +100,7 @@ def test_relu_gradient_near_zero() raises:
         [2, 3], DType.float32, seed=555, low=-0.01, high=0.01
     )
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return relu(inp)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises -> AnyTensor:
-        return relu_backward(grad_out, inp)
-
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_ReluFwd(), _ReluBwd(),
         x, epsilon=1e-5, tolerance=1e-2
     )
     assert_true(passed, "ReLU gradient check failed near zero")
@@ -122,16 +117,8 @@ def test_relu_gradient_large_values() raises:
         [2, 3], DType.float32, seed=42, low=10.0, high=20.0
     )
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return relu(inp)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises -> AnyTensor:
-        return relu_backward(grad_out, inp)
-
     # Use wider tolerance (5%) for large values due to numerical precision
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_ReluFwd(), _ReluBwd(),
         x, epsilon=1e-5, tolerance=0.05
     )
     assert_true(passed, "ReLU gradient check failed for large values")
@@ -146,16 +133,7 @@ def test_sigmoid_gradient_normal_range() raises:
         [2, 3], DType.float32, seed=42, low=-2.0, high=2.0
     )
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return sigmoid(inp)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises -> AnyTensor:
-        var output = sigmoid(inp)  # Compute sigmoid(x) first
-        return sigmoid_backward(grad_out, output)
-
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_SigmoidFwd(), _SigmoidBwd(),
         x, epsilon=1e-5, tolerance=1e-2
     )
     assert_true(passed, "Sigmoid gradient check failed")
@@ -172,17 +150,8 @@ def test_sigmoid_gradient_saturation_positive() raises:
     shape.append(3)
     var x = full(shape, 10.0, DType.float32)
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return sigmoid(inp)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises -> AnyTensor:
-        var output = sigmoid(inp)  # Compute sigmoid(x) first
-        return sigmoid_backward(grad_out, output)
-
     # Use tighter tolerance for near-zero gradients
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_SigmoidFwd(), _SigmoidBwd(),
         x, epsilon=1e-4, tolerance=1e-3
     )
     assert_true(passed, "Sigmoid gradient check failed in positive saturation")
@@ -199,17 +168,8 @@ def test_sigmoid_gradient_saturation_negative() raises:
     shape.append(3)
     var x = full(shape, -10.0, DType.float32)
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return sigmoid(inp)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises -> AnyTensor:
-        var output = sigmoid(inp)  # Compute sigmoid(x) first
-        return sigmoid_backward(grad_out, output)
-
     # Use tighter tolerance for near-zero gradients
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_SigmoidFwd(), _SigmoidBwd(),
         x, epsilon=1e-4, tolerance=1e-3
     )
     assert_true(passed, "Sigmoid gradient check failed in negative saturation")

--- a/tests/shared/core/test_gradient_validation_layers.mojo
+++ b/tests/shared/core/test_gradient_validation_layers.mojo
@@ -24,9 +24,70 @@ from shared.core.conv import conv2d, conv2d_backward
 from shared.core.linear import linear, linear_backward
 from shared.tensor.any_tensor import AnyTensor, zeros
 from shared.core.initializers import kaiming_uniform
-from shared.testing.gradient_checker import check_gradients
+from shared.testing.gradient_checker import check_gradients, NumericalForward, NumericalBackward
 from shared.testing.special_values import create_seeded_random_tensor
 from shared.testing.assertions import assert_true
+
+
+# ---- Tanh (no captures) ----
+
+@fieldwise_init
+struct _TanhFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return tanh(inp)
+
+@fieldwise_init
+struct _TanhBwd(NumericalBackward):
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var output = tanh(inp)  # Compute tanh(x) first
+        return tanh_backward(grad_out, output)
+
+
+# ---- GELU (no captures) ----
+
+@fieldwise_init
+struct _GeluFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return gelu(inp)
+
+@fieldwise_init
+struct _GeluBwd(NumericalBackward):
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return gelu_backward(grad_out, inp)
+
+
+# ---- Conv2D input gradient (captures kernel, bias) ----
+
+@fieldwise_init
+struct _Conv2dInputFwd(NumericalForward):
+    var kernel: AnyTensor
+    var bias: AnyTensor
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return conv2d(inp, self.kernel, self.bias, stride=1, padding=1)
+
+@fieldwise_init
+struct _Conv2dInputBwd(NumericalBackward):
+    var kernel: AnyTensor
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var result = conv2d_backward(grad_out, inp, self.kernel, stride=1, padding=1)
+        return result.grad_input
+
+
+# ---- Linear input gradient (captures weights, bias) ----
+
+@fieldwise_init
+struct _LinearFwd(NumericalForward):
+    var weights: AnyTensor
+    var bias: AnyTensor
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return linear(inp, self.weights, self.bias)
+
+@fieldwise_init
+struct _LinearBwd(NumericalBackward):
+    var weights: AnyTensor
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var result = linear_backward(grad_out, inp, self.weights)
+        return result.grad_input
 
 
 def test_tanh_gradient() raises:
@@ -38,16 +99,7 @@ def test_tanh_gradient() raises:
         [2, 3], DType.float32, seed=42, low=-2.0, high=2.0
     )
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return tanh(inp)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises unified {read} -> AnyTensor:
-        var output = tanh(inp)  # Compute tanh(x) first
-        return tanh_backward(grad_out, output)
-
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_TanhFwd(), _TanhBwd(),
         x, epsilon=1e-5, tolerance=1e-2
     )
     assert_true(passed, "Tanh gradient check failed")
@@ -62,15 +114,7 @@ def test_gelu_gradient() raises:
         [2, 3], DType.float32, seed=42, low=-2.0, high=2.0
     )
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return gelu(inp)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises unified {read} -> AnyTensor:
-        return gelu_backward(grad_out, inp)
-
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_GeluFwd(), _GeluBwd(),
         x, epsilon=1e-5, tolerance=1e-2
     )
     assert_true(passed, "GELU gradient check failed")
@@ -107,17 +151,8 @@ def test_conv2d_gradient_input() raises:
     input_shape.append(8)
     var x = create_seeded_random_tensor(input_shape, DType.float32, seed=42)
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return conv2d(inp, kernel, bias, stride=1, padding=1)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises unified {read} -> AnyTensor:
-        var result = conv2d_backward(grad_out, inp, kernel, stride=1, padding=1)
-        return result.grad_input
-
     # Use slightly larger epsilon for conv (more complex operation)
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_Conv2dInputFwd(kernel, bias), _Conv2dInputBwd(kernel),
         x, epsilon=1e-4, tolerance=1e-2
     )
     assert_true(passed, "Conv2D input gradient check failed")
@@ -150,17 +185,8 @@ def test_linear_gradient_input() raises:
     input_shape.append(in_features)
     var x = create_seeded_random_tensor(input_shape, DType.float32, seed=42)
 
-    def forward(inp: AnyTensor) raises -> AnyTensor:
-        return linear(inp, weights, bias)
-
-    def backward_fn(
-        grad_out: AnyTensor, inp: AnyTensor
-    ) raises unified {read} -> AnyTensor:
-        var result = linear_backward(grad_out, inp, weights)
-        return result.grad_input
-
     # Wider tolerance (1.5%) for matrix operations
-    var passed = check_gradients(forward, backward_fn,
+    var passed = check_gradients(_LinearFwd(weights, bias), _LinearBwd(weights),
         x, epsilon=1e-5, tolerance=0.015
     )
     assert_true(passed, "Linear input gradient check failed")

--- a/tests/shared/core/test_losses.mojo
+++ b/tests/shared/core/test_losses.mojo
@@ -19,7 +19,7 @@ from shared.core.loss import binary_cross_entropy, binary_cross_entropy_backward
 from shared.core.loss import mean_squared_error, mean_squared_error_backward
 from shared.core.reduction import mean
 from shared.core.loss import smooth_l1_loss, smooth_l1_loss_backward
-from shared.testing import check_gradient
+from shared.testing import check_gradient, NumericalForward, NumericalBackward
 from shared.core.loss import hinge_loss, hinge_loss_backward
 from shared.core.loss import focal_loss, focal_loss_backward
 from shared.core.loss import kl_divergence, kl_divergence_backward
@@ -256,6 +256,22 @@ def test_loss_numerical_stability() raises:
     print("  ✓ Numerical stability test passed")
 
 
+@fieldwise_init
+struct _BCEFwd(NumericalForward):
+    var targets: AnyTensor
+
+    def __call__(self, pred: AnyTensor) raises -> AnyTensor:
+        return binary_cross_entropy(pred, self.targets)
+
+
+@fieldwise_init
+struct _BCEBwd(NumericalBackward):
+    var targets: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, pred: AnyTensor) raises -> AnyTensor:
+        return binary_cross_entropy_backward(grad_out, pred, self.targets)
+
+
 def test_binary_cross_entropy_backward_gradient() raises:
     """Test BCE backward with numerical gradient checking."""
     print("Testing BCE backward gradient checking...")
@@ -276,23 +292,31 @@ def test_binary_cross_entropy_backward_gradient() raises:
     targets._set_float64(2, 1.0)
     targets._set_float64(3, 0.0)
 
-    # Forward function wrapper
-    def forward(pred: AnyTensor) raises unified {read} -> AnyTensor:
-        return binary_cross_entropy(pred, targets)
-
-    # Backward function wrapper
-    def backward(grad_out: AnyTensor, pred: AnyTensor) raises unified {read} -> AnyTensor:
-        return binary_cross_entropy_backward(grad_out, pred, targets)
-
-    var loss = forward(predictions)
+    var loss = binary_cross_entropy(predictions, targets)
     var grad_output = ones(shape, DType.float32)
 
     # Numerical gradient checking (relaxed tolerance for float32 precision)
     check_gradient(
-        forward, backward, predictions, grad_output, rtol=2e-3, atol=1e-5
+        _BCEFwd(targets), _BCEBwd(targets), predictions, grad_output, rtol=2e-3, atol=1e-5
     )
 
     print("  ✓ BCE backward gradient check passed")
+
+
+@fieldwise_init
+struct _MSEFwd(NumericalForward):
+    var targets: AnyTensor
+
+    def __call__(self, pred: AnyTensor) raises -> AnyTensor:
+        return mean_squared_error(pred, self.targets)
+
+
+@fieldwise_init
+struct _MSEBwd(NumericalBackward):
+    var targets: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, pred: AnyTensor) raises -> AnyTensor:
+        return mean_squared_error_backward(grad_out, pred, self.targets)
 
 
 def test_mean_squared_error_backward_gradient() raises:
@@ -317,20 +341,12 @@ def test_mean_squared_error_backward_gradient() raises:
     targets._set_float64(3, 4.5)
     targets._set_float64(4, 0.8)
 
-    # Forward function wrapper
-    def forward(pred: AnyTensor) raises unified {read} -> AnyTensor:
-        return mean_squared_error(pred, targets)
-
-    # Backward function wrapper
-    def backward(grad_out: AnyTensor, pred: AnyTensor) raises unified {read} -> AnyTensor:
-        return mean_squared_error_backward(grad_out, pred, targets)
-
-    var loss = forward(predictions)
+    var loss = mean_squared_error(predictions, targets)
     var grad_output = ones(shape, DType.float32)
 
     # Numerical gradient checking (relaxed tolerance for float32 precision)
     check_gradient(
-        forward, backward, predictions, grad_output, rtol=2e-3, atol=1e-5
+        _MSEFwd(targets), _MSEBwd(targets), predictions, grad_output, rtol=2e-3, atol=1e-5
     )
 
     print("  ✓ MSE backward gradient check passed")
@@ -501,6 +517,24 @@ def test_smooth_l1_backward_linear() raises:
     print("  ✓ Smooth L1 backward linear test passed")
 
 
+@fieldwise_init
+struct _SmoothL1Fwd(NumericalForward):
+    var targets: AnyTensor
+    var beta: Float32
+
+    def __call__(self, pred: AnyTensor) raises -> AnyTensor:
+        return smooth_l1_loss(pred, self.targets, beta=self.beta)
+
+
+@fieldwise_init
+struct _SmoothL1Bwd(NumericalBackward):
+    var targets: AnyTensor
+    var beta: Float32
+
+    def __call__(self, grad_out: AnyTensor, pred: AnyTensor) raises -> AnyTensor:
+        return smooth_l1_loss_backward(grad_out, pred, self.targets, beta=self.beta)
+
+
 def test_smooth_l1_backward_gradient() raises:
     """Test Smooth L1 backward with numerical gradient checking."""
     print("Testing Smooth L1 backward gradient checking...")
@@ -523,20 +557,12 @@ def test_smooth_l1_backward_gradient() raises:
     targets._set_float64(2, 2.8)
     targets._set_float64(3, 0.5)
 
-    # Forward function wrapper
-    def forward(pred: AnyTensor) raises unified {read} -> AnyTensor:
-        return smooth_l1_loss(pred, targets, beta=beta)
-
-    # Backward function wrapper
-    def backward(grad_out: AnyTensor, pred: AnyTensor) raises unified {read} -> AnyTensor:
-        return smooth_l1_loss_backward(grad_out, pred, targets, beta=beta)
-
-    var loss = forward(predictions)
+    var loss = smooth_l1_loss(predictions, targets, beta=beta)
     var grad_output = ones(shape, DType.float32)
 
     # Numerical gradient checking (relaxed tolerance for smooth L1)
     check_gradient(
-        forward, backward, predictions, grad_output, rtol=1e-2, atol=1e-3
+        _SmoothL1Fwd(targets, beta), _SmoothL1Bwd(targets, beta), predictions, grad_output, rtol=1e-2, atol=1e-3
     )
 
     print("  ✓ Smooth L1 backward gradient check passed")
@@ -676,6 +702,22 @@ def test_hinge_loss_backward() raises:
     print("  ✓ Hinge backward test passed")
 
 
+@fieldwise_init
+struct _HingeFwd(NumericalForward):
+    var targets: AnyTensor
+
+    def __call__(self, pred: AnyTensor) raises -> AnyTensor:
+        return hinge_loss(pred, self.targets)
+
+
+@fieldwise_init
+struct _HingeBwd(NumericalBackward):
+    var targets: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, pred: AnyTensor) raises -> AnyTensor:
+        return hinge_loss_backward(grad_out, pred, self.targets)
+
+
 def test_hinge_loss_backward_gradient() raises:
     """Test hinge loss backward with gradient checking."""
     print("Testing hinge loss backward gradient checking...")
@@ -696,20 +738,12 @@ def test_hinge_loss_backward_gradient() raises:
     targets._set_float64(2, 1.0)
     targets._set_float64(3, 1.0)
 
-    # Forward function wrapper
-    def forward(pred: AnyTensor) raises unified {read} -> AnyTensor:
-        return hinge_loss(pred, targets)
-
-    # Backward function wrapper
-    def backward(grad_out: AnyTensor, pred: AnyTensor) raises unified {read} -> AnyTensor:
-        return hinge_loss_backward(grad_out, pred, targets)
-
-    var loss = forward(predictions)
+    var loss = hinge_loss(predictions, targets)
     var grad_output = ones(shape, DType.float32)
 
     # Numerical gradient checking (relaxed tolerance for discontinuous gradient)
     check_gradient(
-        forward, backward, predictions, grad_output, rtol=1e-2, atol=1e-3
+        _HingeFwd(targets), _HingeBwd(targets), predictions, grad_output, rtol=1e-2, atol=1e-3
     )
 
     print("  ✓ Hinge backward gradient check passed")
@@ -801,6 +835,22 @@ def test_focal_loss_backward_shape() raises:
     print("  ✓ Focal loss backward shape test passed")
 
 
+@fieldwise_init
+struct _FocalFwd(NumericalForward):
+    var targets: AnyTensor
+
+    def __call__(self, pred: AnyTensor) raises -> AnyTensor:
+        return focal_loss(pred, self.targets)
+
+
+@fieldwise_init
+struct _FocalBwd(NumericalBackward):
+    var targets: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, pred: AnyTensor) raises -> AnyTensor:
+        return focal_loss_backward(grad_out, pred, self.targets)
+
+
 def test_focal_loss_backward_gradient() raises:
     """Test focal loss backward with numerical gradient checking."""
     print("Testing focal loss backward gradient checking...")
@@ -821,20 +871,12 @@ def test_focal_loss_backward_gradient() raises:
     targets._set_float64(2, 1.0)
     targets._set_float64(3, 0.0)
 
-    # Forward function wrapper
-    def forward(pred: AnyTensor) raises unified {read} -> AnyTensor:
-        return focal_loss(pred, targets)
-
-    # Backward function wrapper
-    def backward(grad_out: AnyTensor, pred: AnyTensor) raises unified {read} -> AnyTensor:
-        return focal_loss_backward(grad_out, pred, targets)
-
-    var loss = forward(predictions)
+    var loss = focal_loss(predictions, targets)
     var grad_output = ones(shape, DType.float32)
 
     # Numerical gradient checking (relaxed tolerance for float32 precision)
     check_gradient(
-        forward, backward, predictions, grad_output, rtol=2e-2, atol=1e-4
+        _FocalFwd(targets), _FocalBwd(targets), predictions, grad_output, rtol=2e-2, atol=1e-4
     )
 
     print("  ✓ Focal loss backward gradient check passed")
@@ -929,6 +971,22 @@ def test_kl_divergence_backward_shape() raises:
     print("  ✓ KL divergence backward shape test passed")
 
 
+@fieldwise_init
+struct _KLFwd(NumericalForward):
+    var p: AnyTensor
+
+    def __call__(self, q_dist: AnyTensor) raises -> AnyTensor:
+        return kl_divergence(self.p, q_dist)
+
+
+@fieldwise_init
+struct _KLBwd(NumericalBackward):
+    var p: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, q_dist: AnyTensor) raises -> AnyTensor:
+        return kl_divergence_backward(grad_out, self.p, q_dist)
+
+
 def test_kl_divergence_backward_gradient() raises:
     """Test KL divergence backward with numerical gradient checking."""
     print("Testing KL divergence backward gradient checking...")
@@ -949,21 +1007,11 @@ def test_kl_divergence_backward_gradient() raises:
     q._set_float64(2, 0.2)
     q._set_float64(3, 0.1)
 
-    # Forward function wrapper
-    def forward(q_dist: AnyTensor) raises unified {read} -> AnyTensor:
-        return kl_divergence(p, q_dist)
-
-    # Backward function wrapper
-    def backward(
-        grad_out: AnyTensor, q_dist: AnyTensor
-    ) raises unified {read} -> AnyTensor:
-        return kl_divergence_backward(grad_out, p, q_dist)
-
-    var kl = forward(q)
+    var kl = kl_divergence(p, q)
     var grad_output = ones(shape, DType.float32)
 
     # Numerical gradient checking (relaxed tolerance for float32 precision)
-    check_gradient(forward, backward, q, grad_output, rtol=2e-2, atol=1e-4)
+    check_gradient(_KLFwd(p), _KLBwd(p), q, grad_output, rtol=2e-2, atol=1e-4)
 
     print("  ✓ KL divergence backward gradient check passed")
 

--- a/tests/shared/core/test_matrix.mojo
+++ b/tests/shared/core/test_matrix.mojo
@@ -51,7 +51,55 @@ from shared.testing import (
     check_gradient,
     compute_numerical_gradient,
     assert_gradients_close,
+    NumericalForward,
+    NumericalBackward,
 )
+
+
+@fieldwise_init
+struct _MatmulAFwd(NumericalForward):
+    var b: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return matmul(inp, self.b)
+
+
+@fieldwise_init
+struct _MatmulABwd(NumericalBackward):
+    var b: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var grads = matmul_backward(grad_out, inp, self.b)
+        return grads.grad_a
+
+
+@fieldwise_init
+struct _MatmulBFwd(NumericalForward):
+    var a: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return matmul(self.a, inp)
+
+
+@fieldwise_init
+struct _MatmulBBwd(NumericalBackward):
+    var a: AnyTensor
+
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        var grads = matmul_backward(grad_out, self.a, inp)
+        return grads.grad_b
+
+
+@fieldwise_init
+struct _TransposeFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return transpose(inp)
+
+
+@fieldwise_init
+struct _TransposeBwd(NumericalBackward):
+    def __call__(self, grad_out: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return transpose_backward(grad_out)
 
 
 def test_matmul_shapes() raises:
@@ -378,21 +426,12 @@ def test_matmul_backward_gradient_a() raises:
     for i in range(k * n):
         b.set(i, Float32(Float32(i) * 0.2 + 0.1))
 
-    # Forward function wrapper
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return matmul(inp, b)
-
-    # Backward function wrapper for grad_a
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = matmul_backward(grad_out, inp, b)
-        return grads.grad_a
-
-    var output = forward(a)
+    var output = _MatmulAFwd(b)(a)
     var grad_output = ones_like(output)
 
     # Numerical gradient checking
     # Note: atol=1e-3 for robustness against numerical noise in small gradients
-    check_gradient(forward, backward, a, grad_output, rtol=1e-3, atol=1e-3)
+    check_gradient(_MatmulAFwd(b), _MatmulABwd(b), a, grad_output, rtol=1e-3, atol=1e-3)
 
 
 def test_matmul_backward_gradient_b() raises:
@@ -425,21 +464,12 @@ def test_matmul_backward_gradient_b() raises:
     for i in range(k * n):
         b.set(i, Float32(Float32(i) * 0.2 + 0.1))
 
-    # Forward function wrapper
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return matmul(a, inp)
-
-    # Backward function wrapper for grad_b
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var grads = matmul_backward(grad_out, a, inp)
-        return grads.grad_b
-
-    var output = forward(b)
+    var output = _MatmulBFwd(a)(b)
     var grad_output = ones_like(output)
 
     # Numerical gradient checking
     # Note: atol=1e-3 for robustness against numerical noise in small gradients
-    check_gradient(forward, backward, b, grad_output, rtol=1e-3, atol=1e-3)
+    check_gradient(_MatmulBFwd(a), _MatmulBBwd(a), b, grad_output, rtol=1e-3, atol=1e-3)
 
 
 def test_matmul_matrix_vector() raises:
@@ -791,19 +821,11 @@ def test_transpose_backward_gradient() raises:
     for i in range(m * n):
         x.set(i, Float32(Float32(i) * 0.15 - 2.0))
 
-    # Forward function wrapper
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return transpose(inp)
-
-    # Backward function wrapper
-    def backward(grad_out: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return transpose_backward(grad_out)
-
-    var output = forward(x)
+    var output = _TransposeFwd()(x)
     var grad_output = ones_like(output)
 
     # Numerical gradient checking
-    check_gradient(forward, backward, x, grad_output, rtol=1e-3, atol=1e-6)
+    check_gradient(_TransposeFwd(), _TransposeBwd(), x, grad_output, rtol=1e-3, atol=1e-6)
 
 
 def test_transpose_combination_at_b() raises:

--- a/tests/shared/core/test_normalization.mojo
+++ b/tests/shared/core/test_normalization.mojo
@@ -27,7 +27,104 @@ from tests.shared.conftest import TestFixtures
 from shared.testing import (
     compute_numerical_gradient,
     assert_gradients_close,
+    NumericalForward,
 )
+
+
+@fieldwise_init
+struct _BNormInputFwd(NumericalForward):
+    var training: Bool
+    var gamma: AnyTensor
+    var beta: AnyTensor
+    var running_mean: AnyTensor
+    var running_var: AnyTensor
+    var grad_output: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        var res = batch_norm2d(
+            inp,
+            self.gamma,
+            self.beta,
+            self.running_mean,
+            self.running_var,
+            training=self.training,
+            epsilon=1e-5,
+        )
+        var out = res[0]
+        var weighted = multiply(out, self.grad_output)
+        var result = weighted
+        while result.dim() > 0:
+            result = reduce_sum(result, axis=0, keepdims=False)
+        return result
+
+
+@fieldwise_init
+struct _BNormGammaFwd(NumericalForward):
+    var training: Bool
+    var x: AnyTensor
+    var beta: AnyTensor
+    var running_mean: AnyTensor
+    var running_var: AnyTensor
+    var grad_output: AnyTensor
+
+    def __call__(self, g: AnyTensor) raises -> AnyTensor:
+        var res = batch_norm2d(
+            self.x,
+            g,
+            self.beta,
+            self.running_mean,
+            self.running_var,
+            training=self.training,
+            epsilon=1e-5,
+        )
+        var out = res[0]
+        var weighted = multiply(out, self.grad_output)
+        var result = weighted
+        while result.dim() > 0:
+            result = reduce_sum(result, axis=0, keepdims=False)
+        return result
+
+
+@fieldwise_init
+struct _BNormBetaFwd(NumericalForward):
+    var training: Bool
+    var x: AnyTensor
+    var gamma: AnyTensor
+    var running_mean: AnyTensor
+    var running_var: AnyTensor
+    var grad_output: AnyTensor
+
+    def __call__(self, b: AnyTensor) raises -> AnyTensor:
+        var res = batch_norm2d(
+            self.x,
+            self.gamma,
+            b,
+            self.running_mean,
+            self.running_var,
+            training=self.training,
+            epsilon=1e-5,
+        )
+        var out = res[0]
+        var weighted = multiply(out, self.grad_output)
+        var result = weighted
+        while result.dim() > 0:
+            result = reduce_sum(result, axis=0, keepdims=False)
+        return result
+
+
+@fieldwise_init
+struct _LayerNormInputFwd(NumericalForward):
+    var gamma: AnyTensor
+    var beta: AnyTensor
+    var grad_output: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        var out = layer_norm(inp, self.gamma, self.beta, epsilon=1e-5)
+        var weighted = multiply(out, self.grad_output)
+        var result_inner = weighted
+        while result_inner.dim() > 0:
+            result_inner = reduce_sum(result_inner, axis=0, keepdims=False)
+        return result_inner
 from shared.tensor.any_tensor import AnyTensor, zeros, ones, zeros_like, ones_like
 from shared.core.normalization import (
     batch_norm2d,
@@ -115,25 +212,10 @@ def _check_grad_input_batch_size(batch_size: Int) raises:
             )
     else:
         # Standard gradient check for batch_size=2 and batch_size=4.
-        def forward_for_grad(inp: AnyTensor) raises unified {read} -> AnyTensor:
-            var res = batch_norm2d(
-                inp,
-                gamma,
-                beta,
-                running_mean,
-                running_var,
-                training=True,
-                epsilon=1e-5,
-            )
-            var out = res[0]
-            var weighted = multiply(out, grad_output)
-            var result = weighted
-            while result.dim() > 0:
-                result = reduce_sum(result, axis=0, keepdims=False)
-            return result
-
         var numerical_grad = compute_numerical_gradient(
-            forward_for_grad, x, epsilon=1e-3
+            _BNormInputFwd(True, gamma, beta, running_mean, running_var, grad_output),
+            x,
+            epsilon=1e-3,
         )
 
         assert_gradients_close(
@@ -203,19 +285,10 @@ def _check_grad_gamma_batch_size(batch_size: Int) raises:
             )
     else:
         # Standard gradient check: perturb gamma.
-        def forward_for_gamma(g: AnyTensor) raises unified {read} -> AnyTensor:
-            var res = batch_norm2d(
-                x, g, beta, running_mean, running_var, training=True, epsilon=1e-5
-            )
-            var out = res[0]
-            var weighted = multiply(out, grad_output)
-            var result = weighted
-            while result.dim() > 0:
-                result = reduce_sum(result, axis=0, keepdims=False)
-            return result
-
         var numerical_grad_gamma = compute_numerical_gradient(
-            forward_for_gamma, gamma, epsilon=1e-3
+            _BNormGammaFwd(True, x, beta, running_mean, running_var, grad_output),
+            gamma,
+            epsilon=1e-3,
         )
 
         assert_gradients_close(
@@ -288,19 +361,10 @@ def _check_grad_beta_batch_size(batch_size: Int) raises:
             )
     else:
         # Standard gradient check: perturb beta.
-        def forward_for_beta(b: AnyTensor) raises unified {read} -> AnyTensor:
-            var res = batch_norm2d(
-                x, gamma, b, running_mean, running_var, training=True, epsilon=1e-5
-            )
-            var out = res[0]
-            var weighted = multiply(out, grad_output)
-            var result = weighted
-            while result.dim() > 0:
-                result = reduce_sum(result, axis=0, keepdims=False)
-            return result
-
         var numerical_grad_beta = compute_numerical_gradient(
-            forward_for_beta, beta, epsilon=1e-3
+            _BNormBetaFwd(True, x, gamma, running_mean, running_var, grad_output),
+            beta,
+            epsilon=1e-3,
         )
 
         assert_gradients_close(
@@ -604,29 +668,12 @@ def test_batch_norm2d_backward_gradient_input() raises:
     var grad_input = result7[0]
 
     # Numerical gradient via finite differences.
-    # forward_for_grad computes weighted sum: sum(output * grad_output)
+    # forward computes weighted sum: sum(output * grad_output)
     # so the numerical gradient matches what the backward should compute.
-    def forward_for_grad(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var result_nested = batch_norm2d(
-            inp,
-            gamma,
-            beta,
-            running_mean,
-            running_var,
-            training=True,
-            epsilon=1e-5,
-        )
-        var out = result_nested[0]
-        # Compute weighted sum: sum(output * grad_output)
-        # This matches the backward with our non-uniform grad_output
-        var weighted = multiply(out, grad_output)
-        var result = weighted
-        while result.dim() > 0:
-            result = reduce_sum(result, axis=0, keepdims=False)
-        return result
-
     var numerical_grad = compute_numerical_gradient(
-        forward_for_grad, x, epsilon=1e-3
+        _BNormInputFwd(True, gamma, beta, running_mean, running_var, grad_output),
+        x,
+        epsilon=1e-3,
     )
 
     # Validate analytical gradient matches numerical gradient
@@ -712,27 +759,11 @@ def test_batch_norm2d_backward_gradient_input_inference_mode() raises:
     )
     var grad_input = result_bwd[0]
 
-    # Numerical gradient: closure uses training=False with fixed running stats
-    def forward_for_grad_infer(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var res = batch_norm2d(
-            inp,
-            gamma,
-            beta,
-            running_mean,
-            running_var,
-            training=False,
-            epsilon=1e-5,
-        )
-        var out = res[0]
-        # Weighted sum matching our grad_output=ones backward
-        var weighted = multiply(out, grad_output)
-        var result = weighted
-        while result.dim() > 0:
-            result = reduce_sum(result, axis=0, keepdims=False)
-        return result
-
+    # Numerical gradient: uses training=False with fixed running stats
     var numerical_grad = compute_numerical_gradient(
-        forward_for_grad_infer, x, epsilon=3e-4
+        _BNormInputFwd(False, gamma, beta, running_mean, running_var, grad_output),
+        x,
+        epsilon=3e-4,
     )
 
     # Inference mode gradient is a simple linear rescaling; tolerances can be tight
@@ -801,21 +832,12 @@ def test_batch_norm2d_backward_gradient_gamma() raises:
     var grad_gamma_analytical = result_bwd[1]
 
     # Numerical gradient: perturb gamma
-    # The forward closure computes: sum(batch_norm2d(x, g, ...) * grad_output)
+    # The forward computes: sum(batch_norm2d(x, g, ...) * grad_output)
     # so the numerical gradient matches what batch_norm2d_backward should produce.
-    def forward_for_gamma(g: AnyTensor) raises unified {read} -> AnyTensor:
-        var res = batch_norm2d(
-            x, g, beta, running_mean, running_var, training=True, epsilon=1e-5
-        )
-        var out = res[0]
-        var weighted = multiply(out, grad_output)
-        var result = weighted
-        while result.dim() > 0:
-            result = reduce_sum(result, axis=0, keepdims=False)
-        return result
-
     var numerical_grad_gamma = compute_numerical_gradient(
-        forward_for_gamma, gamma, epsilon=1e-3
+        _BNormGammaFwd(True, x, beta, running_mean, running_var, grad_output),
+        gamma,
+        epsilon=1e-3,
     )
 
     assert_gradients_close(
@@ -882,19 +904,10 @@ def test_batch_norm2d_backward_gradient_beta() raises:
     var grad_beta_analytical = result_bwd[2]
 
     # Numerical gradient: perturb beta
-    def forward_for_beta(b: AnyTensor) raises unified {read} -> AnyTensor:
-        var res = batch_norm2d(
-            x, gamma, b, running_mean, running_var, training=True, epsilon=1e-5
-        )
-        var out = res[0]
-        var weighted = multiply(out, grad_output)
-        var result = weighted
-        while result.dim() > 0:
-            result = reduce_sum(result, axis=0, keepdims=False)
-        return result
-
     var numerical_grad_beta = compute_numerical_gradient(
-        forward_for_beta, beta, epsilon=1e-3
+        _BNormBetaFwd(True, x, gamma, running_mean, running_var, grad_output),
+        beta,
+        epsilon=1e-3,
     )
 
     assert_gradients_close(
@@ -1351,17 +1364,8 @@ def test_layer_norm_backward_gradient_input() raises:
     # Numerical gradient via finite differences.
     # The scalar loss is sum(layer_norm(x) * grad_output), so the numerical
     # gradient matches what layer_norm_backward(grad_output, x, gamma) computes.
-    def forward_for_grad(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var out = layer_norm(inp, gamma, beta, epsilon=1e-5)
-        # Weighted sum: sum(out * grad_output) matches backward with non-uniform grad_output
-        var weighted = multiply(out, grad_output)
-        var result_inner = weighted
-        while result_inner.dim() > 0:
-            result_inner = reduce_sum(result_inner, axis=0, keepdims=False)
-        return result_inner
-
     var numerical_grad = compute_numerical_gradient(
-        forward_for_grad, x, epsilon=1e-4
+        _LayerNormInputFwd(gamma, beta, grad_output), x, epsilon=1e-4
     )
 
     # Validate analytical gradient matches numerical gradient
@@ -1464,17 +1468,8 @@ def test_layer_norm_backward_gradient_input_4d() raises:
     # Numerical gradient via finite differences.
     # The scalar loss is sum(layer_norm(x) * grad_output), so the numerical
     # gradient matches what layer_norm_backward(grad_output, x, gamma) computes.
-    def forward_for_grad_4d(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        var out = layer_norm(inp, gamma, beta, epsilon=1e-5)
-        # Weighted sum: sum(out * grad_output) matches backward with non-uniform grad_output
-        var weighted = multiply(out, grad_output)
-        var result_inner = weighted
-        while result_inner.dim() > 0:
-            result_inner = reduce_sum(result_inner, axis=0, keepdims=False)
-        return result_inner
-
     var numerical_grad = compute_numerical_gradient(
-        forward_for_grad_4d, x, epsilon=1e-4
+        _LayerNormInputFwd(gamma, beta, grad_output), x, epsilon=1e-4
     )
 
     # Validate analytical gradient matches numerical gradient
@@ -1631,19 +1626,10 @@ def test_batch_norm2d_backward_gradient_gamma_inference_mode() raises:
     var grad_gamma_analytical = result_bwd[1]
 
     # Numerical gradient: perturb gamma in inference mode
-    def forward_for_gamma_infer(g: AnyTensor) raises unified {read} -> AnyTensor:
-        var res = batch_norm2d(
-            x, g, beta, running_mean, running_var, training=False, epsilon=1e-5
-        )
-        var out = res[0]
-        var weighted = multiply(out, grad_output)
-        var result = weighted
-        while result.dim() > 0:
-            result = reduce_sum(result, axis=0, keepdims=False)
-        return result
-
     var numerical_grad_gamma = compute_numerical_gradient(
-        forward_for_gamma_infer, gamma, epsilon=1e-3
+        _BNormGammaFwd(False, x, beta, running_mean, running_var, grad_output),
+        gamma,
+        epsilon=1e-3,
     )
 
     assert_gradients_close(
@@ -1715,19 +1701,10 @@ def test_batch_norm2d_backward_gradient_beta_inference_mode() raises:
     var grad_beta_analytical = result_bwd[2]
 
     # Numerical gradient: perturb beta in inference mode
-    def forward_for_beta_infer(b: AnyTensor) raises unified {read} -> AnyTensor:
-        var res = batch_norm2d(
-            x, gamma, b, running_mean, running_var, training=False, epsilon=1e-5
-        )
-        var out = res[0]
-        var weighted = multiply(out, grad_output)
-        var result = weighted
-        while result.dim() > 0:
-            result = reduce_sum(result, axis=0, keepdims=False)
-        return result
-
     var numerical_grad_beta = compute_numerical_gradient(
-        forward_for_beta_infer, beta, epsilon=1e-3
+        _BNormBetaFwd(False, x, gamma, running_mean, running_var, grad_output),
+        beta,
+        epsilon=1e-3,
     )
 
     assert_gradients_close(

--- a/tests/shared/core/test_reduction.mojo
+++ b/tests/shared/core/test_reduction.mojo
@@ -34,7 +34,7 @@ from shared.core.reduction import (
 from shared.testing import check_gradient, NumericalForward, NumericalBackward
 from shared.core.reduction import (
     variance,
-    std as stdev,
+    std_reduce as stdev,
     variance_backward,
     std_backward,
 )

--- a/tests/shared/core/test_reduction.mojo
+++ b/tests/shared/core/test_reduction.mojo
@@ -31,7 +31,7 @@ from shared.core.reduction import (
     max_reduce_backward,
     min_reduce_backward,
 )
-from shared.testing import check_gradient
+from shared.testing import check_gradient, NumericalForward, NumericalBackward
 from shared.core.reduction import (
     variance,
     std as stdev,
@@ -44,6 +44,78 @@ from shared.core.reduction import (
     median_backward,
     percentile_backward,
 )
+
+
+@fieldwise_init
+struct _SumFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return sum(inp, axis=1)
+
+
+@fieldwise_init
+struct _SumBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return sum_backward(grad, inp, axis=1)
+
+
+@fieldwise_init
+struct _MeanFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return mean(inp, axis=1)
+
+
+@fieldwise_init
+struct _MeanBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return mean_backward(grad, inp, axis=1)
+
+
+@fieldwise_init
+struct _MaxReduceFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return max_reduce(inp, axis=1)
+
+
+@fieldwise_init
+struct _MaxReduceBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return max_reduce_backward(grad, inp, axis=1)
+
+
+@fieldwise_init
+struct _MinReduceFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return min_reduce(inp, axis=1)
+
+
+@fieldwise_init
+struct _MinReduceBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return min_reduce_backward(grad, inp, axis=1)
+
+
+@fieldwise_init
+struct _VarianceFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return variance(inp, axis=1, ddof=0)
+
+
+@fieldwise_init
+struct _VarianceBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return variance_backward(grad, inp, axis=1, ddof=0)
+
+
+@fieldwise_init
+struct _StdFwd(NumericalForward):
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        return stdev(inp, axis=1, ddof=0)
+
+
+@fieldwise_init
+struct _StdBwd(NumericalBackward):
+    def __call__(self, grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
+        return std_backward(grad, inp, axis=1, ddof=0)
 
 
 def test_sum_backward_shapes() raises:
@@ -87,20 +159,12 @@ def test_sum_backward_gradient() raises:
     x.set(4, Float32(0.1))
     x.set(5, Float32(0.7))
 
-    # Forward function wrapper (sum along axis 1)
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return sum(inp, axis=1)
-
-    var y = forward(x)
+    var y = _SumFwd()(x)
     var grad_out = ones_like(y)
-
-    # Backward function wrapper
-    def backward(grad: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return sum_backward(grad, inp, axis=1)
 
     # Use numerical gradient checking (gold standard)
     # Note: rtol=2e-3 accounts for Float32 precision in sum accumulation
-    check_gradient(forward, backward, x, grad_out, rtol=2e-3, atol=1e-6)
+    check_gradient(_SumFwd(), _SumBwd(), x, grad_out, rtol=2e-3, atol=1e-6)
 
 
 def test_mean_backward_shapes() raises:
@@ -144,20 +208,12 @@ def test_mean_backward_gradient() raises:
     x.set(4, Float32(0.1))
     x.set(5, Float32(0.7))
 
-    # Forward function wrapper (mean along axis 1)
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return mean(inp, axis=1)
-
-    var y = forward(x)
+    var y = _MeanFwd()(x)
     var grad_out = ones_like(y)
-
-    # Backward function wrapper
-    def backward(grad: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return mean_backward(grad, inp, axis=1)
 
     # Use numerical gradient checking (gold standard)
     # Note: rtol=2e-3 accounts for Float32 precision in division
-    check_gradient(forward, backward, x, grad_out, rtol=2e-3, atol=1e-6)
+    check_gradient(_MeanFwd(), _MeanBwd(), x, grad_out, rtol=2e-3, atol=1e-6)
 
 
 def test_max_reduce_backward_shapes() raises:
@@ -199,20 +255,12 @@ def test_max_reduce_backward_gradient() raises:
     x.set(4, Float32(0.1))
     x.set(5, Float32(0.7))
 
-    # Forward function wrapper (max along axis 1)
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return max_reduce(inp, axis=1)
-
-    var y = forward(x)
+    var y = _MaxReduceFwd()(x)
     var grad_out = ones_like(y)
-
-    # Backward function wrapper
-    def backward(grad: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return max_reduce_backward(grad, inp, axis=1)
 
     # Use numerical gradient checking (gold standard)
     # Note: rtol=2e-3 accounts for Float32 precision
-    check_gradient(forward, backward, x, grad_out, rtol=2e-3, atol=1e-6)
+    check_gradient(_MaxReduceFwd(), _MaxReduceBwd(), x, grad_out, rtol=2e-3, atol=1e-6)
 
 
 def test_min_reduce_backward_shapes() raises:
@@ -254,20 +302,12 @@ def test_min_reduce_backward_gradient() raises:
     x.set(4, Float32(0.1))
     x.set(5, Float32(0.7))
 
-    # Forward function wrapper (min along axis 1)
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return min_reduce(inp, axis=1)
-
-    var y = forward(x)
+    var y = _MinReduceFwd()(x)
     var grad_out = ones_like(y)
-
-    # Backward function wrapper
-    def backward(grad: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return min_reduce_backward(grad, inp, axis=1)
 
     # Use numerical gradient checking (gold standard)
     # Note: rtol=2e-3 accounts for Float32 precision
-    check_gradient(forward, backward, x, grad_out, rtol=2e-3, atol=1e-6)
+    check_gradient(_MinReduceFwd(), _MinReduceBwd(), x, grad_out, rtol=2e-3, atol=1e-6)
 
 
 def test_var_forward_uniform() raises:
@@ -357,16 +397,10 @@ def test_var_backward_gradient() raises:
     x.set(4, Float32(0.1))
     x.set(5, Float32(0.7))
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return variance(inp, axis=1, ddof=0)
-
-    var y = forward(x)
+    var y = _VarianceFwd()(x)
     var grad_out = ones_like(y)
 
-    def backward(grad: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return variance_backward(grad, inp, axis=1, ddof=0)
-
-    check_gradient(forward, backward, x, grad_out, rtol=2e-3, atol=1e-6)
+    check_gradient(_VarianceFwd(), _VarianceBwd(), x, grad_out, rtol=2e-3, atol=1e-6)
 
 
 def test_std_forward_simple() raises:
@@ -397,16 +431,10 @@ def test_std_backward_gradient() raises:
     x.set(4, Float32(0.1))
     x.set(5, Float32(0.7))
 
-    def forward(inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return stdev(inp, axis=1, ddof=0)
-
-    var y = forward(x)
+    var y = _StdFwd()(x)
     var grad_out = ones_like(y)
 
-    def backward(grad: AnyTensor, inp: AnyTensor) raises unified {read} -> AnyTensor:
-        return std_backward(grad, inp, axis=1, ddof=0)
-
-    check_gradient(forward, backward, x, grad_out, rtol=2e-3, atol=1e-6)
+    check_gradient(_StdFwd(), _StdBwd(), x, grad_out, rtol=2e-3, atol=1e-6)
 
 
 def test_median_forward_odd() raises:

--- a/tests/shared/data/loaders/test_base_loader.mojo
+++ b/tests/shared/data/loaders/test_base_loader.mojo
@@ -37,10 +37,6 @@ struct StubBatch(Copyable, Movable, Sized):
     def __init__(out self, capacity: Int):
         self.batch_size = capacity
 
-    def __moveinit__(out self, deinit existing: Self):
-        """Move initializer."""
-        self.batch_size = existing.batch_size
-
     def __len__(self) -> Int:
         """Return batch size for len() builtin."""
         return self.batch_size

--- a/tests/shared/fixtures/test_io_helpers.mojo
+++ b/tests/shared/fixtures/test_io_helpers.mojo
@@ -60,7 +60,7 @@ def _cleanup_tmp_dir(path: String) raises:
     # Only clean paths under /tmp/ for safety
     if not path.startswith("/tmp/"):
         raise Error("Refusing to clean non-/tmp/ path: " + path)
-    from python import Python
+    from std.python import Python
 
     var shutil = Python.import_module("shutil")
     try:

--- a/tests/shared/test_model_utils.mojo
+++ b/tests/shared/test_model_utils.mojo
@@ -228,7 +228,7 @@ def _file_exists(path: String) -> Bool:
 
 def _cleanup_directory(path: String):
     """Remove directory and all contents."""
-    from python import Python
+    from std.python import Python
 
     try:
         var shutil = Python.import_module("shutil")

--- a/tests/shared/test_serialization.mojo
+++ b/tests/shared/test_serialization.mojo
@@ -351,7 +351,7 @@ def _create_temp_dir(prefix: String) -> String:
     Returns:
         Full path to the created temporary directory.
     """
-    from python import Python
+    from std.python import Python
 
     try:
         var tempfile = Python.import_module("tempfile")

--- a/tests/shared/testing/test_gradient_checker_meta.mojo
+++ b/tests/shared/testing/test_gradient_checker_meta.mojo
@@ -30,17 +30,14 @@ References:
 
 from std.testing import assert_true, assert_equal
 from shared.testing import (
+    NumericalForward,
+    NumericalBackward,
     check_gradients,
     compute_numerical_gradient,
     relative_error,
+    check_gradients_verbose,
 )
 from shared.tensor.any_tensor import AnyTensor, zeros, ones, full, zeros_like
-from shared.testing import (
-    check_gradients,
-    check_gradients_verbose,
-    compute_numerical_gradient,
-    relative_error,
-)
 
 
 def square_forward(input: AnyTensor) raises -> AnyTensor:
@@ -98,6 +95,48 @@ def square_backward_wrong_triple(
     return grad_in^
 
 
+# ============================================================================
+# NumericalForward/NumericalBackward struct wrappers
+#
+# Mojo 0.26.3 makes all inner `def` closures nonescaping, so they cannot be
+# passed to functions expecting bare function pointer types. These structs
+# wrap the top-level square_forward/backward_* functions via @fieldwise_init
+# to satisfy the NumericalForward and NumericalBackward traits.
+# ============================================================================
+
+
+@fieldwise_init
+struct _SquareFwd(NumericalForward):
+    """Forward pass wrapper: f(x) = x^2."""
+
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        return square_forward(x)
+
+
+@fieldwise_init
+struct _SquareBwdCorrect(NumericalBackward):
+    """Correct backward wrapper: df/dx = 2x."""
+
+    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        return square_backward_correct(grad_out, x)
+
+
+@fieldwise_init
+struct _SquareBwdWrongLinear(NumericalBackward):
+    """Wrong backward wrapper: df/dx = x (incorrect)."""
+
+    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        return square_backward_wrong_linear(grad_out, x)
+
+
+@fieldwise_init
+struct _SquareBwdWrongTriple(NumericalBackward):
+    """Wrong backward wrapper: df/dx = 3x (incorrect)."""
+
+    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        return square_backward_wrong_triple(grad_out, x)
+
+
 def test_gradient_checker_accepts_correct_gradient() raises:
     """Meta-test: Gradient checker should PASS for correct gradient.
 
@@ -112,13 +151,7 @@ def test_gradient_checker_accepts_correct_gradient() raises:
 
     var x = full([1], 1.0, DType.float32)
 
-    def forward(t: AnyTensor) raises -> AnyTensor:
-        return square_forward(t)
-
-    def backward(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-        return square_backward_correct(grad, inp)
-
-    var passed = check_gradients(forward, backward,
+    var passed = check_gradients(_SquareFwd(), _SquareBwdCorrect(),
         x,
         epsilon=1e-5,
         tolerance=1e-2,
@@ -146,13 +179,7 @@ def test_gradient_checker_correct_gradient_multiple_values() raises:
         var test_val = test_values[i]
         var x = full([1], test_val, DType.float32)
 
-        def forward(t: AnyTensor) raises -> AnyTensor:
-            return square_forward(t)
-
-        def backward(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-            return square_backward_correct(grad, inp)
-
-        var passed = check_gradients(forward, backward,
+        var passed = check_gradients(_SquareFwd(), _SquareBwdCorrect(),
         x,
             epsilon=1e-5,
             tolerance=1e-2,
@@ -173,13 +200,7 @@ def test_gradient_checker_correct_gradient_multidimensional() raises:
 
     var x = full([2, 3], 1.5, DType.float32)
 
-    def forward(t: AnyTensor) raises -> AnyTensor:
-        return square_forward(t)
-
-    def backward(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-        return square_backward_correct(grad, inp)
-
-    var passed = check_gradients(forward, backward,
+    var passed = check_gradients(_SquareFwd(), _SquareBwdCorrect(),
         x,
         epsilon=1e-5,
         tolerance=1e-2,
@@ -202,13 +223,7 @@ def test_gradient_checker_rejects_wrong_gradient_linear() raises:
 
     var x = full([1], 1.0, DType.float32)
 
-    def forward(t: AnyTensor) raises -> AnyTensor:
-        return square_forward(t)
-
-    def backward(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-        return square_backward_wrong_linear(grad, inp)
-
-    var passed = check_gradients(forward, backward,
+    var passed = check_gradients(_SquareFwd(), _SquareBwdWrongLinear(),
         x,
         epsilon=1e-5,
         tolerance=1e-2,
@@ -228,13 +243,7 @@ def test_gradient_checker_rejects_wrong_gradient_triple() raises:
 
     var x = full([1], 1.0, DType.float32)
 
-    def forward(t: AnyTensor) raises -> AnyTensor:
-        return square_forward(t)
-
-    def backward(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-        return square_backward_wrong_triple(grad, inp)
-
-    var passed = check_gradients(forward, backward,
+    var passed = check_gradients(_SquareFwd(), _SquareBwdWrongTriple(),
         x,
         epsilon=1e-5,
         tolerance=1e-2,
@@ -261,13 +270,7 @@ def test_gradient_checker_wrong_gradient_multiple_values() raises:
         var test_val = test_values[i]
         var x = full([1], test_val, DType.float32)
 
-        def forward(t: AnyTensor) raises -> AnyTensor:
-            return square_forward(t)
-
-        def backward(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-            return square_backward_wrong_linear(grad, inp)
-
-        var passed = check_gradients(forward, backward,
+        var passed = check_gradients(_SquareFwd(), _SquareBwdWrongLinear(),
         x,
             epsilon=1e-5,
             tolerance=1e-2,
@@ -291,10 +294,7 @@ def test_compute_numerical_gradient_matches_analytical() raises:
 
     var x = full([1], 2.0, DType.float32)
 
-    def forward(t: AnyTensor) raises -> AnyTensor:
-        return square_forward(t)
-
-    var numerical_grad = compute_numerical_gradient(forward, x, epsilon=1e-5)
+    var numerical_grad = compute_numerical_gradient(_SquareFwd(), x, epsilon=1e-5)
 
     # Expected: df/dx = 2x = 2*2.0 = 4.0
     var expected = 4.0
@@ -339,13 +339,7 @@ def test_gradient_checker_zero_input() raises:
 
     var x = full([1], 0.0, DType.float32)
 
-    def forward(t: AnyTensor) raises -> AnyTensor:
-        return square_forward(t)
-
-    def backward(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-        return square_backward_correct(grad, inp)
-
-    var passed = check_gradients(forward, backward,
+    var passed = check_gradients(_SquareFwd(), _SquareBwdCorrect(),
         x,
         epsilon=1e-5,
         tolerance=1e-2,
@@ -368,13 +362,7 @@ def test_gradient_checker_negative_input() raises:
 
     var x = full([1], -2.0, DType.float32)
 
-    def forward(t: AnyTensor) raises -> AnyTensor:
-        return square_forward(t)
-
-    def backward(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-        return square_backward_correct(grad, inp)
-
-    var passed = check_gradients(forward, backward,
+    var passed = check_gradients(_SquareFwd(), _SquareBwdCorrect(),
         x,
         epsilon=1e-5,
         tolerance=1e-2,
@@ -398,14 +386,8 @@ def test_gradient_checker_large_input() raises:
 
     var x = full([1], 5.0, DType.float32)
 
-    def forward(t: AnyTensor) raises -> AnyTensor:
-        return square_forward(t)
-
-    def backward(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-        return square_backward_correct(grad, inp)
-
     # Moderate inputs still need larger tolerance for float32 precision
-    var passed = check_gradients(forward, backward,
+    var passed = check_gradients(_SquareFwd(), _SquareBwdCorrect(),
         x,
         epsilon=1e-5,
         tolerance=0.05,
@@ -425,13 +407,7 @@ def test_gradient_checker_small_epsilon() raises:
 
     var x = full([1], 1.0, DType.float32)
 
-    def forward(t: AnyTensor) raises -> AnyTensor:
-        return square_forward(t)
-
-    def backward(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-        return square_backward_correct(grad, inp)
-
-    var passed = check_gradients(forward, backward,
+    var passed = check_gradients(_SquareFwd(), _SquareBwdCorrect(),
         x,
         epsilon=1e-4,
         tolerance=1e-2,
@@ -451,13 +427,7 @@ def test_gradient_checker_large_epsilon() raises:
 
     var x = full([1], 1.0, DType.float32)
 
-    def forward(t: AnyTensor) raises -> AnyTensor:
-        return square_forward(t)
-
-    def backward(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-        return square_backward_correct(grad, inp)
-
-    var passed = check_gradients(forward, backward,
+    var passed = check_gradients(_SquareFwd(), _SquareBwdCorrect(),
         x,
         epsilon=1e-3,
         tolerance=1e-2,
@@ -485,13 +455,7 @@ def test_check_gradients_does_not_mutate_input() raises:
     for i in range(x.numel()):
         before.append(x._get_float64(i))
 
-    def forward(t: AnyTensor) raises -> AnyTensor:
-        return square_forward(t)
-
-    def backward(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-        return square_backward_correct(grad, inp)
-
-    _ = check_gradients(forward, backward, x, epsilon=1e-5, tolerance=1e-2)
+    _ = check_gradients(_SquareFwd(), _SquareBwdCorrect(), x, epsilon=1e-5, tolerance=1e-2)
 
     # Assert every element is unchanged
     for i in range(x.numel()):
@@ -525,14 +489,8 @@ def test_check_gradients_verbose_does_not_mutate_input() raises:
     for i in range(x.numel()):
         before.append(x._get_float64(i))
 
-    def forward(t: AnyTensor) raises -> AnyTensor:
-        return square_forward(t)
-
-    def backward(grad: AnyTensor, inp: AnyTensor) raises -> AnyTensor:
-        return square_backward_correct(grad, inp)
-
     _ = check_gradients_verbose(
-        forward, backward, x, epsilon=1e-5, tolerance=1e-2
+        _SquareFwd(), _SquareBwdCorrect(), x, epsilon=1e-5, tolerance=1e-2
     )
 
     # Assert every element is unchanged

--- a/tests/shared/testing/test_gradient_checker_noncont_tensors.mojo
+++ b/tests/shared/testing/test_gradient_checker_noncont_tensors.mojo
@@ -10,6 +10,8 @@ Issue #3801: Add non-contiguous tensor support to gradient checker
 
 from std.testing import assert_true, assert_false
 from shared.testing import (
+    NumericalForward,
+    NumericalBackward,
     check_gradients,
     check_gradients_verbose,
     compute_numerical_gradient,
@@ -17,6 +19,61 @@ from shared.testing import (
 from shared.tensor.any_tensor import AnyTensor, zeros, ones, full, randn
 from shared.core import shape
 from shared.core import matrix
+
+
+# ============================================================================
+# Shared function structs for gradient checking
+# ============================================================================
+
+
+@fieldwise_init
+struct _SimpleSquareFwd(NumericalForward):
+    """Forward pass: f(x) = x^2."""
+
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        var result = zeros(x.shape(), x.dtype())
+        for i in range(x.numel()):
+            var val = x._get_float64(i)
+            result._set_float64(i, val * val)
+        return result^
+
+
+@fieldwise_init
+struct _SimpleSquareBwd(NumericalBackward):
+    """Backward pass: f'(x) = 2*x."""
+
+    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        var result = zeros(x.shape(), x.dtype())
+        for i in range(x.numel()):
+            var grad = grad_out._get_float64(i)
+            var x_val = x._get_float64(i)
+            result._set_float64(i, grad * 2.0 * x_val)
+        return result^
+
+
+@fieldwise_init
+struct _ReluFwd(NumericalForward):
+    """Forward pass: ReLU."""
+
+    def __call__(self, x: AnyTensor) raises -> AnyTensor:
+        var result = zeros(x.shape(), x.dtype())
+        for i in range(x.numel()):
+            var val = x._get_float64(i)
+            result._set_float64(i, max(val, 0.0))
+        return result^
+
+
+@fieldwise_init
+struct _ReluBwd(NumericalBackward):
+    """Backward pass: ReLU."""
+
+    def __call__(self, grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
+        var result = zeros(x.shape(), x.dtype())
+        for i in range(x.numel()):
+            var grad = grad_out._get_float64(i)
+            var x_val = x._get_float64(i)
+            result._set_float64(i, grad if x_val > 0.0 else 0.0)
+        return result^
 
 
 # ============================================================================
@@ -31,21 +88,6 @@ def test_gradient_check_transposed_input() raises:
     """
     print("Testing gradient checking with transposed input...")
 
-    def simple_square(x: AnyTensor) raises -> AnyTensor:
-        var result = zeros(x.shape(), x.dtype())
-        for i in range(x.numel()):
-            var val = x._get_float64(i)
-            result._set_float64(i, val * val)
-        return result^
-
-    def simple_square_backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        var result = zeros(x.shape(), x.dtype())
-        for i in range(x.numel()):
-            var grad = grad_out._get_float64(i)
-            var x_val = x._get_float64(i)
-            result._set_float64(i, grad * 2.0 * x_val)
-        return result^
-
     # Create a small 2x3 tensor
     var shape_2d = [2, 3]
     var x = full(shape_2d, 2.0, DType.float32)
@@ -58,7 +100,7 @@ def test_gradient_check_transposed_input() raises:
 
     # Check gradients on the non-contiguous tensor
     # For f(x) = x*x, f'(x) = 2*x
-    var passed = check_gradients(simple_square, simple_square_backward,
+    var passed = check_gradients(_SimpleSquareFwd(), _SimpleSquareBwd(),
         x_transposed, epsilon=1e-4, tolerance=1e-2
     )
     assert_true(passed, "Gradient check should pass on transposed tensor")
@@ -72,21 +114,6 @@ def test_gradient_check_transposed_relu() raises:
     exactly (within floating-point precision) even on non-contiguous tensors.
     """
     print("Testing ReLU gradient checking with transposed input...")
-
-    def relu_forward(x: AnyTensor) raises -> AnyTensor:
-        var result = zeros(x.shape(), x.dtype())
-        for i in range(x.numel()):
-            var val = x._get_float64(i)
-            result._set_float64(i, max(val, 0.0))
-        return result^
-
-    def relu_backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        var result = zeros(x.shape(), x.dtype())
-        for i in range(x.numel()):
-            var grad = grad_out._get_float64(i)
-            var x_val = x._get_float64(i)
-            result._set_float64(i, grad if x_val > 0.0 else 0.0)
-        return result^
 
     # Create a 3x2 tensor with mixed positive/negative values
     var shape_2d = [3, 2]
@@ -103,7 +130,7 @@ def test_gradient_check_transposed_relu() raises:
     )
 
     # ReLU gradient should be exact on transposed input
-    var passed = check_gradients(relu_forward, relu_backward,
+    var passed = check_gradients(_ReluFwd(), _ReluBwd(),
         x_transposed, epsilon=3e-4, tolerance=1e-3
     )
     assert_true(passed, "ReLU gradient check should pass on transposed tensor")
@@ -117,21 +144,6 @@ def test_gradient_check_partial_transpose() raises:
     validating that gradient checking handles complex stride patterns.
     """
     print("Testing gradient checking with partial axis permutation...")
-
-    def simple_square(x: AnyTensor) raises -> AnyTensor:
-        var result = zeros(x.shape(), x.dtype())
-        for i in range(x.numel()):
-            var val = x._get_float64(i)
-            result._set_float64(i, val * val)
-        return result^
-
-    def simple_square_backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        var result = zeros(x.shape(), x.dtype())
-        for i in range(x.numel()):
-            var grad = grad_out._get_float64(i)
-            var x_val = x._get_float64(i)
-            result._set_float64(i, grad * 2.0 * x_val)
-        return result^
 
     # Create a 2x3x2 tensor
     var shape_3d = [2, 3, 2]
@@ -148,7 +160,7 @@ def test_gradient_check_partial_transpose() raises:
     )
 
     # Test gradient checking on the permuted tensor
-    var passed = check_gradients(simple_square, simple_square_backward,
+    var passed = check_gradients(_SimpleSquareFwd(), _SimpleSquareBwd(),
         x_permuted, epsilon=1e-4, tolerance=1e-2
     )
     assert_true(passed, "Gradient check should pass on permuted tensor")
@@ -163,21 +175,6 @@ def test_gradient_check_contiguous_copy() raises:
     """
     print("Testing gradient check after as_contiguous() conversion...")
 
-    def simple_square(x: AnyTensor) raises -> AnyTensor:
-        var result = zeros(x.shape(), x.dtype())
-        for i in range(x.numel()):
-            var val = x._get_float64(i)
-            result._set_float64(i, val * val)
-        return result^
-
-    def simple_square_backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        var result = zeros(x.shape(), x.dtype())
-        for i in range(x.numel()):
-            var grad = grad_out._get_float64(i)
-            var x_val = x._get_float64(i)
-            result._set_float64(i, grad * 2.0 * x_val)
-        return result^
-
     # Create transposed tensor (non-contiguous)
     var shape_2d = [2, 3]
     var x = full(shape_2d, 1.5, DType.float32)
@@ -191,7 +188,7 @@ def test_gradient_check_contiguous_copy() raises:
     )
 
     # Gradient check on contiguous version should pass
-    var passed = check_gradients(simple_square, simple_square_backward,
+    var passed = check_gradients(_SimpleSquareFwd(), _SimpleSquareBwd(),
         x_contiguous, epsilon=1e-4, tolerance=1e-2
     )
     assert_true(passed, "Gradient check should pass on contiguous tensor")
@@ -206,13 +203,6 @@ def test_numerical_gradient_noncont() raises:
     """
     print("Testing numerical gradient computation on non-contiguous tensor...")
 
-    def simple_square(x: AnyTensor) raises -> AnyTensor:
-        var result = zeros(x.shape(), x.dtype())
-        for i in range(x.numel()):
-            var val = x._get_float64(i)
-            result._set_float64(i, val * val)
-        return result^
-
     # Create a small transposed tensor
     var shape_2d = [2, 3]
     var x = full(shape_2d, 2.0, DType.float32)
@@ -221,7 +211,7 @@ def test_numerical_gradient_noncont() raises:
     assert_false(x_transposed.is_contiguous(), "Tensor should be non-contiguous")
 
     # Compute numerical gradient
-    var num_grad = compute_numerical_gradient(simple_square, x_transposed, epsilon=1e-4)
+    var num_grad = compute_numerical_gradient(_SimpleSquareFwd(), x_transposed, epsilon=1e-4)
 
     # For f(x) = x*x, numerical gradient at x=2.0 should be ~4.0
     # Check a few elements
@@ -247,21 +237,6 @@ def test_gradient_check_verbose_noncont() raises:
     """
     print("Testing verbose gradient checking with non-contiguous tensor...")
 
-    def simple_square(x: AnyTensor) raises -> AnyTensor:
-        var result = zeros(x.shape(), x.dtype())
-        for i in range(x.numel()):
-            var val = x._get_float64(i)
-            result._set_float64(i, val * val)
-        return result^
-
-    def simple_square_backward(grad_out: AnyTensor, x: AnyTensor) raises -> AnyTensor:
-        var result = zeros(x.shape(), x.dtype())
-        for i in range(x.numel()):
-            var grad = grad_out._get_float64(i)
-            var x_val = x._get_float64(i)
-            result._set_float64(i, grad * 2.0 * x_val)
-        return result^
-
     # Create small tensor
     var shape_2d = [2, 2]
     var x = full(shape_2d, 1.0, DType.float32)
@@ -271,8 +246,8 @@ def test_gradient_check_verbose_noncont() raises:
 
     # Run verbose gradient check
     var passed = check_gradients_verbose(
-        simple_square,
-        simple_square_backward,
+        _SimpleSquareFwd(),
+        _SimpleSquareBwd(),
         x_transposed,
         epsilon=1e-4,
         tolerance=1e-2,

--- a/tests/shared/training/test_mixed_precision_simd.mojo
+++ b/tests/shared/training/test_mixed_precision_simd.mojo
@@ -222,7 +222,7 @@ def test_roundtrip_fp16_fp32_fp16() raises:
     var fp16_ptr = fp16_original._data.bitcast[Float16]()
 
     for i in range(64):
-        fp16_ptr[i] = Float16(Float32((i % 10) / 10.0))
+        fp16_ptr[i] = Float16(Float32(Float64(i % 10) / 10.0))
 
     # Convert to FP32
     var fp32_intermediate = convert_to_fp32_master(fp16_original)

--- a/tests/shared/training/test_training_loop.mojo
+++ b/tests/shared/training/test_training_loop.mojo
@@ -681,20 +681,28 @@ def test_run_epoch_with_batches() raises:
     # Create callbacks (verbose=False to suppress output in tests)
     var callbacks = TrainingCallbacks(verbose=False)
 
-    # Define step function that computes loss from batch
-    # For each batch: loss = sum(batch_data) - batch_labels
-    # With ones input and zeros labels, each batch should have positive loss
-    def step_fn(batch_data: AnyTensor, batch_labels: AnyTensor) raises unified {read} -> AnyTensor:
-        # Simple loss: sum squared differences
-        # Since batch_data=ones and batch_labels=zeros, loss will be > 0
-        var diff = subtract(batch_data, batch_labels)
-        var squared = multiply(diff, diff)
-        var loss_scalar = ones([1], DType.float32)
-        # Return scalar loss (simplified for testing)
-        return loss_scalar
+    # Define step function that computes loss from batch.
+    # Inner def closures are nonescaping in Mojo 0.26.3+, so we use a
+    # @fieldwise_init struct implementing StepFn instead of a bare closure.
+    from shared.training.script_runner import StepFn
+
+    @fieldwise_init
+    struct SimpleStepFn(StepFn):
+        """Step function: returns ones([1]) as a simplified scalar loss."""
+
+        def __call__(
+            self, batch_data: AnyTensor, batch_labels: AnyTensor
+        ) raises -> AnyTensor:
+            # Simple loss: sum squared differences
+            # Since batch_data=ones and batch_labels=zeros, loss will be > 0
+            var diff = subtract(batch_data, batch_labels)
+            var squared = multiply(diff, diff)
+            var loss_scalar = ones([1], DType.float32)
+            # Return scalar loss (simplified for testing)
+            return loss_scalar
 
     # Run epoch with batches
-    var avg_loss = run_epoch_with_batches(loader, callbacks, step_fn)
+    var avg_loss = run_epoch_with_batches(loader, callbacks, SimpleStepFn())
 
     # Verify avg_loss > 0.0 (each step_fn returns ones, avg should be ~1.0)
     assert_greater(Float64(avg_loss), Float64(0.0))

--- a/tests/shared/utils/test_serialization.mojo
+++ b/tests/shared/utils/test_serialization.mojo
@@ -22,20 +22,20 @@ from std.testing import assert_true, assert_equal
 
 def create_test_dir(base: String) raises -> String:
     """Create a unique test directory."""
-    from python import Python
+    from std.python import Python
 
     var uuid = Python.import_module("uuid")
     var test_id_str = String(uuid.uuid4())
-    var test_id = test_id_str[0:8]
+    var test_id = String(test_id_str[byte=0:8])
     var test_dir = base + "/test_checkpoint_" + test_id
     return test_dir
 
 
 def cleanup_test_dir(dir_path: String) -> Bool:
     """Clean up test directory after testing."""
-    try:
-        from python import Python
+    from std.python import Python
 
+    try:
         var shutil = Python.import_module("shutil")
         shutil.rmtree(dir_path)
         return True


### PR DESCRIPTION
## Summary

Consolidated all remaining Mojo 0.26.3 CI fixes into a single PR (follows PR #5208 which fixed syntax deprecations and added gradient checker trait infrastructure).

Root-causes fixed, not workarounds:

## Root Cause Fixes

### 1. Missing `write_to` + `write_repr_to` on Writable structs
`AnyTensor`, `Tensor[dtype]`, and `PrecisionMode` declared the `Writable` trait but never implemented `write_to[W: Writer]` (for `str()`) or `write_repr_to[W: Writer]` (for `repr()`). This caused runtime exceptions in `test_utility.mojo`, all `test_extensor_*.mojo`, and `test_precision_config.mojo`.
- `shared/tensor/any_tensor.mojo` — add `write_to` + `write_repr_to`
- `shared/tensor/tensor.mojo` — add `write_to` + `write_repr_to`
- `shared/training/precision_config.mojo` — add `write_to` + `write_repr_to` to `PrecisionMode`

### 2. Capturing closures as bare function types (nonescaping in Mojo 0.26.3)
~35 test files used inner `def` closures as arguments to `check_gradient`/`check_gradients`/`compute_numerical_gradient`. In 0.26.3, ALL inner `def` closures are nonescaping and cannot be passed as bare function pointer types. Migrated all to `@fieldwise_init` structs implementing `NumericalForward`/`NumericalBackward` traits (infrastructure added in PR #5208).

Also added `StepFn` trait to `shared/training/script_runner.mojo` for `run_epoch_with_batches` callers.

### 3. `__moveinit__` lifecycle method with `def` syntax
`test_base_loader.mojo` had an explicit `def __moveinit__(out self, deinit existing: Self)` on `StubBatch`. In Mojo 0.26.3, using `def` for lifecycle methods causes `self` to be typed as `None` rather than `Self`. Fix: remove unnecessary `__moveinit__` (compiler synthesizes correct move semantics automatically).

### 4. Pre-existing stdlib import + scope issues
Several files had implicit stdlib imports (need `std.` prefix) and imports inside `try:` blocks (must be at function scope).

### 5. Implicit numeric conversions
`Float32 → Float64` and `Int → Float64` conversions that were deprecated.

## Files Changed

**Shared library:**
- `shared/tensor/any_tensor.mojo` — write_to + write_repr_to
- `shared/tensor/tensor.mojo` — write_to + write_repr_to
- `shared/training/precision_config.mojo` — write_to + write_repr_to for PrecisionMode
- `shared/training/script_runner.mojo` — StepFn trait + parametric run_epoch_with_batches overload
- `shared/training/__init__.mojo` — export StepFn

**Test closure migrations (~35 files):**
- `tests/shared/core/test_activations.mojo` — 10 closure pairs
- `tests/shared/core/test_losses.mojo` — 6 closure pairs
- `tests/shared/core/test_arithmetic_backward.mojo` — 11+3 broadcast closure pairs
- `tests/shared/core/test_backward_linear.mojo` — 1 closure pair
- `tests/shared/core/test_backward_conv_padding.mojo` — 4 closure pairs
- `tests/shared/core/test_backward_conv_pool.mojo` — 5 closure pairs
- `tests/shared/core/test_backward_losses.mojo` — 3 closure pairs
- `tests/shared/core/test_dropout.mojo` — 2 closure pairs + Float32→Float64
- `tests/shared/core/test_reduction.mojo` — 6 closure pairs + std alias fix
- `tests/shared/core/test_elementwise.mojo` — 9 closure pairs
- `tests/shared/core/test_matrix.mojo` — 3 closure pairs
- `tests/shared/core/test_conv.mojo` — 2 forward structs
- `tests/shared/core/test_depthwise_conv_grad_check.mojo` — 2 closure pairs
- `tests/shared/core/test_normalization.mojo` — 4 forward structs
- `tests/shared/core/test_gradient_checking_basic.mojo` — 5 closure pairs
- `tests/shared/core/test_gradient_checking_dtype.mojo` — 6 closure pairs
- `tests/shared/core/test_gradient_checking_batch_norm.mojo` — 4 closure pairs
- `tests/shared/core/test_gradient_checking_conv2d.mojo` — 6 closure pairs
- `tests/shared/core/test_gradient_checking_depthwise_conv2d.mojo` — 6 closure pairs
- `tests/shared/core/test_gradient_validation.mojo` — 12 closure pairs
- `tests/shared/core/test_gradient_validation_activations.mojo` — 2 closure pairs
- `tests/shared/core/test_gradient_validation_layers.mojo` — 4 closure pairs
- `tests/shared/testing/test_gradient_checker_noncont_tensors.mojo` — 4 closure pairs
- `tests/shared/testing/test_gradient_checker_meta.mojo` — 4 reusable structs for 15 tests
- `tests/shared/training/test_training_loop.mojo` — StepFn struct migration
- `tests/shared/training/test_mixed_precision_simd.mojo` — Int→Float64 casts

**Pre-existing fixes:**
- `tests/shared/test_model_utils.mojo` — implicit stdlib import
- `tests/shared/test_serialization.mojo` — implicit stdlib import
- `tests/shared/utils/test_serialization.mojo` — stdlib import + scope + string slicing
- `tests/shared/fixtures/test_io_helpers.mojo` — implicit stdlib import
- `tests/shared/data/loaders/test_base_loader.mojo` — remove broken __moveinit__

## Test plan

- [ ] CI: Comprehensive Tests workflow passes (covers all migrated test files)
- [ ] CI: Pre-commit Checks workflow passes
- [ ] CI: ASAN Tests workflow passes

Note: ~20 tests still show JIT crashes (`test_activation_funcs`, `test_cache`, `test_prefetch`, etc.) — these are pre-existing Mojo compiler infrastructure issues unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)