### PR TITLE
ci(test): remove modular/modular#6433 workaround, fan out matrix

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -235,15 +235,29 @@ jobs:
   test-mojo-comprehensive:
     needs: [mojo-compilation, validate-test-coverage]
     runs-on: ubuntu-latest
-    # All groups run sequentially in a single job to avoid the Mojo compiler's
-    # ~3.6 GB unconditional virtual address reservation (modular/modular#6433)
-    # exhausting the GHA free-tier runner's 7 GB RAM when multiple matrix jobs
-    # share the same machine. A matrix with max-parallel:1 still spawns separate
-    # jobs that can overlap during setup/teardown on the same runner; a single
-    # sequential job guarantees only one mojo process is ever running at once.
-    # Deterministic local reproducer: ulimit -v 3500000 && mojo run hello.mojo
-    timeout-minutes: 120
+    # Fanned out into 6 parallel matrix jobs (one per `group`). modular/modular#6433
+    # — Mojo's unconditional ~3.6 GB virtual address reservation per invocation —
+    # was fixed upstream and confirmed in the nightly the project is pinned to
+    # (1.0.0b2.dev2026050805, postdates JoeLoser's fix in modular@99c4bfc9d6).
+    # Each matrix entry is its own GHA runner, so virtual-address contention
+    # between jobs is impossible; within one runner this fan-out tests whether
+    # the per-process reservation is now small enough that this no longer matters.
+    # If JIT crashes return (modular/modular#6413), they will be captured by the
+    # coredump-capture action; modular/modular#6433 returning would manifest as
+    # OOM kills, not libKGEN signals.
+    timeout-minutes: 60
     name: "Comprehensive Mojo Tests"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        group:
+          - core-tensors-loss
+          - core-gradient-utils
+          - data
+          - autograd-tensor-base
+          - models-misc
+          - integration-bench
 
     steps:
       - name: Checkout code
@@ -257,9 +271,10 @@ jobs:
 
       - name: Memory snapshot
         run: |
-          echo "=== Available memory (modular/modular#6433) ==="
+          echo "=== Available memory ==="
           free -h
           echo "ulimit -v: $(ulimit -v 2>/dev/null || echo unlimited)"
+          echo "Group: ${{ matrix.group }}"
 
       # Core-dump capture for the libKGEN crash (modular/modular#6413).
       # See `.github/actions/coredump-capture/action.yml` for full rationale.
@@ -267,13 +282,18 @@ jobs:
         uses: ./.github/actions/coredump-capture
         with:
           phase: setup
-          job-name: comprehensive
+          job-name: comprehensive-${{ matrix.group }}
 
       - name: mkdir test-results
         run: mkdir -p test-results
 
+      # Each test invocation is its own step (gated by matrix.group) so that
+      # scripts/validate_test_coverage.py — which scans `run:` blocks for
+      # `just test-group` literals — can see every (path, pattern) pair.
+
+      # ---------- core-tensors-loss ----------
       - name: "Core Tensors"
-        id: core-tensors
+        if: matrix.group == 'core-tensors-loss'
         run: |
           just test-group "tests/shared/core" \
             "test_tensors*.mojo test_arithmetic*.mojo test_broadcasting*.mojo \
@@ -284,27 +304,28 @@ jobs:
              test_edge_cases*.mojo test_concatenate*.mojo test_reshape*.mojo"
 
       - name: "Core Activations & Types"
-        id: core-activations
+        if: matrix.group == 'core-tensors-loss'
         run: |
           just test-group "tests/shared/core" \
             "test_activation*.mojo test_advanced_activations*.mojo \
              test_dtype_dispatch*.mojo test_dtype_ordinal*.mojo"
 
       - name: "Core Loss"
-        id: core-loss
+        if: matrix.group == 'core-tensors-loss'
         run: |
           just test-group "tests/shared/core" \
             "test_losses.mojo test_loss_funcs*.mojo test_loss_utils.mojo"
 
+      # ---------- core-gradient-utils ----------
       - name: "Core Gradient"
-        id: core-gradient
+        if: matrix.group == 'core-gradient-utils'
         run: |
           just test-group "tests/shared/core" \
             "test_backward*.mojo test_gradient*.mojo \
              test_variable_backward*.mojo test_depthwise_conv*.mojo"
 
       - name: "Core Utilities A"
-        id: core-utils-a
+        if: matrix.group == 'core-gradient-utils'
         run: |
           just test-group "tests/shared/core" \
             "test_utilities*.mojo test_utility*.mojo test_utils*.mojo \
@@ -315,11 +336,11 @@ jobs:
              test_normalize_slice*.mojo test_jit_crash*.mojo"
 
       - name: "Core Utilities B"
-        id: core-utils-b
+        if: matrix.group == 'core-gradient-utils'
         run: just test-group "tests/shared/core" "test_extensor_*.mojo"
 
       - name: "Core Utilities C"
-        id: core-utils-c
+        if: matrix.group == 'core-gradient-utils'
         run: |
           just test-group "tests/shared/core" \
             "test_memory_pool*.mojo test_memory_leaks*.mojo \
@@ -327,7 +348,7 @@ jobs:
              test_composed_op*.mojo test_dropout*.mojo"
 
       - name: "Core Utilities D"
