### PR TITLE
feat(ci): wrap mojo tests in gdb -batch to capture real ELF cores

### DIFF
--- a/.github/actions/coredump-capture/action.yml
+++ b/.github/actions/coredump-capture/action.yml
@@ -5,6 +5,12 @@ description: |
   After the test job, bundles cores + matching `mojo` binary + relevant
   `.so` files into a `crash-bundle-<job-name>` artifact (14-day retention).
 
+  When MOJO_TEST_UNDER_GDB=1 is set (CI default), mojo test invocations run
+  under gdb -batch with handle SIGABRT stop nopass. On crash, gdb writes:
+    - core.gdb.<timestamp>.mojo  — real ELF core (multi-MB)
+    - gdb-<timestamp>.log        — full bt, threads, shlibs text dump
+  Both are collected here alongside any kernel cores and the mojo binary.
+
   Use this action TWICE in each test job:
     1. As a setup step BEFORE the test runs (to enable cores)
     2. As a teardown step AFTER the test runs (to bundle + upload)
@@ -93,8 +99,20 @@ runs:
           for so in "$ENV_DIR"/lib/libKGEN*.so "$ENV_DIR"/lib/libAsync*.so "$ENV_DIR"/lib/libMojo*.so "$ENV_DIR"/lib/libMSupport*.so; do
             [ -e "$so" ] && cp -av "$so" /workspace/crash-bundle/symbols/ 2>/dev/null || true
           done
+          # Bundle gdb itself so the crash can be analyzed offline without
+          # needing a matching gdb version installed.
+          GDB_BIN=$(which gdb 2>/dev/null || true)
+          if [ -n "$GDB_BIN" ] && [ -x "$GDB_BIN" ]; then
+            cp -av "$GDB_BIN" /workspace/crash-bundle/symbols/ 2>/dev/null || true
+          fi
           ls -la /workspace/crash-bundle/symbols/
         ' || true
+
+        # gdb-mode: collect gdb-*.log and core.gdb.* files written by
+        # scripts/mojo-under-gdb.sh when MOJO_TEST_UNDER_GDB=1.
+        # These live in crash-bundle/cores/ alongside any kernel cores.
+        ls -la crash-bundle/cores/gdb-*.log 2>/dev/null || true
+        ls -la crash-bundle/cores/core.gdb.* 2>/dev/null || true
 
         {
           echo "=== mojo --version ==="
@@ -111,16 +129,22 @@ runs:
           podman compose exec -T projectodyssey-dev bash -c 'ulimit -c' 2>&1 || true
           echo "=== Coredumps found in crash-bundle/cores/ ==="
           ls -la crash-bundle/cores/ 2>/dev/null
+          echo "=== GDB logs (from mojo-under-gdb.sh) ==="
+          ls -la crash-bundle/cores/gdb-*.log 2>/dev/null || echo "(none)"
+          echo "=== GDB ELF cores (from mojo-under-gdb.sh) ==="
+          ls -la crash-bundle/cores/core.gdb.* 2>/dev/null || echo "(none)"
           echo "=== Symbols bundled ==="
           ls -la crash-bundle/symbols/ 2>/dev/null
         } > crash-bundle/metadata.txt
 
-        # If no cores, still upload the metadata + symbols so the artifact
-        # appears in the run (proves the action executed end-to-end).
-        if [ -z "$(ls -A crash-bundle/cores/ 2>/dev/null)" ]; then
-          echo "No cores captured this run — uploading metadata + symbols only."
-          echo "(If a crash signature appeared in test logs, the capture action " \
-               "is mis-wired: see docs comment in this file.)" \
+        # If no cores (kernel or gdb), still upload the metadata + symbols so
+        # the artifact appears in the run (proves the action ran end-to-end).
+        HAVE_CORES=$(ls crash-bundle/cores/core* 2>/dev/null | head -1 || true)
+        HAVE_GDB_LOGS=$(ls crash-bundle/cores/gdb-*.log 2>/dev/null | head -1 || true)
+        if [ -z "$HAVE_CORES" ] && [ -z "$HAVE_GDB_LOGS" ]; then
+          echo "No cores or gdb logs captured this run — uploading metadata + symbols only."
+          echo "(If a crash signature appeared in test logs, check that" \
+               "MOJO_TEST_UNDER_GDB=1 is set for this job.)" \
                >> crash-bundle/metadata.txt
         fi
 

