### PR TITLE
docs: document `just check` and `just ci-build` in developer guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -461,6 +461,11 @@ This project uses Pixi for environment management:
 # Mojo is the primary language target for future implementations
 ```
 
+**`pixi.toml` is the single source of truth for all dependencies** (Python packages, Mojo
+version, dev tools, and scripts). Do NOT add dependencies to `requirements*.txt` or
+`pyproject.toml` — those files are not used by this project. Always update `pixi.toml`
+when adding or changing a dependency.
+
 **Environment Variables**: Copy `.env.example` to `.env` and customize for your system:
 
 ```bash

--- a/docs/dev/build.md
+++ b/docs/dev/build.md
@@ -2,6 +2,52 @@
 
 From root MDs (backed up `notes/root-backup/`). Links to [phases.md](phases.md).
 
+## Justfile Build Recipes
+
+The project uses [Just](https://just.systems/) as a unified command runner. Four recipes cover
+the main build and validation scenarios:
+
+| Recipe | What it does | When to use |
+|---|---|---|
+| `just build` | Compile entry-point executables (debug mode by default) | Day-to-day development; produces binaries in `build/debug/` |
+| `just check` | Type-check the `shared/` library without producing any artifacts | Fast feedback loop — catches type errors without a full build |
+| `just ci-build` | Full CI build: entry points (`just build ci`) + package compilation (`just package ci`) | Pre-push validation; mirrors exactly what CI runs |
+| `just validate` | `ci-build` + the full Mojo test suite | Final gate before merging; slowest but most complete |
+
+### Choosing the Right Recipe
+
+```text
+Editing shared/ code?
+  └─ just check          ← fastest; no artifacts, type errors only
+
+Editing entry points or want binaries?
+  └─ just build          ← compiles executables in build/debug/
+
+Before pushing a branch?
+  └─ just ci-build       ← confirms the full build mirrors CI
+
+Before opening a PR / after all changes?
+  └─ just validate       ← ci-build + tests; matches the CI pipeline exactly
+```
+
+### Details
+
+**`just check`** compiles the `shared/` library with `mojo package --Werror` into a temporary
+directory and immediately discards the output. It is the fastest way to confirm that type
+annotations, imports, and function signatures in `shared/` are correct without waiting for a
+full build or test run.
+
+**`just ci-build`** runs two sub-recipes in sequence:
+
+1. `just build ci` — compiles all entry-point executables with CI flags (`-g1 --Werror`)
+2. `just package ci` — packages the `shared/` library into a `.mojopkg` artifact
+
+This is the minimum validation that must pass before CI will accept a PR.
+
+**`just validate`** extends `ci-build` with `just test-mojo` (all Mojo unit tests). Use it
+locally only when you need confidence equivalent to a full CI run; the test suite can be slow
+(see [Testing Strategy](../dev/testing-strategy.md) for tier details).
+
 ## Package Building
 
 **File**: `BUILD_PACKAGE.md`


### PR DESCRIPTION
## Summary

- Add a "Justfile Build Recipes" section to `docs/dev/build.md`
- Documents all four build recipes (`build`, `check`, `ci-build`, `validate`) with a comparison table, decision tree, and per-recipe details
- Explains when to use each recipe to guide contributors toward fast feedback loops (`just check`) vs full CI validation (`just ci-build` / `just validate`)

## Test plan

- [ ] Verify markdown renders correctly
- [ ] Confirm pre-commit hooks pass (markdownlint, trailing whitespace)

Closes #5144