### PR TITLE
ci: extend JIT-crash core-dump capture to all 5 test jobs

### DIFF
--- a/.github/actions/coredump-capture/action.yml
+++ b/.github/actions/coredump-capture/action.yml
@@ -1,0 +1,89 @@
+name: Coredump Capture
+description: |
+  Enable host-side core_pattern + container ulimit so the libKGEN JIT crash
+  (modular/modular#6413) produces a real coredump we can attach to gdb.
+  After the test job, bundles cores + matching `mojo` binary + relevant
+  `.so` files into a `crash-bundle-<job-name>` artifact (14-day retention).
+
+  Use this action TWICE in each test job:
+    1. As a setup step BEFORE the test runs (to enable cores)
+    2. As a teardown step AFTER the test runs (to bundle + upload)
+
+  The two-step split is implemented via the `phase` input.
+
+inputs:
+  phase:
+    description: "'setup' before tests, 'collect' after tests"
+    required: true
+  job-name:
+    description: "Short job identifier used in artifact name (e.g. gradient-checking, data-utilities)"
+    required: true
+    default: "test"
+
+runs:
+  using: composite
+  steps:
+    - name: Enable core dumps (host kernel)
+      if: inputs.phase == 'setup'
+      shell: bash
+      run: |
+        set -x
+        mkdir -p crash-bundle/cores
+        chmod 1777 crash-bundle/cores
+        echo "$(pwd)/crash-bundle/cores/core.%p.%e.%t" | sudo tee /proc/sys/kernel/core_pattern
+        sudo sysctl -w fs.suid_dumpable=2 || true
+        sudo systemctl stop apport.service 2>/dev/null || true
+        sudo systemctl stop systemd-coredump.socket 2>/dev/null || true
+        podman compose exec -T projectodyssey-dev bash -c \
+          "ulimit -c unlimited && ulimit -a | grep core" || true
+
+    - name: Collect core dumps + symbols (modular/modular#6413)
+      if: inputs.phase == 'collect' && always()
+      shell: bash
+      run: |
+        set -x
+        mkdir -p crash-bundle/cores
+        ls -la crash-bundle/cores/ 2>/dev/null || true
+
+        # If no cores, exit early — don't waste time bundling symbols
+        if [ -z "$(ls -A crash-bundle/cores/ 2>/dev/null)" ]; then
+          echo "No cores captured this run."
+          exit 0
+        fi
+
+        podman compose exec -T projectodyssey-dev bash -c '
+          set -e
+          ENV_DIR=$(pixi info --json 2>/dev/null | sed -n "s/.*\"prefix\":[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -1)
+          if [ -z "$ENV_DIR" ] || [ ! -d "$ENV_DIR/lib" ]; then
+            echo "Could not resolve pixi env dir; skipping symbol bundle"
+            exit 0
+          fi
+          mkdir -p /workspace/crash-bundle/symbols
+          cp -av "$ENV_DIR/bin/mojo" /workspace/crash-bundle/symbols/ 2>/dev/null || true
+          for so in "$ENV_DIR"/lib/libKGEN*.so "$ENV_DIR"/lib/libAsync*.so "$ENV_DIR"/lib/libMojo*.so "$ENV_DIR"/lib/libMSupport*.so; do
+            [ -e "$so" ] && cp -av "$so" /workspace/crash-bundle/symbols/ 2>/dev/null || true
+          done
+          ls -la /workspace/crash-bundle/symbols/
+        ' || true
+
+        {
+          echo "=== mojo --version ==="
+          podman compose exec -T projectodyssey-dev pixi run mojo --version 2>&1 || true
+          echo "=== uname -a ==="
+          uname -a
+          echo "=== glibc ==="
+          ldd --version | head -1
+          echo "=== /proc/sys/kernel/core_pattern ==="
+          cat /proc/sys/kernel/core_pattern 2>/dev/null
+          echo "=== Coredumps found ==="
+          ls -la crash-bundle/cores/ 2>/dev/null
+        } > crash-bundle/metadata.txt
+
+    - name: Upload crash bundle
+      if: inputs.phase == 'collect' && always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+      with:
+        name: crash-bundle-${{ inputs.job-name }}
+        path: crash-bundle/
+        retention-days: 14
+        if-no-files-found: ignore

--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -255,28 +255,12 @@ jobs:
           echo "ulimit -v: $(ulimit -v 2>/dev/null || echo unlimited)"
 
       # Core-dump capture for the libKGEN crash (modular/modular#6413).
-      # Frame 4 in the published stack trace is `<unmapped>` and signal-handler
-      # frames 0–2 just point at Mojo's Crashpad chain. To diagnose the actual
-      # fault site we need a real coredump.
-      #
-      # We write cores to /workspace/crash-bundle/cores/ (already bind-mounted
-      # into the container) so they survive container teardown without needing
-      # an extra mount.
-      - name: Enable core dumps (host kernel)
-        run: |
-          set -x
-          mkdir -p crash-bundle/cores
-          chmod 1777 crash-bundle/cores
-          # Absolute path needed because core_pattern is a global kernel setting.
-          echo "$(pwd)/crash-bundle/cores/core.%p.%e.%t" | sudo tee /proc/sys/kernel/core_pattern
-          # Make sure cores are written even after privilege drops in the container
-          sudo sysctl -w fs.suid_dumpable=2 || true
-          # Disable apport / systemd-coredump if running, so we get raw ELF cores
-          sudo systemctl stop apport.service 2>/dev/null || true
-          sudo systemctl stop systemd-coredump.socket 2>/dev/null || true
-          # Bump container's per-process core size limit to unlimited
-          podman compose exec -T projectodyssey-dev bash -c \
-            "ulimit -c unlimited && ulimit -a | grep core"
+      # See `.github/actions/coredump-capture/action.yml` for full rationale.
+      - name: Enable core dumps (setup)
+        uses: ./.github/actions/coredump-capture
+        with:
+          phase: setup
+          job-name: comprehensive
 
       - name: mkdir test-results
         run: mkdir -p test-results
@@ -432,59 +416,13 @@ jobs:
           path: test-results/
           retention-days: 7
 
-      # Bundle core dumps + matching mojo / libKGEN binaries so we can run gdb
-      # offline on the artifacts. Filtered to just the JIT-crash candidates
-      # so the artifact stays small.
-      - name: Collect core dumps + symbols (modular/modular#6413)
+      # Bundle core dumps + matching mojo / libKGEN binaries (composite action)
+      - name: Collect crash bundle
         if: always()
-        run: |
-          set -x
-          # crash-bundle/cores is already written into by the host kernel via
-          # core_pattern. Just gather it + grab symbols from the container.
-          mkdir -p crash-bundle/cores
-          ls -la crash-bundle/cores/ 2>/dev/null || true
-
-          # Pull mojo binary + relevant .so files so gdb can resolve frames
-          # later. Use bash glob inside the container; resolve env path from
-          # the well-known pixi cache root (avoids needing python).
-          podman compose exec -T projectodyssey-dev bash -c '
-            set -e
-            ENV_DIR=$(pixi info --json 2>/dev/null | sed -n "s/.*\"prefix\":[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -1)
-            if [ -z "$ENV_DIR" ] || [ ! -d "$ENV_DIR/lib" ]; then
-              echo "Could not resolve pixi env dir; skipping symbol bundle"
-              exit 0
-            fi
-            mkdir -p /workspace/crash-bundle/symbols
-            cp -av "$ENV_DIR/bin/mojo" /workspace/crash-bundle/symbols/ 2>/dev/null || true
-            for so in "$ENV_DIR"/lib/libKGEN*.so "$ENV_DIR"/lib/libAsync*.so "$ENV_DIR"/lib/libMojo*.so "$ENV_DIR"/lib/libMSupport*.so; do
-              [ -e "$so" ] && cp -av "$so" /workspace/crash-bundle/symbols/ 2>/dev/null || true
-            done
-            ls -la /workspace/crash-bundle/symbols/
-          ' || true
-
-          # Snapshot env metadata
-          {
-            echo "=== mojo --version ==="
-            podman compose exec -T projectodyssey-dev pixi run mojo --version 2>&1 || true
-            echo "=== uname -a ==="
-            uname -a
-            echo "=== glibc ==="
-            ldd --version | head -1
-            echo "=== /proc/sys/kernel/core_pattern ==="
-            cat /proc/sys/kernel/core_pattern 2>/dev/null
-            echo "=== Coredumps found ==="
-            ls -la crash-bundle/cores/ 2>/dev/null || echo "(none)"
-          } > crash-bundle/metadata.txt
-          ls -laR crash-bundle/ | head -40
-
-      - name: Upload crash bundle (cores + symbols)
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        uses: ./.github/actions/coredump-capture
         with:
-          name: crash-bundle-comprehensive
-          path: crash-bundle/
-          retention-days: 14
-          if-no-files-found: ignore
+          phase: collect
+          job-name: comprehensive
 
   # ============================================================================
   # Configs Tests
@@ -522,6 +460,12 @@ jobs:
       - name: Install Just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
 
+      - name: Enable core dumps (modular/modular#6413)
+        uses: ./.github/actions/coredump-capture
+        with:
+          phase: setup
+          job-name: configs
+
       - name: Run Configs tests
         run: just test-group tests/configs "test_*.mojo"
 
@@ -532,6 +476,13 @@ jobs:
           name: test-results-Configs
           path: test-results/
           retention-days: 7
+
+      - name: Collect crash bundle
+        if: always()
+        uses: ./.github/actions/coredump-capture
+        with:
+          phase: collect
+          job-name: configs
 
   # ============================================================================
   # NOTE: Training tests moved to weekly workflow (requires dataset downloads)
@@ -556,6 +507,12 @@ jobs:
       - name: Install Just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
 
+      - name: Enable core dumps (modular/modular#6413)
+        uses: ./.github/actions/coredump-capture
+        with:
+          phase: setup
+          job-name: benchmarks
+
       - name: Run Benchmarks tests
         run: just test-group tests/shared/benchmarks "bench_*.mojo"
 
@@ -566,6 +523,13 @@ jobs:
           name: test-results-Benchmarks
           path: test-results/
           retention-days: 7
+
+      - name: Collect crash bundle
+        if: always()
+        uses: ./.github/actions/coredump-capture
+        with:
+          phase: collect
+          job-name: benchmarks
 
   # ============================================================================
   # Core Layers Tests
@@ -586,6 +550,12 @@ jobs:
       - name: Install Just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
 
+      - name: Enable core dumps (modular/modular#6413)
+        uses: ./.github/actions/coredump-capture
+        with:
+          phase: setup
+          job-name: core-layers
+
       - name: Run Core Layers tests
         run: just test-group tests/shared/core/layers "test_*.mojo"
 
@@ -596,6 +566,13 @@ jobs:
           name: test-results-Core-Layers
           path: test-results/
           retention-days: 7
+
+      - name: Collect crash bundle
+        if: always()
+        uses: ./.github/actions/coredump-capture
+        with:
+          phase: collect
+          job-name: core-layers
 
   # ============================================================================
   # Python Tests
@@ -856,6 +833,12 @@ jobs:
       - name: Install Just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
 
+      - name: Enable core dumps (modular/modular#6413)
+        uses: ./.github/actions/coredump-capture
+        with:
+          phase: setup
+          job-name: gradient-checking
+
       - name: Run gradient checking tests
         run: |
           mkdir -p test-results
@@ -890,6 +873,13 @@ jobs:
           name: test-results-Gradient-Checking-Tests
           path: test-results/
           retention-days: 7
+
+      - name: Collect crash bundle
+        if: always()
+        uses: ./.github/actions/coredump-capture
+        with:
+          phase: collect
+          job-name: gradient-checking
 
       - name: Check test results
         if: failure()
@@ -969,6 +959,12 @@ jobs:
 
       - name: Install Just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
+
+      - name: Enable core dumps (modular/modular#6413)
+        uses: ./.github/actions/coredump-capture
+        with:
+          phase: setup
+          job-name: data-utilities
 
       - name: Check if test files exist
         id: check-tests
@@ -1050,6 +1046,13 @@ jobs:
           name: test-results-Data-Utilities
           path: test-results/
           retention-days: 7
+
+      - name: Collect crash bundle
+        if: always()
+        uses: ./.github/actions/coredump-capture
+        with:
+          phase: collect
+          job-name: data-utilities
 
   # ============================================================================
   # Test Metrics / Coverage (absorbed from coverage.yml)


### PR DESCRIPTION
## Summary

PR #5364 surfaced a gap: the original capture infra (#5363) only wired the post-step bundling onto `test-mojo-comprehensive`, but the JIT crash bounces between **5 different test jobs** in `comprehensive-tests.yml`:

- `test-mojo-comprehensive`
- `test-configs`
- `test-benchmarks`
- `test-core-layers`
- `gradient-tests`
- `test-data-utilities`

PR #5364's CI run had crashes on `Data Utilities Test Suite` and `Gradient Checking Tests` — the two jobs that didn't have capture — so no cores were collected.

## Approach

Refactored capture into a **composite action** at `.github/actions/coredump-capture/action.yml`:

```yaml
- uses: ./.github/actions/coredump-capture
  with:
    phase: setup    # before tests
    job-name: configs

# ... run tests ...

- uses: ./.github/actions/coredump-capture
  with:
    phase: collect  # after tests; if: always()
    job-name: configs
```

Each test job calls the action twice. The collect step exits early if no cores were produced (no wasted artifact bandwidth).

## Result

The next JIT crash on any of the 6 jobs will land:
- ELF coredump in `crash-bundle-<job-name>/cores/`
- Matching `mojo` binary + `libKGEN*` / `libAsync*` / `libMojo*` / `libMSupport*` `.so` files in `symbols/`
- Env metadata (mojo --version, glibc, kernel, core_pattern)
- 14-day artifact retention

## Test plan

- [ ] CI green
- [ ] If crash hits any test job, the corresponding `crash-bundle-<job>` artifact appears