### PR TITLE
test: add float64 gradient clipping and float16 SIMD edge case tests

### DIFF
--- a/tests/shared/core/test_numerical_safety_simd.mojo
+++ b/tests/shared/core/test_numerical_safety_simd.mojo
@@ -62,7 +62,8 @@ def test_has_nan_first_element() raises:
 
 
 def test_has_nan_tail_element() raises:
-    """Detect NaN in scalar tail (last element, size not divisible by SIMD width)."""
+    """Detect NaN in scalar tail (last element, size not divisible by SIMD width).
+    """
     print("Testing has_nan with NaN in scalar tail...")
     # Size 19: with SIMD width 8, tail is elements 16..18
     var tensor = full(_shape1(19), 1.0, DType.float32)
@@ -172,6 +173,90 @@ def test_count_nan_large_tensor() raises:
     print("  PASS")
 
 
+# ============================================================================
+# Float16 SIMD edge-case tests (Issue #5136)
+# Float16 SIMD width is typically 16 (AVX-512) or 8 (AVX2).
+# Its narrow range (max ~65504) means overflow/NaN/Inf can arise at
+# boundaries different from float32/float64.
+# ============================================================================
+
+
+def test_has_nan_float16_small_tensor() raises:
+    """Detect NaN in float16 tensor smaller than SIMD width (pure scalar tail path).
+
+    Float16 SIMD width is 8-16. Size 3 is fully below SIMD width.
+    """
+    print("Testing has_nan with float16 small tensor (size 3)...")
+    var tensor = full(_shape1(3), 1.0, DType.float16)
+    var ptr = tensor._data.bitcast[Float16]()
+    ptr[1] = nan[DType.float16]()
+    if not has_nan(tensor):
+        raise Error("has_nan should detect NaN in float16 small tensor")
+
+    # Clean small tensor should return False
+    var clean = full(_shape1(3), 0.5, DType.float16)
+    if has_nan(clean):
+        raise Error(
+            "has_nan should return False for clean float16 small tensor"
+        )
+    print("  PASS")
+
+
+def test_has_nan_float16_tail_region() raises:
+    """Detect NaN in scalar tail of float16 tensor beyond SIMD boundary.
+
+    Size 19 ensures a tail region after SIMD-width chunks (SIMD width 8 or 16).
+    NaN placed at index 18 (tail) exercises the scalar fallback path.
+    """
+    print("Testing has_nan with float16 NaN in tail region (size 19)...")
+    var tensor = full(_shape1(19), 1.0, DType.float16)
+    var ptr = tensor._data.bitcast[Float16]()
+    ptr[18] = nan[DType.float16]()
+    if not has_nan(tensor):
+        raise Error("has_nan should detect NaN in float16 tail region")
+    print("  PASS")
+
+
+def test_has_inf_float16_near_overflow() raises:
+    """Detect Inf in float16 tensor; verify values near float16 max (~65504) are finite.
+
+    Float16 max is ~65504. Values just below must not be treated as Inf.
+    Values assigned as Inf must be detected.
+    """
+    print("Testing has_inf with float16 near-overflow values...")
+
+    # 65000.0 is below float16 max (~65504) -- should be finite
+    var finite_tensor = full(_shape1(8), 65000.0, DType.float16)
+    if has_inf(finite_tensor):
+        raise Error(
+            "has_inf should return False for float16 values near but below max"
+        )
+
+    # Tensor with explicit +Inf
+    var inf_tensor = full(_shape1(8), 1.0, DType.float16)
+    var ptr = inf_tensor._data.bitcast[Float16]()
+    ptr[4] = inf[DType.float16]()
+    if not has_inf(inf_tensor):
+        raise Error("has_inf should detect +Inf in float16 tensor")
+    print("  PASS")
+
+
+def test_count_nan_float16_mixed() raises:
+    """Count NaNs scattered across float16 SIMD chunks and scalar tail."""
+    print("Testing count_nan with float16 scattered NaNs (size 20)...")
+    var tensor = full(_shape1(20), 1.0, DType.float16)
+    var ptr = tensor._data.bitcast[Float16]()
+    # Place NaNs across SIMD chunks and tail region
+    ptr[0] = nan[DType.float16]()
+    ptr[7] = nan[DType.float16]()
+    ptr[16] = nan[DType.float16]()
+    ptr[19] = nan[DType.float16]()
+    var count = count_nan(tensor)
+    if count != 4:
+        raise Error("count_nan float16 expected 4, got " + String(count))
+    print("  PASS")
+
+
 def main() raises:
     test_has_nan_all_normal()
     test_has_nan_first_element()
