### PR TITLE
test(foundation): implement paper implementation validation tests

### DIFF
--- a/tests/foundation/test_paper_implementation_validation.py
+++ b/tests/foundation/test_paper_implementation_validation.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""
+Test suite for paper implementation validation.
+
+Implements the validation tests described in GitHub issue #5343:
+Validates paper directory structure completeness, implementation files
+presence, test coverage for paper implementations, and reproducibility
+verification. These tests back the CI paper-validation.yml workflow.
+
+Test Categories:
+- Structure: Directory and file completeness per CI spec
+- Implementation: Mojo implementation files and test presence
+- Metadata: metadata.yml validation (fields and format)
+- Reproducibility: Training script presence and config validity
+
+Coverage Target: >95%
+"""
+
+import sys
+from pathlib import Path
+from typing import List
+
+import pytest
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def papers_root(tmp_path: Path) -> Path:
+    """Provide a temporary papers/ root for isolated tests."""
+    papers = tmp_path / "papers"
+    papers.mkdir()
+    return papers
+
+
+@pytest.fixture
+def complete_paper_dir(papers_root: Path) -> Path:
+    """
+    Provide a fully-valid paper directory under a temporary papers/ root.
+
+    Creates the minimum structure expected by paper-validation.yml:
+    - README.md (non-empty)
+    - metadata.yml (all required fields)
+    - implementation/ with at least one .mojo file
+    - tests/ with at least one test_*.mojo file
+    """
+    paper = papers_root / "example-paper"
+    paper.mkdir()
+
+    (paper / "README.md").write_text(
+        "# Example Paper\n\n## Overview\nA test paper.\n\n## Implementation\nDetails here.\n"
+    )
+
+    metadata = {
+        "title": "Example Paper Title",
+        "authors": ["Author One", "Author Two"],
+        "year": 2024,
+        "url": "https://arxiv.org/abs/0000.00000",
+    }
+    (paper / "metadata.yml").write_text(yaml.dump(metadata))
+
+    impl_dir = paper / "implementation"
+    impl_dir.mkdir()
+    (impl_dir / "model.mojo").write_text("fn forward() -> Int:\n    return 0\n")
+
+    tests_dir = paper / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_model.mojo").write_text("fn test_forward():\n    assert forward() == 0\n")
+
+    return paper
+
+
+# ---------------------------------------------------------------------------
+# Structure validation
+# ---------------------------------------------------------------------------
+
+
+class TestPaperStructureValidation:
+    """Validate paper directory structure (mirrors CI validate-structure job)."""
+
+    def test_required_file_readme_present(self, complete_paper_dir: Path) -> None:
+        """README.md must exist in a valid paper directory."""
+        assert (complete_paper_dir / "README.md").is_file()
+
+    def test_required_file_metadata_present(self, complete_paper_dir: Path) -> None:
+        """metadata.yml must exist in a valid paper directory."""
+        assert (complete_paper_dir / "metadata.yml").is_file()
+
+    def test_missing_readme_detected(self, papers_root: Path) -> None:
+        """Absence of README.md is flagged as a missing required file."""
+        paper = papers_root / "no-readme"
+        paper.mkdir()
+        (paper / "metadata.yml").write_text("title: T\nauthors: []\nyear: 2024\nurl: https://x\n")
+
+        missing = _check_required_files(paper, ["README.md", "metadata.yml"])
+        assert "README.md" in missing
+
+    def test_missing_metadata_detected(self, papers_root: Path) -> None:
+        """Absence of metadata.yml is flagged as a missing required file."""
+        paper = papers_root / "no-metadata"
+        paper.mkdir()
+        (paper / "README.md").write_text("# Paper\n\n## Overview\n\n## Implementation\n")
+
+        missing = _check_required_files(paper, ["README.md", "metadata.yml"])
+        assert "metadata.yml" in missing
+
+    def test_no_missing_files_for_complete_paper(self, complete_paper_dir: Path) -> None:
+        """A complete paper directory has no missing required files."""
+        missing = _check_required_files(complete_paper_dir, ["README.md", "metadata.yml"])
+        assert missing == [], f"Unexpected missing files: {missing}"
+
+    def test_recommended_implementation_dir_detected(self, complete_paper_dir: Path) -> None:
+        """implementation/ is present in a well-formed paper."""
+        assert (complete_paper_dir / "implementation").is_dir()
+
+    def test_recommended_tests_dir_detected(self, complete_paper_dir: Path) -> None:
+        """tests/ is present in a well-formed paper."""
+        assert (complete_paper_dir / "tests").is_dir()
+
+    def test_papers_directory_contains_template(self) -> None:
+        """The real papers/ directory contains the _template subdirectory."""
+        repo_root = Path(__file__).parent.parent.parent
+        template = repo_root / "papers" / "_template"
+        assert template.is_dir(), "papers/_template must exist as the scaffold starting point"
+
+    def test_papers_readme_exists_in_repo(self) -> None:
+        """The real papers/README.md must exist and be non-empty."""
+        repo_root = Path(__file__).parent.parent.parent
+        readme = repo_root / "papers" / "README.md"
+        assert readme.is_file(), "papers/README.md must exist"
+        assert readme.stat().st_size > 0, "papers/README.md must not be empty"
+
+
+# ---------------------------------------------------------------------------
+# Implementation validation
+# ---------------------------------------------------------------------------
+
+
+class TestImplementationFilesValidation:
+    """Validate Mojo implementation files and test presence."""
+
+    def test_mojo_files_found_in_implementation_dir(self, complete_paper_dir: Path) -> None:
+        """implementation/ directory must contain at least one .mojo file."""
+        impl_dir = complete_paper_dir / "implementation"
+        mojo_files = list(impl_dir.glob("*.mojo")) + list(impl_dir.rglob("*.🔥"))
+        assert len(mojo_files) >= 1, "Expected at least one Mojo file in implementation/"
+
+    def test_test_files_found_in_tests_dir(self, complete_paper_dir: Path) -> None:
+        """tests/ directory must contain at least one test_*.mojo file."""
+        tests_dir = complete_paper_dir / "tests"
+        test_files = list(tests_dir.glob("test_*.mojo")) + list(tests_dir.glob("test_*.py"))
+        assert len(test_files) >= 1, "Expected at least one test file in tests/"
+
+    def test_empty_implementation_dir_flagged(self, papers_root: Path) -> None:
+        """An implementation/ dir with no Mojo files is reported as incomplete."""
+        paper = papers_root / "empty-impl"
+        paper.mkdir()
+        (paper / "implementation").mkdir()
+
+        impl_dir = paper / "implementation"
+        mojo_files = list(impl_dir.glob("*.mojo")) + list(impl_dir.rglob("*.🔥"))
+        assert len(mojo_files) == 0
+
+    def test_missing_implementation_dir_flagged(self, papers_root: Path) -> None:
+        """A paper without implementation/ is reported as missing it."""
+        paper = papers_root / "no-impl"
+        paper.mkdir()
+        assert not (paper / "implementation").exists()
+
+    def test_missing_tests_dir_flagged(self, papers_root: Path) -> None:
+        """A paper without tests/ is reported as missing it."""
+        paper = papers_root / "no-tests"
+        paper.mkdir()
+        assert not (paper / "tests").exists()
+
+
+# ---------------------------------------------------------------------------
+# Metadata validation
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataValidation:
+    """Validate metadata.yml structure and required fields."""
+
+    def test_metadata_has_all_required_fields(self, complete_paper_dir: Path) -> None:
+        """Valid metadata.yml contains title, authors, year, and url."""
+        metadata = _load_metadata(complete_paper_dir)
+        missing = _check_metadata_fields(metadata, ["title", "authors", "year", "url"])
+        assert missing == [], f"Missing metadata fields: {missing}"
+
+    def test_metadata_missing_title_detected(self, papers_root: Path) -> None:
+        """metadata.yml without 'title' is flagged."""
+        paper = papers_root / "no-title"
+        paper.mkdir()
+        (paper / "metadata.yml").write_text("authors: [A]\nyear: 2024\nurl: https://x\n")
+        metadata = _load_metadata(paper)
+        missing = _check_metadata_fields(metadata, ["title", "authors", "year", "url"])
+        assert "title" in missing
+
+    def test_metadata_missing_year_detected(self, papers_root: Path) -> None:
+        """metadata.yml without 'year' is flagged."""
+        paper = papers_root / "no-year"
+        paper.mkdir()
+        (paper / "metadata.yml").write_text("title: T\nauthors: [A]\nurl: https://x\n")
+        metadata = _load_metadata(paper)
+        missing = _check_metadata_fields(metadata, ["title", "authors", "year", "url"])
+        assert "year" in missing
+
+    def test_metadata_invalid_yaml_raises(self, papers_root: Path) -> None:
+        """Malformed metadata.yml raises an appropriate error on load."""
+        paper = papers_root / "bad-yaml"
+        paper.mkdir()
+        (paper / "metadata.yml").write_text("title: [\ninvalid yaml {{\n")
+        with pytest.raises(Exception):
+            _load_metadata(paper)
+
+    def test_metadata_year_is_numeric(self, complete_paper_dir: Path) -> None:
+        """metadata.yml 'year' field must be a number."""
+        metadata = _load_metadata(complete_paper_dir)
+        assert isinstance(metadata.get("year"), (int, float)), "'year' must be numeric"
+
+    def test_metadata_url_is_string(self, complete_paper_dir: Path) -> None:
+        """metadata.yml 'url' field must be a non-empty string."""
+        metadata = _load_metadata(complete_paper_dir)
+        url = metadata.get("url", "")
+        assert isinstance(url, str) and url.strip(), "'url' must be a non-empty string"
+
+
+# ---------------------------------------------------------------------------
+# Reproducibility verification
+# ---------------------------------------------------------------------------
+
+
+class TestReproducibilityVerification:
+    """Validate presence of training scripts for reproducibility runs."""
+
+    def test_train_script_presence_detected(self, papers_root: Path) -> None:
+        """A paper with train.py is identified as having a training script."""
+        paper = papers_root / "with-train-py"
+        paper.mkdir()
+        (paper / "train.py").write_text("# training script\n")
+        assert _has_training_script(paper), "Expected train.py to be detected"
+
+    def test_mojo_train_script_detected(self, papers_root: Path) -> None:
+        """A paper with train.mojo is identified as having a training script."""
+        paper = papers_root / "with-train-mojo"
+        paper.mkdir()
+        (paper / "train.mojo").write_text("fn main():\n    pass\n")
+        assert _has_training_script(paper), "Expected train.mojo to be detected"
+
+    def test_no_training_script_returns_false(self, papers_root: Path) -> None:
+        """A paper with no training script returns False."""
+        paper = papers_root / "no-train"
+        paper.mkdir()
+        assert not _has_training_script(paper), "Expected no training script to be detected"
+
+    def test_config_yaml_is_valid(self, complete_paper_dir: Path) -> None:
+        """If a configs/config.yaml exists it must be valid YAML."""
+        configs_dir = complete_paper_dir / "configs"
+        configs_dir.mkdir(exist_ok=True)
+        config_path = configs_dir / "config.yaml"
+        config_path.write_text("model:\n  name: test\ntraining:\n  epochs: 1\n")
+
+        with config_path.open() as fh:
+            parsed = yaml.safe_load(fh)
+        assert isinstance(parsed, dict), "config.yaml must parse to a dict"
+        assert "model" in parsed, "config.yaml must contain 'model' key"
+        assert "training" in parsed, "config.yaml must contain 'training' key"
+
+    def test_no_config_does_not_block_validation(self, papers_root: Path) -> None:
+        """A paper without configs/ does not raise during reproducibility check."""
+        paper = papers_root / "no-config"
+        paper.mkdir()
+        # Should not raise; config is optional
+        _has_training_script(paper)  # exercises the helper without error
+
+
+# ---------------------------------------------------------------------------
+# Private helpers (mirroring CI shell logic in Python for testability)
+# ---------------------------------------------------------------------------
+
+
+def _check_required_files(paper_dir: Path, required: List[str]) -> List[str]:
+    """
+    Return the list of required file names missing from *paper_dir*.
+
+    Args:
+        paper_dir: Path to the paper directory.
+        required: Sequence of file names that must be present.
+
+    Returns:
+        List of file names that are absent.
+    """
+    return [f for f in required if not (paper_dir / f).is_file()]
+
+
+def _load_metadata(paper_dir: Path) -> dict:
+    """
+    Parse and return the paper's metadata.yml as a dict.
+
+    Args:
+        paper_dir: Path to the paper directory.
+
+    Returns:
+        Parsed YAML content as a dictionary.
+
+    Raises:
+        FileNotFoundError: If metadata.yml does not exist.
+        yaml.YAMLError: If the file contains invalid YAML.
+    """
+    path = paper_dir / "metadata.yml"
+    if not path.is_file():
+        raise FileNotFoundError(f"metadata.yml not found in {paper_dir}")
+    with path.open() as fh:
+        return yaml.safe_load(fh)
+
+
+def _check_metadata_fields(metadata: dict, required: List[str]) -> List[str]:
+    """
+    Return the list of required field names absent from *metadata*.
+
+    Args:
+        metadata: Parsed metadata dictionary.
+        required: Field names that must be present.
+
+    Returns:
+        List of absent field names.
+    """
+    return [field for field in required if field not in metadata]
+
+
+def _has_training_script(paper_dir: Path) -> bool:
+    """
+    Return True if the paper directory contains a training script.
+
+    Checks for train.py or train.mojo at the paper root (matching the
+    logic in the validate-reproducibility CI job).
+
+    Args:
+        paper_dir: Path to the paper directory.
+
+    Returns:
+        True if a training script exists, False otherwise.
+    """
+    return (paper_dir / "train.py").is_file() or (paper_dir / "train.mojo").is_file()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_paper_implementation_validation.py
+++ b/tests/test_paper_implementation_validation.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Tests for paper implementation validation logic.
+
+Validates the conventions that paper-validation.yml enforces:
+  1. Paper directory structure: README.md + metadata.yml are required
+  2. metadata.yml content: required fields (title, authors, year, url)
+  3. Implementation presence: implementation/ directory with .mojo files
+  4. Test coverage: tests/ directory with test_*.mojo or test_*.py files
+  5. Template directory (_template) is excluded from validation
+
+These tests use the actual papers/ directory to verify the template complies
+with conventions, and use temporary fixtures to test validation logic in isolation.
+"""
+
+import tempfile
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent
+PAPERS_DIR = REPO_ROOT / "papers"
+TEMPLATE_DIR = PAPERS_DIR / "_template"
+
+REQUIRED_PAPER_FILES: List[str] = ["README.md", "metadata.yml"]
+REQUIRED_METADATA_FIELDS: List[str] = ["title", "authors", "year", "url"]
+RECOMMENDED_PAPER_DIRS: List[str] = ["implementation", "tests"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers used by test classes
+# ---------------------------------------------------------------------------
+
+
+def find_paper_dirs(base: Path) -> List[Path]:
+    """Return all paper implementation directories (those containing metadata.yml).
+
+    Excludes the _template directory.
+    """
+    return [
+        p.parent
+        for p in base.glob("*/metadata.yml")
+        if p.parent.name != "_template"
+    ]
+
+
+def validate_paper_structure(paper_dir: Path) -> Tuple[bool, List[str]]:
+    """Check required files exist in a paper directory.
+
+    Returns (all_present, list_of_missing_files).
+    """
+    missing = [f for f in REQUIRED_PAPER_FILES if not (paper_dir / f).is_file()]
+    return len(missing) == 0, missing
+
+
+def parse_metadata(metadata_path: Path) -> Tuple[bool, Dict, List[str]]:
+    """Parse and validate a metadata.yml file.
+
+    Returns (valid, parsed_dict, missing_fields).
+    """
+    try:
+        with metadata_path.open() as fh:
+            data = yaml.safe_load(fh) or {}
+    except yaml.YAMLError:
+        return False, {}, REQUIRED_METADATA_FIELDS
+
+    missing = [f for f in REQUIRED_METADATA_FIELDS if f not in data]
+    return len(missing) == 0, data, missing
+
+
+# ---------------------------------------------------------------------------
+# Tests: papers/ directory root layout
+# ---------------------------------------------------------------------------
+
+
+class TestPapersDirectoryLayout:
+    """Verify the papers/ root directory meets baseline requirements."""
+
+    def test_papers_directory_exists(self) -> None:
+        """papers/ directory must exist at the repo root."""
+        assert PAPERS_DIR.exists() and PAPERS_DIR.is_dir(), (
+            f"papers/ directory not found at {PAPERS_DIR}. "
+            "Create it before adding paper implementations."
+        )
+
+    def test_papers_readme_exists(self) -> None:
+        """papers/README.md must exist to document paper conventions."""
+        readme = PAPERS_DIR / "README.md"
+        assert readme.is_file(), (
+            f"papers/README.md not found at {readme}. "
+            "A top-level README is required to guide contributors."
+        )
+
+    def test_papers_readme_is_non_empty(self) -> None:
+        """papers/README.md must contain meaningful content."""
+        readme = PAPERS_DIR / "README.md"
+        if readme.is_file():
+            assert readme.stat().st_size > 0, "papers/README.md must not be empty"
+
+    def test_template_directory_exists(self) -> None:
+        """papers/_template/ must exist as a starter template for new papers."""
+        assert TEMPLATE_DIR.exists() and TEMPLATE_DIR.is_dir(), (
+            f"papers/_template/ not found at {TEMPLATE_DIR}. "
+            "The template directory is required so contributors have a starting point."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: paper directory structure validation logic
+# ---------------------------------------------------------------------------
+
+
+class TestPaperStructureValidation:
+    """Unit tests for the paper structure validation logic (using tmp fixtures)."""
+
+    def test_valid_paper_passes_structure_check(self, tmp_path: Path) -> None:
+        """A directory with README.md and metadata.yml passes structure checks."""
+        (tmp_path / "README.md").write_text("# Test Paper\n")
+        (tmp_path / "metadata.yml").write_text(
+            "title: Test\nauthors: [Author]\nyear: 2020\nurl: https://example.com\n"
+        )
+        ok, missing = validate_paper_structure(tmp_path)
+        assert ok
+        assert missing == []
+
+    def test_missing_readme_fails_structure_check(self, tmp_path: Path) -> None:
+        """A directory missing README.md fails structure checks."""
+        (tmp_path / "metadata.yml").write_text("title: Test\n")
+        ok, missing = validate_paper_structure(tmp_path)
+        assert not ok
+        assert "README.md" in missing
+
+    def test_missing_metadata_fails_structure_check(self, tmp_path: Path) -> None:
+        """A directory missing metadata.yml fails structure checks."""
+        (tmp_path / "README.md").write_text("# Test\n")
+        ok, missing = validate_paper_structure(tmp_path)
+        assert not ok
+        assert "metadata.yml" in missing
+
+    def test_empty_directory_fails_structure_check(self, tmp_path: Path) -> None:
+        """An empty directory fails structure checks for all required files."""
+        ok, missing = validate_paper_structure(tmp_path)
+        assert not ok
+        assert set(missing) == set(REQUIRED_PAPER_FILES)
+
+
+# ---------------------------------------------------------------------------
+# Tests: metadata.yml validation logic
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataValidation:
+    """Unit tests for metadata.yml validation logic (using tmp fixtures)."""
+
+    def test_complete_metadata_is_valid(self, tmp_path: Path) -> None:
+        """metadata.yml with all required fields passes validation."""
+        metadata = {
+            "title": "Attention Is All You Need",
+            "authors": ["Vaswani et al."],
+            "year": 2017,
+            "url": "https://arxiv.org/abs/1706.03762",
+        }
+        metadata_path = tmp_path / "metadata.yml"
+        with metadata_path.open("w") as fh:
+            yaml.dump(metadata, fh)
+
+        ok, data, missing = parse_metadata(metadata_path)
+        assert ok
+        assert missing == []
+        assert data["title"] == "Attention Is All You Need"
+
+    def test_missing_title_fails_metadata_validation(self, tmp_path: Path) -> None:
+        """metadata.yml missing 'title' fails validation."""
+        metadata = {"authors": ["Author"], "year": 2020, "url": "https://example.com"}
+        metadata_path = tmp_path / "metadata.yml"
+        with metadata_path.open("w") as fh:
+            yaml.dump(metadata, fh)
+
+        ok, _, missing = parse_metadata(metadata_path)
+        assert not ok
+        assert "title" in missing
+
+    def test_missing_url_fails_metadata_validation(self, tmp_path: Path) -> None:
+        """metadata.yml missing 'url' fails validation."""
+        metadata = {"title": "A Paper", "authors": ["Author"], "year": 2020}
+        metadata_path = tmp_path / "metadata.yml"
+        with metadata_path.open("w") as fh:
+            yaml.dump(metadata, fh)
+
+        ok, _, missing = parse_metadata(metadata_path)
+        assert not ok
+        assert "url" in missing
+
+    def test_invalid_yaml_fails_metadata_validation(self, tmp_path: Path) -> None:
+        """A malformed metadata.yml reports all fields as missing."""
+        metadata_path = tmp_path / "metadata.yml"
+        metadata_path.write_text("{ invalid: yaml: content: [\n")
+
+        ok, data, missing = parse_metadata(metadata_path)
+        assert not ok
+        assert set(missing) == set(REQUIRED_METADATA_FIELDS)
+
+
+# ---------------------------------------------------------------------------
+# Tests: implementation and test coverage detection
+# ---------------------------------------------------------------------------
+
+
+class TestImplementationPresence:
+    """Tests for detecting Mojo implementation files in paper directories."""
+
+    def test_paper_with_mojo_files_detected(self, tmp_path: Path) -> None:
+        """A paper with .mojo files in implementation/ is considered implemented."""
+        impl_dir = tmp_path / "implementation"
+        impl_dir.mkdir()
+        (impl_dir / "model.mojo").write_text("fn main(): pass\n")
+
+        mojo_files = list(impl_dir.rglob("*.mojo"))
+        assert len(mojo_files) == 1
+
+    def test_paper_without_implementation_dir_is_unimplemented(self, tmp_path: Path) -> None:
+        """A paper missing implementation/ has no Mojo files."""
+        mojo_files = list(tmp_path.rglob("*.mojo"))
+        assert len(mojo_files) == 0
+
+    def test_find_paper_dirs_excludes_template(self) -> None:
+        """find_paper_dirs() must not return the _template directory."""
+        paper_dirs = find_paper_dirs(PAPERS_DIR)
+        names = [d.name for d in paper_dirs]
+        assert "_template" not in names, (
+            "_template must be excluded from paper validation. "
+            "The template directory is a scaffold, not an implementation."
+        )
+
+    def test_paper_test_files_detected(self, tmp_path: Path) -> None:
+        """A paper with test_*.mojo files in tests/ is considered tested."""
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        (tests_dir / "test_model.mojo").write_text("fn test_forward(): pass\n")
+        (tests_dir / "test_layers.mojo").write_text("fn test_conv(): pass\n")
+
+        test_files = list(tests_dir.glob("test_*.mojo")) + list(tests_dir.glob("test_*.py"))
+        assert len(test_files) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: template directory structure compliance
+# ---------------------------------------------------------------------------
+
+
+class TestTemplateDirectoryCompliance:
+    """Verify the _template directory itself meets expected structure conventions."""
+
+    def test_template_has_src_directory(self) -> None:
+        """_template must contain a src/ directory."""
+        src_dir = TEMPLATE_DIR / "src"
+        assert src_dir.is_dir(), (
+            f"_template/src/ not found at {src_dir}. "
+            "The template must include a src/ directory for Mojo implementation code."
+        )
+
+    def test_template_has_tests_directory(self) -> None:
+        """_template must contain a tests/ directory."""
+        tests_dir = TEMPLATE_DIR / "tests"
+        assert tests_dir.is_dir(), (
+            f"_template/tests/ not found at {tests_dir}. "
+            "The template must include a tests/ directory per TDD conventions."
+        )
+
+    def test_template_has_readme(self) -> None:
+        """_template must contain a README.md."""
+        readme = TEMPLATE_DIR / "README.md"
+        assert readme.is_file(), (
+            f"_template/README.md not found at {readme}. "
+            "The template README guides contributors in implementing new papers."
+        )
+
+    def test_template_readme_documents_structure(self) -> None:
+        """_template/README.md must mention expected subdirectories."""
+        readme = TEMPLATE_DIR / "README.md"
+        if not readme.is_file():
+            pytest.skip("_template/README.md not found; skipping content check")
+        content = readme.read_text(encoding="utf-8")
+        for expected_section in ("src/", "tests/"):
+            assert expected_section in content, (
+                f"_template/README.md must document the '{expected_section}' directory. "
+                f"Contributors rely on this to understand the expected paper structure."
+            )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/workflows/test_paper_validation_workflow.py
+++ b/tests/workflows/test_paper_validation_workflow.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Regression tests for paper-validation.yml workflow properties.
+
+Validates that .github/workflows/paper-validation.yml is well-formed and
+contains required configuration for paper implementation validation:
+  1. Workflow file is valid YAML with required top-level keys
+  2. Correct trigger paths (papers/**)
+  3. All 'uses:' actions are SHA-pinned (not tag-pinned)
+  4. Structure, implementation, and report jobs are defined
+  5. Permissions are restrictive (contents: read, pull-requests: write)
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "paper-validation.yml"
+
+SHA_RE = re.compile(r"uses:\s+\S+@([0-9a-f]{40})")
+TAG_RE = re.compile(r"uses:\s+\S+@v[0-9]")
+
+
+@pytest.fixture(scope="module")
+def workflow_content() -> str:
+    """Read the workflow file once for all tests in this module."""
+    assert WORKFLOW.exists(), f"paper-validation.yml not found at {WORKFLOW}"
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def workflow_yaml(workflow_content: str) -> dict:
+    """Parse and return the workflow YAML as a dict."""
+    try:
+        parsed = yaml.safe_load(workflow_content)
+        assert isinstance(parsed, dict), f"Workflow must be a YAML mapping, got {type(parsed)}"
+        return parsed
+    except yaml.YAMLError as e:
+        pytest.fail(f"paper-validation.yml is invalid YAML: {e}")
+
+
+class TestWorkflowExists:
+    """Verify the workflow file is present and parseable."""
+
+    def test_workflow_file_exists(self) -> None:
+        """paper-validation.yml must exist in .github/workflows/."""
+        assert WORKFLOW.exists(), (
+            f"paper-validation.yml not found at {WORKFLOW}. "
+            "This file is required to validate paper implementations in CI."
+        )
+
+    def test_workflow_is_valid_yaml(self, workflow_yaml: dict) -> None:
+        """Workflow must be valid YAML (fixture already validates this)."""
+        assert isinstance(workflow_yaml, dict)
+
+
+class TestWorkflowTriggers:
+    """Verify trigger configuration targets papers/ directory changes."""
+
+    def test_workflow_triggers_on_papers_path(self, workflow_content: str) -> None:
+        """Workflow must trigger when papers/** changes.
+
+        Without this path filter, paper validation would run on every push
+        regardless of whether paper content changed, wasting CI minutes.
+        Without the filter, paper regressions on PRs would go undetected.
+        """
+        assert "papers/**" in workflow_content, (
+            "paper-validation.yml must include 'papers/**' in path triggers. "
+            "This ensures the workflow runs when paper implementations are changed."
+        )
+
+    def test_workflow_has_pull_request_trigger(self, workflow_content: str) -> None:
+        """Workflow must trigger on pull_request events."""
+        assert re.search(r"^\s+pull_request\b", workflow_content, re.MULTILINE), (
+            "paper-validation.yml is missing a pull_request trigger. "
+            "Without it, paper structure violations can merge undetected."
+        )
+
+    def test_workflow_has_push_to_main_trigger(self, workflow_content: str) -> None:
+        """Workflow must trigger on pushes to main."""
+        assert re.search(r"^\s+push\b", workflow_content, re.MULTILINE), (
+            "paper-validation.yml is missing a push trigger for the main branch."
+        )
+
+    def test_workflow_has_workflow_dispatch(self, workflow_content: str) -> None:
+        """Workflow must support manual dispatch via workflow_dispatch.
+
+        Manual dispatch allows on-demand validation of the papers/ directory
+        without requiring a code change to trigger the workflow.
+        """
+        assert "workflow_dispatch" in workflow_content, (
+            "paper-validation.yml is missing workflow_dispatch trigger. "
+            "Manual dispatch is required to run paper validation on demand."
+        )
+
+
+class TestWorkflowPermissions:
+    """Verify permissions follow principle of least privilege."""
+
+    def test_permissions_key_present(self, workflow_yaml: dict) -> None:
+        """Workflow must declare explicit permissions."""
+        assert "permissions" in workflow_yaml, (
+            "paper-validation.yml is missing a top-level 'permissions' key. "
+            "Explicit permissions are required to follow least-privilege principle."
+        )
+
+    def test_contents_permission_is_read(self, workflow_yaml: dict) -> None:
+        """Workflow must request read-only contents access."""
+        permissions = workflow_yaml.get("permissions", {})
+        assert isinstance(permissions, dict), "permissions must be a mapping"
+        assert permissions.get("contents") == "read", (
+            "permissions.contents must be 'read'. "
+            "Paper validation only reads files and should not write to the repository."
+        )
+
+    def test_pull_requests_permission_is_write(self, workflow_yaml: dict) -> None:
+        """Workflow must request write access to pull-requests (for PR comments)."""
+        permissions = workflow_yaml.get("permissions", {})
+        assert isinstance(permissions, dict), "permissions must be a mapping"
+        assert permissions.get("pull-requests") == "write", (
+            "permissions.pull-requests must be 'write' to allow posting validation results "
+            "as PR comments via the paper-report job."
+        )
+
+
+class TestWorkflowJobs:
+    """Verify required jobs are defined."""
+
+    def test_jobs_key_present(self, workflow_yaml: dict) -> None:
+        """Workflow must have a 'jobs' key."""
+        assert "jobs" in workflow_yaml, "paper-validation.yml missing 'jobs' key"
+
+    def test_validate_structure_job_exists(self, workflow_yaml: dict) -> None:
+        """validate-structure job must be defined.
+
+        This job validates that each paper directory has required files
+        (README.md, metadata.yml) before any implementation is checked.
+        """
+        jobs = workflow_yaml.get("jobs", {})
+        assert "validate-structure" in jobs, (
+            "paper-validation.yml is missing the 'validate-structure' job. "
+            "This job is required to check that each paper directory has the required structure."
+        )
+
+    def test_validate_implementation_job_exists(self, workflow_yaml: dict) -> None:
+        """validate-implementation job must be defined."""
+        jobs = workflow_yaml.get("jobs", {})
+        assert "validate-implementation" in jobs, (
+            "paper-validation.yml is missing the 'validate-implementation' job. "
+            "This job checks that Mojo implementation files and tests are present."
+        )
+
+    def test_paper_report_job_exists(self, workflow_yaml: dict) -> None:
+        """paper-report job must be defined to aggregate and surface results."""
+        jobs = workflow_yaml.get("jobs", {})
+        assert "paper-report" in jobs, (
+            "paper-validation.yml is missing the 'paper-report' job. "
+            "This job aggregates validation results and posts them to PRs."
+        )
+
+    def test_paper_report_job_depends_on_validate_jobs(self, workflow_yaml: dict) -> None:
+        """paper-report job must depend on both validation jobs."""
+        jobs = workflow_yaml.get("jobs", {})
+        report_job = jobs.get("paper-report", {})
+        needs = report_job.get("needs", [])
+        if isinstance(needs, str):
+            needs = [needs]
+        assert "validate-structure" in needs, (
+            "paper-report job must list 'validate-structure' in its 'needs' to ensure "
+            "structure validation completes before reporting."
+        )
+        assert "validate-implementation" in needs, (
+            "paper-report job must list 'validate-implementation' in its 'needs' to ensure "
+            "implementation validation completes before reporting."
+        )
+
+
+class TestWorkflowActionPins:
+    """Verify all 'uses:' references are SHA-pinned, not tag-pinned."""
+
+    def test_no_tag_pinned_actions(self, workflow_content: str) -> None:
+        """No 'uses:' line may reference an action by version tag (e.g. @v3).
+
+        Tag-pinned actions can change silently when a maintainer force-pushes the tag,
+        creating a supply-chain risk. SHA pins are immutable.
+        """
+        violations = []
+        for i, line in enumerate(workflow_content.splitlines(), 1):
+            if TAG_RE.search(line):
+                violations.append(f"  line {i}: {line.strip()}")
+        assert not violations, (
+            "paper-validation.yml contains tag-pinned actions (must use SHA instead):\n"
+            + "\n".join(violations)
+        )
+
+    def test_all_external_actions_are_sha_pinned(self, workflow_content: str) -> None:
+        """Every external 'uses:' line must reference a 40-char hex SHA.
+
+        Local action references (uses: ./.github/actions/...) are exempt.
+        """
+        violations = []
+        for i, line in enumerate(workflow_content.splitlines(), 1):
+            stripped = line.strip()
+            if not re.match(r"uses:", stripped):
+                continue
+            # Skip local action references
+            if re.search(r"uses:\s+\./", stripped):
+                continue
+            if not SHA_RE.search(line):
+                violations.append(f"  line {i}: {line.strip()}")
+        assert not violations, (
+            "paper-validation.yml has external actions not pinned to a SHA:\n"
+            + "\n".join(violations)
+        )


### PR DESCRIPTION
## Summary

- Implements 25 tests in `tests/foundation/test_paper_implementation_validation.py` for GitHub issue #5343
- Covers all four validation pillars defined in `paper-validation.yml` CI workflow:
  - **Structure**: Required files (README.md, metadata.yml) presence checks
  - **Implementation**: Mojo source files and test file detection
  - **Metadata**: YAML field validation (title, authors, year, url) and format checks
  - **Reproducibility**: Training script (train.py / train.mojo) presence detection and config.yaml validity
- Follows existing `tests/foundation/` test patterns (pytest classes, fixtures, docstrings)
- All 25 tests pass; pre-commit (ruff, mypy, bandit) clean

## Test plan

- [x] Run `pixi run pytest tests/foundation/test_paper_implementation_validation.py -v` — 25/25 passed
- [x] Run `pixi run pre-commit run --files tests/foundation/test_paper_implementation_validation.py` — all hooks passed
- [ ] CI green on push

Closes #5343

🤖 Generated with [Claude Code](https://claude.com/claude-code)