--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -241,6 +241,14 @@ jobs:
     # Deterministic local reproducer: ulimit -v 3500000 && mojo run hello.mojo
     timeout-minutes: 120
     name: "Comprehensive Mojo Tests"
+    env:
+      # Route mojo test invocations through gdb to intercept the in-process
+      # SIGABRT handler in libKGEN (modular/modular#6413) before it swallows
+      # the crash. Without gdb, the kernel never generates a core because the
+      # process handles SIGABRT itself and exits cleanly.
+      # Set to "0" locally to skip gdb overhead (default when unset).
+      MOJO_TEST_UNDER_GDB: "1"
+      CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
       - name: Checkout code
@@ -444,6 +452,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: "Configs"
+    env:
+      MOJO_TEST_UNDER_GDB: "1"
+      CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     strategy:
       fail-fast: false
@@ -500,6 +511,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: "Benchmarks"
+    env:
+      MOJO_TEST_UNDER_GDB: "1"
+      CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
       - name: Checkout code
@@ -543,6 +557,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: "Core Layers"
+    env:
+      MOJO_TEST_UNDER_GDB: "1"
+      CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
       - name: Checkout code
@@ -826,6 +843,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: "Gradient Checking Tests"
+    env:
+      MOJO_TEST_UNDER_GDB: "1"
+      CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
       - name: Checkout code
@@ -953,6 +973,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: "Data Utilities Test Suite"
+    env:
+      MOJO_TEST_UNDER_GDB: "1"
+      CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
       - name: Checkout code

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y \
     wget \
     uuid \
     sudo \
+    gdb \
     && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub CLI (gh) as root

--- a/docs/dev/mojo-jit-crash-workaround.md
+++ b/docs/dev/mojo-jit-crash-workaround.md
@@ -151,6 +151,83 @@ higher memory pressure than a single test file produces. The targeted import fix
 the correct defensive measure -- it reduces compilation footprint by ~95% per test file,
 which lowers the probability of hitting the JIT buffer overflow regardless of environment.
 
