### PR TITLE
ci: fix path trailing-space and align checkout SHA

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -565,7 +565,7 @@ jobs:
             TEST_PATHS="$TEST_PATHS tests/unit/"
           fi
           # Claude hook tests
-          if [ -d "tests/claude " ] && [ -n "$(find tests/claude -name 'test_*.py' 2>/dev/null)" ]; then
+          if [ -d "tests/claude" ] && [ -n "$(find tests/claude -name 'test_*.py' 2>/dev/null)" ]; then
             TEST_PATHS="$TEST_PATHS tests/claude/"
           fi
 


### PR DESCRIPTION
Remove trailing space from `'tests/claude '` directory check in comprehensive-tests.yml (line 568), fixing silent exclusion of Python hook tests in CI.

The `build-validation` job SHA was already aligned to `de0fac2e4500dabe0009e67214ff5f5447ce83dd` in a prior commit; no further change needed for #5305.

Closes #5306
Closes #5305