### PR TITLE
infra: extend resource limits to ci/prod + dep-sync pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,6 +118,18 @@ repos:
         types: [python]
         pass_filenames: true
 
+  # Dependency sync check — ensures pixi.toml, pyproject.toml, and requirements*.txt
+  # stay consistent with each other (Issue #5137).
+  - repo: local
+    hooks:
+      - id: check-dep-sync
+        name: Check Dependency Sync
+        description: Validate dependency consistency across pixi.toml, pyproject.toml, and requirements*.txt (Issue #5137)
+        entry: python3 scripts/check_dep_sync.py
+        language: system
+        files: ^(pixi\.toml|pyproject\.toml|requirements.*\.txt)$
+        pass_filenames: false
+
   # Version consistency check — ensures .pre-commit-config.yaml revs match pixi.toml (Issue #4030)
   - repo: local
     hooks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,14 @@ services:
       - PIXI_HOME=/home/${USER_NAME:-dev}/.pixi
       - PIXI_CACHE_DIR=/home/${USER_NAME:-dev}/.cache/pixi
     working_dir: /workspace
+    # Resource limits guard the host from runaway CI jobs OOMing the box
+    # (#5313/#5317). Tunable via env vars; same defaults as the dev service.
+    # Override per-host with:
+    #   ODYSSEY_MEM_LIMIT=8g ODYSSEY_CPU_LIMIT=4 just podman-up
+    # cgroups v1 hosts will silently ignore these — that's fine; on cgroups v2
+    # they enforce.
+    mem_limit: ${ODYSSEY_MEM_LIMIT:-12g}
+    cpus: ${ODYSSEY_CPU_LIMIT:-6.0}
 
   # Production environment
   projectodyssey-prod:
@@ -85,6 +93,14 @@ services:
       - ENVIRONMENT=production
       - PIXI_HOME=/home/${USER_NAME:-dev}/.pixi
     working_dir: /workspace
+    # Resource limits guard the host from runaway training jobs OOMing the box
+    # (#5313/#5317). Tunable via env vars; same defaults as the dev service.
+    # Override per-host with:
+    #   ODYSSEY_MEM_LIMIT=8g ODYSSEY_CPU_LIMIT=4 just podman-up
+    # cgroups v1 hosts will silently ignore these — that's fine; on cgroups v2
+    # they enforce.
+    mem_limit: ${ODYSSEY_MEM_LIMIT:-12g}
+    cpus: ${ODYSSEY_CPU_LIMIT:-6.0}
 
 volumes:
   pixi-cache:


### PR DESCRIPTION
## Summary

- Extend `mem_limit`/`cpus` env-var resource guards to `projectodyssey-ci` and `projectodyssey-prod` services in `docker-compose.yml`, matching the pattern added to `projectodyssey-dev` in #5363. Defaults: `ODYSSEY_MEM_LIMIT=12g`, `ODYSSEY_CPU_LIMIT=6.0`. cgroups v1 hosts silently ignore; cgroups v2 enforces.
- Add `check-dep-sync` pre-commit hook that runs `python3 scripts/check_dep_sync.py` on changes to `pixi.toml`, `pyproject.toml`, or `requirements*.txt` to keep dependency declarations in sync.

## Files Modified

- `docker-compose.yml` — added resource limits blocks to `projectodyssey-ci` and `projectodyssey-prod`
- `.pre-commit-config.yaml` — added `check-dep-sync` hook

## Verification

- YAML parses: `python3 -c "import yaml; yaml.safe_load(open('docker-compose.yml')); yaml.safe_load(open('.pre-commit-config.yaml'))"` → OK
- All pre-commit hooks passed on staged files
- Net LOC: +28 (well within 50-line budget)

Closes #5317
Closes #5137