### PR TITLE
chore(security): tighten Semgrep gate, fix contact placeholders

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -75,7 +75,6 @@ jobs:
       - name: Run Semgrep
         id: semgrep
         run: semgrep scan --config auto --sarif --output semgrep.sarif .
-        continue-on-error: true
 
       - name: Verify SARIF file exists
         run: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,11 +8,10 @@ We take security seriously. If you discover a security vulnerability, please rep
 
 ## How to Report
 
-### Email (Preferred)
+### GitHub Security Advisory (Preferred)
 
-Send an email to: **<security@ml-odyssey.dev>**
-
-Or use the GitHub private vulnerability reporting feature if available.
+Use GitHub's private vulnerability reporting:
+**<https://github.com/HomericIntelligence/ProjectOdyssey/security/advisories/new>**
 
 ### What to Include
 
@@ -129,7 +128,7 @@ Security updates are released as:
 For security-related questions that are not vulnerability reports:
 
 - Open a GitHub Discussion with the "security" tag
-- Email: <security@ml-odyssey.dev>
+- Use GitHub Security Advisories: <https://github.com/HomericIntelligence/ProjectOdyssey/security/advisories/new>
 
 ## Recognition
 


### PR DESCRIPTION
## Summary

- Remove `continue-on-error: true` from the Semgrep SAST step so findings block merges
- Replace fictional `security@ml-odyssey.dev` placeholder in SECURITY.md with the GitHub Security Advisory link
- #5333 (CODE_OF_CONDUCT.md) already has a real contact address; closed via this PR

## Files Modified

- `.github/workflows/security.yml` — remove `continue-on-error: true` (1 line)
- `SECURITY.md` — replace placeholder email with GitHub Security Advisory URL

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/security.yml'))"` passes
- Pre-commit hooks pass (SKIP=mojo-format)
- Net diff: 4 insertions, 6 deletions (≤15 LOC budget)

Closes #5315
Closes #5311
Closes #5333