### PR TITLE
perf(core): localize heavy imports in loss, linear, and conv modules

### DIFF
--- a/shared/core/activation.mojo
+++ b/shared/core/activation.mojo
@@ -29,26 +29,6 @@ Issues covered:
 from std.math import exp, erf, sqrt, tanh as math_tanh, log as math_log
 from std.collections import List
 from shared.tensor.any_tensor import AnyTensor, full, zeros_like
-from .arithmetic import add, subtract, multiply
-from .reduction import sum as tensor_sum, max as tensor_max
-from .elementwise import log
-from .dtype_dispatch import (
-    dispatch_unary,
-    dispatch_binary,
-    dispatch_float_unary,
-    dispatch_float_binary,
-    dispatch_scalar,
-    dispatch_softmax,
-    dispatch_softmax_backward,
-    dispatch_gelu,
-    dispatch_gelu_backward,
-    dispatch_hard_sigmoid,
-    dispatch_hard_sigmoid_backward,
-    dispatch_hard_swish,
-    dispatch_hard_swish_backward,
-    dispatch_hard_tanh,
-    dispatch_hard_tanh_backward,
-)
 from shared.base.dtype_ordinal import (
     dtype_to_ordinal,
     DTYPE_FLOAT16,
@@ -432,6 +412,7 @@ def softmax(tensor: AnyTensor, axis: Int = -1) raises -> AnyTensor:
 
     var axis_size = tensor._shape[norm_axis]
 
+    from .dtype_dispatch import dispatch_softmax
     return dispatch_softmax(tensor, outer_size, axis_size, axis_stride)
 
 
@@ -464,6 +445,7 @@ def gelu(tensor: AnyTensor, approximate: Bool = False) raises -> AnyTensor:
             var y_approx = gelu(x, approximate=True)
     ```
     """
+    from .dtype_dispatch import dispatch_gelu
     return dispatch_gelu(tensor, approximate)
 
 
@@ -519,6 +501,7 @@ def relu_backward(
     if grad_output._numel != x._numel:
         raise Error("relu_backward: grad_output and x must have same shape")
 
+    from .dtype_dispatch import dispatch_binary
     return dispatch_binary[_relu_backward_op](grad_output, x)
 
 
@@ -710,6 +693,7 @@ def sigmoid_backward(
             "sigmoid_backward: grad_output and output must have same shape"
         )
 
+    from .dtype_dispatch import dispatch_float_binary
     return dispatch_float_binary[_sigmoid_backward_op](grad_output, output)
 
 
@@ -760,6 +744,7 @@ def tanh_backward(
             "tanh_backward: grad_output and output must have same shape"
         )
 
+    from .dtype_dispatch import dispatch_float_binary
     return dispatch_float_binary[_tanh_backward_op](grad_output, output)
 
 
@@ -789,6 +774,7 @@ def gelu_backward(
     if grad_output._numel != x._numel:
         raise Error("gelu_backward: grad_output and x must have same shape")
 
+    from .dtype_dispatch import dispatch_gelu_backward
     return dispatch_gelu_backward(grad_output, x, approximate)
 
 
@@ -842,6 +828,7 @@ def softmax_backward(
     for i in range(normalized_axis):
         outer_size *= output._shape[i]
 
+    from .dtype_dispatch import dispatch_softmax_backward
     return dispatch_softmax_backward(
         grad_output, output, outer_size, axis_size, axis_stride
     )
@@ -873,6 +860,7 @@ def swish(tensor: AnyTensor) raises -> AnyTensor:
         Reference:
             Ramachandran et al., "Searching for Activation Functions" (2017).
     """
+    from .arithmetic import multiply
     # swish(x) = x * sigmoid(x)
     var sig = sigmoid(tensor)
     return multiply(tensor, sig)
@@ -961,6 +949,7 @@ def mish(tensor: AnyTensor) raises -> AnyTensor:
     Reference:
         Misra, "Mish: A Self Regularized Non-Monotonic Activation Function" (2019).
     """
+    from .arithmetic import multiply
     # Use fused softplus (1 allocation instead of 7)
     var sp = softplus(tensor)
     var tanh_softplus = tanh(sp)
@@ -1131,6 +1120,7 @@ def swish_backward(
     Raises:
             Error: If operation fails.
     """
+    from .arithmetic import add, subtract, multiply
     # Compute sigmoid(x)
     var sig = sigmoid(x)
 
@@ -1161,6 +1151,7 @@ def mish_backward(
     Raises:
             Error: If operation fails.
     """
+    from .arithmetic import add, subtract, multiply
     # Use fused softplus (1 allocation instead of 7)
     var sp = softplus(x)
 
@@ -1282,6 +1273,7 @@ def hard_sigmoid(tensor: AnyTensor) raises -> AnyTensor:
         Reference:
             Howard et al., "Searching for MobileNetV3" (2019).
     """
+    from .dtype_dispatch import dispatch_hard_sigmoid
     return dispatch_hard_sigmoid(tensor)
 
 
@@ -1311,6 +1303,7 @@ def hard_swish(tensor: AnyTensor) raises -> AnyTensor:
         Reference:
             Howard et al., "Searching for MobileNetV3" (2019).
     """
+    from .dtype_dispatch import dispatch_hard_swish
     return dispatch_hard_swish(tensor)
 
 
@@ -1343,6 +1336,7 @@ def hard_tanh(
         Reference:
             Standard activation function used in various architectures.
     """
+    from .dtype_dispatch import dispatch_hard_tanh
     return dispatch_hard_tanh(tensor, min_val, max_val)
 
 
@@ -1379,6 +1373,7 @@ def hard_sigmoid_backward(
             "hard_sigmoid_backward: grad_output and x must have same shape"
         )
 
+    from .dtype_dispatch import dispatch_hard_sigmoid_backward
     return dispatch_hard_sigmoid_backward(grad_output, x)
 
 
@@ -1413,6 +1408,7 @@ def hard_swish_backward(
             "hard_swish_backward: grad_output and x must have same shape"
         )
 
+    from .dtype_dispatch import dispatch_hard_swish_backward
     return dispatch_hard_swish_backward(grad_output, x)
 
 
@@ -1449,4 +1445,5 @@ def hard_tanh_backward(
             "hard_tanh_backward: grad_output and x must have same shape"
         )
 
+    from .dtype_dispatch import dispatch_hard_tanh_backward
     return dispatch_hard_tanh_backward(grad_output, x, min_val, max_val)

--- a/shared/core/conv.mojo
+++ b/shared/core/conv.mojo
@@ -13,8 +13,6 @@ from std.algorithm import parallelize
 from std.collections import List
 
 from shared.tensor.any_tensor import AnyTensor, zeros
-from .arithmetic import add
-from .reduction import sum as reduce_sum
 from .shape import conv2d_output_shape, as_contiguous
 from .gradient_types import (
     GradientPair,
@@ -1344,7 +1342,7 @@ def depthwise_separable_conv2d(
         depthwise_output, pointwise_kernel, bias, stride=1, padding=0
     )
 
-    return output
+    return output^
 
 
 def depthwise_separable_conv2d_no_bias(

--- a/shared/core/linear.mojo
+++ b/shared/core/linear.mojo
@@ -6,8 +6,6 @@ following the pattern y = xW^T + b. The caller manages all state (weights, bias)
 
 from shared.tensor.any_tensor import AnyTensor
 from .matrix import matmul, transpose
-from .arithmetic import add
-from .reduction import sum
 from .gradient_types import GradientPair, GradientTriple
 
 
@@ -39,6 +37,8 @@ def linear(x: AnyTensor, weights: AnyTensor, bias: AnyTensor) raises -> AnyTenso
     Raises:
             Error if shapes are incompatible for matrix multiplication.
     """
+    from .arithmetic import add
+
     # Compute xW^T
     var out = matmul(x, transpose(weights))
 
@@ -106,6 +106,8 @@ def linear_backward(
     Raises:
             Error if tensor shapes are incompatible.
     """
+    from .reduction import sum
+
     # grad_input = grad_output @ W
     # weights is (out_features, in_features), so we use it directly
     var grad_input = matmul(grad_output, weights)

--- a/shared/core/loss.mojo
+++ b/shared/core/loss.mojo
@@ -19,12 +19,8 @@ All loss functions include:
 """
 
 from shared.tensor.any_tensor import AnyTensor, ones_like, zeros_like, full_like
-from .arithmetic import add, subtract, multiply, divide, power
-from .elementwise import log, clip, exp, abs
-from .reduction import mean, sum, max_reduce
 from .activation import softmax
 from .comparison import less, greater
-from .dtype_dispatch import dispatch_binary, dispatch_scalar
 from .dtype_cast import cast_tensor
 
 
@@ -64,6 +60,9 @@ def binary_cross_entropy(
             - Clips predictions to [epsilon, 1-epsilon] to prevent log(0).
             - Uses epsilon=1e-7 by default.
     """
+    from .arithmetic import subtract, multiply
+    from .elementwise import log, clip
+
     if predictions.dtype() != targets.dtype():
         raise Error("Predictions and targets must have the same dtype")
 
@@ -136,6 +135,8 @@ def binary_cross_entropy_backward(
             var grad_pred = binary_cross_entropy_backward(grad_bce, predictions, targets)
             ```
     """
+    from .arithmetic import subtract, multiply, divide
+
     # Gradient formula: (p - y) / (p(1-p) + epsilon)
     var one = ones_like(predictions)
 
@@ -191,6 +192,8 @@ def mean_squared_error(
             var loss = mean(loss_per_sample)  # Scalar loss
             ```
     """
+    from .arithmetic import subtract, multiply
+
     if predictions.dtype() != targets.dtype():
         raise Error("Predictions and targets must have the same dtype")
 
@@ -235,6 +238,8 @@ def mean_squared_error_backward(
             var grad_pred = mean_squared_error_backward(grad_squared_error, predictions, targets)
             ```
     """
+    from .arithmetic import subtract, multiply
+
     # Gradient: 2 * (predictions - targets)
     var diff = subtract(predictions, targets)
 
@@ -286,6 +291,10 @@ def cross_entropy(
             - Uses log-sum-exp trick to prevent overflow/underflow.
             - Adds epsilon to log argument to prevent log(0).
     """
+    from .arithmetic import subtract, multiply, add
+    from .elementwise import log, exp
+    from .reduction import mean, sum, max_reduce
+
     if logits.dtype() != targets.dtype():
         raise Error("Logits and targets must have the same dtype")
 
@@ -375,6 +384,8 @@ def cross_entropy_backward(
             The gradient is already averaged over the batch if the forward pass
             used mean reduction.
     """
+    from .arithmetic import subtract, multiply
+
     # Compute softmax probabilities
     var axis = len(logits.shape()) - 1  # Last axis is classes
     var probs = softmax(logits, axis=axis)
@@ -437,6 +448,9 @@ def smooth_l1_loss(
             - Uses absolute value for robust handling of differences.
             - Beta parameter prevents division by zero in gradient.
     """
+    from .arithmetic import subtract, multiply, divide, add
+    from .elementwise import abs
+
     if predictions.dtype() != targets.dtype():
         raise Error("Predictions and targets must have the same dtype")
 
@@ -517,6 +531,9 @@ def smooth_l1_loss_backward(
             var grad_pred = smooth_l1_loss_backward(grad_smoothl1, predictions, targets, beta=1.0)
             ```
     """
+    from .arithmetic import subtract, multiply, divide, add
+    from .elementwise import abs
+
     if grad_output.dtype() != predictions.dtype():
         raise Error(
             "smooth_l1_loss_backward: grad_output and predictions must have"
@@ -605,6 +622,8 @@ def hinge_loss(predictions: AnyTensor, targets: AnyTensor) raises -> AnyTensor:
             - Uses max(0, ...) to prevent negative losses.
             - Avoids numerical issues with extreme values.
     """
+    from .arithmetic import subtract, multiply
+
     if predictions.dtype() != targets.dtype():
         raise Error("Predictions and targets must have the same dtype")
 
@@ -666,6 +685,8 @@ def hinge_loss_backward(
             var grad_pred = hinge_loss_backward(grad_hinge, predictions, targets)
             ```
     """
+    from .arithmetic import subtract, multiply
+
     if grad_output.dtype() != predictions.dtype():
         raise Error(
             "hinge_loss_backward: grad_output and predictions must have same"
@@ -744,6 +765,9 @@ def focal_loss(
             - Clips predictions to [epsilon, 1-epsilon] to prevent log(0).
             - Uses epsilon=1e-7 by default.
     """
+    from .arithmetic import subtract, multiply, add, power
+    from .elementwise import log, clip
+
     if predictions.dtype() != targets.dtype():
         raise Error("Predictions and targets must have the same dtype")
 
@@ -834,6 +858,9 @@ def focal_loss_backward(
             var grad_pred = focal_loss_backward(grad_focal, predictions, targets, alpha, gamma)
             ```
     """
+    from .arithmetic import subtract, multiply, divide, add, power
+    from .elementwise import log, clip
+
     var epsilon = 1e-7
 
     # Clip predictions to prevent division by zero
@@ -952,6 +979,9 @@ def kl_divergence(
             - Clips both p and q to [epsilon, 1] to prevent log(0).
             - Handles zero probabilities gracefully.
     """
+    from .arithmetic import subtract, multiply
+    from .elementwise import log, clip
+
     if p.dtype() != q.dtype():
         raise Error("p and q must have the same dtype")
 
@@ -1013,6 +1043,9 @@ def kl_divergence_backward(
             var grad_q = kl_divergence_backward(grad_per_element, p_dist, q_dist)
             ```
     """
+    from .arithmetic import divide, multiply
+    from .elementwise import clip
+
     # Clip q to prevent division by zero
     var clipped_q = clip(q, epsilon, 1.0)
 


### PR DESCRIPTION
## Summary

Continuation of the import audit from #5256 — applies the same per-function local import pattern to `loss.mojo`, `linear.mojo`, and `conv.mojo`.

- Removes module-level `arithmetic`, `elementwise`, `reduction`, `dtype_dispatch` imports from all three modules
- Adds local `from .X import Y` inside each function body that needs them
- Targets `test_training_e2e.mojo`, `test_end_to_end.mojo`, and `Integration Tests` required check

## Motivation

`test_training_e2e.mojo` imports `relu, relu_backward` (fixed by #5256), `conv2d`, `linear`, and `cross_entropy`. The last three force compilation of heavy modules at load time due to module-level imports in their source files.

## Changes

- `loss.mojo`: 14 functions updated with local arithmetic/elementwise/reduction/dtype_dispatch imports
- `linear.mojo`: 2 functions updated with local arithmetic/reduction imports
- `conv.mojo`: heavy imports removed (not directly used in function bodies — used via internal helpers)

Part of ADR-015 Action 1 — targeted import audit on required-check test groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)