### PR TITLE
fix(core): fix BFloat16 latent bug in AnyTensor FP8/BF8 conversion

### DIFF
--- a/shared/tensor/any_tensor.mojo
+++ b/shared/tensor/any_tensor.mojo
@@ -2098,6 +2098,8 @@ struct AnyTensor(
                 val = self._data.bitcast[Float32]()[i]
             elif self._dtype == DType.float64:
                 val = self._data.bitcast[Float64]()[i].cast[DType.float32]()
+            elif self._dtype == DType.bfloat16:
+                val = self._data.bitcast[BFloat16]()[i].cast[DType.float32]()
             else:
                 # Defensive re-validation (fixes DATA-003)
                 raise Error("Invalid dtype for FP8 conversion")
@@ -2619,6 +2621,8 @@ struct AnyTensor(
                 val = self._data.bitcast[Float32]()[i]
             elif self._dtype == DType.float64:
                 val = self._data.bitcast[Float64]()[i].cast[DType.float32]()
+            elif self._dtype == DType.bfloat16:
+                val = self._data.bitcast[BFloat16]()[i].cast[DType.float32]()
             else:
                 raise Error("Invalid dtype for BF8 conversion")
 


### PR DESCRIPTION
## Summary

- Add missing `bfloat16` branch to dtype dispatch in both `to_fp8()` and `to_bf8()` methods
- BFloat16 tensors passed initial validation but hit the defensive else-raise because no bfloat16 case existed
- The fix casts BFloat16 to Float32 before FP8/BF8 conversion, matching the pattern used for Float16 and Float64

## Test plan

- [ ] CI build validation passes
- [ ] Existing FP8/BF8 conversion tests still pass

Closes #5179