### PR TITLE
fix(tests): fix Mojo compile errors blocking CI on main

### DIFF
--- a/tests/shared/integration/test_end_to_end.mojo
+++ b/tests/shared/integration/test_end_to_end.mojo
@@ -22,6 +22,7 @@ from tests.shared.conftest import (
 from shared.testing.models import SimpleMLP
 from shared.tensor.any_tensor import AnyTensor, zeros, ones
 from shared.core.loss import mean_squared_error
+from shared.core.reduction import mean
 from shared.core.activation import softmax
 
 
@@ -81,7 +82,6 @@ def test_model_training_to_evaluation() raises:
         var output = model.forward(input_tensor)
 
         # Compute MSE loss
-        from shared.core.reduction import mean
         var squared_error = mean_squared_error(output, target_tensor)
         var loss = mean(squared_error, axis=0, keepdims=False)
 
@@ -508,7 +508,6 @@ def test_full_pipeline_integration() raises:
             var output = model.forward(train_inputs[sample_idx])
 
             # Compute loss
-            from shared.core.reduction import mean
             var mse = mean_squared_error(output, train_targets[sample_idx])
             var loss = mean(mse, axis=0, keepdims=False)
             epoch_loss += loss._get_float32(0)

--- a/tests/shared/test_imports.mojo
+++ b/tests/shared/test_imports.mojo
@@ -275,7 +275,7 @@ def test_training_loops_imports() raises:
 
 def test_data_imports() raises:
     """Test data package imports work correctly."""
-from shared.data.datasets import AnyTensorDataset, CIFAR10Dataset, Dataset, EMNISTDataset
+    from shared.data.datasets import AnyTensorDataset, CIFAR10Dataset, Dataset
 
     print("✓ Data imports test passed")
 

--- a/tests/shared/testing/test_gradient_checker_meta.mojo
+++ b/tests/shared/testing/test_gradient_checker_meta.mojo
@@ -47,7 +47,7 @@ def square_forward(x: AnyTensor) raises -> AnyTensor:
         x: Input tensor.
 
     Returns:
-        x^2: Element-wise squaring.
+        Squared result (x^2): Element-wise squaring.
     """
     var result = zeros_like(x)
     for i in range(x.numel()):


### PR DESCRIPTION
## Summary

- Move `from shared.core.reduction import mean` to module top in `test_end_to_end.mojo` (was inside a for-loop body at lines 84 & 511 — Mojo compile error)
- Fix `test_data_imports()` in `test_imports.mojo`: restore correct indentation (import was at module scope) and drop `EMNISTDataset` (not exported by `shared.data.datasets`)
- Fix docstring `Returns:` section capitalization in `test_gradient_checker_meta.mojo` (Mojo parser requires capital-letter section body start)

These three compile errors caused `Integration Tests` and `Shared Infra & Testing` groups to fail in CI run #24762067420. All other failing groups show only `libKGENCompilerRTShared.so` execution crashes (tracked separately as JIT runtime issues).

## Files Modified

- `tests/shared/integration/test_end_to_end.mojo` — move import, remove 2 in-body duplicates
- `tests/shared/test_imports.mojo` — fix indentation + drop unexported symbol
- `tests/shared/testing/test_gradient_checker_meta.mojo` — docstring capitalization

## Verification

Pre-commit hooks passed locally (Mojo Format, Trim Trailing Whitespace, Fix End of Files, all clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>