### PR TITLE
fix(shared/testing): import shape symbols from shared.core.shape

### DIFF
--- a/shared/testing/layer_testers.mojo
+++ b/shared/testing/layer_testers.mojo
@@ -51,10 +51,11 @@ Usage:
 
 from std.math import isnan, isinf
 from shared.tensor.any_tensor import AnyTensor, zeros_like, ones_like
-from shared.core.conv import conv2d, conv2d_output_shape, conv2d_backward
+from shared.core.conv import conv2d, conv2d_backward
+from shared.core.shape import conv2d_output_shape, pool_output_shape
 from shared.core.linear import linear, linear_backward
 from shared.core.normalization import batch_norm2d, batch_norm2d_backward
-from shared.core.pooling import maxpool2d, avgpool2d, pool_output_shape
+from shared.core.pooling import maxpool2d, avgpool2d
 from shared.core.reduction import sum as tensor_sum
 from shared.core.activation import (
     relu,


### PR DESCRIPTION
## Summary

- Fixes compile error introduced by ADR-015 import localization commits `fb5d87dd` / `2842b95d`
- `conv2d_output_shape` and `pool_output_shape` are defined in `shared/core/shape.mojo`; `layer_testers.mojo` was still importing them from `conv` and `pooling` which no longer re-export them at module scope
- Splits the broken import lines and points them at the canonical source

## Root Cause

`shared/testing/layer_testers.mojo:54,57` relied on module-level re-exports that were removed when imports were localized inside functions in the perf commits. This is a hard compile error, not a flaky test.

## Files Changed

- `shared/testing/layer_testers.mojo` — split conv/pooling import lines; add `from shared.core.shape import conv2d_output_shape, pool_output_shape`

## Verification

- `grep -rn "conv2d_output_shape\|pool_output_shape" shared/ --include="*.mojo"` shows no remaining broken import paths
- Build Validation and Mojo Package Compilation CI jobs should go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)