### PR TITLE
docs: add external install guide and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ just validate
 ## Documentation
 
 - [Installation Guide](docs/getting-started/installation.md)
+- [External Consumer Install Guide](docs/INSTALL.md)
+- [Roadmap](ROADMAP.md)
 - [Quickstart](docs/getting-started/quickstart.md)
 - [Your First Model](docs/getting-started/first_model.md)
 - [Repository Structure](docs/getting-started/repository-structure.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,46 @@
+# ML Odyssey Roadmap
+
+This document describes what is currently shipped and the near-term direction
+based on open GitHub issues. No dates are promised; progress is tracked via
+issues and PRs.
+
+## Current State
+
+**7 neural network architectures** fully implemented with layerwise unit tests
+(run on every PR) and end-to-end integration tests (run weekly with real datasets):
+
+| Architecture | Paper |
+| --- | --- |
+| LeNet-5 | LeCun et al., 1998 |
+| AlexNet | Krizhevsky et al., 2012 |
+| VGG-16 | Simonyan & Zisserman, 2014 |
+| ResNet-18 | He et al., 2015 |
+| MobileNetV1 | Howard et al., 2017 |
+| GoogLeNet | Szegedy et al., 2014 |
+
+**Shared library** (`shared/`) provides tensor ops, autograd, layers, optimizers,
+schedulers, mixed-precision training, checkpointing, and evaluation — all in Mojo.
+
+~198K lines of Mojo code; 298+ tests across CI tiers.
+
+## Near-Term Direction
+
+Active work tracked in open issues:
+
+- **Training infrastructure** — improvements to the `Trainer` API and data
+  pipeline (see issues #5183, #5184).
+- **Paper implementations** — additional architectures from `papers/`; priority
+  is driven by community interest and issue upvotes.
+- **Quality and observability** — version automation (#5327), security/privacy
+  documentation (#5332), and general codebase health from the triage swarm
+  (#5354).
+
+## How to Contribute
+
+1. Browse [open issues](https://github.com/HomericIntelligence/ProjectOdyssey/issues)
+   for work that interests you.
+2. Read [`CONTRIBUTING.md`](CONTRIBUTING.md) for the branch → PR → auto-merge
+   workflow.
+3. Check [`docs/getting-started/`](docs/getting-started/) for setup instructions.
+
+All changes go through a pull request — the `main` branch is protected.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,85 @@
+# External Consumer Install Guide
+
+This guide is for developers who want to use ML Odyssey's `shared/` library
+(tensor ops, autograd, layers, training infrastructure) in their own Mojo project.
+
+## Prerequisites
+
+| Requirement | Version | Notes |
+| --- | --- | --- |
+| Mojo | 1.0.0b2+ | Install via `pixi add modular` or [mojolang.org](https://mojolang.org/) |
+| glibc | ≥ 2.32 | Ubuntu 22.04+, Debian 12+, or use Podman (see below) |
+| [Pixi](https://pixi.sh/) | latest | Environment and package manager |
+
+### GLIBC Compatibility
+
+Mojo 1.0.0b2 requires glibc ≥ 2.32. Older distributions (Debian 10/11, Ubuntu 20.04)
+will see `GLIBC_2.32 not found` errors. Compatible OS versions:
+
+| OS | glibc | Status |
+| --- | --- | --- |
+| Ubuntu 22.04 (Jammy) | 2.35 | Compatible |
+| Ubuntu 24.04 (Noble) | 2.39 | Compatible (CI environment) |
+| Debian 12 (Bookworm) | 2.36 | Compatible |
+| Ubuntu 20.04 / Debian 11 | 2.31 | **Incompatible** — use Podman |
+
+If your host is incompatible, run everything inside the project's Podman container:
+
+```bash
+just podman-up
+just shell   # opens a shell with Mojo 1.0.0b2 and glibc 2.39
+```
+
+See [`docs/dev/mojo-glibc-compatibility.md`](dev/mojo-glibc-compatibility.md) for details.
+
+## Quick Start: Clone the Repo
+
+The simplest way to consume `shared/` is to clone this repo and add it to your
+Mojo package path:
+
+```bash
+git clone https://github.com/HomericIntelligence/ProjectOdyssey.git
+cd ProjectOdyssey
+pixi install          # installs Mojo 1.0.0b2 and all Python tooling
+just build            # compiles shared/ into .mojopkg artifacts
+```
+
+Then, in your project's `pixi.toml`, add the `shared/` directory to `MOJO_PATH`:
+
+```toml
+[feature.default.activation.env]
+MOJO_PATH = "/path/to/ProjectOdyssey/shared"
+```
+
+## Importing the Shared Library
+
+Once `MOJO_PATH` includes the `shared/` directory you can import directly:
+
+```mojo
+from shared.core.any_tensor import AnyTensor, zeros
+from shared.tensor.tensor import Tensor
+from shared.autograd.variable import Variable
+from shared.training.trainer import Trainer
+```
+
+The dual-type tensor system (`Tensor[dtype]` for compile-time dispatch, `AnyTensor`
+for runtime-typed collections) is documented in
+[`docs/adr/ADR-012-parametric-dtype-tensor-architecture.md`](adr/ADR-012-parametric-dtype-tensor-architecture.md).
+
+## Building a Distributable Package
+
+```bash
+just package   # compiles shared/ into a .mojopkg archive
+```
+
+The output `.mojopkg` file can then be distributed and added to downstream
+projects via `MOJO_PATH` or `--import-path`.
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| `GLIBC_2.32 not found` | Use Ubuntu 22.04+, Debian 12+, or `just shell` in Podman |
+| `cannot find module 'shared'` | Verify `MOJO_PATH` includes `ProjectOdyssey/shared` |
+| `mojo: command not found` | Run `pixi install` first; Mojo is installed by pixi |
+| Build fails with import errors | Run `just build` before importing; compiled artifacts are required |


### PR DESCRIPTION
## Summary

- Adds `docs/INSTALL.md`: external-consumer guide covering prerequisites (Mojo 1.0.0b2+, glibc ≥2.32), quick-start clone + pixi install, import paths for `shared/`, `just package` usage, and GLIBC troubleshooting table.
- Adds `ROADMAP.md`: current state (7 implemented architectures, shared library scope), near-term direction (issues #5183, #5184, #5327, #5332, #5354), and contributor entry points.
- Updates `README.md` Documentation section to link both new files.

## Test plan

- [ ] Pre-commit hooks pass (markdown lint, trailing whitespace, file size)
- [ ] All links in new docs resolve to real repo paths
- [ ] LOC budget: 133 net lines added (≤200 limit)

Closes #5326
Closes #5321

🤖 Generated with [Claude Code](https://claude.com/claude-code)