### PR TITLE
ci: add concurrency groups to cancel stale PR runs

### DIFF
--- a/.github/workflows/asan-tests.yml
+++ b/.github/workflows/asan-tests.yml
@@ -21,6 +21,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   asan-tests:
     name: AddressSanitizer Tests

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,6 +31,10 @@ permissions:
   contents: read
   pull-requests: write  # For PR comments
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # ============================================================================
   # Benchmark Execution - Matrix Strategy

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -25,6 +25,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-validation:
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,10 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   claude-review:
     # Optional: Filter by PR author

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -27,6 +27,10 @@ permissions:
   contents: read
   pull-requests: write  # For PR comments
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # ============================================================================
   # Mojo Syntax Validation - Catch deprecated patterns early

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -27,6 +27,10 @@ permissions:
   packages: write
   security-events: write  # For Trivy SARIF uploads
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # ============================================================================
   # Build and Push Container Images

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,6 +45,10 @@ permissions:
   id-token: write
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/model-e2e-tests-weekly.yml
+++ b/.github/workflows/model-e2e-tests-weekly.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   model-e2e-tests:
     name: Model E2E Tests

--- a/.github/workflows/mojo-version-check.yml
+++ b/.github/workflows/mojo-version-check.yml
@@ -18,6 +18,10 @@ permissions:
   contents: read
   issues: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   check-mojo-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/paper-validation.yml
+++ b/.github/workflows/paper-validation.yml
@@ -23,6 +23,10 @@ permissions:
   contents: read
   pull-requests: write  # For PR comments
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # ============================================================================
   # Validate Paper Directory Structure

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,6 +18,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/precommit-benchmark.yml
+++ b/.github/workflows/precommit-benchmark.yml
@@ -19,6 +19,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   precommit-benchmark:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ permissions:
   pull-requests: read
   actions: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # ============================================================================
   # Version Validation

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,6 +27,10 @@ permissions:
   security-events: write
   issues: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # ============================================================================
   # Secret Scanning

--- a/.github/workflows/simd-benchmarks-weekly.yml
+++ b/.github/workflows/simd-benchmarks-weekly.yml
@@ -15,6 +15,10 @@ permissions:
   contents: read
   pull-requests: write  # For optional PR comments
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   simd-benchmarks:
     name: SIMD Performance Benchmarks

--- a/.github/workflows/skills-migration-audit.yml
+++ b/.github/workflows/skills-migration-audit.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   audit-skills:
     runs-on: ubuntu-latest

--- a/.github/workflows/training-tests-weekly.yml
+++ b/.github/workflows/training-tests-weekly.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   training-tests:
     name: Training Unit Tests

--- a/.github/workflows/validate-configs.yml
+++ b/.github/workflows/validate-configs.yml
@@ -34,6 +34,10 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate-yaml:
     name: Validate YAML Syntax

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -15,6 +15,10 @@ on:
       - '.github/workflows/validate-workflows.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate-checkout-order:
     name: Enforce Composite Action Checkout-First Ordering

--- a/.github/workflows/workflow-smoke-test.yml
+++ b/.github/workflows/workflow-smoke-test.yml
@@ -29,6 +29,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   smoke-test-security-workflows:
     name: Security Workflow Property Checks

--- a/.github/workflows/worktree-sync-check.yml
+++ b/.github/workflows/worktree-sync-check.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   worktree-sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `concurrency:` blocks to all 22 CI workflow files that lacked them
- PR-triggered workflows: `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` (cancels on force-push, preserves push-to-main runs)
- Release/tag/schedule workflows (`release.yml`, `container-publish.yml`, `model-e2e-tests-weekly.yml`, `simd-benchmarks-weekly.yml`, `training-tests-weekly.yml`, `mojo-version-check.yml`): `cancel-in-progress: false`
- `_required.yml` already had a concurrency block — skipped

## Test plan
- [ ] Verify YAML parses cleanly (all 23 files validated locally)
- [ ] Push two commits rapidly to a PR branch and confirm older run is cancelled
- [ ] Verify release/nightly workflows are NOT cancelled on new pushes

Closes #5051