### PR TITLE
ci(security): extend audit to pixi/conda packages

### DIFF
--- a/.github/SECURITY-AUDIT.md
+++ b/.github/SECURITY-AUDIT.md
@@ -1,0 +1,30 @@
+# Security Audit Coverage
+
+## Automated CVE Scanning
+
+| Package Source | Tool | Coverage |
+|---|---|---|
+| Python (`requirements*.txt`) | `safety` + `pip-audit` | Full — PyPI advisory DB |
+| PyPI packages in `pixi.lock` | `pip-audit` (pixi-audit job) | Full — PyPI advisory DB |
+| conda-forge packages in `pixi.lock` | None (see gap below) | Manual review only |
+
+## Known Gap: conda-forge / Mojo Runtime Packages
+
+No public, machine-readable CVE feed covers conda-forge packages with the same
+fidelity as PyPI. The Mojo runtime (`max`, `mojo`, `modular`) is distributed via
+`conda.modular.com` and has no external CVE database.
+
+**Mitigation (manual review checklist, run weekly with the audit job):**
+
+- [ ] Check [Modular security advisories](https://www.modular.com/security) for
+  Mojo/MAX runtime issues.
+- [ ] Review the conda-forge GitHub repo for CVE-related issues on packages locked
+  in `pixi.lock` that are not also available on PyPI.
+- [ ] Verify `pixi.lock` has not pinned any conda package to a version with a known
+  upstream CVE (check NVD at <https://nvd.nist.gov/> manually for high-profile
+  packages such as `openssl`, `libxml2`, `zlib`).
+
+## Updating This Document
+
+When a new conda package class is added to `pixi.toml`, add a row to the table
+above and update the manual checklist if needed.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -320,6 +320,50 @@ jobs:
           echo "" >> pixi-audit-report.md
           echo "Mojo version: $(pixi run mojo --version 2>/dev/null | head -1)" >> pixi-audit-report.md
 
+      - name: Audit PyPI packages from pixi lockfile
+        # pip-audit covers PyPI-sourced packages locked in pixi.lock (pypi: entries).
+        # No public CVE feed exists for conda-forge native packages (e.g. the Mojo
+        # runtime itself); those are tracked via manual review — see SECURITY-AUDIT.md.
+        run: |
+          pip install pip-audit 2>/dev/null
+
+          echo "" >> pixi-audit-report.md
+          echo "### PyPI Package CVE Scan (pip-audit)" >> pixi-audit-report.md
+          echo "" >> pixi-audit-report.md
+
+          # Extract name==version for every pypi-sourced entry in pixi.lock
+          python3 - <<'PYEOF' > pypi-from-pixi.txt
+          import re, sys
+          with open("pixi.lock") as f:
+              content = f.read()
+          # Match "- pypi: https://files.pythonhosted.org/.../name-version-..."
+          for m in re.finditer(r"name:\s+(\S+)\s+version:\s+(\S+)", content):
+              print(f"{m.group(1)}=={m.group(2)}")
+          PYEOF
+
+          PKG_COUNT=$(wc -l < pypi-from-pixi.txt)
+          echo "Packages extracted from pixi.lock: $PKG_COUNT" >> pixi-audit-report.md
+          echo "" >> pixi-audit-report.md
+
+          if [ "$PKG_COUNT" -gt 0 ]; then
+            if pip-audit --require-hashes=false \
+                $(sed 's/^/-p /' pypi-from-pixi.txt | tr '\n' ' ') \
+                --format json --output pixi-pypi-audit.json 2>/dev/null; then
+              echo "No CVEs found in PyPI packages from pixi.lock" >> pixi-audit-report.md
+            else
+              COUNT=$(python3 -c "import json,sys; d=json.load(open('pixi-pypi-audit.json')); print(len(d))" 2>/dev/null || echo "?")
+              echo "WARNING: $COUNT vulnerable PyPI package(s) found — review pixi-pypi-audit.json" >> pixi-audit-report.md
+            fi
+          else
+            echo "No PyPI packages found in pixi.lock — skipping pip-audit." >> pixi-audit-report.md
+          fi
+
+          echo "" >> pixi-audit-report.md
+          echo "### Conda-Native Package Gap" >> pixi-audit-report.md
+          echo "" >> pixi-audit-report.md
+          echo "No automated CVE feed covers conda-forge packages (including the Mojo" >> pixi-audit-report.md
+          echo "runtime). These are reviewed manually per .github/SECURITY-AUDIT.md." >> pixi-audit-report.md
+
       - name: Upload Pixi audit results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
@@ -327,6 +371,8 @@ jobs:
           path: |
             pixi-audit-report.md
             pixi-packages.json
+            pypi-from-pixi.txt
+            pixi-pypi-audit.json
           retention-days: 30
 
   # ============================================================================


### PR DESCRIPTION
## Summary

- Adds a `pip-audit` step inside the existing `pixi-audit` CI job to scan all PyPI-sourced packages pinned in `pixi.lock` for CVEs
- Extracts `name==version` pairs from `pixi.lock` using a Python one-liner and feeds them to `pip-audit`
- Documents the conda-native package gap (Mojo runtime, conda-forge packages) in a new `.github/SECURITY-AUDIT.md` with a manual review checklist

## Gap documented

No public machine-readable CVE feed covers conda-forge packages. `SECURITY-AUDIT.md` records the gap and links to Modular security advisories and NVD for manual review of high-profile native packages (`openssl`, `libxml2`, `zlib`).

## Test plan

- [ ] Workflow `security.yml` YAML is valid (check-yaml pre-commit hook passed)
- [ ] `pixi-audit` job runs on `schedule` / `workflow_dispatch` only (unchanged trigger)
- [ ] Artifact `pixi-audit-results` now includes `pypi-from-pixi.txt` and `pixi-pypi-audit.json`

Closes #5314