### PR TITLE
feat: validate pypi-dependencies in check_dep_sync.py and add coverage check to CI

### DIFF
--- a/.github/workflows/validate-configs.yml
+++ b/.github/workflows/validate-configs.yml
@@ -589,6 +589,29 @@ jobs:
           comment-marker: "Paper Validation Results"
 
   # ============================================================================
+  # Test Coverage Validation - Ensure all test_*.mojo files are in CI matrix
+  # ============================================================================
+  validate-test-coverage:
+    name: Validate Test Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Validate test coverage
+        run: python scripts/validate_test_coverage.py
+
+  # ============================================================================
   # Workflow Checkout Order (absorbed from validate-workflows.yml)
   # ============================================================================
   validate-checkout-order:

--- a/scripts/check_dep_sync.py
+++ b/scripts/check_dep_sync.py
@@ -67,12 +67,12 @@ def version_satisfies(version: Tuple[int, ...], constraints: List[VersionRange])
 
 
 def parse_pixi_toml(path: Path) -> Dict[str, str]:
-    """Extract package name → version spec from pixi.toml [dependencies]."""
+    """Extract package name → version spec from pixi.toml [dependencies] and [pypi-dependencies]."""
     deps: Dict[str, str] = {}
     in_deps = False
     for line in path.read_text().splitlines():
         stripped = line.strip()
-        if stripped.startswith("[dependencies]"):
+        if stripped.startswith("[dependencies]") or stripped.startswith("[pypi-dependencies]"):
             in_deps = True
             continue
         if stripped.startswith("[") and in_deps:


### PR DESCRIPTION
## Summary

- Extends `parse_pixi_toml()` in `scripts/check_dep_sync.py` to also parse the `[pypi-dependencies]` section so packages like `homericintelligence-hephaestus` are included in requirements sync checks
- Adds `validate_test_coverage.py` as a lightweight CI job (`validate-test-coverage`) in `.github/workflows/validate-configs.yml` so test-file coverage is checked on every PR that touches scripts or workflow files

## Changes Made

### `scripts/check_dep_sync.py` (#5138)

- Extended `parse_pixi_toml()` docstring and condition to detect both `[dependencies]` and `[pypi-dependencies]` section headers
- Packages in `[pypi-dependencies]` are now included when checking requirements files for sync mismatches

### `.github/workflows/validate-configs.yml` (#5129)

- Added a new `validate-test-coverage` job that runs `python scripts/validate_test_coverage.py`
- Uses the same Python 3.11 + pyyaml setup as the existing `comprehensive-tests.yml` job
- Runs on every PR touching scripts, workflows, or configs (inheriting the workflow's path filters)

## Verification

- Pre-commit hooks passed on both changed files
- YAML syntax validated by check-yaml hook
- Python ruff format and lint passed on `check_dep_sync.py`
- mypy passed

Closes #5138
Closes #5129