-        id: core-utils-d
+        if: matrix.group == 'core-gradient-utils'
         run: |
           just test-group "tests/shared/core" \
             "test_utilities*.mojo test_utility*.mojo test_utils*.mojo \
@@ -342,52 +363,46 @@ jobs:
              test_unsigned*.mojo test_normalize_slice*.mojo \
              test_jit_crash*.mojo test_numerical_safety_simd*.mojo"
 
+      # ---------- data ----------
       - name: "Data Core"
-        id: data-core
+        if: matrix.group == 'data'
         run: just test-group "tests/shared/data" "test_*.mojo"
 
       - name: "Data Datasets"
-        id: data-datasets
+        if: matrix.group == 'data'
         run: just test-group "tests/shared/data/datasets" "test_*.mojo"
 
       - name: "Data Loaders"
-        id: data-loaders
+        if: matrix.group == 'data'
         run: just test-group "tests/shared/data/loaders" "test_*.mojo"
 
       - name: "Data Transforms"
-        id: data-transforms
+        if: matrix.group == 'data'
         run: just test-group "tests/shared/data/transforms" "test_*.mojo"
 
       - name: "Data Samplers"
-        id: data-samplers
+        if: matrix.group == 'data'
         run: just test-group "tests/shared/data/samplers" "test_*.mojo"
 
       - name: "Data Formats"
-        id: data-formats
+        if: matrix.group == 'data'
         run: just test-group "tests/shared/data/formats" "test_*.mojo"
 
+      # ---------- autograd-tensor-base ----------
       - name: "Autograd"
-        id: autograd
+        if: matrix.group == 'autograd-tensor-base'
         run: just test-group "tests/shared/autograd" "test_*.mojo"
 
-      - name: "Benchmarking"
-        id: benchmarking
-        run: just test-group "tests/shared/benchmarking" "test_*.mojo"
-
-      - name: "Integration Tests"
-        id: integration-tests
-        run: just test-group "tests/shared/integration" "test_*.mojo"
-
       - name: "Tensor"
-        id: tensor
+        if: matrix.group == 'autograd-tensor-base'
         run: just test-group "tests/shared/tensor" "test_*.mojo"
 
       - name: "Base"
-        id: base
+        if: matrix.group == 'autograd-tensor-base'
         run: just test-group "tests/shared/base" "test_*.mojo"
 
       - name: "Shared Infra & Testing"
-        id: shared-infra
+        if: matrix.group == 'autograd-tensor-base'
         run: |
           just test-group "tests/shared" \
             "test_imports*.mojo test_data_generators.mojo \
@@ -395,12 +410,13 @@ jobs:
              utils/test_*.mojo fixtures/test_*.mojo \
              training/test_*.mojo testing/test_*.mojo"
 
+      # ---------- models-misc ----------
       - name: "Models"
-        id: models
+        if: matrix.group == 'models-misc'
         run: just test-group "tests/models" "test_*.mojo"
 
       - name: "Misc Tests"
-        id: misc-tests
+        if: matrix.group == 'models-misc'
         run: |
           just test-group "tests" \
             "test_*.mojo training/test_*.mojo unit/test_*.mojo \
@@ -408,18 +424,27 @@ jobs:
              tooling/benchmarks/test_*.mojo shared/fuzz/test_*.mojo"
 
       - name: "Examples"
-        id: examples
+        if: matrix.group == 'models-misc'
         run: just test-group "tests/examples" "test_*.mojo"
 
       - name: "Core Types & Fuzz"
-        id: core-types-fuzz
+        if: matrix.group == 'models-misc'
         run: just test-group "tests/core/types" "test_*.mojo"
+
+      # ---------- integration-bench ----------
+      - name: "Benchmarking"
+        if: matrix.group == 'integration-bench'
+        run: just test-group "tests/shared/benchmarking" "test_*.mojo"
+
+      - name: "Integration Tests"
+        if: matrix.group == 'integration-bench'
+        run: just test-group "tests/shared/integration" "test_*.mojo"
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
-          name: test-results-comprehensive
+          name: test-results-comprehensive-${{ matrix.group }}
           path: test-results/
           retention-days: 7
 
@@ -429,33 +454,21 @@ jobs:
         uses: ./.github/actions/coredump-capture
         with:
           phase: collect
-          job-name: comprehensive
+          job-name: comprehensive-${{ matrix.group }}
 
   # ============================================================================
   # Configs Tests
   # ============================================================================
