### PR TITLE
chore(adr): reconcile superseded ADRs with tree

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -231,7 +231,8 @@ jobs:
     timeout-minutes: 15  # Job timeout for all matrix groups. Monitor wall-clock times after
                           # consolidating test files. If any group consistently takes >10 min,
                           # split it into two separate entries. See Issue #3357 for monitoring
-                          # guidance and ADR-009 for heap corruption splitting constraints.
+                          # guidance. Test groups are isolated for parallel execution and
+                          # job-timeout management.
     strategy:
       fail-fast: false  # Run all test groups even if one fails
       max-parallel: 2  # Each mojo invocation maps ~3.6 GB virtual address space (VmPeak).
@@ -258,15 +259,12 @@ jobs:
             path: "tests/shared/core"
             pattern: "test_losses.mojo test_loss_funcs*.mojo test_loss_utils.mojo"
           # ---- Gradient math ----
-          # Mojo JIT crashes (libKGENCompilerRTShared.so) on CI runners.
-          # Non-blocking pending Mojo runtime fix.
           - name: "Core Gradient"
             path: "tests/shared/core"
             pattern: "test_backward*.mojo test_gradient*.mojo test_variable_backward*.mojo test_depthwise_conv*.mojo"
-          # ---- Core Utilities (split into A/B/C/D per Issue #4116 and ADR-009) ----
+          # ---- Core Utilities (split into A/B/C/D per Issue #4116) ----
           # Previously a single group with 91 files. Split to reduce per-job
-          # wall-clock time, improve failure isolation, and stay within ADR-009
-          # heap corruption safety margins.
+          # wall-clock time and improve failure isolation.
           # Glob wildcards are supported and preferred — use them where practical
           # so that new test files are auto-discovered without manual CI updates.
           # ---- Core Utilities A: General utilities, validation, bitwise, integration ----
@@ -336,13 +334,11 @@ jobs:
           #   - fixtures/test_*.mojo: ✓ (2+ test files)
           #   - training/test_*.mojo: ✓ (11+ test files)
           #   - testing/test_*.mojo: ✓ (10+ test files)
-          # Mojo JIT crashes on CI runners — non-blocking pending investigation.
           - name: "Shared Infra & Testing"
             path: "tests/shared"
             pattern: "test_imports*.mojo test_data_generators.mojo test_model_utils.mojo test_serialization.mojo utils/test_*.mojo fixtures/test_*.mojo training/test_*.mojo testing/test_*.mojo"
           # ---- Model layer tests (the main PR-blocking test suite) ----
           # test_*.mojo glob auto-discovers all model tests without requiring manual CI updates.
-          # Mojo JIT crashes on CI runners — non-blocking pending investigation.
           - name: "Models"
             path: "tests/models"
             pattern: "test_*.mojo"

--- a/docs/adr/ADR-009-heap-corruption-workaround.md
+++ b/docs/adr/ADR-009-heap-corruption-workaround.md
@@ -2,6 +2,10 @@
 
 **Status**: Resolved (2026-03-20)
 
