### PR TITLE
fix(docs): blank line before list in repro/README (MD032) + table style (MD060)

### DIFF
--- a/repro/README.md
+++ b/repro/README.md
@@ -135,7 +135,7 @@ When multiple `mojo` processes run concurrently on GitHub Actions free runners
 **Measured findings (from `investigate_import_threshold.sh`):**
 
 | Variable | Impact on RSS |
-|----------|---------------|
+| -------- | ------------- |
 | Monomorphization count (1–300) | None (all ~330MB RSS) |
 | Line count (50–1000 concrete fns) | None |
 | Module-level vs per-function imports | None (same ~330MB RSS) |
@@ -149,6 +149,7 @@ shorter compile time means fewer processes overlap in time, reducing peak memory
 pressure across the runner's 7GB.
 
 **Fix options (in order of impact):**
+
 1. Reduce parallel CI jobs competing for memory (e.g., `max-parallel: 2`)
 2. Use larger GitHub Actions runners (16GB) for Mojo test matrix
 3. Per-function imports in library modules still help by reducing compilation time


### PR DESCRIPTION
## Summary

- `repro/README.md:152`: adds blank line between `**Fix options (in order of impact):**` and the ordered list — fixes `MD032/blanks-around-lists`
- `repro/README.md:138`: adds spaces inside separator row pipes (`|----------|` → `| -------- |`) — fixes `MD060/table-column-style`

## Root Cause

`Pre-commit Checks → Run pre-commit hooks → markdownlint-cli2` was reporting `Summary: 1 error(s)` for MD032. Also found and fixed an adjacent MD060 violation in the same file's table separator row.

## Test plan

- [ ] `pixi run npx markdownlint-cli2 repro/README.md` reports `Summary: 0 error(s)`
- [ ] `Pre-commit Checks` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)