@@ -182,4 +267,8 @@ def main() raises:
     test_count_inf_mixed()
     test_has_nan_float64()
     test_count_nan_large_tensor()
+    test_has_nan_float16_small_tensor()
+    test_has_nan_float16_tail_region()
+    test_has_inf_float16_near_overflow()
+    test_count_nan_float16_mixed()
     print("All numerical safety SIMD tests passed!")

--- a/tests/shared/training/test_gradient_clipping.mojo
+++ b/tests/shared/training/test_gradient_clipping.mojo
@@ -435,63 +435,228 @@ def test_clip_per_param_non_aligned() raises:
         )
 
 
+# ============================================================================
+# Float64 SIMD coverage tests (Issue #5143)
+# Exercises _norm_sq_simd_f64, _scale_simd_f64, _clamp_simd_f64 code paths.
+# ============================================================================
+
+
+def create_test_gradients_f64() raises -> List[AnyTensor]:
+    """Create float64 test gradients with known norms."""
+    var grads = List[AnyTensor]()
+
+    # Gradient 1: all ones (norm_sq = 100)
+    grads.append(ones([100], DType.float64))
+
+    # Gradient 2: all twos (norm_sq = 50 * 4 = 200)
+    grads.append(full([50], 2.0, DType.float64))
+
+    return grads^
+
+
+def test_compute_gradient_norm_f64() raises:
+    """Test global gradient norm computation with float64 tensors.
+
+    Exercises _norm_sq_simd_f64 code path.
+    """
+    var grads = create_test_gradients_f64()
+
+    # Total norm = sqrt(100 + 200) = sqrt(300) ~ 17.32
+    var norm = compute_gradient_norm_list(grads)
+    var expected = Float32(sqrt(Float64(300.0)))
+
+    assert_close_float(
+        Float64(norm),
+        Float64(expected),
+        atol=1e-10,
+        message="Float64 gradient norm should match expected",
+    )
+
+
+def test_clip_by_global_norm_f64_with_clipping() raises:
+    """Test global norm clipping with float64 tensors when norm exceeds threshold.
+
+    Exercises _norm_sq_simd_f64 and _scale_simd_f64 code paths.
+    """
+    var grads = create_test_gradients_f64()
+
+    var orig_norm = compute_gradient_norm_list(grads)
+    # Norm ~17.32, clip to 10.0
+    var clipped_norm = clip_gradients_by_global_norm(grads, max_norm=10.0)
+
+    # Returns original norm
+    assert_close_float(
+        Float64(clipped_norm),
+        Float64(orig_norm),
+        atol=1e-10,
+        message="Float64 clip should return original norm",
+    )
+
+    # After clipping, norm should be ~10.0
+    var new_norm = compute_gradient_norm_list(grads)
+    assert_close_float(
+        Float64(new_norm),
+        10.0,
+        atol=1e-8,
+        message="Float64 clipped norm should be 10.0",
+    )
+
+    # Verify scale factor applied correctly (higher precision than f32)
+    var clip_coef = 10.0 / Float64(orig_norm)
+    for i in range(10):
+        var expected = 1.0 * clip_coef
+        assert_close_float(
+            grads[0]._get_float64(i),
+            expected,
+            atol=1e-10,
+            message="Float64 grad1 element should be scaled",
+        )
+
+
+def test_clip_by_value_f64() raises:
+    """Test value clamping with float64 tensors.
+
+    Exercises _clamp_simd_f64 code path.
+    """
+    var grads = List[AnyTensor]()
+
+    # Values at 5.0, clip to [-1.0, 1.0]
+    grads.append(full([100], 5.0, DType.float64))
+    clip_gradients_by_value_list(grads, min_value=-1.0, max_value=1.0)
+
+    for i in range(grads[0].numel()):
+        assert_close_float(
+            grads[0]._get_float64(i),
+            1.0,
+            atol=1e-15,
+            message="Float64 values should be clamped to 1.0",
+        )
+
+    # Negative side: values at -5.0, clip to [-2.0, 2.0]
+    var grads2 = List[AnyTensor]()
+    grads2.append(full([50], -5.0, DType.float64))
+    clip_gradients_by_value_list(grads2, min_value=-2.0, max_value=2.0)
+
+    for i in range(grads2[0].numel()):
+        assert_close_float(
+            grads2[0]._get_float64(i),
+            -2.0,
+            atol=1e-15,
+            message="Float64 negative values should be clamped to -2.0",
+        )
+
+
+def test_clip_per_param_f64() raises:
+    """Test per-parameter clipping with float64 tensors.
+
+    Exercises _norm_sq_simd_f64 and _scale_simd_f64 code paths.
+    """
+    var grads = List[AnyTensor]()
+
+    # 100 elements, all 10.0 -> norm = sqrt(100*100) = 100
+    grads.append(full([100], 10.0, DType.float64))
+
+    # 50 elements, all 0.1 -> norm = sqrt(50*0.01) = sqrt(0.5) ~ 0.707
+    grads.append(full([50], 0.1, DType.float64))
+
+    clip_gradients_per_param(grads, max_norm=5.0)
+
+    # Grad1 clipped: norm 100 -> 5.0
+    var grad1_norm_sq = Float64(0.0)
+    for i in range(grads[0].numel()):
+        var val = grads[0]._get_float64(i)
+        grad1_norm_sq += val * val
+    var grad1_norm = sqrt(grad1_norm_sq)
+    assert_close_float(
+        grad1_norm,
+        5.0,
+        atol=1e-8,
+        message="Float64 grad1 norm should be 5.0 after per-param clipping",
+    )
+
+    # Grad2 unchanged: norm ~0.707 < 5.0
+    for i in range(10):
+        assert_close_float(
+            grads[1]._get_float64(i),
+            0.1,
+            atol=1e-15,
+            message="Float64 grad2 should be unchanged",
+        )
+
+
 def main() raises:
     """Run all gradient clipping tests."""
     print("Testing Gradient Clipping...")
     print("=" * 70)
 
