### PR TITLE
fix(ci): install hephaestus in pip-only CI jobs

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -545,6 +545,9 @@ jobs:
             pip install -r requirements-dev.txt
           fi
 
+      - name: Install hephaestus
+        run: pip install "homericintelligence-hephaestus>=0.7.0,<1"
+
       - name: Run Python tests
         run: |
           mkdir -p test-results

--- a/.github/workflows/validate-configs.yml
+++ b/.github/workflows/validate-configs.yml
@@ -269,6 +269,9 @@ jobs:
       - name: Install dependencies
         run: pip install pyyaml
 
+      - name: Install hephaestus
+        run: pip install "homericintelligence-hephaestus>=0.7.0,<1"
+
       - name: Validate agent configurations
         run: python3 tests/agents/validate_configs.py .claude/agents/
 


### PR DESCRIPTION
## Summary

Two CI jobs fail with `ModuleNotFoundError: No module named 'hephaestus'` because they use raw pip (not pixi) but never install `homericintelligence-hephaestus`.

- `test-python` job in `comprehensive-tests.yml` → `tests/unit/scripts/test_check_stale_scripts.py` → `scripts/check_stale_scripts.py` imports `hephaestus.*`
- `test-agents` job in `validate-configs.yml` → `tests/agents/test_loading.py` → `scripts/agents/agent_utils.py` imports `hephaestus.agents`

## Changes Made

- **`comprehensive-tests.yml`**: Added `Install hephaestus` step in `test-python` job after the requirements install steps. Mirrors the existing pattern in the `validate-dep-sync` job (L219-220).
- **`validate-configs.yml`**: Added `Install hephaestus` step in `test-agents` job after `pip install pyyaml`.

## Verification

Both workflow YAML files validated with `yaml.safe_load`. No other pip-only jobs run hephaestus-importing scripts (full audit performed).