### PR TITLE
fix(ci): fix remaining markdownlint and end-of-file pre-commit failures

### DIFF
--- a/.claude/shared/mojo-guidelines.md
+++ b/.claude/shared/mojo-guidelines.md
@@ -8,7 +8,7 @@ Official docs: <https://docs.modular.com/mojo/manual/>
 ## When to Use Mojo vs Python
 
 | Use Case | Language | Reason |
-|----------|----------|--------|
+| -------- | -------- | ------ |
 | ML/AI implementations | Mojo (required) | Performance, type safety |
 | Performance-critical code | Mojo (required) | SIMD, optimization |
 | Subprocess output capture | Python (allowed) | Mojo v0.26.3 limitation |
@@ -22,7 +22,7 @@ Official docs: <https://docs.modular.com/mojo/manual/>
 ### Parameter Conventions
 
 | Convention | Use For | Example |
-|------------|---------|---------|
+| ---------- | ------- | ------- |
 | `out self` | Constructors | `fn __init__(out self, value: Int)` |
 | `mut self` | Mutating methods | `fn modify(mut self)` |
 | `read` (default) | Read-only access | `fn get(self) -> Int` |
@@ -31,7 +31,7 @@ Official docs: <https://docs.modular.com/mojo/manual/>
 ### Deprecated Patterns
 
 | Wrong | Correct | Notes |
-|-------|---------|-------|
+| ----- | ------- | ----- |
 | `borrowed self` | `self` | Deprecated keyword |
 | `inout self` | `mut self` | Deprecated keyword |
 | `@value` | `@fieldwise_init` + traits | Add `(Copyable, Movable)` |

