### PR TITLE
feat(dispatch): add DTYPE_BOOL to dtype_ordinal and float16 to normalization

### DIFF
--- a/shared/base/dtype_ordinal.mojo
+++ b/shared/base/dtype_ordinal.mojo
@@ -24,6 +24,7 @@ Supported DTypes:
 - UInt16 - ordinal 8
 - UInt32 - ordinal 9
 - UInt64 - ordinal 10
+- Bool - ordinal 11
 
 Usage:
     from .dtype_ordinal import dtype_to_ordinal, DTYPE_FLOAT32
@@ -46,9 +47,10 @@ comptime DTYPE_UINT8: Int = 7
 comptime DTYPE_UINT16: Int = 8
 comptime DTYPE_UINT32: Int = 9
 comptime DTYPE_UINT64: Int = 10
+comptime DTYPE_BOOL: Int = 11
 comptime DTYPE_UNSUPPORTED: Int = -1
 
-comptime SUPPORTED_DTYPE_COUNT: Int = 11
+comptime SUPPORTED_DTYPE_COUNT: Int = 12
 
 
 def dtype_to_ordinal(dtype: DType) -> Int:
@@ -97,6 +99,8 @@ def dtype_to_ordinal(dtype: DType) -> Int:
         return DTYPE_UINT32
     elif dtype == DType.uint64:
         return DTYPE_UINT64
+    elif dtype == DType.bool:
+        return DTYPE_BOOL
     else:
         return DTYPE_UNSUPPORTED
 
@@ -142,5 +146,7 @@ def format_dtype_name(dtype: DType) -> String:
         return "uint32"
     elif dtype == DType.uint64:
         return "uint64"
+    elif dtype == DType.bool:
+        return "bool"
     else:
         return "unknown"

--- a/shared/core/comparison.mojo
+++ b/shared/core/comparison.mojo
@@ -20,6 +20,7 @@ from shared.base.dtype_ordinal import (
     DTYPE_UINT16,
     DTYPE_UINT32,
     DTYPE_UINT64,
+    DTYPE_BOOL,
 )
 
 
