### PR TITLE
fix(scripts): update hephaestus wrappers to 0.7.0 API

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -217,7 +217,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install hephaestus
-        run: pip install "homericintelligence-hephaestus>=0.6.0,<1"
+        run: pip install "homericintelligence-hephaestus>=0.7.0,<1"
 
       - name: Validate dependency consistency
         run: python scripts/check_dep_sync.py

--- a/scripts/agents/agent_stats.py
+++ b/scripts/agents/agent_stats.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """agent_stats.py - Generate usage statistics for the agent system."""
+
 # Thin re-export wrapper — functionality moved to hephaestus.
 # Remove in next release cycle after consumers are updated.
 # See: HomericIntelligence/ProjectHephaestus v0.7.0
@@ -8,4 +9,5 @@ from hephaestus.agents.stats import *  # noqa: F401,F403
 if __name__ == "__main__":
     import sys
     from hephaestus.agents.stats import main
+
     sys.exit(main())

--- a/scripts/agents/agent_utils.py
+++ b/scripts/agents/agent_utils.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Shared utilities for agent configuration scripts."""
+
 # Thin re-export wrapper — functionality moved to hephaestus.
 # Remove in next release cycle after consumers are updated.
 # See: HomericIntelligence/ProjectHephaestus v0.7.0

--- a/scripts/agents/check_frontmatter.py
+++ b/scripts/agents/check_frontmatter.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Check YAML frontmatter in agent configuration files."""
+
 # Thin re-export wrapper — functionality moved to hephaestus.
 # Remove in next release cycle after consumers are updated.
 # See: HomericIntelligence/ProjectHephaestus v0.7.0
@@ -8,4 +9,5 @@ from hephaestus.agents.frontmatter import *  # noqa: F401,F403
 if __name__ == "__main__":
     import sys
     from hephaestus.agents.frontmatter import validate_agents_main
+
     sys.exit(validate_agents_main())

--- a/scripts/agents/list_agents.py
+++ b/scripts/agents/list_agents.py
@@ -5,7 +5,20 @@
 # See: HomericIntelligence/ProjectHephaestus v0.7.0
 from hephaestus.agents.loader import *  # noqa: F401,F403
 
+
+def main() -> None:
+    """List all available agents by loading from hephaestus.agents.loader."""
+    from pathlib import Path
+
+    from hephaestus.agents.loader import load_all_agents
+
+    # Resolve the .claude/agents directory relative to this script's repo root
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    agents_dir = repo_root / ".claude" / "agents"
+    agents = load_all_agents(agents_dir)
+    for agent in agents:
+        print(agent)
+
+
 if __name__ == "__main__":
-    import sys
-    from hephaestus.agents.loader import main
-    sys.exit(main())
+    main()

--- a/scripts/agents/list_agents.py
+++ b/scripts/agents/list_agents.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """List all available agents."""
+
 # Thin re-export wrapper — functionality moved to hephaestus.
 # Remove in next release cycle after consumers are updated.
 # See: HomericIntelligence/ProjectHephaestus v0.7.0

--- a/scripts/agents/validate_agents.py
+++ b/scripts/agents/validate_agents.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Comprehensive validation of agent configuration files."""
+
 # Thin re-export wrapper — functionality moved to hephaestus.
 # Remove in next release cycle after consumers are updated.
 # See: HomericIntelligence/ProjectHephaestus v0.7.0
@@ -8,4 +9,5 @@ from hephaestus.agents.frontmatter import *  # noqa: F401,F403
 if __name__ == "__main__":
     import sys
     from hephaestus.agents.frontmatter import validate_agents_main
+
     sys.exit(validate_agents_main())

--- a/scripts/bench_precommit.py
+++ b/scripts/bench_precommit.py
@@ -7,5 +7,5 @@ from hephaestus.ci.precommit import *  # noqa: F401,F403
 
 if __name__ == "__main__":
     import sys
-    from hephaestus.ci.precommit import main
+    from hephaestus.ci.precommit import bench_precommit_main as main
     sys.exit(main())

--- a/scripts/bench_precommit.py
+++ b/scripts/bench_precommit.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Pre-commit hook performance benchmark helper."""
+
 # Thin re-export wrapper — functionality moved to hephaestus.
 # Remove in next release cycle after consumers are updated.
 # See: HomericIntelligence/ProjectHephaestus v0.7.0
@@ -8,4 +9,5 @@ from hephaestus.ci.precommit import *  # noqa: F401,F403
 if __name__ == "__main__":
     import sys
     from hephaestus.ci.precommit import bench_precommit_main as main
