### PR TITLE
tooling(version): add version-sync automation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,21 @@
 # See https://pre-commit.com for more information
 
 repos:
+  # Version sync check — ensures pyproject.toml, pixi.toml, mojo.toml, and VERSION
+  # all carry the same version string. Fails if any file drifts. Use `just bump-version`
+  # to update all files atomically. Resolves #5327 and #5190.
+  - repo: local
+    hooks:
+      - id: check-version-sync
+        name: Check Version Sync
+        description: >-
+          Ensure version in pyproject.toml, pixi.toml, mojo.toml, and VERSION are all in sync.
+          Use `just bump-version <new_version>` to bump atomically.
+        entry: python3 scripts/check_version_sync.py
+        language: system
+        files: ^(pyproject\.toml|pixi\.toml|mojo\.toml|VERSION)$
+        pass_filenames: false
+
   # mojo-format: Requires Mojo binary (glibc >= 2.32, i.e., Ubuntu 22.04+, Debian 12+).
   # On older hosts (Debian 10-11, glibc < 2.32) the wrapper script detects the
   # incompatibility and exits 0 with a warning instead of failing the commit.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -352,6 +352,44 @@ pixi run mojo format path/to/file.mojo
 
 See [docs/dev/mojo-glibc-compatibility.md](docs/dev/mojo-glibc-compatibility.md) for full details.
 
+## Version Bump Process
+
+The project version is defined in four files that must always stay in sync:
+
+| File | Format | Field |
+| --- | --- | --- |
+| `pyproject.toml` | TOML | `[project] version` (authoritative source) |
+| `pixi.toml` | TOML | top-level `version` |
+| `mojo.toml` | TOML | top-level `version` |
+| `VERSION` | plain text | entire file content |
+
+A pre-commit hook (`check-version-sync`) enforces consistency automatically.
+Any commit that touches one of these files but leaves the others out of sync will be rejected.
+
+### How to Bump the Version
+
+Use the `just bump-version` recipe to update all four files atomically:
+
+```bash
+just bump-version 0.2.0
+```
+
+This updates all four files and then calls `scripts/check_version_sync.py` to verify the
+result before you commit.
+
+### Manual Verification
+
+```bash
+just check-version-sync
+# or directly:
+python3 scripts/check_version_sync.py
+```
+
+### Never Edit Version Files Individually
+
+Editing only one file creates version drift that the pre-commit hook will catch and block.
+Always use `just bump-version`.
+
 ## Changelog Guidelines
 
 [CHANGELOG.md](CHANGELOG.md) is a living document. Contributors are expected to update it as part

--- a/justfile
+++ b/justfile
@@ -951,3 +951,32 @@ audit:
     @echo ""
     @echo "=== License Check ==="
     @pip-licenses --format=markdown
+
+# ==============================================================================
+# Version Management
+# ==============================================================================
+
+# Check that version numbers are in sync across pyproject.toml, pixi.toml, mojo.toml, and VERSION
+check-version-sync:
+    @python3 scripts/check_version_sync.py
+
+# Bump project version atomically across all version files and verify sync.
+# Usage: just bump-version 0.2.0
+bump-version new_version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ -z "{{new_version}}" ]]; then
+        echo "Usage: just bump-version <new_version>"
+        exit 1
+    fi
+    echo "Bumping version to {{new_version}} in all version files..."
+    # VERSION (plain text)
+    echo "{{new_version}}" > VERSION
+    # pyproject.toml — update [project] version line
+    sed -i 's/^\(version\s*=\s*\)"[^"]*"/\1"{{new_version}}"/' pyproject.toml
+    # pixi.toml — update top-level version line
+    sed -i 's/^\(version\s*=\s*\)"[^"]*"/\1"{{new_version}}"/' pixi.toml
+    # mojo.toml — update version line
+    sed -i 's/^\(version\s*=\s*\)"[^"]*"/\1"{{new_version}}"/' mojo.toml
+    echo "All files updated. Verifying sync..."
+    python3 scripts/check_version_sync.py