+## GDB Wrapper: Capturing Real ELF Cores (modular/modular#6413)
+
+PRs #5380 and #5382 wired up host-side `core_pattern` (path-based then pipe-based) but
+produced **zero core files** across all CI runs even when the libKGEN JIT crash signature
+appeared in test logs:
+
+```text
+libKGENCompilerRTShared.so+0x6ef7b → +0x6c156 → +0x6fc27
+mojo: error: execution crashed
+```
+
+Root cause: libKGEN registers an in-process SIGABRT handler that catches the abort, prints
+its own 3-frame post-handler trace, and exits cleanly. The kernel never generates a core for
+a process that handles its own fatal signal.
+
+### The Fix: `scripts/mojo-under-gdb.sh`
+
+Mojo test invocations are wrapped in `gdb -batch` with:
+
+- `handle SIGABRT stop nopass` — gdb intercepts the signal BEFORE libKGEN's handler runs
+- `generate-core-file` — dumps a real ELF core on the stopped inferior
+- `bt full`, `info threads`, `info sharedlibrary` — captures rich text context to a log
+
+This produces two files per crash in `crash-bundle/cores/`:
+
+- `core.gdb.<timestamp>.mojo` — real ELF core (multi-MB, readable by gdb offline)
+- `gdb-<timestamp>.log` — full pre-signal backtrace + threads + shared library map
+
+### Using the Wrapper Locally
+
+The wrapper is **disabled by default** (`MOJO_TEST_UNDER_GDB` defaults to 0 so local dev
+runs mojo directly with no overhead).
+
+To reproduce a crash locally with gdb capture:
+
+```bash
+# One test file
+MOJO_TEST_UNDER_GDB=1 just test-group tests/shared/core \
+    "test_gradient_checking_basic.mojo"
+
+# The wrapper writes to crash-bundle/cores/ by default
+ls crash-bundle/cores/
+# core.gdb.<ts>.mojo   (ELF core)
+# gdb-<ts>.log         (text backtrace)
+```
+
+To completely bypass the wrapper when gdb is unavailable:
+
+```bash
+MOJO_UNDER_GDB=0 MOJO_TEST_UNDER_GDB=1 just test-group ...
+# or simply omit MOJO_TEST_UNDER_GDB (defaults to 0)
+```
+
+### Analyzing a Captured Core
+
+```bash
+# Download crash-bundle artifact from the GitHub Actions run
+cd crash-bundle/
+gdb symbols/mojo cores/core.gdb.<timestamp>.mojo
+# Inside gdb:
+(gdb) bt
+(gdb) info threads
+(gdb) frame N   # navigate to the faulting frame
+```
+
+The `gdb-<timestamp>.log` text file contains the same information without needing a
+local gdb installation.
+
+### CI Configuration
+
+`MOJO_TEST_UNDER_GDB=1` is set in the `env:` block of all Mojo test jobs in
+`.github/workflows/comprehensive-tests.yml`. Build-only jobs are unaffected.
+
+The coredump-capture composite action (`.github/actions/coredump-capture/action.yml`)
+collects both kernel cores and gdb-written files, and bundles gdb itself into
+`crash-bundle/symbols/` for offline analysis.
+
 ## References
 
 - [Issue #5108](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5108) -- JIT crash comprehensive tracking

--- a/justfile
+++ b/justfile
@@ -693,6 +693,11 @@ _test-group-inner path pattern:
         exit 1
     fi
 
+    # gdb wrapper path: set MOJO_TEST_UNDER_GDB=1 in CI to intercept the
+    # in-process SIGABRT handler in libKGEN before it swallows the crash
+    # (modular/modular#6413). Default 0 so local dev runs mojo directly.
+    CORE_DIR="${CRASH_BUNDLE_DIR:-${REPO_ROOT}/crash-bundle/cores}"
+
     # Run each test file
     for test_file in $test_files; do
         if [ -f "$test_file" ]; then
@@ -701,13 +706,20 @@ _test-group-inner path pattern:
             test_count=$((test_count + 1))
 
             ulimit -v unlimited 2>/dev/null || true
-            pixi run mojo --Werror -debug-level=line-tables -I "$REPO_ROOT" -I . "$test_file" || test_exit=$?
-            if [ "${test_exit:-0}" -eq 0 ]; then
+            test_exit=0
+            if [ "${MOJO_TEST_UNDER_GDB:-0}" = "1" ]; then
+                bash "$REPO_ROOT/scripts/mojo-under-gdb.sh" "$CORE_DIR" \
+                    --Werror -debug-level=line-tables -I "$REPO_ROOT" -I . "$test_file" \
+                    || test_exit=$?
+            else
+                pixi run mojo --Werror -debug-level=line-tables -I "$REPO_ROOT" -I . "$test_file" \
+                    || test_exit=$?
+            fi
+            if [ "${test_exit}" -eq 0 ]; then
                 passed_count=$((passed_count + 1))
             else
                 failed_count=$((failed_count + 1))
                 failed_tests="$failed_tests\n  - $test_file"
-                test_exit=0
             fi
         fi
     done

--- a/scripts/mojo-under-gdb.sh
+++ b/scripts/mojo-under-gdb.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Run `mojo` under gdb to catch the in-process SIGABRT handler in libKGEN
+# (modular/modular#6413) and dump a real ELF core via generate-core-file.
+#
+# Without gdb interception, libKGEN's SIGABRT handler catches the abort,
+# prints its own 3-frame post-handler trace, and exits cleanly — the
+# kernel never generates a core because the process handles the signal itself.
+# Running under gdb forces the signal to stop in the debugger BEFORE the
+# user handler runs, so we get the real pre-signal frame frozen in the core.
+#
+# Usage:
+#   mojo-under-gdb.sh <core-dir> <mojo-args...>
+#
+#   <core-dir>   Directory where cores and gdb logs are written (created if absent)
+#   <mojo-args>  All remaining arguments are passed verbatim to `pixi run mojo`
+#
+# Environment variables:
+#   MOJO_UNDER_GDB=0   Skip gdb and exec mojo directly (local dev escape hatch)
+#
+# Output files (on crash):
+#   <core-dir>/core.gdb.<timestamp>.mojo  — ELF core (multi-MB)
+#   <core-dir>/gdb-<timestamp>.log        — full backtrace + threads + shlibs
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+    echo "[mojo-under-gdb] usage: $0 <core-dir> <mojo-args...>" >&2
+    exit 1
+fi
+
+CORE_DIR="$1"
+shift
+
+# Escape hatch: MOJO_UNDER_GDB=0 bypasses gdb for local dev where overhead matters.
+if [ "${MOJO_UNDER_GDB:-1}" = "0" ]; then
+    exec pixi run mojo "$@"
+fi
+
+mkdir -p "$CORE_DIR"
+TS=$(date +%s)
+GDB_LOG="${CORE_DIR}/gdb-${TS}.log"
+CORE_FILE="${CORE_DIR}/core.gdb.${TS}.mojo"
+
+# Resolve the real mojo binary so gdb has a concrete ELF file argument.
+# `pixi run which mojo` prints any activation preamble on stderr; `tail -1`
+# grabs the last line (the actual path) to handle noisy pixi output.
+MOJO_BIN=$(pixi run which mojo 2>/dev/null | tail -1 || true)
+if [ -z "$MOJO_BIN" ] || [ ! -x "$MOJO_BIN" ]; then
+    echo "[mojo-under-gdb] WARNING: could not resolve mojo binary; falling back to direct exec" >&2
+    exec pixi run mojo "$@"
+fi
+
+# Write the gdb command script to a temp file to avoid multi-line -ex quoting issues.
+# gdb multi-line strings via -ex are not portable across gdb versions; -x is reliable.
+GDB_SCRIPT=$(mktemp /tmp/mojo-gdb-XXXXXX.gdb)
+# shellcheck disable=SC2064
+trap "rm -f '$GDB_SCRIPT'" EXIT
+
+cat > "$GDB_SCRIPT" <<GDBEOF
+set pagination off
+set confirm off
+set logging file ${GDB_LOG}
+set logging overwrite on
+set logging enabled on
+
+# Intercept crash signals before user (libKGEN) handlers run.
+# "nopass" prevents the signal from being delivered to the inferior.
+handle SIGABRT stop nopass print
+handle SIGSEGV stop nopass print
+handle SIGBUS  stop nopass print
+
+run
+
+# If gdb stopped due to a signal, dump a core and capture context.
+if \$_siginfo
+  printf "[mojo-under-gdb] caught signal %d at ", \$_siginfo.si_signo
+  info frame
+  printf "Generating core: ${CORE_FILE}\\n"
+  generate-core-file ${CORE_FILE}
+end
+
+bt full
+info threads
+info sharedlibrary
+set logging enabled off
+quit
+GDBEOF
+
+echo "[mojo-under-gdb] gdb log  : ${GDB_LOG}" >&2
+echo "[mojo-under-gdb] core file: ${CORE_FILE} (written on crash)" >&2
+echo "[mojo-under-gdb] binary   : ${MOJO_BIN}" >&2
+echo "[mojo-under-gdb] args     : $*" >&2
+
+# --args passes everything after it verbatim as the inferior's argv.
+# stdout/stderr from the mojo process flow through gdb normally so CI
+# logs remain readable.
+exec gdb -batch -nx -x "$GDB_SCRIPT" --args "$MOJO_BIN" "$@"


### PR DESCRIPTION
## Summary

Follow-up to #5382. Wraps `mojo` test invocations in `gdb -batch` so the kernel
actually generates a core when libKGEN crashes — without this, the in-process
SIGABRT handler swallows the abort and the core_pattern (path-based or pipe-based)
never fires.

## Evidence the previous approach was blocked

PRs #5380 and #5382 set `core_pattern` correctly. The pipe handler is installed and
verified in CI metadata. But across multiple CI runs with libKGEN crashes in the
logs, **no core files are ever created**.

Why: the libKGEN `+0x6fc27 → +0x6c156 → +0x6ef7b` trace is the **post-handler**
stack, not the original fault site. Mojo's runtime registers its own SIGABRT handler,
prints those 3 frames, and exits cleanly. The kernel doesn't generate cores for
processes that catch their own fatal signals.

## The fix

Run `mojo` under `gdb -batch` with:

- `handle SIGABRT stop nopass` — stop on signal, do NOT pass it through to the user handler
- `generate-core-file` — dump real ELF on stop
- `bt full`, `info threads`, `info sharedlibrary` — capture rich context to a gdb log

This intercepts the signal BEFORE libKGEN's handler can run, so we get a real
pre-handler stack frozen in the core.

## Components

- `Dockerfile`: add `gdb` to apt-get install list in the base stage
- `scripts/mojo-under-gdb.sh`: wrapper script (uses `-x tempfile` not multi-line `-ex`
  to avoid gdb version portability issues; `MOJO_UNDER_GDB=0` escape hatch)
- `justfile` `_test-group-inner`: routes through wrapper when `MOJO_TEST_UNDER_GDB=1`
- `.github/workflows/comprehensive-tests.yml`: sets `MOJO_TEST_UNDER_GDB=1` on all
  Mojo test jobs (comprehensive, gradient, configs, benchmarks, core-layers,
  data-utilities)
- `.github/actions/coredump-capture/action.yml`: bundles `gdb-*.log` + `core.gdb.*` +
  gdb binary itself for offline analysis
- `docs/dev/mojo-jit-crash-workaround.md`: documents gdb wrapper usage

## Local dev: unchanged

Default `MOJO_TEST_UNDER_GDB=0`. Local tests run `mojo` directly with no overhead.
To repro locally:

```bash
MOJO_TEST_UNDER_GDB=1 just test-group tests/shared/core "test_gradient_checking_basic.mojo"
# Cores and logs land in crash-bundle/cores/
```

## Implementation note: -x tempfile vs multi-line -ex

The gdb command script is written to a temp file and passed via `-x file` rather than
using multiple `-ex` flags. Multi-line strings in `-ex` are not portable across gdb
versions (some require one `-ex` per command, others accept newlines). Writing to a
temp file and using `-x` is universally supported and avoids shell quoting hazards.

## Verification path

1. Merge this PR
2. Wait for next libKGEN crash run (basically next comprehensive or gradient test CI run)
3. Download `crash-bundle-*` artifact — should contain `core.gdb.<ts>.mojo` (multi-MB ELF)
   AND `gdb-<ts>.log` (text trace with pre-signal frames)
4. `gdb symbols/mojo cores/core.gdb.X.mojo` and walk pre-signal frames
5. Post the symbolicated faulting frame and `gdb-X.log` to modular/modular#6413

## Test plan

- [ ] CI passes (ignoring expected JIT-crash flakes — that's what we're capturing)
- [ ] On next JIT-crash run, crash-bundle contains `core.gdb.*` > 1MB AND `gdb-*.log`
- [ ] `gdb symbols/mojo cores/core.gdb.*` opens the core cleanly
- [ ] Local `MOJO_TEST_UNDER_GDB=0` (default) skips gdb with zero overhead

## Image size impact

`gdb` adds ~30MB to the dev/CI image base. Production target (`FROM base`) inherits
gdb since it's in the base stage — this is acceptable as gdb is a standard debugging
tool and the production stage doesn't execute tests.

Refs: #5380
Refs: #5382
Refs: modular/modular#6413

🤖 Generated with [Claude Code](https://claude.com/claude-code)