### PR TITLE
fix(audit): add pip-audit and pip-licenses to pixi.toml

### DIFF
--- a/justfile
+++ b/justfile
@@ -909,7 +909,6 @@ clean-worktrees mode="dry-run":
 # Run dependency audit locally
 audit:
     @echo "Running dependency audit..."
-    @pip install safety pip-audit pip-licenses 2>/dev/null || true
     @echo ""
     @echo "=== Safety Scan ==="
     -@safety check --file requirements.txt

--- a/pixi.toml
+++ b/pixi.toml
@@ -41,6 +41,7 @@ bandit = ">=1.7.5"
 mypy = ">=1.19.1,<2"
 types-PyYAML = ">=6.0"
 safety = ">=3.0.0,<4"
+pip-audit = ">=2.7.0,<3"
 
 # Pre-commit
 pre-commit = ">=3.5.0"
@@ -65,6 +66,7 @@ notebook = { features = ["notebook", "dev"], solve-group = "default" }
 
 [pypi-dependencies]
 homericintelligence-hephaestus = ">=0.7.0,<1"
+pip-licenses = ">=4.0.0,<5"
 
 [tasks]
 bandit = "bandit --ini .bandit"


### PR DESCRIPTION
## Summary

- Add `pip-audit` to `[feature.dev.dependencies]` (available on conda-forge)
- Add `pip-licenses` to `[pypi-dependencies]` (PyPI only)
- Remove bare `pip install` line from `audit` justfile recipe

`just audit` was failing with exit 127 because these tools were not declared in `pixi.toml`.
The recipe was attempting a runtime `pip install` as a workaround, which bypasses pixi.

## Test Plan

- [ ] `pixi install` resolves without conflict
- [ ] `just audit` runs safety/pip-audit/pip-licenses without exit 127
- [ ] CI green

Closes #5336