-    print("\n[1/13] Testing gradient norm computation...")
+    print("\n[1/17] Testing gradient norm computation...")
     test_compute_gradient_norm()
     print("✓ PASSED")
 
-    print("[2/13] Testing global norm clipping (no clipping)...")
+    print("[2/17] Testing global norm clipping (no clipping)...")
     test_clip_by_global_norm_no_clipping()
     print("✓ PASSED")
 
-    print("[3/13] Testing global norm clipping (with clipping)...")
+    print("[3/17] Testing global norm clipping (with clipping)...")
     test_clip_by_global_norm_with_clipping()
     print("✓ PASSED")
 
-    print("[4/13] Testing per-parameter clipping...")
+    print("[4/17] Testing per-parameter clipping...")
     test_clip_per_param()
     print("✓ PASSED")
 
-    print("[5/13] Testing value clipping (positive)...")
+    print("[5/17] Testing value clipping (positive)...")
     test_clip_by_value()
     print("✓ PASSED")
 
-    print("[6/13] Testing value clipping (negative)...")
+    print("[6/17] Testing value clipping (negative)...")
     test_clip_by_value_negative()
     print("✓ PASSED")
 
-    print("[7/13] Testing gradient statistics...")
+    print("[7/17] Testing gradient statistics...")
     test_gradient_statistics()
     print("✓ PASSED")
 