@@ -46,10 +47,6 @@ def equal(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
     if a.dtype() != b.dtype():
         raise Error("Cannot compare tensors with different dtypes")
 
-    # Handle DType.bool separately (not in ordinal table)
-    if a.dtype() == DType.bool:
-        return _equal_dispatch[DType.bool](a, b)
-
     var ordinal = dtype_to_ordinal(a.dtype())
 
     if ordinal == DTYPE_FLOAT16:
@@ -74,6 +71,8 @@ def equal(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
         return _equal_dispatch[DType.uint32](a, b)
     elif ordinal == DTYPE_UINT64:
         return _equal_dispatch[DType.uint64](a, b)
+    elif ordinal == DTYPE_BOOL:
+        return _equal_dispatch[DType.bool](a, b)
     else:
         raise Error("equal: unsupported dtype")
 
@@ -95,9 +94,6 @@ def not_equal(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
 
     if a.dtype() != b.dtype():
         raise Error("Cannot compare tensors with different dtypes")
-
-    if a.dtype() == DType.bool:
-        return _not_equal_dispatch[DType.bool](a, b)
 
     var ordinal = dtype_to_ordinal(a.dtype())
 
@@ -123,6 +119,8 @@ def not_equal(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
         return _not_equal_dispatch[DType.uint32](a, b)
     elif ordinal == DTYPE_UINT64:
         return _not_equal_dispatch[DType.uint64](a, b)
+    elif ordinal == DTYPE_BOOL:
+        return _not_equal_dispatch[DType.bool](a, b)
     else:
         raise Error("not_equal: unsupported dtype")
 
@@ -144,9 +142,6 @@ def less(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
 
     if a.dtype() != b.dtype():
         raise Error("Cannot compare tensors with different dtypes")
-
-    if a.dtype() == DType.bool:
-        return _less_dispatch[DType.bool](a, b)
 
     var ordinal = dtype_to_ordinal(a.dtype())
 
@@ -172,6 +167,8 @@ def less(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
         return _less_dispatch[DType.uint32](a, b)
     elif ordinal == DTYPE_UINT64:
         return _less_dispatch[DType.uint64](a, b)
+    elif ordinal == DTYPE_BOOL:
+        return _less_dispatch[DType.bool](a, b)
     else:
         raise Error("less: unsupported dtype")
 
@@ -193,9 +190,6 @@ def less_equal(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
 
     if a.dtype() != b.dtype():
         raise Error("Cannot compare tensors with different dtypes")
-
-    if a.dtype() == DType.bool:
-        return _less_equal_dispatch[DType.bool](a, b)
 
     var ordinal = dtype_to_ordinal(a.dtype())
 
@@ -221,6 +215,8 @@ def less_equal(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
         return _less_equal_dispatch[DType.uint32](a, b)
     elif ordinal == DTYPE_UINT64:
         return _less_equal_dispatch[DType.uint64](a, b)
+    elif ordinal == DTYPE_BOOL:
+        return _less_equal_dispatch[DType.bool](a, b)
     else:
         raise Error("less_equal: unsupported dtype")
 
@@ -242,9 +238,6 @@ def greater(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
 
     if a.dtype() != b.dtype():
         raise Error("Cannot compare tensors with different dtypes")
-
-    if a.dtype() == DType.bool:
-        return _greater_dispatch[DType.bool](a, b)
 
     var ordinal = dtype_to_ordinal(a.dtype())
 
@@ -270,6 +263,8 @@ def greater(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
         return _greater_dispatch[DType.uint32](a, b)
     elif ordinal == DTYPE_UINT64:
         return _greater_dispatch[DType.uint64](a, b)
+    elif ordinal == DTYPE_BOOL:
+        return _greater_dispatch[DType.bool](a, b)
     else:
         raise Error("greater: unsupported dtype")
 
@@ -291,9 +286,6 @@ def greater_equal(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
 
     if a.dtype() != b.dtype():
         raise Error("Cannot compare tensors with different dtypes")
-
-    if a.dtype() == DType.bool:
-        return _greater_equal_dispatch[DType.bool](a, b)
 
     var ordinal = dtype_to_ordinal(a.dtype())
 
@@ -319,5 +311,7 @@ def greater_equal(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
         return _greater_equal_dispatch[DType.uint32](a, b)
     elif ordinal == DTYPE_UINT64:
         return _greater_equal_dispatch[DType.uint64](a, b)
+    elif ordinal == DTYPE_BOOL:
+        return _greater_equal_dispatch[DType.bool](a, b)
     else:
         raise Error("greater_equal: unsupported dtype")

--- a/shared/core/matrix.mojo
+++ b/shared/core/matrix.mojo
@@ -35,6 +35,7 @@ from shared.base.dtype_ordinal import (
     DTYPE_UINT16,
     DTYPE_UINT32,
     DTYPE_UINT64,
+    DTYPE_BOOL,
 )
 
 
@@ -337,58 +338,146 @@ def _dispatch_matmul_batched(
     var ordinal = dtype_to_ordinal(a._dtype)
     if ordinal == DTYPE_FLOAT16:
         _matmul_batched_impl[DType.float16](
-            result, a, b, batch_size, a_rows, a_cols, b_cols,
-            matrix_size_a, matrix_size_b, matrix_size_result,
+            result,
+            a,
+            b,
+            batch_size,
+            a_rows,
+            a_cols,
+            b_cols,
+            matrix_size_a,
+            matrix_size_b,
+            matrix_size_result,
         )
     elif ordinal == DTYPE_FLOAT32:
         _matmul_batched_impl[DType.float32](
-            result, a, b, batch_size, a_rows, a_cols, b_cols,
-            matrix_size_a, matrix_size_b, matrix_size_result,
+            result,
+            a,
+            b,
+            batch_size,
+            a_rows,
+            a_cols,
+            b_cols,
+            matrix_size_a,
+            matrix_size_b,
+            matrix_size_result,
         )
     elif ordinal == DTYPE_FLOAT64:
         _matmul_batched_impl[DType.float64](
-            result, a, b, batch_size, a_rows, a_cols, b_cols,
-            matrix_size_a, matrix_size_b, matrix_size_result,
+            result,
+            a,
+            b,
+            batch_size,
+            a_rows,
+            a_cols,
+            b_cols,
+            matrix_size_a,
+            matrix_size_b,
+            matrix_size_result,
         )
     elif ordinal == DTYPE_INT8:
         _matmul_batched_impl[DType.int8](
-            result, a, b, batch_size, a_rows, a_cols, b_cols,
-            matrix_size_a, matrix_size_b, matrix_size_result,
+            result,
+            a,
+            b,
+            batch_size,
+            a_rows,
+            a_cols,
+            b_cols,
+            matrix_size_a,
+            matrix_size_b,
+            matrix_size_result,
         )
     elif ordinal == DTYPE_INT16:
         _matmul_batched_impl[DType.int16](
-            result, a, b, batch_size, a_rows, a_cols, b_cols,
-            matrix_size_a, matrix_size_b, matrix_size_result,
+            result,
+            a,
+            b,
+            batch_size,
+            a_rows,
+            a_cols,
+            b_cols,
+            matrix_size_a,
+            matrix_size_b,
+            matrix_size_result,
         )
     elif ordinal == DTYPE_INT32:
         _matmul_batched_impl[DType.int32](
-            result, a, b, batch_size, a_rows, a_cols, b_cols,
-            matrix_size_a, matrix_size_b, matrix_size_result,
+            result,
+            a,
+            b,
+            batch_size,
+            a_rows,
+            a_cols,
+            b_cols,
+            matrix_size_a,
+            matrix_size_b,
+            matrix_size_result,
         )
     elif ordinal == DTYPE_INT64:
         _matmul_batched_impl[DType.int64](
-            result, a, b, batch_size, a_rows, a_cols, b_cols,
-            matrix_size_a, matrix_size_b, matrix_size_result,
+            result,
+            a,
+            b,
+            batch_size,
+            a_rows,
+            a_cols,
+            b_cols,
+            matrix_size_a,
+            matrix_size_b,
+            matrix_size_result,
         )
     elif ordinal == DTYPE_UINT8:
         _matmul_batched_impl[DType.uint8](
-            result, a, b, batch_size, a_rows, a_cols, b_cols,
-            matrix_size_a, matrix_size_b, matrix_size_result,
+            result,
+            a,
+            b,
+            batch_size,
+            a_rows,
+            a_cols,
+            b_cols,
+            matrix_size_a,
+            matrix_size_b,
+            matrix_size_result,
         )
     elif ordinal == DTYPE_UINT16:
         _matmul_batched_impl[DType.uint16](
-            result, a, b, batch_size, a_rows, a_cols, b_cols,
-            matrix_size_a, matrix_size_b, matrix_size_result,
+            result,
+            a,
+            b,
+            batch_size,
+            a_rows,
+            a_cols,
+            b_cols,
+            matrix_size_a,
+            matrix_size_b,
+            matrix_size_result,
         )
     elif ordinal == DTYPE_UINT32:
         _matmul_batched_impl[DType.uint32](
-            result, a, b, batch_size, a_rows, a_cols, b_cols,
-            matrix_size_a, matrix_size_b, matrix_size_result,
+            result,
+            a,
+            b,
+            batch_size,
+            a_rows,
+            a_cols,
+            b_cols,
+            matrix_size_a,
+            matrix_size_b,
+            matrix_size_result,
         )
     elif ordinal == DTYPE_UINT64:
         _matmul_batched_impl[DType.uint64](
-            result, a, b, batch_size, a_rows, a_cols, b_cols,
-            matrix_size_a, matrix_size_b, matrix_size_result,
+            result,
+            a,
+            b,
+            batch_size,
+            a_rows,
+            a_cols,
+            b_cols,
+            matrix_size_a,
+            matrix_size_b,
+            matrix_size_result,
         )
     else:
         raise Error(
@@ -484,8 +573,7 @@ def _dispatch_transpose_copy(
         _transpose_copy_impl[DType.uint64](
             result, tensor, ndim, result_shape, input_strides, perm, numel
         )
-    elif tensor._dtype == DType.bool:
-        # Bool is not in the ordinal system; handle directly
+    elif ordinal == DTYPE_BOOL:
         _transpose_copy_impl[DType.bool](
             result, tensor, ndim, result_shape, input_strides, perm, numel
         )

--- a/shared/core/normalization.mojo
+++ b/shared/core/normalization.mojo
@@ -32,8 +32,12 @@ from .scalar_ops import (
 
 
 @always_inline
-def _idx4d(b: Int, c: Int, h: Int, w: Int, channels: Int, height: Int, width: Int) -> Int:
-    return b * (channels * height * width) + c * (height * width) + h * width + w
+def _idx4d(
+    b: Int, c: Int, h: Int, w: Int, channels: Int, height: Int, width: Int
+) -> Int:
+    return (
+        b * (channels * height * width) + c * (height * width) + h * width + w
+    )
 
 
 # ============================================================================
@@ -44,13 +48,15 @@ def _idx4d(b: Int, c: Int, h: Int, w: Int, channels: Int, height: Int, width: In
 @always_inline
 def _sqrt_typed[dtype: DType](x: Scalar[dtype]) -> Scalar[dtype]:
     """Compute square root for any float dtype using Scalar[dtype]."""
-    return x ** 0.5
+    return x**0.5
 
 
 @always_inline
-def _pow_typed[dtype: DType](x: Scalar[dtype], y: Scalar[dtype]) -> Scalar[dtype]:
+def _pow_typed[
+    dtype: DType
+](x: Scalar[dtype], y: Scalar[dtype]) -> Scalar[dtype]:
     """Compute x^y for any float dtype using Scalar[dtype]."""
-    return x ** y
+    return x**y
 
 
 # ============================================================================
@@ -285,40 +291,122 @@ def batch_norm2d(
         var batch_mean = zeros([channels], x.dtype())
         var batch_var = zeros([channels], x.dtype())
 
-        if x.dtype() == DType.float32:
+        if x.dtype() == DType.float16:
+            _batch_norm2d_compute_stats[DType.float16](
+                x._data,
+                batch_mean,
+                batch_var,
+                batch,
+                channels,
+                height,
+                width,
+                spatial_size,
+            )
+        elif x.dtype() == DType.float32:
             _batch_norm2d_compute_stats[DType.float32](
-                x._data, batch_mean, batch_var, batch, channels, height, width, spatial_size
+                x._data,
+                batch_mean,
+                batch_var,
+                batch,
+                channels,
+                height,
+                width,
+                spatial_size,
             )
         elif x.dtype() == DType.float64:
             _batch_norm2d_compute_stats[DType.float64](
-                x._data, batch_mean, batch_var, batch, channels, height, width, spatial_size
+                x._data,
+                batch_mean,
+                batch_var,
+                batch,
+                channels,
+                height,
+                width,
+                spatial_size,
             )
         else:
-            raise Error("batch_norm2d: only float32/64 dtypes supported")
+            raise Error(
+                "batch_norm2d: only float16/float32/float64 dtypes supported"
+            )
 
         var output = zeros_like(x)
-        if x.dtype() == DType.float32:
+        if x.dtype() == DType.float16:
+            _batch_norm2d_normalize[DType.float16](
+                x._data,
+                output,
+                batch_mean._data,
+                batch_var._data,
+                gamma._data,
+                beta._data,
+                batch,
+                channels,
+                height,
+                width,
+                epsilon,
+            )
+        elif x.dtype() == DType.float32:
             _batch_norm2d_normalize[DType.float32](
-                x._data, output, batch_mean._data, batch_var._data,
-                gamma._data, beta._data, batch, channels, height, width, epsilon
+                x._data,
+                output,
+                batch_mean._data,
+                batch_var._data,
+                gamma._data,
+                beta._data,
+                batch,
+                channels,
+                height,
+                width,
+                epsilon,
             )
         elif x.dtype() == DType.float64:
             _batch_norm2d_normalize[DType.float64](
-                x._data, output, batch_mean._data, batch_var._data,
-                gamma._data, beta._data, batch, channels, height, width, epsilon
+                x._data,
+                output,
+                batch_mean._data,
+                batch_var._data,
+                gamma._data,
+                beta._data,
+                batch,
+                channels,
+                height,
+                width,
+                epsilon,
             )
 
         var new_running_mean = zeros_like(running_mean)
         var new_running_var = zeros_like(running_var)
-        if x.dtype() == DType.float32:
+        if x.dtype() == DType.float16:
+            _batch_norm2d_update_running_stats[DType.float16](
+                running_mean,
+                running_var,
+                batch_mean,
+                batch_var,
+                new_running_mean,
+                new_running_var,
+                channels,
+                momentum,
+            )
+        elif x.dtype() == DType.float32:
             _batch_norm2d_update_running_stats[DType.float32](
-                running_mean, running_var, batch_mean, batch_var,
-                new_running_mean, new_running_var, channels, momentum
+                running_mean,
+                running_var,
+                batch_mean,
+                batch_var,
+                new_running_mean,
+                new_running_var,
+                channels,
+                momentum,
             )
         elif x.dtype() == DType.float64:
             _batch_norm2d_update_running_stats[DType.float64](
-                running_mean, running_var, batch_mean, batch_var,
-                new_running_mean, new_running_var, channels, momentum
+                running_mean,
+                running_var,
+                batch_mean,
+                batch_var,
+                new_running_mean,
+                new_running_var,
+                channels,
+                momentum,
             )
 
         return (output, new_running_mean, new_running_var)
@@ -326,18 +414,52 @@ def batch_norm2d(
     else:
         # Inference mode: use running statistics
         var output = zeros_like(x)
-        if x.dtype() == DType.float32:
+        if x.dtype() == DType.float16:
+            _batch_norm2d_normalize[DType.float16](
+                x._data,
+                output,
+                running_mean._data,
+                running_var._data,
+                gamma._data,
+                beta._data,
+                batch,
+                channels,
+                height,
+                width,
+                epsilon,
+            )
+        elif x.dtype() == DType.float32:
             _batch_norm2d_normalize[DType.float32](
-                x._data, output, running_mean._data, running_var._data,
-                gamma._data, beta._data, batch, channels, height, width, epsilon
+                x._data,
+                output,
+                running_mean._data,
+                running_var._data,
+                gamma._data,
+                beta._data,
+                batch,
+                channels,
+                height,
+                width,
+                epsilon,
             )
         elif x.dtype() == DType.float64:
             _batch_norm2d_normalize[DType.float64](
-                x._data, output, running_mean._data, running_var._data,
-                gamma._data, beta._data, batch, channels, height, width, epsilon
+                x._data,
+                output,
+                running_mean._data,
+                running_var._data,
+                gamma._data,
+                beta._data,
+                batch,
+                channels,
+                height,
+                width,
+                epsilon,
             )
         else:
-            raise Error("batch_norm2d: only float32/64 dtypes supported")
+            raise Error(
+                "batch_norm2d: only float16/float32/float64 dtypes supported"
+            )
 
         # Running stats unchanged in inference mode
         return (output, running_mean, running_var)
@@ -387,7 +509,10 @@ def _batch_norm2d_backward_training[
         for b in range(batch):
             for h in range(height):
                 for w in range(width):
-                    var diff = xp[_idx4d(b, c, h, w, channels, height, width)] - mean_val
+                    var diff = (
+                        xp[_idx4d(b, c, h, w, channels, height, width)]
+                        - mean_val
+                    )
                     sum_sq_diff += diff * diff
         var var_val = sum_sq_diff / N
         var std = _sqrt_typed[dtype](var_val + eps)
@@ -427,7 +552,11 @@ def _batch_norm2d_backward_training[
                     var idx = _idx4d(b, c, h, w, channels, height, width)
                     var grad_out = go[idx]
                     var x_norm = (xp[idx] - mean_val) * invstd
-                    gi_ptr[idx] = (grad_out - k / N - x_norm * dotp / N) * gamma_val * invstd
+                    gi_ptr[idx] = (
+                        (grad_out - k / N - x_norm * dotp / N)
+                        * gamma_val
+                        * invstd
+                    )
 
 
 def _batch_norm2d_backward_inference[
@@ -604,40 +733,109 @@ def batch_norm2d_backward(
     var grad_beta = zeros([channels], x.dtype())
 
     if training:
-        if x.dtype() == DType.float32:
+        if x.dtype() == DType.float16:
+            _batch_norm2d_backward_training[DType.float16](
+                grad_output._data,
+                x._data,
+                gamma._data,
+                grad_input,
+                grad_gamma,
+                grad_beta,
+                batch,
+                channels,
+                height,
+                width,
+                spatial_size,
+                epsilon,
+            )
+        elif x.dtype() == DType.float32:
             _batch_norm2d_backward_training[DType.float32](
-                grad_output._data, x._data, gamma._data,
-                grad_input, grad_gamma, grad_beta,
-                batch, channels, height, width, spatial_size, epsilon
+                grad_output._data,
+                x._data,
+                gamma._data,
+                grad_input,
+                grad_gamma,
+                grad_beta,
+                batch,
+                channels,
+                height,
+                width,
+                spatial_size,
+                epsilon,
             )
         elif x.dtype() == DType.float64:
             _batch_norm2d_backward_training[DType.float64](
-                grad_output._data, x._data, gamma._data,
-                grad_input, grad_gamma, grad_beta,
-                batch, channels, height, width, spatial_size, epsilon
+                grad_output._data,
+                x._data,
+                gamma._data,
+                grad_input,
+                grad_gamma,
+                grad_beta,
+                batch,
+                channels,
+                height,
+                width,
+                spatial_size,
+                epsilon,
             )
         else:
             raise Error(
-                "batch_norm2d_backward: only float32/64 dtypes supported"
+                "batch_norm2d_backward: only float16/float32/float64 dtypes"
+                " supported"
             )
     else:
-        if x.dtype() == DType.float32:
+        if x.dtype() == DType.float16:
+            _batch_norm2d_backward_inference[DType.float16](
+                grad_output._data,
+                x._data,
+                gamma._data,
+                running_mean._data,
+                running_var._data,
+                grad_input,
+                grad_gamma,
+                grad_beta,
+                batch,
+                channels,
+                height,
+                width,
+                epsilon,
+            )
+        elif x.dtype() == DType.float32:
             _batch_norm2d_backward_inference[DType.float32](
-                grad_output._data, x._data, gamma._data,
-                running_mean._data, running_var._data,
-                grad_input, grad_gamma, grad_beta,
-                batch, channels, height, width, epsilon
+                grad_output._data,
+                x._data,
+                gamma._data,
+                running_mean._data,
+                running_var._data,
+                grad_input,
+                grad_gamma,
+                grad_beta,
+                batch,
+                channels,
+                height,
+                width,
+                epsilon,
             )
         elif x.dtype() == DType.float64:
             _batch_norm2d_backward_inference[DType.float64](
-                grad_output._data, x._data, gamma._data,
-                running_mean._data, running_var._data,
-                grad_input, grad_gamma, grad_beta,
-                batch, channels, height, width, epsilon
+                grad_output._data,
+                x._data,
+                gamma._data,
+                running_mean._data,
+                running_var._data,
+                grad_input,
+                grad_gamma,
+                grad_beta,
+                batch,
+                channels,
+                height,
+                width,
+                epsilon,
             )
         else:
             raise Error(
-                "batch_norm2d_backward: only float32/64 dtypes supported"
+                "batch_norm2d_backward: only float16/float32/float64 dtypes"
+                " supported"
             )
 
     return (grad_input, grad_gamma, grad_beta)
@@ -719,7 +917,10 @@ def _layer_norm_4d[
         for c in range(channels):
             for h in range(height):
                 for w in range(width):
-                    var diff = xp[_idx4d(b, c, h, w, channels, height, width)] - mean_val
+                    var diff = (
+                        xp[_idx4d(b, c, h, w, channels, height, width)]
+                        - mean_val
+                    )
                     sum_sq_diff += diff * diff
         var std = _sqrt_typed[dtype](sum_sq_diff / N + eps)
 
@@ -786,16 +987,40 @@ def layer_norm(
         var features = x_shape[1]
         var output = zeros_like(x)
 
-        if x.dtype() == DType.float32:
+        if x.dtype() == DType.float16:
+            _layer_norm_2d[DType.float16](
+                x._data,
+                output,
+                gamma._data,
+                beta._data,
+                batch,
+                features,
+                epsilon,
+            )
+        elif x.dtype() == DType.float32:
             _layer_norm_2d[DType.float32](
-                x._data, output, gamma._data, beta._data, batch, features, epsilon
+                x._data,
+                output,
+                gamma._data,
+                beta._data,
+                batch,
+                features,
+                epsilon,
             )
         elif x.dtype() == DType.float64:
             _layer_norm_2d[DType.float64](
-                x._data, output, gamma._data, beta._data, batch, features, epsilon
+                x._data,
+                output,
+                gamma._data,
+                beta._data,
+                batch,
+                features,
+                epsilon,
             )
         else:
-            raise Error("layer_norm: only float32/64 dtypes supported")
+            raise Error(
+                "layer_norm: only float16/float32/float64 dtypes supported"
+            )
         return output
 
     elif len(x_shape) == 4:
@@ -805,18 +1030,46 @@ def layer_norm(
         var width = x_shape[3]
         var output = zeros_like(x)
 
-        if x.dtype() == DType.float32:
+        if x.dtype() == DType.float16:
+            _layer_norm_4d[DType.float16](
+                x._data,
+                output,
+                gamma._data,
+                beta._data,
+                batch,
+                channels,
+                height,
+                width,
+                epsilon,
+            )
+        elif x.dtype() == DType.float32:
             _layer_norm_4d[DType.float32](
-                x._data, output, gamma._data, beta._data,
-                batch, channels, height, width, epsilon
+                x._data,
+                output,
+                gamma._data,
+                beta._data,
+                batch,
+                channels,
+                height,
+                width,
+                epsilon,
             )
         elif x.dtype() == DType.float64:
             _layer_norm_4d[DType.float64](
-                x._data, output, gamma._data, beta._data,
-                batch, channels, height, width, epsilon
+                x._data,
+                output,
+                gamma._data,
+                beta._data,
+                batch,
+                channels,
+                height,
+                width,
+                epsilon,
             )
         else:
-            raise Error("layer_norm: only float32/64 dtypes supported")
+            raise Error(
+                "layer_norm: only float16/float32/float64 dtypes supported"
+            )
         return output
 
     else:
@@ -893,7 +1146,12 @@ def _layer_norm_backward_2d[
             var idx = b * features + f
             var x_minus_mean = xp[idx] - mean_val
             var grad_x_norm = go[idx] * gp[f]
-            grad_var += grad_x_norm * x_minus_mean * Scalar[dtype](-0.5) * _pow_typed[dtype](var_val + eps, Scalar[dtype](-1.5))
+            grad_var += (
+                grad_x_norm
+                * x_minus_mean
+                * Scalar[dtype](-0.5)
+                * _pow_typed[dtype](var_val + eps, Scalar[dtype](-1.5))
+            )
             grad_mean += grad_x_norm * Scalar[dtype](-1.0) / std
 
         for f in range(features):
@@ -945,7 +1203,10 @@ def _layer_norm_backward_4d[
         for c in range(channels):
             for h in range(height):
                 for w in range(width):
-                    var diff = xp[_idx4d(b, c, h, w, channels, height, width)] - mean_val
+                    var diff = (
+                        xp[_idx4d(b, c, h, w, channels, height, width)]
+                        - mean_val
+                    )
                     sum_sq_diff += diff * diff
         var std = _sqrt_typed[dtype](sum_sq_diff / N + eps)
 
@@ -972,7 +1233,10 @@ def _layer_norm_backward_4d[
         for c in range(channels):
             for h in range(height):
                 for w in range(width):
-                    var diff = xp[_idx4d(b, c, h, w, channels, height, width)] - mean_val
+                    var diff = (
+                        xp[_idx4d(b, c, h, w, channels, height, width)]
+                        - mean_val
+                    )
                     sum_sq_diff += diff * diff
         var var_val = sum_sq_diff / N
         var std = _sqrt_typed[dtype](var_val + eps)
@@ -987,7 +1251,12 @@ def _layer_norm_backward_4d[
                     var gamma_idx = c * (height * width) + h * width + w
                     var x_minus_mean = xp[idx] - mean_val
                     var grad_x_norm = go[idx] * gp[gamma_idx]
-                    grad_var += grad_x_norm * x_minus_mean * Scalar[dtype](-0.5) * _pow_typed[dtype](var_val + eps, Scalar[dtype](-1.5))
+                    grad_var += (
+                        grad_x_norm
+                        * x_minus_mean
+                        * Scalar[dtype](-0.5)
+                        * _pow_typed[dtype](var_val + eps, Scalar[dtype](-1.5))
+                    )
                     grad_mean += grad_x_norm * Scalar[dtype](-1.0) / std
 
         for c in range(channels):
@@ -1004,7 +1273,10 @@ def _layer_norm_backward_4d[
 
 
 def layer_norm_backward(
-    grad_output: AnyTensor, x: AnyTensor, gamma: AnyTensor, epsilon: Float64 = 1e-5
+    grad_output: AnyTensor,
+    x: AnyTensor,
+    gamma: AnyTensor,
+    epsilon: Float64 = 1e-5,
 ) raises -> Tuple[AnyTensor, AnyTensor, AnyTensor]:
     """Backward pass for layer normalization.
 
@@ -1083,18 +1355,47 @@ def layer_norm_backward(
         var grad_gamma = zeros_like(gamma)
         var grad_beta = zeros_like(gamma)
 
-        if x.dtype() == DType.float32:
+        if x.dtype() == DType.float16:
+            _layer_norm_backward_2d[DType.float16](
+                grad_output._data,
+                x._data,
+                gamma._data,
+                grad_input,
+                grad_gamma,
+                grad_beta,
+                batch,
+                features,
+                epsilon,
+            )
+        elif x.dtype() == DType.float32:
             _layer_norm_backward_2d[DType.float32](
-                grad_output._data, x._data, gamma._data,
-                grad_input, grad_gamma, grad_beta, batch, features, epsilon
+                grad_output._data,
+                x._data,
+                gamma._data,
+                grad_input,
+                grad_gamma,
+                grad_beta,
+                batch,
+                features,
+                epsilon,
             )
         elif x.dtype() == DType.float64:
             _layer_norm_backward_2d[DType.float64](
-                grad_output._data, x._data, gamma._data,
-                grad_input, grad_gamma, grad_beta, batch, features, epsilon
+                grad_output._data,
+                x._data,
+                gamma._data,
+                grad_input,
+                grad_gamma,
+                grad_beta,
+                batch,
+                features,
+                epsilon,
             )
         else:
-            raise Error("layer_norm_backward: only float32/64 dtypes supported")
+            raise Error(
+                "layer_norm_backward: only float16/float32/float64 dtypes"
+                " supported"
+            )
 
         return (grad_input, grad_gamma, grad_beta)
 
@@ -1108,20 +1409,53 @@ def layer_norm_backward(
         var grad_gamma = zeros_like(gamma)
         var grad_beta = zeros_like(gamma)
 
-        if x.dtype() == DType.float32:
+        if x.dtype() == DType.float16:
+            _layer_norm_backward_4d[DType.float16](
+                grad_output._data,
+                x._data,
+                gamma._data,
+                grad_input,
+                grad_gamma,
+                grad_beta,
+                batch,
+                channels,
+                height,
+                width,
+                epsilon,
+            )
+        elif x.dtype() == DType.float32:
             _layer_norm_backward_4d[DType.float32](
-                grad_output._data, x._data, gamma._data,
-                grad_input, grad_gamma, grad_beta,
-                batch, channels, height, width, epsilon
+                grad_output._data,
+                x._data,
+                gamma._data,
+                grad_input,
+                grad_gamma,
+                grad_beta,
+                batch,
+                channels,
+                height,
+                width,
+                epsilon,
             )
         elif x.dtype() == DType.float64:
             _layer_norm_backward_4d[DType.float64](
-                grad_output._data, x._data, gamma._data,
-                grad_input, grad_gamma, grad_beta,
-                batch, channels, height, width, epsilon
+                grad_output._data,
+                x._data,
+                gamma._data,
+                grad_input,
+                grad_gamma,
+                grad_beta,
+                batch,
+                channels,
+                height,
+                width,
+                epsilon,
             )
         else:
-            raise Error("layer_norm_backward: only float32/64 dtypes supported")
+            raise Error(
+                "layer_norm_backward: only float16/float32/float64 dtypes"
+                " supported"
+            )
 
         return (grad_input, grad_gamma, grad_beta)
 
@@ -1167,14 +1501,19 @@ def _group_norm_impl[
             for c in range(c_start, c_end):
                 for h in range(height):
                     for w in range(width):
-                        sum_val += xp[_idx4d(b, c, h, w, channels, height, width)]
+                        sum_val += xp[
+                            _idx4d(b, c, h, w, channels, height, width)
+                        ]
             var mean_val = sum_val / N
 
             var sum_sq_diff = Scalar[dtype](0.0)
             for c in range(c_start, c_end):
                 for h in range(height):
                     for w in range(width):
-                        var diff = xp[_idx4d(b, c, h, w, channels, height, width)] - mean_val
+                        var diff = (
+                            xp[_idx4d(b, c, h, w, channels, height, width)]
+                            - mean_val
+                        )
                         sum_sq_diff += diff * diff
             var std = _sqrt_typed[dtype](sum_sq_diff / N + eps)
 
@@ -1253,20 +1592,53 @@ def group_norm(
     var group_size = channels_per_group * height * width
     var output = zeros_like(x)
 
-    if x.dtype() == DType.float32:
+    if x.dtype() == DType.float16:
+        _group_norm_impl[DType.float16](
+            x._data,
+            output,
+            gamma._data,
+            beta._data,
+            batch,
+            channels,
+            height,
+            width,
+            num_groups,
+            channels_per_group,
+            group_size,
+            epsilon,
+        )
+    elif x.dtype() == DType.float32:
         _group_norm_impl[DType.float32](
-            x._data, output, gamma._data, beta._data,
-            batch, channels, height, width, num_groups,
-            channels_per_group, group_size, epsilon
+            x._data,
+            output,
+            gamma._data,
+            beta._data,
+            batch,
+            channels,
+            height,
+            width,
+            num_groups,
+            channels_per_group,
+            group_size,
+            epsilon,
         )
     elif x.dtype() == DType.float64:
         _group_norm_impl[DType.float64](
-            x._data, output, gamma._data, beta._data,
-            batch, channels, height, width, num_groups,
-            channels_per_group, group_size, epsilon
+            x._data,
+            output,
+            gamma._data,
+            beta._data,
+            batch,
+            channels,
+            height,
+            width,
+            num_groups,
+            channels_per_group,
+            group_size,
+            epsilon,
         )
     else:
-        raise Error("group_norm: only float32/64 dtypes supported")
+        raise Error("group_norm: only float16/float32/float64 dtypes supported")
 
     return output
 
@@ -1314,14 +1686,19 @@ def _group_norm_backward_impl[
             for c in range(c_start, c_end):
                 for h in range(height):
                     for w in range(width):
-                        sum_val += xp[_idx4d(b, c, h, w, channels, height, width)]
+                        sum_val += xp[
+                            _idx4d(b, c, h, w, channels, height, width)
+                        ]
             var mean_val = sum_val / N
 
             var sum_sq_diff = Scalar[dtype](0.0)
             for c in range(c_start, c_end):
                 for h in range(height):
                     for w in range(width):
-                        var diff = xp[_idx4d(b, c, h, w, channels, height, width)] - mean_val
+                        var diff = (
+                            xp[_idx4d(b, c, h, w, channels, height, width)]
+                            - mean_val
+                        )
                         sum_sq_diff += diff * diff
             var std = _sqrt_typed[dtype](sum_sq_diff / N + eps)
 
@@ -1344,14 +1721,19 @@ def _group_norm_backward_impl[
             for c in range(c_start, c_end):
                 for h in range(height):
                     for w in range(width):
-                        sum_val += xp[_idx4d(b, c, h, w, channels, height, width)]
+                        sum_val += xp[
+                            _idx4d(b, c, h, w, channels, height, width)
+                        ]
             var mean_val = sum_val / N
 
             var sum_sq_diff = Scalar[dtype](0.0)
             for c in range(c_start, c_end):
                 for h in range(height):
                     for w in range(width):
-                        var diff = xp[_idx4d(b, c, h, w, channels, height, width)] - mean_val
+                        var diff = (
+                            xp[_idx4d(b, c, h, w, channels, height, width)]
+                            - mean_val
+                        )
                         sum_sq_diff += diff * diff
             var var_val = sum_sq_diff / N
             var std = _sqrt_typed[dtype](var_val + eps)
@@ -1366,7 +1748,14 @@ def _group_norm_backward_impl[
                         var idx = _idx4d(b, c, h, w, channels, height, width)
                         var x_minus_mean = xp[idx] - mean_val
                         var grad_x_norm = go[idx] * gamma_val
-                        grad_var += grad_x_norm * x_minus_mean * Scalar[dtype](-0.5) * _pow_typed[dtype](var_val + eps, Scalar[dtype](-1.5))
+                        grad_var += (
+                            grad_x_norm
+                            * x_minus_mean
+                            * Scalar[dtype](-0.5)
+                            * _pow_typed[dtype](
+                                var_val + eps, Scalar[dtype](-1.5)
+                            )
+                        )
                         grad_mean += grad_x_norm * Scalar[dtype](-1.0) / std
 
             for c in range(c_start, c_end):
@@ -1377,7 +1766,9 @@ def _group_norm_backward_impl[
                         var x_minus_mean = xp[idx] - mean_val
                         var grad_x_norm = go[idx] * gamma_val
                         var term1 = grad_x_norm / std
-                        var term2 = grad_var * Scalar[dtype](2.0) * x_minus_mean / N
+                        var term2 = (
+                            grad_var * Scalar[dtype](2.0) * x_minus_mean / N
+                        )
                         var term3 = grad_mean / N
                         gi_ptr[idx] = term1 + term2 + term3
 
@@ -1451,22 +1842,61 @@ def group_norm_backward(
     var grad_gamma = zeros([channels], x.dtype())
     var grad_beta = zeros([channels], x.dtype())
 
-    if x.dtype() == DType.float32:
+    if x.dtype() == DType.float16:
+        _group_norm_backward_impl[DType.float16](
+            grad_output._data,
+            x._data,
+            gamma._data,
+            grad_input,
+            grad_gamma,
+            grad_beta,
+            batch,
+            channels,
+            height,
+            width,
+            num_groups,
+            channels_per_group,
+            group_size,
+            epsilon,
+        )
+    elif x.dtype() == DType.float32:
         _group_norm_backward_impl[DType.float32](
-            grad_output._data, x._data, gamma._data,
-            grad_input, grad_gamma, grad_beta,
-            batch, channels, height, width, num_groups,
-            channels_per_group, group_size, epsilon
+            grad_output._data,
+            x._data,
+            gamma._data,
+            grad_input,
+            grad_gamma,
+            grad_beta,
+            batch,
+            channels,
+            height,
+            width,
+            num_groups,
+            channels_per_group,
+            group_size,
+            epsilon,
         )
     elif x.dtype() == DType.float64:
         _group_norm_backward_impl[DType.float64](
-            grad_output._data, x._data, gamma._data,
-            grad_input, grad_gamma, grad_beta,
-            batch, channels, height, width, num_groups,
-            channels_per_group, group_size, epsilon
+            grad_output._data,
+            x._data,
+            gamma._data,
+            grad_input,
+            grad_gamma,
+            grad_beta,
+            batch,
+            channels,
+            height,
+            width,
+            num_groups,
+            channels_per_group,
+            group_size,
+            epsilon,
         )
     else:
-        raise Error("group_norm_backward: only float32/64 dtypes supported")
+        raise Error(
+            "group_norm_backward: only float16/float32/float64 dtypes supported"
+        )
 
     return (grad_input, grad_gamma, grad_beta)
 
@@ -1508,7 +1938,10 @@ def _instance_norm_impl[
             var sum_sq_diff = Scalar[dtype](0.0)
             for h in range(height):
                 for w in range(width):
-                    var diff = xp[_idx4d(b, c, h, w, channels, height, width)] - mean_val
+                    var diff = (
+                        xp[_idx4d(b, c, h, w, channels, height, width)]
+                        - mean_val
+                    )
                     sum_sq_diff += diff * diff
             var std = _sqrt_typed[dtype](sum_sq_diff / N + eps)
 
@@ -1577,18 +2010,46 @@ def instance_norm(
     var width = x_shape[3]
     var output = zeros_like(x)
 
-    if x.dtype() == DType.float32:
+    if x.dtype() == DType.float16:
+        _instance_norm_impl[DType.float16](
+            x._data,
+            output,
+            gamma._data,
+            beta._data,
+            batch,
+            channels,
+            height,
+            width,
+            epsilon,
+        )
+    elif x.dtype() == DType.float32:
         _instance_norm_impl[DType.float32](
-            x._data, output, gamma._data, beta._data,
-            batch, channels, height, width, epsilon
+            x._data,
+            output,
+            gamma._data,
+            beta._data,
+            batch,
+            channels,
+            height,
+            width,
+            epsilon,
         )
     elif x.dtype() == DType.float64:
         _instance_norm_impl[DType.float64](
-            x._data, output, gamma._data, beta._data,
-            batch, channels, height, width, epsilon
+            x._data,
+            output,
+            gamma._data,
+            beta._data,
+            batch,
+            channels,
+            height,
+            width,
+            epsilon,
         )
     else:
-        raise Error("instance_norm: only float32/64 dtypes supported")
+        raise Error(
+            "instance_norm: only float16/float32/float64 dtypes supported"
+        )
 
     return output
 
@@ -1636,7 +2097,10 @@ def _instance_norm_backward_impl[
             var sum_sq_diff = Scalar[dtype](0.0)
             for h in range(height):
                 for w in range(width):
-                    var diff = xp[_idx4d(b, c, h, w, channels, height, width)] - mean_val
+                    var diff = (
+                        xp[_idx4d(b, c, h, w, channels, height, width)]
+                        - mean_val
+                    )
                     sum_sq_diff += diff * diff
             var std = _sqrt_typed[dtype](sum_sq_diff / N + eps)
 
@@ -1660,7 +2124,10 @@ def _instance_norm_backward_impl[
             var sum_sq_diff = Scalar[dtype](0.0)
             for h in range(height):
                 for w in range(width):
-                    var diff = xp[_idx4d(b, c, h, w, channels, height, width)] - mean_val
+                    var diff = (
+                        xp[_idx4d(b, c, h, w, channels, height, width)]
+                        - mean_val
+                    )
                     sum_sq_diff += diff * diff
             var var_val = sum_sq_diff / N
             var std = _sqrt_typed[dtype](var_val + eps)
@@ -1674,7 +2141,12 @@ def _instance_norm_backward_impl[
                     var idx = _idx4d(b, c, h, w, channels, height, width)
                     var x_minus_mean = xp[idx] - mean_val
                     var grad_x_norm = go[idx] * gamma_val
-                    grad_var += grad_x_norm * x_minus_mean * Scalar[dtype](-0.5) * _pow_typed[dtype](var_val + eps, Scalar[dtype](-1.5))
+                    grad_var += (
+                        grad_x_norm
+                        * x_minus_mean
+                        * Scalar[dtype](-0.5)
+                        * _pow_typed[dtype](var_val + eps, Scalar[dtype](-1.5))
+                    )
                     grad_mean += grad_x_norm * Scalar[dtype](-1.0) / std
 
             for h in range(height):
@@ -1747,19 +2219,52 @@ def instance_norm_backward(
     var grad_gamma = zeros([channels], x.dtype())
     var grad_beta = zeros([channels], x.dtype())
 
-    if x.dtype() == DType.float32:
+    if x.dtype() == DType.float16:
+        _instance_norm_backward_impl[DType.float16](
+            grad_output._data,
+            x._data,
+            gamma._data,
+            grad_input,
+            grad_gamma,
+            grad_beta,
+            batch,
+            channels,
+            height,
+            width,
+            epsilon,
+        )
+    elif x.dtype() == DType.float32:
         _instance_norm_backward_impl[DType.float32](
-            grad_output._data, x._data, gamma._data,
-            grad_input, grad_gamma, grad_beta,
-            batch, channels, height, width, epsilon
+            grad_output._data,
+            x._data,
+            gamma._data,
+            grad_input,
+            grad_gamma,
+            grad_beta,
+            batch,
+            channels,
+            height,
+            width,
+            epsilon,
         )
     elif x.dtype() == DType.float64:
         _instance_norm_backward_impl[DType.float64](
-            grad_output._data, x._data, gamma._data,
-            grad_input, grad_gamma, grad_beta,
-            batch, channels, height, width, epsilon
+            grad_output._data,
+            x._data,
+            gamma._data,
+            grad_input,
+            grad_gamma,
+            grad_beta,
+            batch,
+            channels,
+            height,
+            width,
+            epsilon,
         )
     else:
-        raise Error("instance_norm_backward: only float32/64 dtypes supported")
+        raise Error(
+            "instance_norm_backward: only float16/float32/float64 dtypes"
+            " supported"
+        )
 
     return (grad_input, grad_gamma, grad_beta)

--- a/tests/shared/core/test_dtype_ordinal.mojo
+++ b/tests/shared/core/test_dtype_ordinal.mojo
@@ -18,6 +18,7 @@ from shared.base.dtype_ordinal import (
     DTYPE_UINT16,
     DTYPE_UINT32,
     DTYPE_UINT64,
+    DTYPE_BOOL,
     DTYPE_UNSUPPORTED,
     SUPPORTED_DTYPE_COUNT,
 )
@@ -36,7 +37,14 @@ def test_dtype_to_ordinal_all_supported() raises:
     assert_equal(dtype_to_ordinal(DType.uint16), DTYPE_UINT16)
     assert_equal(dtype_to_ordinal(DType.uint32), DTYPE_UINT32)
     assert_equal(dtype_to_ordinal(DType.uint64), DTYPE_UINT64)
+    assert_equal(dtype_to_ordinal(DType.bool), DTYPE_BOOL)
     print("✓ All supported dtypes map to correct ordinals")
+
+
+def test_dtype_to_ordinal_bool() raises:
+    """Test that DType.bool maps to DTYPE_BOOL ordinal."""
+    assert_equal(dtype_to_ordinal(DType.bool), DTYPE_BOOL)
+    print("✓ DType.bool maps to DTYPE_BOOL ordinal")
 
 
 def test_dtype_to_ordinal_unsupported() raises:
@@ -60,6 +68,7 @@ def test_ordinal_uniqueness() raises:
     ordinals.append(DTYPE_UINT16)
     ordinals.append(DTYPE_UINT32)
     ordinals.append(DTYPE_UINT64)
+    ordinals.append(DTYPE_BOOL)
 
     # Check uniqueness by comparing all pairs
     for i in range(len(ordinals)):
@@ -72,7 +81,7 @@ def test_ordinal_uniqueness() raises:
 
 def test_ordinal_count() raises:
     """Test that SUPPORTED_DTYPE_COUNT matches actual count."""
-    assert_equal(SUPPORTED_DTYPE_COUNT, 11)
+    assert_equal(SUPPORTED_DTYPE_COUNT, 12)
     print("✓ SUPPORTED_DTYPE_COUNT is correct")
 
 
@@ -89,6 +98,7 @@ def test_format_dtype_name_all_supported() raises:
     assert_equal(format_dtype_name(DType.uint16), "uint16")
     assert_equal(format_dtype_name(DType.uint32), "uint32")
     assert_equal(format_dtype_name(DType.uint64), "uint64")
+    assert_equal(format_dtype_name(DType.bool), "bool")
     print("✓ All supported dtypes format correctly")
 
 
@@ -111,6 +121,7 @@ def test_ordinal_values_sequential() raises:
     assert_equal(DTYPE_UINT16, 8)
     assert_equal(DTYPE_UINT32, 9)
     assert_equal(DTYPE_UINT64, 10)
+    assert_equal(DTYPE_BOOL, 11)
     assert_equal(DTYPE_UNSUPPORTED, -1)
     print("✓ Ordinal values are sequential")
 
@@ -121,6 +132,7 @@ def main() raises:
     print()
 
     test_dtype_to_ordinal_all_supported()
+    test_dtype_to_ordinal_bool()
     test_dtype_to_ordinal_unsupported()
     test_ordinal_uniqueness()
     test_ordinal_count()


### PR DESCRIPTION
## Summary

- Add `DTYPE_BOOL` (ordinal 11) to `dtype_ordinal.mojo` for complete dispatch coverage
- Update `SUPPORTED_DTYPE_COUNT` from 11 to 12
- Remove hybrid dispatch pattern (ordinal + direct `DType.bool` check) from `comparison.mojo` and `matrix.mojo`, replacing with uniform ordinal-based dispatch via `DTYPE_BOOL`
- Add `float16` dispatch branches to all 8 public normalization functions in `normalization.mojo`, enabling mixed-precision training through normalization layers
- Update `test_dtype_ordinal.mojo` to verify `DTYPE_BOOL` ordinal value, uniqueness, format name, and count

## Test plan

- [ ] `test_dtype_ordinal.mojo`: new `test_dtype_to_ordinal_bool()` test, updated count to 12, bool added to uniqueness and sequential value checks
- [ ] Pre-commit hooks pass (mojo-format, lint checks)
- [ ] CI runs comprehensive tests

Closes #5152
Closes #5154