+
     sys.exit(main())

--- a/scripts/check_dep_sync.py
+++ b/scripts/check_dep_sync.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Validate dependency consistency across project configuration files."""
+
 # Thin re-export wrapper — functionality moved to hephaestus.
 # Remove in next release cycle after consumers are updated.
 # See: HomericIntelligence/ProjectHephaestus v0.7.0
@@ -8,4 +9,5 @@ from hephaestus.config.dep_sync import *  # noqa: F401,F403
 if __name__ == "__main__":
     import sys
     from hephaestus.config.dep_sync import check_dep_sync_main as main
+
     sys.exit(main())

--- a/scripts/check_dep_sync.py
+++ b/scripts/check_dep_sync.py
@@ -7,5 +7,5 @@ from hephaestus.config.dep_sync import *  # noqa: F401,F403
 
 if __name__ == "__main__":
     import sys
-    from hephaestus.config.dep_sync import main
+    from hephaestus.config.dep_sync import check_dep_sync_main as main
     sys.exit(main())

--- a/scripts/check_precommit_versions.py
+++ b/scripts/check_precommit_versions.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Check pre-commit version consistency against pixi.toml."""
+
 # Thin re-export wrapper — functionality moved to hephaestus.
 # Remove in next release cycle after consumers are updated.
 # See: HomericIntelligence/ProjectHephaestus v0.7.0
@@ -8,4 +9,5 @@ from hephaestus.ci.precommit import *  # noqa: F401,F403
 if __name__ == "__main__":
     import sys
     from hephaestus.ci.precommit import check_precommit_versions_main as main
+
     sys.exit(main())

--- a/scripts/check_precommit_versions.py
+++ b/scripts/check_precommit_versions.py
@@ -7,5 +7,5 @@ from hephaestus.ci.precommit import *  # noqa: F401,F403
 
 if __name__ == "__main__":
     import sys
-    from hephaestus.ci.precommit import main
+    from hephaestus.ci.precommit import check_precommit_versions_main as main
     sys.exit(main())

