### PR TITLE
fix(docker): allow container to run as non-image UID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,8 @@ ARG USER_NAME=dev
 RUN groupadd -g ${GROUP_ID} ${USER_NAME} 2>/dev/null || \
     groupmod -n ${USER_NAME} $(getent group ${GROUP_ID} | cut -d: -f1) && \
     useradd -m -u ${USER_ID} -g ${GROUP_ID} -s /bin/bash ${USER_NAME} 2>/dev/null || \
-    usermod -l ${USER_NAME} -d /home/${USER_NAME} -m $(id -nu ${USER_ID} 2>/dev/null || echo nobody)
+    usermod -l ${USER_NAME} -d /home/${USER_NAME} -m $(id -nu ${USER_ID} 2>/dev/null || echo nobody) && \
+    chmod 755 /home/${USER_NAME}
 
 # Set environment for dev user
 ENV HOME=/home/${USER_NAME}
@@ -69,8 +70,7 @@ WORKDIR /workspace
 # Ensure Pixi home and cache directories exist
 ENV PIXI_HOME=/home/${USER_NAME}/.pixi
 ENV PIXI_CACHE_DIR=/home/${USER_NAME}/.cache/pixi
-RUN mkdir -p $PIXI_HOME $PIXI_CACHE_DIR $HOME/.cache/rattler && \
-    chmod -R 700 $PIXI_HOME $PIXI_CACHE_DIR $HOME/.cache/rattler
+RUN mkdir -p $PIXI_HOME $PIXI_CACHE_DIR $HOME/.cache/rattler
 
 # Install Pixi as dev user (pinned version for reproducible builds)
 ENV PIXI_VERSION=0.65.0

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,27 @@
 #!/usr/bin/env bash
 set -e
 
+# ---------------------------------------------------------------------------
+# Ensure $HOME/.modular exists and is writable by the current user.
+#
+# Mojo's runtime (libAsyncRTMojoBindings.so) calls std::filesystem::status()
+# on $HOME/.modular during startup via getAcceleratorArchOrEmpty(). If the
+# path is inaccessible (e.g., HOME is owned by a different UID), the uncaught
+# filesystem_error aborts the process before any user code runs.
+#
+# This is a Mojo upstream bug (filed: modular/modular). Workaround: ensure
+# $HOME/.modular exists and is owned by the current UID before invoking mojo.
+# ---------------------------------------------------------------------------
+if [ ! -d "${HOME}/.modular" ]; then
+    mkdir -p "${HOME}/.modular" 2>/dev/null || {
+        # HOME is not writable by this UID (e.g., CI UID mismatch).
+        # Redirect HOME to a writable location for the duration of this session.
+        export HOME="/tmp/mojo-home-$(id -u)"
+        mkdir -p "${HOME}/.modular"
+        export PIXI_HOME="${HOME}/.pixi"
+    }
+fi
+
 # Ensure the workspace .pixi environment is functional.
 # The named volume at /workspace/.pixi shadows the bind-mounted host .pixi/,
 # but starts empty on first run. Run pixi install to populate it if needed.


### PR DESCRIPTION
## Summary

Fixes the deterministic CI crash where `mojo run` aborts with `filesystem error: status: Permission denied [/home/dev/.modular]` when the container runs as a UID different from the image build UID.

- `Dockerfile`: `chmod 755 /home/$USER_NAME` — home dir was `750` (drwxr-x---), blocking UID 1001 from traversing it entirely
- `Dockerfile`: Remove `chmod -R 700` on `$PIXI_HOME` and `$PIXI_CACHE_DIR` — made pixi environment inaccessible to non-owner UIDs
- `entrypoint.sh`: Pre-create `$HOME/.modular`; fall back to `HOME=/tmp/mojo-home-$UID` if HOME is not writable (workaround for upstream Mojo bug filed against modular/modular)

## Root Cause

`libAsyncRTMojoBindings.so` calls `std::filesystem::status("$HOME/.modular")` at startup in `getAcceleratorArchOrEmpty()`. The C++ code does not catch the `filesystem_error` thrown when the path is inaccessible — it propagates to `std::terminate` and calls `abort()`. Crash is 100% deterministic when HOME is owned by a different UID.

Reproduced locally with `USER_ID=1001 GROUP_ID=1001 podman compose up -d` + cold volumes.

## Test plan

- [ ] Rebuild image with `podman build --target development -t projectodyssey:dev .`
- [ ] `USER_ID=1001 GROUP_ID=1001 podman compose up -d`
- [ ] `USER_ID=1001 GROUP_ID=1001 podman compose exec -T projectodyssey-dev bash -c "cd /workspace && just test-group tests/configs 'test_*.mojo'"` — should pass, no crash
- [ ] CI passes (container build + comprehensive tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)