### PR TITLE
perf(data): localize shape/reduction imports to fix Data Utilities and Integration Tests JIT crashes

### DIFF
--- a/shared/data/datasets/cifar10.mojo
+++ b/shared/data/datasets/cifar10.mojo
@@ -28,7 +28,6 @@ References:
 """
 
 from shared.tensor.any_tensor import AnyTensor, zeros
-from shared.core.shape import concatenate
 from shared.data.formats import load_cifar10_batch
 from std.collections import List
 
@@ -269,7 +268,7 @@ struct CIFAR10Dataset(Copyable, Movable):
         if len(tensors) == 1:
             return tensors[0]
 
-        # Use concatenate function to join all tensors along axis 0
+        from shared.core.shape import concatenate
         return concatenate(tensors, axis=0)
 
     def get_class_name(self, class_idx: Int) raises -> String:

--- a/tests/shared/integration/test_end_to_end.mojo
+++ b/tests/shared/integration/test_end_to_end.mojo
@@ -22,7 +22,6 @@ from tests.shared.conftest import (
 from shared.testing.models import SimpleMLP
 from shared.tensor.any_tensor import AnyTensor, zeros, ones
 from shared.core.loss import mean_squared_error
-from shared.core.reduction import mean
 from shared.core.activation import softmax
 
 
@@ -82,6 +81,7 @@ def test_model_training_to_evaluation() raises:
         var output = model.forward(input_tensor)
 
         # Compute MSE loss
+        from shared.core.reduction import mean
         var squared_error = mean_squared_error(output, target_tensor)
         var loss = mean(squared_error, axis=0, keepdims=False)
 
@@ -508,6 +508,7 @@ def test_full_pipeline_integration() raises:
             var output = model.forward(train_inputs[sample_idx])
 
             # Compute loss
+            from shared.core.reduction import mean
             var mse = mean_squared_error(output, train_targets[sample_idx])
             var loss = mean(mse, axis=0, keepdims=False)
             epoch_loss += loss._get_float32(0)


### PR DESCRIPTION
## Summary

Continues ADR-015 Action 1 (import audit) for the two remaining failing required CI checks:

- **Data Utilities Test Suite**: `test_tensor_dataset.mojo` crashes because importing
  `TensorDataset` from `shared.data.datasets` triggers compilation of `cifar10.mojo`
  (via `__init__.mojo`), which imports `shape.mojo` (1371 lines) at module level.
  Fix: move `from shared.core.shape import concatenate` inside `_concatenate_tensors()`.

- **Integration Tests**: `test_end_to_end.mojo` crashes because it imports
  `from shared.core.reduction import mean` at module level, pulling in
  `reduction.mojo` (1254 lines) + `shape.mojo` (1371 lines) + `reduction_ops.mojo`
  (507 lines) = ~3132 lines at load time.
  Fix: move import inside each of the two call sites.

Both follow the per-function local import pattern from PRs #5256 and #5257.

## Files Modified

| File | Change |
|------|--------|
| `shared/data/datasets/cifar10.mojo` | Move `concatenate` import to inside `_concatenate_tensors()` |
| `tests/shared/integration/test_end_to_end.mojo` | Move `mean` import to inside call sites |

## References

- ADR-015: targeted import audit to prevent JIT compilation volume overflow
- Follows pattern from PR #5256 (activation.mojo) and PR #5257 (loss/linear/conv)
- Tracking: Issue #5108

Closes #5108