--- a/scripts/check_stale_scripts.py
+++ b/scripts/check_stale_scripts.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Detect scripts/*.py files with no references in .github/, justfile, or other scripts/."""
+
 # Thin re-export wrapper — functionality moved to hephaestus.
 # Remove in next release cycle after consumers are updated.
 # See: HomericIntelligence/ProjectHephaestus v0.7.0
@@ -8,4 +9,5 @@ from hephaestus.validation.stale_scripts import *  # noqa: F401,F403
 if __name__ == "__main__":
     import sys
     from hephaestus.validation.stale_scripts import main
+
     sys.exit(main())

--- a/scripts/check_workflow_inventory.py
+++ b/scripts/check_workflow_inventory.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Check workflow inventory drift between .github/workflows/*.yml files and README.md table."""
+
 # Thin re-export wrapper — functionality moved to hephaestus.
 # Remove in next release cycle after consumers are updated.
 # See: HomericIntelligence/ProjectHephaestus v0.7.0
@@ -8,4 +9,5 @@ from hephaestus.ci.workflows import *  # noqa: F401,F403
 if __name__ == "__main__":
     import sys
     from hephaestus.ci.workflows import check_workflow_inventory_main as main
+
     sys.exit(main())

--- a/scripts/check_workflow_inventory.py
+++ b/scripts/check_workflow_inventory.py
@@ -7,5 +7,5 @@ from hephaestus.ci.workflows import *  # noqa: F401,F403
 
 if __name__ == "__main__":
     import sys
-    from hephaestus.ci.workflows import main
+    from hephaestus.ci.workflows import check_workflow_inventory_main as main
     sys.exit(main())

--- a/scripts/detect_stale_scripts.py
+++ b/scripts/detect_stale_scripts.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Detect potentially stale scripts in the scripts/ directory."""
+
 # Thin re-export wrapper — functionality moved to hephaestus.
 # Remove in next release cycle after consumers are updated.
 # See: HomericIntelligence/ProjectHephaestus v0.7.0
@@ -8,4 +9,5 @@ from hephaestus.validation.stale_scripts import *  # noqa: F401,F403
 if __name__ == "__main__":
     import sys
     from hephaestus.validation.stale_scripts import main
+
     sys.exit(main())

--- a/scripts/download_cifar10.py
+++ b/scripts/download_cifar10.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Download and prepare CIFAR-10 dataset for ML Odyssey AlexNet example."""
+
 # Thin re-export wrapper — functionality moved to hephaestus.
 # Remove in next release cycle after consumers are updated.
 # See: HomericIntelligence/ProjectHephaestus v0.7.0
@@ -7,4 +8,5 @@ from hephaestus.datasets.downloader import CIFAR10Downloader, main  # noqa: F401
 
 if __name__ == "__main__":
     from hephaestus.datasets.downloader import main
+
     main()

--- a/scripts/download_cifar10.py
+++ b/scripts/download_cifar10.py
@@ -6,6 +6,5 @@
 from hephaestus.datasets.downloader import CIFAR10Downloader, main  # noqa: F401
 
 if __name__ == "__main__":
-    import sys
     from hephaestus.datasets.downloader import main
-    sys.exit(main())
+    main()

--- a/scripts/download_cifar100.py
+++ b/scripts/download_cifar100.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Download CIFAR-100 dataset for ML Odyssey."""
+
 # Thin re-export wrapper — functionality moved to hephaestus.
 # Remove in next release cycle after consumers are updated.
 # See: HomericIntelligence/ProjectHephaestus v0.7.0
@@ -7,4 +8,5 @@ from hephaestus.datasets.downloader import CIFAR100Downloader, main  # noqa: F40
 
 if __name__ == "__main__":
     from hephaestus.datasets.downloader import main
+
     main()

--- a/scripts/download_cifar100.py
+++ b/scripts/download_cifar100.py
@@ -6,6 +6,5 @@
 from hephaestus.datasets.downloader import CIFAR100Downloader, main  # noqa: F401
 
 if __name__ == "__main__":
-    import sys
     from hephaestus.datasets.downloader import main
-    sys.exit(main())
+    main()

--- a/scripts/download_datasets.py
+++ b/scripts/download_datasets.py
@@ -6,6 +6,5 @@
 from hephaestus.datasets.downloader import main  # noqa: F401
 
 if __name__ == "__main__":
-    import sys
     from hephaestus.datasets.downloader import main
-    sys.exit(main())
+    main()

--- a/scripts/download_datasets.py
+++ b/scripts/download_datasets.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Unified dataset downloader for ML Odyssey."""
+
 # Thin re-export wrapper — functionality moved to hephaestus.
 # Remove in next release cycle after consumers are updated.
 # See: HomericIntelligence/ProjectHephaestus v0.7.0
@@ -7,4 +8,5 @@ from hephaestus.datasets.downloader import main  # noqa: F401
 
 if __name__ == "__main__":
     from hephaestus.datasets.downloader import main
+
     main()

--- a/scripts/download_emnist.py
+++ b/scripts/download_emnist.py
@@ -6,6 +6,5 @@
 from hephaestus.datasets.downloader import EMNISTDownloader, EMNIST_SPLITS, main  # noqa: F401
 
 if __name__ == "__main__":
-    import sys
     from hephaestus.datasets.downloader import main
-    sys.exit(main())
+    main()

--- a/scripts/download_emnist.py
+++ b/scripts/download_emnist.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Download and extract EMNIST dataset."""
+
 # Thin re-export wrapper — functionality moved to hephaestus.
 # Remove in next release cycle after consumers are updated.
 # See: HomericIntelligence/ProjectHephaestus v0.7.0
@@ -7,4 +8,5 @@ from hephaestus.datasets.downloader import EMNISTDownloader, EMNIST_SPLITS, main
 
 if __name__ == "__main__":
     from hephaestus.datasets.downloader import main
+
     main()

--- a/scripts/download_fashion_mnist.py
+++ b/scripts/download_fashion_mnist.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Download Fashion-MNIST dataset for ML Odyssey."""
+
 # Thin re-export wrapper — functionality moved to hephaestus.
 # Remove in next release cycle after consumers are updated.
 # See: HomericIntelligence/ProjectHephaestus v0.7.0
@@ -7,4 +8,5 @@ from hephaestus.datasets.downloader import FashionMNISTDownloader, main  # noqa:
 
 if __name__ == "__main__":
     from hephaestus.datasets.downloader import main
+
     main()

--- a/scripts/download_fashion_mnist.py
+++ b/scripts/download_fashion_mnist.py
@@ -6,6 +6,5 @@
 from hephaestus.datasets.downloader import FashionMNISTDownloader, main  # noqa: F401
 
 if __name__ == "__main__":
-    import sys
     from hephaestus.datasets.downloader import main
-    sys.exit(main())
+    main()

--- a/scripts/download_mnist.py
+++ b/scripts/download_mnist.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Download MNIST dataset for ML Odyssey."""
+
 # Thin re-export wrapper — functionality moved to hephaestus.
 # Remove in next release cycle after consumers are updated.
 # See: HomericIntelligence/ProjectHephaestus v0.7.0
@@ -7,4 +8,5 @@ from hephaestus.datasets.downloader import MNISTDownloader, main  # noqa: F401
 
 if __name__ == "__main__":
     from hephaestus.datasets.downloader import main
+
     main()

--- a/scripts/download_mnist.py
+++ b/scripts/download_mnist.py
@@ -6,6 +6,5 @@
 from hephaestus.datasets.downloader import MNISTDownloader, main  # noqa: F401
 
 if __name__ == "__main__":
-    import sys
     from hephaestus.datasets.downloader import main
-    sys.exit(main())
+    main()

--- a/scripts/sync_requirements.py
+++ b/scripts/sync_requirements.py
@@ -7,5 +7,5 @@ from hephaestus.config.dep_sync import *  # noqa: F401,F403
 
 if __name__ == "__main__":
     import sys
-    from hephaestus.config.dep_sync import main
+    from hephaestus.config.dep_sync import sync_requirements_main as main
     sys.exit(main())

--- a/scripts/sync_requirements.py
+++ b/scripts/sync_requirements.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Synchronize requirements*.txt from pixi.toml resolved versions."""
+
 # Thin re-export wrapper — functionality moved to hephaestus.
 # Remove in next release cycle after consumers are updated.
 # See: HomericIntelligence/ProjectHephaestus v0.7.0
@@ -8,4 +9,5 @@ from hephaestus.config.dep_sync import *  # noqa: F401,F403
 if __name__ == "__main__":
     import sys
     from hephaestus.config.dep_sync import sync_requirements_main as main
+
     sys.exit(main())

--- a/scripts/validate_workflow_inventory.py
+++ b/scripts/validate_workflow_inventory.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Validate that GitHub Actions workflows match documentation."""
+
 # Thin re-export wrapper — functionality moved to hephaestus.
 # Remove in next release cycle after consumers are updated.
 # See: HomericIntelligence/ProjectHephaestus v0.7.0
@@ -8,4 +9,5 @@ from hephaestus.ci.workflows import *  # noqa: F401,F403
 if __name__ == "__main__":
     import sys
     from hephaestus.ci.workflows import validate_workflow_checkout_main as main
+
     sys.exit(main())

--- a/scripts/validate_workflow_inventory.py
+++ b/scripts/validate_workflow_inventory.py
@@ -7,5 +7,5 @@ from hephaestus.ci.workflows import *  # noqa: F401,F403
 
 if __name__ == "__main__":
     import sys
-    from hephaestus.ci.workflows import main
+    from hephaestus.ci.workflows import validate_workflow_checkout_main as main
     sys.exit(main())


### PR DESCRIPTION
## Summary

- Updates 6 script wrappers to use renamed entry points from `hephaestus` 0.7.0 (`main` → `<script>_main`)
- Reimplements `scripts/agents/list_agents.py` entry point locally (upstream removed `agents.loader.main`; uses `load_all_agents(agents_dir)`)
- Fixes `sys.exit(main())` type error in 6 `download_*.py` wrappers (`main()` returns `None`)
- Tightens `homericintelligence-hephaestus` pin in `comprehensive-tests.yml` from `>=0.6.0` to `>=0.7.0` to match `pixi.toml`

## Root Cause

`homericintelligence-hephaestus` 0.7.0 renamed all entry points from `main` to `<script>_main` for disambiguation. Wrappers imported the old symbol and failed at runtime with `ImportError`.

## Files Changed

- `scripts/check_dep_sync.py`, `sync_requirements.py`, `check_precommit_versions.py`, `bench_precommit.py`, `check_workflow_inventory.py`, `validate_workflow_inventory.py` — updated imports
- `scripts/agents/list_agents.py` — local reimplementation of entry point using `load_all_agents(agents_dir)`
- `scripts/download_cifar10.py`, `download_cifar100.py`, `download_emnist.py`, `download_fashion_mnist.py`, `download_mnist.py`, `download_datasets.py` — removed `sys.exit()` wrapper
- `.github/workflows/comprehensive-tests.yml` — tightened hephaestus version pin

## Verification

- `pixi run mypy --exclude generators/ scripts/` returns 0 errors (73 source files)
- Import smoke test passes: `import scripts.check_dep_sync`, `sync_requirements`, `check_precommit_versions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)