### PR TITLE
fix(ci): add non-root USER directive to Dockerfile.ci runtime/ci/production stages

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -106,6 +106,9 @@ FROM runtime AS ci
 # Re-declare ARG (does not persist across FROM)
 ARG USER_NAME=dev
 
+# Explicitly run as non-root user (inherited from runtime, but stated for clarity)
+USER ${USER_NAME}
+
 # Copy additional test dependencies
 COPY --chown=${USER_NAME}:${USER_NAME} requirements-dev.txt ./
 COPY --chown=${USER_NAME}:${USER_NAME} .pre-commit-config.yaml ./
@@ -123,6 +126,12 @@ CMD ["pixi", "run", "pytest", "tests/", "-v", "--timeout=300"]
 # Stage 4: Production - Minimal production image
 # ==============================================================================
 FROM runtime AS production
+
+# Re-declare ARG (does not persist across FROM)
+ARG USER_NAME=dev
+
+# Explicitly run as non-root user (inherited from runtime, but stated for clarity)
+USER ${USER_NAME}
 
 ENV ENVIRONMENT=production
 


### PR DESCRIPTION
## Summary

- Add explicit `USER ${USER_NAME}` directive to the `ci` stage of `Dockerfile.ci`
- Add explicit `USER ${USER_NAME}` directive to the `production` stage of `Dockerfile.ci`
- The `runtime` stage already had a `USER` directive; `ci` and `production` now match

The `ci` and `production` stages extend `runtime` and inherit its non-root user, but
lacked an explicit `USER` directive. Adding these makes the security intent clear and
guards against regressions if a future root-requiring step is added in between.

## Files Modified

- `Dockerfile.ci` — added `USER ${USER_NAME}` to stages 3 (ci) and 4 (production)

## Verification

- Pre-commit hooks passed (trailing-whitespace, end-of-file-fixer, check-large-files, mixed-line-ending, cargo-free-docker)

Closes #5187