--- a/docs/adr/ADR-015-flaky-required-checks-jit-crash.md
+++ b/docs/adr/ADR-015-flaky-required-checks-jit-crash.md
@@ -298,8 +298,7 @@ issue #5108):
   (SUPERSEDED; retry script still wired pending this ADR's action #2)
 - [`docs/dev/mojo-jit-crash-workaround.md`](../dev/mojo-jit-crash-workaround.md) --
   Import explosion root cause, Symbol-to-Submodule Mapping, diagnostic table
-- [`repro/issues/jit-compilation-volume-crash.md`](https://github.com/HomericIntelligence/ProjectOdyssey/blob/main/repro/issues/jit-compilation-volume-crash.md) --
-  0.26.3 minimal reproducer
+- [`repro/issues/jit-compilation-volume-crash.md`][jit-crash-repro] -- 0.26.3 minimal reproducer
 - [modular/modular#6187](https://github.com/modular/modular/issues/6187) -- Upstream
   Mojo bug (cited in ADR-014 and workaround doc)
 - [modular/modular#6413](https://github.com/modular/modular/issues/6413) -- Upstream
@@ -321,3 +320,5 @@ issue #5108):
 | Version | Date | Author | Changes |
 | --- | --- | --- | --- |
 | 1.0 | 2026-04-12 | Claude Code | Initial ADR documenting root cause and corrective actions |
+
+[jit-crash-repro]: https://github.com/HomericIntelligence/ProjectOdyssey/blob/main/repro/issues/jit-compilation-volume-crash.md

--- a/docs/dev/backward-pass-catalog.md
+++ b/docs/dev/backward-pass-catalog.md
@@ -1179,7 +1179,7 @@ Backward pass (per sample, same three-term structure):
 ### Key Differences from batch_norm2d_backward
 
 | Property | batch_norm2d | layer_norm |
-|----------|-------------|------------|
+| -------- | ----------- | ---------- |
 | Normalizes over | N, H, W (across batch+spatial) | feature dims (per sample) |
 | Running statistics | YES (training/inference modes) | NO |
 | gamma shape | `(C,)` | matches feature dims |
@@ -1210,7 +1210,7 @@ NO — gamma is broadcast over the batch dimension via per-sample loops.
 ## SUMMARY TABLE: All Backward Pass Functions
 
 | Module | Function | Count | Broadcasting | Stability | Shape Reduction | Complexity |
-|--------|----------|-------|--------------|-----------|-----------------|-----------|
+| ------ | -------- | ----- | ------------ | --------- | --------------- | ---------- |
 | arithmetic | _reduce_broadcast_dims | Helper | YES | - | YES | Medium |
 | arithmetic | add_backward | 1 | YES | - | YES | Low |
 | arithmetic | subtract_backward | 2 | YES | - | YES | Low |

--- a/docs/dev/mojo-jit-crash-workaround.md
+++ b/docs/dev/mojo-jit-crash-workaround.md
@@ -48,7 +48,7 @@ symbol-to-submodule mapping below.
 ## Symbol-to-Submodule Mapping
 
 | Symbol(s) | Submodule |
-|-----------|-----------|
+| --------- | --------- |
 | AnyTensor, zeros, ones, full, empty, arange, eye, linspace, ones_like, zeros_like, full_like, nan_tensor, inf_tensor, neg_inf_tensor, clone, item, diff, randn | `shared.core.any_tensor` |
 | reshape, squeeze, unsqueeze, expand_dims, flatten, ravel, concatenate, stack, split, tile, repeat, permute, is_contiguous, as_contiguous, view, broadcast_to, ... | `shared.core.shape` |
 | add, subtract, multiply, divide, floor_divide, modulo, power, multiply_scalar, \*\_backward | `shared.core.arithmetic` |
@@ -80,7 +80,7 @@ symbol-to-submodule mapping below.
 The key diagnostic is **where the crash appears relative to test output**:
 
 | Symptom | Cause |
-|---------|-------|
+| ------- | ----- |
 | `execution crashed` appears **before any test output** | Import explosion crash -- check import style |
 | `execution crashed` or segfault appears **after test output** | Likely a real test bug |
 | Specific assertion failure message | Real test bug -- investigate |
@@ -125,7 +125,7 @@ ADR-009 is no longer necessary. The `continue-on-error: true` workaround has bee
 `comprehensive-tests.yml`.
 
 | | JIT Crash (this doc) | Heap Corruption (ADR-009) |
-|-|---------------------|--------------------------|
+| - | ------------------- | ------------------------ |
 | **Trigger** | Package-level import compilation overflow | After exactly ~15 cumulative tests in one file |
 | **Output** | `execution crashed` before any test runs | Crash mid-run after test output |
 | **Root cause** | `__init__.mojo` import explosion -> monomorphization overflow | Cumulative allocations exceed JIT heap limit |
@@ -142,7 +142,7 @@ Two synthetic test files were created to isolate the import-style variable:
 ### Local Results (GLIBC 2.39, Mojo 0.26.1, WSL2 Linux 6.6.87)
 
 | Test | Runs | Pass | Crash | Crash Rate |
-|------|------|------|-------|------------|
+| ---- | ---- | ---- | ----- | ---------- |
 | Heavy (package-level) | 30 | 30 | 0 | 0% |
 | Light (targeted) | 30 | 30 | 0 | 0% |
 
@@ -173,7 +173,7 @@ Only the JIT crash signature triggers a retry.
 **Exit codes from `scripts/test-with-retry.sh`**:
 
 | Code | Meaning |
-|------|---------|
+| ---- | ------- |
 | 0 | Test passed (first attempt or after retry) |
 | 1 | Real test failure (not retried) |
 | 2 | JIT crash persisted after retry |
@@ -184,7 +184,8 @@ See [ADR-014](../adr/ADR-014-jit-crash-retry-mitigation.md) for the full decisio
 
 - [Issue #5108](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5108) -- JIT crash comprehensive tracking
 - [Issue #3330](https://github.com/HomericIntelligence/ProjectOdyssey/issues/3330) -- Document JIT crash workaround
-- [Issue #3120](https://github.com/HomericIntelligence/ProjectOdyssey/issues/3120) -- Core Loss test crashes (follow-up context)
+- [Issue #3120](https://github.com/HomericIntelligence/ProjectOdyssey/issues/3120) --
+  Core Loss test crashes (follow-up context)
 - [ADR-009](../adr/ADR-009-heap-corruption-workaround.md) -- Heap corruption workaround (resolved 2026-03-20)
 - [ADR-014](../adr/ADR-014-jit-crash-retry-mitigation.md) -- JIT crash retry mitigation (SUPERSEDED)
 - [ADR-015](../adr/ADR-015-flaky-required-checks-jit-crash.md) -- Flaky required checks and corrective actions (2026-04-12)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,3 @@
 # These files exist for pip-only contexts (Docker, CI fallback).
 
 -r requirements.txt
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 # AUTO-GENERATED from pixi.toml — do not edit manually.
 # Regenerate with: hephaestus-sync-requirements
 # These files exist for pip-only contexts (Docker, CI fallback).
-

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,8 +29,10 @@ The following one-time scripts were removed in #3337 (stale audit follow-up to #
 - `merge_backward_tests.py` - Duplicate approach to merge backward-tests branch
 - `bisect_heap_test.py` - Git bisect artifact for heap corruption investigation (ADR-009); issue resolved
 - `run_bisect_heap.sh` - Shell wrapper for `bisect_heap_test.py`; same reasoning
-- `check_test_count.py` - Enforced ≤10 tests per file per ADR-009 heap-corruption threshold; ADR-009 resolved 2026-03-20, limit removed
-- `validate_adr009_headers.py` - Validated ADR-009 split-file docstring headers; ADR-009 resolved 2026-03-20, headers no longer required
+- `check_test_count.py` - Enforced ≤10 tests per file per ADR-009 heap-corruption threshold;
+  ADR-009 resolved 2026-03-20, limit removed
+- `validate_adr009_headers.py` - Validated ADR-009 split-file docstring headers;
+  ADR-009 resolved 2026-03-20, headers no longer required
 - `fix-build-errors.py` - One-time autonomous repair script; targeted build errors already fixed
 - `batch_planning_docs.py` - One-time batch doc generation; planning now via GitHub issues directly
 - `add_delegation_to_agents.py` - One-time bulk agent attribute addition; completed


### PR DESCRIPTION
## Summary

Fixes the two remaining pre-commit failures on main (run 24762067425):

- **MD013 line-length** in `docs/adr/ADR-015-flaky-required-checks-jit-crash.md:301` — 163 chars due to absolute GitHub URL. Fixed using reference-style link definition placed at document end.
- **MD013 line-length** in `scripts/README.md:32-33` — 135/136 chars from ADR-009 cleanup entries. Split at semicolons.
- **MD060 compact table separators** in `.claude/shared/mojo-guidelines.md` and `docs/dev/mojo-jit-crash-workaround.md` and `docs/dev/backward-pass-catalog.md`.
- **end-of-file-fixer** — `requirements.txt` and `requirements-dev.txt` had trailing blank lines.

## Test plan

- [ ] Pre-commit Checks workflow passes (no markdownlint errors, no end-of-file-fixer changes)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>