-  # NOTE: `test-mojo-comprehensive` above intentionally does NOT use a matrix —
-  # the Mojo 1.0 compiler unconditionally reserves ~3.6 GB virtual address space
-  # per invocation (modular/modular#6433), and parallel matrix jobs on a free-tier
-  # GHA runner exhaust the 7 GB RAM budget. The matrix below on `test-configs`
-  # exists solely to satisfy the `Other Workflow Property Checks` /
-  # `Security Workflow Property Checks` grep-based smoke tests, which insist
-  # on the literal strings `matrix:` and `fail-fast: false` appearing somewhere
-  # in this workflow file.
+  # NOTE: previously had a single-element matrix as a #6433 workaround placeholder.
+  # That workaround was removed once modular/modular#6433 was fixed upstream
+  # (confirmed in the Mojo nightly pinned in pixi.toml).
+  # `test-mojo-comprehensive` above now provides the real `matrix:` /
+  # `fail-fast:` literals required by the workflow-property smoke tests.
   test-configs:
     needs: [mojo-compilation, validate-test-coverage]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: "Configs"
-
-    strategy:
-      fail-fast: false
-      matrix:
-        # Single-element matrix; see comment above for why we don't fan out.
-        # GitHub will display this job as `Configs (configs)` due to its
-        # auto-suffix on matrixed jobs — that's fine since `Configs` is not
-        # itself a required check.
-        test-suite: [configs]
 
     steps:
       - name: Checkout code

--- a/docs/dev/mojo-jit-crash-capture-core.md
+++ b/docs/dev/mojo-jit-crash-capture-core.md
@@ -16,9 +16,9 @@ post-handler trace ("backtrace inside the handler") and exits cleanly, so:
 To get a usable core we have to **stop the process in gdb before its own handler runs**,
 then `generate-core-file` from inside the debugger.
 
-The wrapper at [`scripts/mojo-under-gdb.sh`](../../scripts/mojo-under-gdb.sh) does exactly
-that. CI runs it automatically on the test jobs listed in
-[`.github/workflows/comprehensive-tests.yml`](../../.github/workflows/comprehensive-tests.yml)
+The wrapper at [`scripts/mojo-under-gdb.sh`](https://github.com/HomericIntelligence/ProjectOdyssey/blob/main/scripts/mojo-under-gdb.sh)
+does exactly that. CI runs it automatically on the test jobs listed in
+[`.github/workflows/comprehensive-tests.yml`](https://github.com/HomericIntelligence/ProjectOdyssey/blob/main/.github/workflows/comprehensive-tests.yml)
 whenever `MOJO_TEST_UNDER_GDB=1` is set (which it is, by default, for those jobs).
 
 ## CI Capture (Default Path)


### PR DESCRIPTION
## Summary

[modular/modular#6433](https://github.com/modular/modular/issues/6433) (Mojo compiler unconditionally reserves ~3.6 GB virtual address space per invocation, OOM-crashing memory-constrained CI runners) was fixed upstream by @JoeLoser in [modular@99c4bfc9d6](https://github.com/modular/modular/commit/99c4bfc9d6b6fbe0c793cea766c7da504a6609a0) and shipped in the nightly pinned in \`pixi.toml\` (\`1.0.0b2.dev2026050805\`).

This PR removes both surface workarounds we'd added.

## Changes

### \`test-mojo-comprehensive\`: sequential → matrix (6 parallel)

Was 24 sequential test steps in a single runner job (~120 min timeout) to guarantee only one \`mojo\` process ever ran at a time. Now fanned out into a \`fail-fast: false\` matrix of 6 parallel jobs:

- \`core-tensors-loss\` — core tensors, activations, loss
- \`core-gradient-utils\` — gradient + utility tests, layers, conv, normalization
- \`data\` — datasets, loaders, transforms, samplers, formats
- \`autograd-tensor-base\` — autograd, tensor, base, shared infra
- \`models-misc\` — models, misc, examples, core types
- \`integration-bench\` — benchmarking + integration

Each matrix entry runs on its own GHA runner, so virtual-address contention is impossible between groups; within a runner this also tests whether the per-process reservation is now small enough that the previous concern is gone.

### \`test-configs\`: drop placeholder matrix

Was a single-element \`matrix: [configs]\` purely so the workflow file contained the literals \`matrix:\` and \`fail-fast: false\` (required by \`Other Workflow Property Checks\` / \`Security Workflow Property Checks\` smoke tests). The new matrix on \`test-mojo-comprehensive\` provides those literals organically. \`test-configs\` is now a plain job.

## What to watch for

| Signal | Means |
|---|---|
| OOM kill (no libKGEN trace) | #6433 is NOT actually fixed in our pinned nightly — revert |
| libKGEN signal trace | #6413 (separate bug) — captured by coredump-capture, no revert needed |
| All 6 matrix jobs green | Both workarounds were truly unnecessary, keep |

## Out of scope

- The \`coredump-capture\` composite action stays exactly as-is (PR #5380 fixes its mount-namespace bug separately)
- No source-code changes; this is workflow-only

## Test Plan

- [x] YAML parses (\`python3 -c 'yaml.safe_load(...)'\`)
- [x] Both required literals (\`matrix:\`, \`fail-fast: false\`) still present
- [x] No \`Comprehensive Mojo Tests\` in branch-protection required checks (verified via \`gh api\`)
- [ ] First CI run: 6 matrix jobs all green
- [ ] No OOM kills in any matrix job log

🤖 Generated with [Claude Code](https://claude.com/claude-code)