--- a/scripts/check_version_sync.py
+++ b/scripts/check_version_sync.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Check that version numbers are in sync across all version files.
+
+Source of truth: pyproject.toml [project] version field.
+Verified against: pixi.toml, mojo.toml, VERSION
+
+Usage:
+    python scripts/check_version_sync.py
+
+Exit codes:
+    0 — all files in sync
+    1 — version drift detected
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).parent.parent
+
+VERSION_FILE = REPO_ROOT / "VERSION"
+PYPROJECT_TOML = REPO_ROOT / "pyproject.toml"
+PIXI_TOML = REPO_ROOT / "pixi.toml"
+MOJO_TOML = REPO_ROOT / "mojo.toml"
+
+
+def read_pyproject_version() -> str:
+    """Read version from pyproject.toml [project] section (authoritative source)."""
+    text = PYPROJECT_TOML.read_text()
+    # Match version under [project] section only
+    match = re.search(
+        r"^\[project\].*?^version\s*=\s*[\"']([^\"']+)[\"']",
+        text,
+        re.DOTALL | re.MULTILINE,
+    )
+    if not match:
+        raise ValueError(f"Could not find [project] version in {PYPROJECT_TOML}")
+    return match.group(1)
+
+
+def read_pixi_version() -> str:
+    """Read version from pixi.toml [package] section."""
+    text = PIXI_TOML.read_text()
+    match = re.search(r'^version\s*=\s*["\']([^"\']+)["\']', text, re.MULTILINE)
+    if not match:
+        raise ValueError(f"Could not find version in {PIXI_TOML}")
+    return match.group(1)
+
+
+def read_mojo_version() -> str:
+    """Read version from mojo.toml."""
+    text = MOJO_TOML.read_text()
+    match = re.search(r'^version\s*=\s*["\']([^"\']+)["\']', text, re.MULTILINE)
+    if not match:
+        raise ValueError(f"Could not find version in {MOJO_TOML}")
+    return match.group(1)
+
+
+def read_version_file() -> str:
+    """Read version from VERSION plain-text file."""
+    return VERSION_FILE.read_text().strip()
+
+
+def check_sync() -> int:
+    """Check all version files. Returns 0 if in sync, 1 if drift detected."""
+    canonical = read_pyproject_version()
+
+    checks = [
+        ("pixi.toml", read_pixi_version),
+        ("mojo.toml", read_mojo_version),
+        ("VERSION", read_version_file),
+    ]
+
+    drift = False
+    print(f"Canonical version (pyproject.toml): {canonical}")
+    for name, reader in checks:
+        try:
+            found = reader()
+            status = "OK" if found == canonical else "DRIFT"
+            print(f"  {name}: {found} [{status}]")
+            if found != canonical:
+                drift = True
+        except ValueError as e:
+            print(f"  ERROR reading {name}: {e}")
+            drift = True
+
+    if drift:
+        print("\nVersion drift detected! Run:\n  just bump-version <new_version>\nto update all files atomically.")
+        return 1
+
+    print("\nAll version files are in sync.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(check_sync())


### PR DESCRIPTION
## Summary

- Add `scripts/check_version_sync.py` — reads version from `pyproject.toml` (authoritative) and verifies `pixi.toml`, `mojo.toml`, and `VERSION` all match; exits 1 on any drift
- Add `check-version-sync` pre-commit hook triggered whenever any of the four version files is staged
- Add `just check-version-sync` and `just bump-version <ver>` recipes to update all four files atomically
- Document the version bump process in `CONTRIBUTING.md`

## Test plan

- [x] `python3 scripts/check_version_sync.py` → "All version files are in sync."
- [x] Deliberate mismatch (VERSION=0.9.9) → hook exits 1 with "DRIFT" and hint to use `just bump-version`
- [x] `pixi run pre-commit run --files scripts/check_version_sync.py .pre-commit-config.yaml CONTRIBUTING.md justfile` → all passed
- [x] `pixi run pre-commit run check-version-sync --files pyproject.toml` → Passed

Closes #5327
Closes #5190

🤖 Generated with [Claude Code](https://claude.com/claude-code)