+**Resolution**: Bitcast UAF fixed by ADR-013 (Mojo 0.25.x runtime fix). No active workarounds
+remain in tree. Last `# ADR-009` annotation removed; all test files use standard isolation
+grouping for parallelism/timeout management only.
+
 **Date**: 2025-12-30
 
 **Issue Reference**: [Issue #3120](https://github.com/HomericIntelligence/ProjectOdyssey/issues/3120)

--- a/docs/adr/ADR-014-jit-crash-retry-mitigation.md
+++ b/docs/adr/ADR-014-jit-crash-retry-mitigation.md
@@ -4,10 +4,8 @@
 issue filing is now the approach for persistent JIT crashes. See `repro/` directory for minimal
 reproducers and upstream issue [modular/modular#6187](https://github.com/modular/modular/issues/6187).
 
-> **ADR-015 (2026-04-12)**: ADR-015 extends the corrective actions by committing to actually
-> removing `scripts/test-with-retry.sh` from the tree (it is still wired in `justfile:664` and
-> `justfile:829` despite this ADR's SUPERSEDED status) and executing a targeted import audit
-> on the two required-check test groups (`Core Types & Fuzz`, `Integration Tests`).
+> **ADR-015 (2026-04-12)**: Retry machinery fully removed by PR #5254 (2026-04-12).
+> ADR-015 subsumes all corrective-action tracking for JIT-related CI instability.
 > See [ADR-015](ADR-015-flaky-required-checks-jit-crash.md) for the full decision record.
 
 **Date**: 2026-03-25
@@ -44,7 +42,7 @@ The same test file may pass or crash depending on ASLR, memory layout, and JIT c
 ### What Has Already Been Done
 
 | Approach | Result |
-|----------|--------|
+| -------- | ------ |
 | Targeted submodule imports (ADR-009 era) | Reduced frequency but didn't eliminate |
 | ADR-009 file splitting | No longer needed (bitcast UAF resolved) |
 | `@always_inline` on helpers | Made things worse (reverted) |
@@ -90,7 +88,7 @@ indicates a harder problem (possibly a real compilation issue). Configurable via
 **Exit codes**:
 
 | Code | Meaning | Retried? |
-|------|---------|----------|
+| ---- | ------- | -------- |
 | 0 | Test passed | First attempt or after retry |
 | 1 | Real test failure | Never |
 | 2 | JIT crash persisted | Yes, once |
@@ -138,7 +136,7 @@ time without improving pass rates.
 ## Files Modified
 
 | File | Change |
-|------|--------|
+| ---- | ------ |
 | `scripts/test-with-retry.sh` | New -- core retry logic |
 | `justfile` | `_test-group-inner` and `_test-mojo-inner` use retry wrapper |
 | `.github/workflows/comprehensive-tests.yml` | Comment documenting retry mechanism |
@@ -165,6 +163,6 @@ time without improving pass rates.
 
 ## Revision History
 
-| Version | Date | Author | Changes |
-|---------|------|--------|---------|
-| 1.0 | 2026-03-25 | Claude Code | Initial ADR documenting retry mitigation |
+| Version | Date       | Author      | Changes                                   |
+| ------- | ---------- | ----------- | ----------------------------------------- |
+| 1.0     | 2026-03-25 | Claude Code | Initial ADR documenting retry mitigation  |

--- a/shared/autograd/grad_utils.mojo
+++ b/shared/autograd/grad_utils.mojo
@@ -16,7 +16,6 @@ Note:
 References:
     - On the difficulty of training Recurrent Neural Networks (Pascanu et al., 2013)
       https://arxiv.org/abs/1211.1541
-    - ADR-009: Heap Corruption Workaround
     - Issue #4513: AnyTensor circular type resolution
 """
 


### PR DESCRIPTION
## Summary

- Removes 3 remaining `# Non-blocking pending investigation` / `# non-blocking pending Mojo runtime fix` comment lines from `comprehensive-tests.yml` (PR #5255 missed these; branch protection is authoritative)
- Reframes `# ADR-009` workflow comments from heap-corruption rationale to parallelism/job-timeout rationale (ADR-009 is Resolved; no workarounds remain)
- Updates `docs/adr/ADR-009` to record Resolved status and removal of last workaround annotations
- Updates `docs/adr/ADR-014` to remove stale claim that retry script is still wired in justfile (PR #5254 removed it)
- Fixes pre-existing MD060 table lint errors in ADR-014 (separator rows missing spaces)
- Removes stale ADR-009 cross-reference from `shared/autograd/grad_utils.mojo` docstring (unrelated to heap corruption)

## Root Cause

ADR-009 was marked Resolved and ADR-014 was Superseded, but code comments and ADR cross-references were not fully cleaned up. Three occurrences were missed by PR #5255.

## Files Changed

- `.github/workflows/comprehensive-tests.yml` — remove non-blocking comments, reframe ADR-009 group-split comments
- `docs/adr/ADR-009-heap-corruption-workaround.md` — add Resolved status with resolution detail
- `docs/adr/ADR-014-jit-crash-retry-mitigation.md` — remove stale wiring reference, point to ADR-015; fix MD060 table lint
- `shared/autograd/grad_utils.mojo` — remove stale ADR-009 reference from docstring

## Verification

- `grep -n "non-blocking" .github/workflows/comprehensive-tests.yml` returns empty
- `grep -n "ADR-009" .github/workflows/comprehensive-tests.yml` returns empty
- `grep -rn "ADR-009" tests/ shared/ --include="*.mojo"` returns empty
- markdownlint passes on all edited ADR files (0 errors)

## ADR-010 Assessment

`shared/training/mixed_precision.mojo` was inspected. The ADR-010 scalar workaround has already been fully replaced with SIMD vectorized paths (`_convert_fp16_to_fp32_simd`, `_convert_fp32_to_fp16_simd`). No dead code remains. ADR-010 Phase 2 checklist reflects this correctly. No code changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)