### PR TITLE
chore(ci)(deps): bump github-actions group + drive JIT-crash core-dump capture

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@ef50f123a3a9be95b60040d042717517407c7256  # v1
+        uses: anthropics/claude-code-action@2cc1ac1331eac7a6a96d716dd204dd2888d0fcd2  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@ef50f123a3a9be95b60040d042717517407c7256  # v1
+        uses: anthropics/claude-code-action@2cc1ac1331eac7a6a96d716dd204dd2888d0fcd2  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -219,7 +219,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy results
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7  # v4
         with:
           sarif_file: 'trivy-results.sarif'
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload SARIF results
         if: always()
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7  # v4
         with:
           sarif_file: semgrep.sarif
 


### PR DESCRIPTION
## Summary

Rebased dependabot bump (was #5352) onto current main. Now that main includes the
core-dump capture infrastructure from #5363 (host `core_pattern`, container
`ulimit -c unlimited`, post-step crash-bundle artifact), this PR provides a
benign vehicle to exercise the capture and (hopefully) snag a real coredump
showing frame 4 of the libKGEN JIT crash (modular/modular#6413).

## Issues touched

- **Bumps github-actions group with 2 updates** — same payload as the closed #5352
- **Closes** none (dependabot PR; no issue link)

## Why this PR exists separately

The original dependabot PR (#5352) was opened before the core-dump capture
landed on main. Rebasing (rather than fast-forward merging the dependabot
branch) is what makes the workflow changes apply to this PR's CI runs.

## Debug capture

If a CI run on this PR triggers the JIT crash, the post-step
`crash-bundle-comprehensive` artifact (14-day retention) will contain:

- `cores/core.<pid>.mojo.<ts>` — the actual ELF coredump
- `symbols/mojo` + `libKGEN*.so` + related `.so` files for gdb resolution
- `metadata.txt` with mojo version / glibc / kernel / core_pattern info

Any captured core lets us run gdb offline to read the unmapped frame 4 and
post the actual fault site to modular/modular#6413.

## Test plan

- [ ] CI runs to completion (pass or fail)
- [ ] If a JIT crash occurs, the `crash-bundle-comprehensive` artifact is
      uploaded and contains `cores/` with a non-empty file
- [ ] Auto-merge after CI green (replaces the closed #5352)