### PR TITLE
feat(ci): implement Test Configuration Loading tests (#5344)

### DIFF
--- a/.github/workflows/validate-configs.yml
+++ b/.github/workflows/validate-configs.yml
@@ -138,8 +138,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
-      - name: Set up Pixi (provides Mojo)
-        uses: ./.github/actions/setup-pixi
+      - name: Set up container
+        uses: ./.github/actions/setup-container
+
+      - name: Install Just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
 
       - name: Test config loading
         run: |

--- a/.github/workflows/validate-configs.yml
+++ b/.github/workflows/validate-configs.yml
@@ -141,15 +141,19 @@ jobs:
       - name: Set up Pixi (provides Mojo)
         uses: ./.github/actions/setup-pixi
 
-      - name: Test config loading (placeholder)
+      - name: Test config loading
         run: |
-          echo "Testing configuration loading..."
-          echo "NOTE: This is a placeholder - implement actual Mojo tests in Issue #73"
-          echo "Tests should validate:"
-          echo "  - Config files can be loaded without errors"
-          echo "  - Config merging works correctly"
-          echo "  - Environment variable substitution works"
-          echo "  - Validation catches invalid configs"
+          echo "Running configuration loading tests..."
+          just test-group tests/configs "test_loading.mojo"
+          echo "Running configuration merging tests..."
+          just test-group tests/configs "test_merging.mojo"
+          echo "Running configuration validation tests..."
+          just test-group tests/configs "test_validation.mojo"
+          echo "Running environment variable substitution tests..."
+          just test-group tests/configs "test_env_vars.mojo"
+          echo "Running configuration integration tests..."
+          just test-group tests/configs "test_integration.mojo"
+          echo "All configuration loading tests passed!"
 
   validate-agents:
     name: Validate Agent Configurations

--- a/tests/configs/__init__.mojo
+++ b/tests/configs/__init__.mojo
@@ -20,9 +20,7 @@ Fixtures:
 Run Tests:
     mojo test tests/configs/test_loading.mojo
     mojo test tests/configs/test_merging.mojo
-    mojo test tests/configs/test_validation_part1.mojo
-    mojo test tests/configs/test_validation_part2.mojo
-    mojo test tests/configs/test_validation_part3.mojo
+    mojo test tests/configs/test_validation.mojo
     mojo test tests/configs/test_env_vars.mojo
     mojo test tests/configs/test_integration.mojo
     pytest tests/configs/test_schema.py


### PR DESCRIPTION
## Summary

- Replace placeholder `echo` commands in `test-config-loading` CI step with actual `just test-group` invocations running the existing Mojo test suite under `tests/configs/`
- Fix stale references in `tests/configs/__init__.mojo` (removes `test_validation_part1/2/3.mojo` which never existed; corrects to `test_validation.mojo`)

## Changes Made

- `.github/workflows/validate-configs.yml`: Replace placeholder with 5 `just test-group` calls covering loading, merging, validation, env vars, and integration tests
- `tests/configs/__init__.mojo`: Fix `Run Tests` section to reference actual file `test_validation.mojo` instead of non-existent `_part1/2/3` splits

## Test plan

- [ ] CI `test-config-loading` job runs `just test-group tests/configs "test_loading.mojo"`
- [ ] CI `test-config-loading` job runs `just test-group tests/configs "test_merging.mojo"`
- [ ] CI `test-config-loading` job runs `just test-group tests/configs "test_validation.mojo"`
- [ ] CI `test-config-loading` job runs `just test-group tests/configs "test_env_vars.mojo"`
- [ ] CI `test-config-loading` job runs `just test-group tests/configs "test_integration.mojo"`
- [ ] All pre-commit hooks pass

Closes #5344

🤖 Generated with [Claude Code](https://claude.com/claude-code)