### PR TITLE
tooling: add CHANGELOG-update reminder for PRs

### DIFF
--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -1,0 +1,19 @@
+name: Changelog Reminder
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  remind:
+    name: Remind to update CHANGELOG.md
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check changelog updated
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: python3 scripts/check_changelog_updated.py

--- a/scripts/check_changelog_updated.py
+++ b/scripts/check_changelog_updated.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Check that CHANGELOG.md is updated when user-facing files change.
+
+Exits 0 always — this is a reminder, not a hard gate.
+In CI (GITHUB_BASE_REF set) it prints a warning; otherwise it is silent.
+"""
+
+import os
+import subprocess
+import sys
+
+
+def changed_files(base_ref: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", f"origin/{base_ref}...HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.splitlines()
+
+
+WATCHED_PREFIXES = ("shared/", "models/", "tools/")
+
+
+def main() -> int:
+    base_ref = os.environ.get("GITHUB_BASE_REF", "")
+    if not base_ref:
+        # Not in CI — silent pass
+        return 0
+
+    files = changed_files(base_ref)
+    has_user_facing = any(f.startswith(WATCHED_PREFIXES) for f in files)
+    has_changelog = "CHANGELOG.md" in files
+
+    if has_user_facing and not has_changelog:
+        print(
+            "::warning::CHANGELOG.md was not updated. "
+            "If this PR includes user-facing changes (feat/fix), "
+            "please add a curated entry to CHANGELOG.md.",
+            flush=True,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/changelog-reminder.yml` — a lightweight GHA check that runs on every PR to `main`
- Adds `scripts/check_changelog_updated.py` — diffs the PR branch against the base, warns (via `::warning::` annotation) if `shared/`, `models/`, or `tools/` files changed but `CHANGELOG.md` did not
- Non-blocking: exits 0 always; authors see a yellow warning annotation, not a red failure

## Test plan

- [ ] Open a PR modifying a file under `shared/` without touching `CHANGELOG.md` — confirm yellow warning annotation appears in Actions
- [ ] Open a PR that also updates `CHANGELOG.md` — confirm no warning is emitted
- [ ] Open a PR that only touches docs/config — confirm no warning is emitted

Closes #5165