### PR TITLE
fix(docs+ci): mkdocs strict out-of-tree links + pixi cache stale-restore fix

### DIFF
--- a/.github/actions/setup-pixi/action.yml
+++ b/.github/actions/setup-pixi/action.yml
@@ -23,5 +23,3 @@ runs:
           ~/.pixi/bin
           ~/.cache/rattler/cache
         key: pixi-${{ runner.os }}-${{ hashFiles('pixi.lock') }}
-        restore-keys: |
-          pixi-${{ runner.os }}-

--- a/docs/adr/ADR-015-flaky-required-checks-jit-crash.md
+++ b/docs/adr/ADR-015-flaky-required-checks-jit-crash.md
@@ -298,7 +298,7 @@ issue #5108):
   (SUPERSEDED; retry script still wired pending this ADR's action #2)
 - [`docs/dev/mojo-jit-crash-workaround.md`](../dev/mojo-jit-crash-workaround.md) --
   Import explosion root cause, Symbol-to-Submodule Mapping, diagnostic table
-- [`repro/issues/jit-compilation-volume-crash.md`](../../repro/issues/jit-compilation-volume-crash.md) --
+- [`repro/issues/jit-compilation-volume-crash.md`](https://github.com/HomericIntelligence/ProjectOdyssey/blob/main/repro/issues/jit-compilation-volume-crash.md) --
   0.26.3 minimal reproducer
 - [modular/modular#6187](https://github.com/modular/modular/issues/6187) -- Upstream
   Mojo bug (cited in ADR-014 and workaround doc)

--- a/docs/dev/mojo-jit-crash-workaround.md
+++ b/docs/dev/mojo-jit-crash-workaround.md
@@ -197,7 +197,7 @@ of the two required status checks -- `Core Types & Fuzz` (path: `tests/core/type
 `Integration Tests` (path: `tests/shared/integration/`). Three consecutive `main` runs on
 2026-04-12 all failed in a different random subset of groups, confirming the classic
 non-deterministic JIT overflow pattern. See
-[`repro/issues/jit-compilation-volume-crash.md`](../../repro/issues/jit-compilation-volume-crash.md)
+[`repro/issues/jit-compilation-volume-crash.md`](https://github.com/HomericIntelligence/ProjectOdyssey/blob/main/repro/issues/jit-compilation-volume-crash.md)
 for the 0.26.3 minimal reproducer.
 
 [ADR-015](../adr/ADR-015-flaky-required-checks-jit-crash.md) formalizes the corrective


### PR DESCRIPTION
## Summary

**Fix 1: MkDocs strict mode broken relative links**

`mkdocs build --strict` in `.github/workflows/docs.yml:63` was aborting Deploy Documentation with 2 warnings about relative links pointing outside `docs/` (the configured `docs_dir`).

Both broken links target `repro/issues/jit-compilation-volume-crash.md`, which exists but lives in a sibling directory outside the MkDocs docs tree. MkDocs cannot include or resolve it.

Files changed:
- `docs/adr/ADR-015-flaky-required-checks-jit-crash.md:301` — relative `../../repro/issues/...` → absolute GitHub blob URL
- `docs/dev/mojo-jit-crash-workaround.md:200` — same fix

**Fix 2: Pixi cache stale-restore causing false pre-commit drift failures**

`setup-pixi/action.yml` had a broad fallback `restore-keys: pixi-${{ runner.os }}-` that restored a pixi environment from ANY prior pixi.lock hash. When pixi.lock changed (hephaestus 0.6.x → 0.7.0), CI restored the old environment instead of installing fresh, causing `check_precommit_versions.py` to report `mypy`, `nbstripout`, `pre-commit-hooks` as MISSING (they weren't in the old hephaestus's DEFAULT_HOOK_TO_PIXI_MAP).

Fix: remove the fallback restore-keys so any pixi.lock change always gets a fresh install.

## Root Causes

- Deploy Documentation: 7 consecutive failures since 2026-04-19 from `--strict` + 2 out-of-tree links
- Pre-commit Checks: false MISSING reports from stale pixi environment (hephaestus 0.6.x)

## Test plan

- [ ] `Deploy Documentation` workflow passes (`pixi run mkdocs build --strict` exits 0)
- [ ] `Pre-commit Checks → Check pre-commit vs pixi version drift` passes (no stale cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)