### PR TITLE
chore(ci): remove stale non-blocking comments (ADR-015 Action 3)

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -312,7 +312,6 @@ jobs:
           - name: "Benchmarking"
             path: "tests/shared/benchmarking"
             pattern: "test_*.mojo"
-          # ---- Integration tests (segfault-prone on CI, kept non-blocking) ----
           - name: "Integration Tests"
             path: "tests/shared/integration"
             pattern: "test_*.mojo"
@@ -352,7 +351,6 @@ jobs:
             path: "tests/examples"
             pattern: "test_*.mojo"
           # ---- Core type system ----
-          # Mojo JIT crashes on CI runners — non-blocking pending investigation.
           - name: "Core Types & Fuzz"
             path: "tests/core/types"
             pattern: "test_*.mojo"


### PR DESCRIPTION
## Summary

ADR-015 corrective action #3 (LOW priority): remove two stale comments in `comprehensive-tests.yml` that falsely claimed `Integration Tests` and `Core Types & Fuzz` were non-blocking or under pending investigation.

- Remove `# Integration tests (segfault-prone on CI, kept non-blocking)` comment above the Integration Tests entry
- Remove `# Mojo JIT crashes on CI runners — non-blocking pending investigation.` comment above Core Types & Fuzz entry

## Why

Both checks ARE required by branch protection. The comments were misleading — implying failures were expected and acceptable when they are in fact blocking merges. The root causes are now understood and being fixed (Crash 2 fixed by PR #5252; Crash 3 addressed by pixi volume seeding in PR #5252). Leaving these comments would suggest to future developers that these failures should be ignored.

## Test plan

- [ ] `Validate YAML Syntax` CI check passes
- [ ] No functional behavior changed — only comments removed

See [ADR-015](docs/adr/ADR-015-flaky-required-checks-jit-crash.md) for full decision record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)