### PR TITLE
perf(core): localize heavy imports in activation.mojo to reduce JIT footprint

### DIFF
--- a/shared/core/activation.mojo
+++ b/shared/core/activation.mojo
@@ -29,26 +29,6 @@ Issues covered:
 from std.math import exp, erf, sqrt, tanh as math_tanh, log as math_log
 from std.collections import List
 from shared.tensor.any_tensor import AnyTensor, full, zeros_like
-from .arithmetic import add, subtract, multiply
-from .reduction import sum as tensor_sum, max as tensor_max
-from .elementwise import log
-from .dtype_dispatch import (
-    dispatch_unary,
-    dispatch_binary,
-    dispatch_float_unary,
-    dispatch_float_binary,
-    dispatch_scalar,
-    dispatch_softmax,
-    dispatch_softmax_backward,
-    dispatch_gelu,
-    dispatch_gelu_backward,
-    dispatch_hard_sigmoid,
-    dispatch_hard_sigmoid_backward,
-    dispatch_hard_swish,
-    dispatch_hard_swish_backward,
-    dispatch_hard_tanh,
-    dispatch_hard_tanh_backward,
-)
 from shared.base.dtype_ordinal import (
     dtype_to_ordinal,
     DTYPE_FLOAT16,
@@ -432,6 +412,7 @@ def softmax(tensor: AnyTensor, axis: Int = -1) raises -> AnyTensor:
 
     var axis_size = tensor._shape[norm_axis]
 
+    from .dtype_dispatch import dispatch_softmax
     return dispatch_softmax(tensor, outer_size, axis_size, axis_stride)
 
 
@@ -464,6 +445,7 @@ def gelu(tensor: AnyTensor, approximate: Bool = False) raises -> AnyTensor:
             var y_approx = gelu(x, approximate=True)
     ```
     """
+    from .dtype_dispatch import dispatch_gelu
     return dispatch_gelu(tensor, approximate)
 
 
@@ -519,6 +501,7 @@ def relu_backward(
     if grad_output._numel != x._numel:
         raise Error("relu_backward: grad_output and x must have same shape")
 
+    from .dtype_dispatch import dispatch_binary
     return dispatch_binary[_relu_backward_op](grad_output, x)
 
 
@@ -710,6 +693,7 @@ def sigmoid_backward(
             "sigmoid_backward: grad_output and output must have same shape"
         )
 
+    from .dtype_dispatch import dispatch_float_binary
     return dispatch_float_binary[_sigmoid_backward_op](grad_output, output)
 
 
@@ -760,6 +744,7 @@ def tanh_backward(
             "tanh_backward: grad_output and output must have same shape"
         )
 
+    from .dtype_dispatch import dispatch_float_binary
     return dispatch_float_binary[_tanh_backward_op](grad_output, output)
 
 
@@ -789,6 +774,7 @@ def gelu_backward(
     if grad_output._numel != x._numel:
         raise Error("gelu_backward: grad_output and x must have same shape")
 
+    from .dtype_dispatch import dispatch_gelu_backward
     return dispatch_gelu_backward(grad_output, x, approximate)
 
 
@@ -842,6 +828,7 @@ def softmax_backward(
     for i in range(normalized_axis):
         outer_size *= output._shape[i]
 
+    from .dtype_dispatch import dispatch_softmax_backward
     return dispatch_softmax_backward(
         grad_output, output, outer_size, axis_size, axis_stride
     )
@@ -873,6 +860,7 @@ def swish(tensor: AnyTensor) raises -> AnyTensor:
         Reference:
             Ramachandran et al., "Searching for Activation Functions" (2017).
     """
+    from .arithmetic import multiply
     # swish(x) = x * sigmoid(x)
     var sig = sigmoid(tensor)
     return multiply(tensor, sig)
@@ -961,6 +949,7 @@ def mish(tensor: AnyTensor) raises -> AnyTensor:
     Reference:
         Misra, "Mish: A Self Regularized Non-Monotonic Activation Function" (2019).
     """
+    from .arithmetic import multiply
     # Use fused softplus (1 allocation instead of 7)
     var sp = softplus(tensor)
     var tanh_softplus = tanh(sp)
@@ -1131,6 +1120,7 @@ def swish_backward(
     Raises:
             Error: If operation fails.
     """
+    from .arithmetic import add, subtract, multiply
     # Compute sigmoid(x)
     var sig = sigmoid(x)
 
@@ -1161,6 +1151,7 @@ def mish_backward(
     Raises:
             Error: If operation fails.
     """
+    from .arithmetic import add, subtract, multiply
     # Use fused softplus (1 allocation instead of 7)
     var sp = softplus(x)
 
@@ -1282,6 +1273,7 @@ def hard_sigmoid(tensor: AnyTensor) raises -> AnyTensor:
         Reference:
             Howard et al., "Searching for MobileNetV3" (2019).
     """
+    from .dtype_dispatch import dispatch_hard_sigmoid
     return dispatch_hard_sigmoid(tensor)
 
 
@@ -1311,6 +1303,7 @@ def hard_swish(tensor: AnyTensor) raises -> AnyTensor:
         Reference:
             Howard et al., "Searching for MobileNetV3" (2019).
     """
+    from .dtype_dispatch import dispatch_hard_swish
     return dispatch_hard_swish(tensor)
 
 
@@ -1343,6 +1336,7 @@ def hard_tanh(
         Reference:
             Standard activation function used in various architectures.
     """
+    from .dtype_dispatch import dispatch_hard_tanh
     return dispatch_hard_tanh(tensor, min_val, max_val)
 
 
@@ -1379,6 +1373,7 @@ def hard_sigmoid_backward(
             "hard_sigmoid_backward: grad_output and x must have same shape"
         )
 
+    from .dtype_dispatch import dispatch_hard_sigmoid_backward
     return dispatch_hard_sigmoid_backward(grad_output, x)
 
 
@@ -1413,6 +1408,7 @@ def hard_swish_backward(
             "hard_swish_backward: grad_output and x must have same shape"
         )
 
+    from .dtype_dispatch import dispatch_hard_swish_backward
     return dispatch_hard_swish_backward(grad_output, x)
 
 
@@ -1449,4 +1445,5 @@ def hard_tanh_backward(
             "hard_tanh_backward: grad_output and x must have same shape"
         )
 
+    from .dtype_dispatch import dispatch_hard_tanh_backward
     return dispatch_hard_tanh_backward(grad_output, x, min_val, max_val)


### PR DESCRIPTION
## Summary

- Converts module-level imports of `dtype_dispatch` (1520 lines), `arithmetic` (554 lines), `reduction` (1254 lines), and `elementwise` (1650 lines) from `activation.mojo` to per-function local imports
- These were unused at module load time but forced compilation of all 4 heavy modules whenever any symbol from `activation.mojo` was imported (e.g., `relu`, `sigmoid`, `tanh`)
- Reduces JIT compilation footprint from ~9600+ lines to ~3900 lines for basic activation imports

## Motivation

CI runs show `tests/shared/core/test_gradient_checking_basic.mojo` and related tests crashing with `libKGENCompilerRTShared.so+0x6d4ab` before any test output — a JIT buffer overflow signature. The test imports only `relu/sigmoid/tanh` from `shared.core.activation`, but the module-level imports transitively pull in `dtype_dispatch` (176+ monomorphizations) and `elementwise` (154+ monomorphizations) at load time.

## Changes

`shared/core/activation.mojo`:
- Remove 5 module-level heavy import lines (`arithmetic`, `reduction`, `elementwise`, `dtype_dispatch` full block)
- Add local `from .dtype_dispatch import X` inside each function body that actually needs it
- Add local `from .arithmetic import add, subtract, multiply` inside `swish`, `mish`, `swish_backward`, `mish_backward`

## Test plan

- [ ] `pre-commit` passes (mojo format, markdownlint)
- [ ] CI: `Gradient Checking Tests` passes (no crash before test output)
- [ ] CI: `Core Activations & Types` passes
- [ ] CI: `Integration Tests` passes

Part of ADR-015 Action 1 — targeted import audit on required-check test groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)