### PR TITLE
fix(justfile): export USER_ID/GROUP_ID to podman compose up/down

### DIFF
--- a/justfile
+++ b/justfile
@@ -94,8 +94,15 @@ _ensure_build_dir mode:
 # ==============================================================================
 
 # Start Podman development environment
+#
+# docker-compose substitutes ${USER_ID}/${GROUP_ID} in docker-compose.yml from
+# its OWN environment, not from just's template vars. Without explicit
+# `USER_ID=... GROUP_ID=...` exports on the same line, the variables expand to
+# empty strings and the container would get `user: ":"` (invalid), causing
+# the compose call to fail or create a stuck container in an invalid state.
 podman-up:
-    @podman compose up -d {{podman_service}}
+    @USER_ID={{USER_ID}} GROUP_ID={{GROUP_ID}} USER_NAME=${USER_NAME:-dev} \
+        podman compose up -d {{podman_service}}
     @# Rootless Podman UID-maps the bind-mounted workspace so the container
     @# user cannot write to host-owned files. Make the workspace world-writable
     @# so `just build`, test fixtures, and pre-commit can create output files.
@@ -104,7 +111,8 @@ podman-up:
 
 # Stop Podman development environment
 podman-down:
-    @podman compose down
+    @USER_ID={{USER_ID}} GROUP_ID={{GROUP_ID}} USER_NAME=${USER_NAME:-dev} \
+        podman compose down
 
 # Build Podman images
 podman-build:


### PR DESCRIPTION
## Summary

\`just podman-up\` was failing with:

\`\`\`
The "USER_ID" variable is not set. Defaulting to a blank string.
The "GROUP_ID" variable is not set. Defaulting to a blank string.
...
container must be in Created or Stopped state to be started: container state improper
\`\`\`

## Root cause

just's \`USER_ID := \`id -u\`\` is a **template variable**, available via
\`{{USER_ID}}\` substitution — but it is **not exported to the recipe's
environment**. The \`podman-up\` and \`podman-down\` recipes invoked
\`podman compose up/down\` without explicit env, so docker-compose's
substitution of \`\${USER_ID}\`/\`\${GROUP_ID}\` in \`docker-compose.yml\`
expanded to empty strings.

Result: container created with invalid \`user: ":"\` mapping, which on
re-run leaves a stuck container that the next \`just podman-up\` can't
recover from.

## Fix

Inline the env on the same shell invocation, matching the pattern already
used by \`podman-build\` and \`podman-rebuild\` (which pass \`--build-arg\`
explicitly):

\`\`\`make
podman-up:
    @USER_ID={{USER_ID}} GROUP_ID={{GROUP_ID}} USER_NAME=\${USER_NAME:-dev} \\
        podman compose up -d {{podman_service}}
\`\`\`

## Test plan

- [x] Local: \`just podman-down && just podman-up\` produces a healthy container with no compose warnings
- [x] Local: \`podman exec projectodyssey-projectodyssey-dev-1 pixi run mojo --version\` works after start
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)