-    print("[8/13] Testing gradient statistics (empty)...")
+    print("[8/17] Testing gradient statistics (empty)...")
     test_gradient_statistics_empty()
     print("✓ PASSED")
 
-    print("[9/13] Testing clipping with zero gradients...")
+    print("[9/17] Testing clipping with zero gradients...")
     test_clip_zero_gradients()
     print("✓ PASSED")
 
-    print("[10/13] Testing SIMD norm with non-aligned sizes...")
+    print("[10/17] Testing SIMD norm with non-aligned sizes...")
     test_norm_simd_non_aligned_sizes()
     print("✓ PASSED")
 
-    print("[11/13] Testing SIMD clipping with large tensor...")
+    print("[11/17] Testing SIMD clipping with large tensor...")
     test_clip_large_tensor()
     print("✓ PASSED")
 
-    print("[12/13] Testing SIMD value clipping with mixed signs...")
+    print("[12/17] Testing SIMD value clipping with mixed signs...")
     test_value_clip_mixed_signs()
     print("✓ PASSED")
 
-    print("[13/13] Testing SIMD per-param clipping non-aligned...")
+    print("[13/17] Testing SIMD per-param clipping non-aligned...")
     test_clip_per_param_non_aligned()
     print("✓ PASSED")
 
+    print("[14/17] Testing float64 gradient norm computation...")
+    test_compute_gradient_norm_f64()
+    print("✓ PASSED")
+
+    print("[15/17] Testing float64 global norm clipping (with clipping)...")
+    test_clip_by_global_norm_f64_with_clipping()
+    print("✓ PASSED")
+
+    print("[16/17] Testing float64 value clipping...")
+    test_clip_by_value_f64()
+    print("✓ PASSED")
+
+    print("[17/17] Testing float64 per-param clipping...")
+    test_clip_per_param_f64()
+    print("✓ PASSED")
+
     print("\n" + "=" * 70)
-    print("All 13 gradient clipping tests PASSED! ✓")
+    print("All 17 gradient clipping tests PASSED! ✓")
     print("Gradient clipping utilities are working correctly.")


### PR DESCRIPTION
## Summary

- Add 4 float64 tests to `test_gradient_clipping.mojo` exercising the previously untested `_norm_sq_simd_f64`, `_scale_simd_f64`, and `_clamp_simd_f64` SIMD code paths
- Add 4 float16 tests to `test_numerical_safety_simd.mojo` covering small tensors below SIMD width, NaN in scalar tail, near-overflow threshold values (~65504), and scattered NaN counting

## Test plan

- [ ] `test_compute_gradient_norm_f64`: verifies `_norm_sq_simd_f64` returns correct L2 norm
- [ ] `test_clip_by_global_norm_f64_with_clipping`: verifies `_scale_simd_f64` scales correctly with higher precision than f32
- [ ] `test_clip_by_value_f64`: verifies `_clamp_simd_f64` clamps both positive and negative values
- [ ] `test_clip_per_param_f64`: verifies per-parameter norm and scaling through f64 paths
- [ ] `test_has_nan_float16_small_tensor`: size 3 (below SIMD width) uses pure scalar path
- [ ] `test_has_nan_float16_tail_region`: size 19 has tail beyond SIMD chunks
- [ ] `test_has_inf_float16_near_overflow`: values at 65000.0 are finite; explicit Inf is detected
- [ ] `test_count_nan_float16_mixed`: NaNs at indices 0, 7, 16, 19 span SIMD chunks and tail

Closes #5143
Closes #5136

🤖 Generated with [Claude Code](https://claude.com/claude-code)