### PR TITLE
fix(docker): add build/ to _ensure_writable so just build-release works

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -52,6 +52,7 @@ _ensure_writable() {
 }
 
 _ensure_writable \
+    build \
     tests/configs/fixtures \
     tests/shared/fixtures \
     /tmp/mojo-tests


### PR DESCRIPTION
## Summary

- Add `build` to the `_ensure_writable` call in `docker/entrypoint.sh` so the Podman dev container creates `/workspace/build` with correct permissions at startup
- This fixes `just build-debug` and `just build-release` which fail with "Permission denied" before reaching the Mojo compiler

## Root Cause

`build/` is gitignored and never exists in the host workspace or the image. The bind-mount `.:/workspace:Z` shadows `/workspace` at runtime, so any `mkdir -p` in `_build-inner` fails. `_ensure_writable` already runs at container startup for other runtime directories but was missing `build`.

## Change

`docker/entrypoint.sh` — one line added to `_ensure_writable` call.

## Test Plan

- [ ] Run `just build-debug` inside container → exits 0
- [ ] Run `just build-release` inside container → exits 0
- [ ] CI green

Closes #5334