### PR TITLE
Repro 6413 workflow: dump disasm + registers around $pc

### DIFF
--- a/.github/workflows/repro-6413.yml
+++ b/.github/workflows/repro-6413.yml
@@ -276,13 +276,45 @@ jobs:
                 if [ "$core_after" -gt "$core_before" ]; then
                     new_core=$(ls -t /workspace/crash-bundle/cores/core.gdb*.mojo 2>/dev/null | head -1)
                     crash_count=$(( crash_count + 1 ))
+                    # Symbolicate against the binary that actually produced the
+                    # core: AOT binary for AOT mode, mojo for JIT mode. Using
+                    # the wrong ELF makes disassembly meaningless if $pc is
+                    # inside user code (rather than libKGEN, which is loaded
+                    # at runtime regardless).
+                    if [ "$REPRO_MODE" = "aot" ]; then
+                        SYM_BIN="/workspace/repro/build/repro_6413_${REPRO_NAME}"
+                    else
+                        SYM_BIN="$MOJO_BIN"
+                    fi
                     {
                         echo "==== iter $i CRASH ($new_core) ===="
                         echo "exit_code=$exit_code"
-                        echo "Top backtrace frames (gdb -batch):"
+                        echo "symbol_binary=$SYM_BIN"
+                        echo "---- Backtrace (top 25 frames) ----"
                         gdb -batch -ex "set pagination off" \
                             -ex "thread apply 1 bt 25" \
-                            "$MOJO_BIN" "$new_core" 2>&1 | head -80
+                            "$SYM_BIN" "$new_core" 2>&1 | head -80
+                        echo "---- Instruction stream around \$pc ----"
+                        # Goal: identify the exact faulting instruction so we can
+                        # tell whether the crash is e.g. an AVX-VNNI / VAES /
+                        # SHA-NI / VPCLMULQDQ / serialize / movdir64b opcode
+                        # the GHA runner CPU does not implement. Dump:
+                        #   - 16 raw instructions before and after $pc
+                        #   - a disassembly window of [-64, +64] bytes
+                        #   - integer + SSE/AVX register state at fault time
+                        #   - the current frame info (PC, AT, source line if any)
+                        #   - /proc/cpuinfo flags re-printed from the core so we
+                        #     can compare CPU flags to the host-env dump above
+                        gdb -batch \
+                            -ex "set pagination off" \
+                            -ex "set print pretty on" \
+                            -ex "info registers" \
+                            -ex "info frame" \
+                            -ex "x/16i \$pc - 30" \
+                            -ex "x/16i \$pc" \
+                            -ex "disassemble \$pc - 64, \$pc + 64" \
+                            -ex "info all-registers" \
+                            "$SYM_BIN" "$new_core" 2>&1 | head -400
                     } | tee -a "repro-output/${REPRO_NAME}-${REPRO_MODE}-symbolicated.log"
                 fi
 


### PR DESCRIPTION
## Summary

Follow-up to #5393. Extends the post-crash symbolicator in `.github/workflows/repro-6413.yml` to dump the **instruction stream and CPU register state at the SIGILL site** so we can identify the exact opcode that traps.

For every captured core, in addition to the 25-frame backtrace, gdb now prints:

- `info registers` — integer + flags state at fault
- `info frame` — PC, function, source line if any
- `x/16i $pc - 30` — 16 raw instructions before $pc
- `x/16i $pc` — 16 raw instructions starting at $pc (the suspect)
- `disassemble $pc - 64, $pc + 64` — a symbolic disassembly window
- `info all-registers` — SSE/AVX/AVX-512 state (useful if a vector intrinsic is the trap)

Also picks the right binary per mode: AOT cores symbolicate against the prebuilt repro binary; JIT cores against `mojo`. Using the wrong ELF makes any disassembly of user-code `$pc` frames meaningless (libKGEN is loaded at runtime regardless).

## Motivation

The PR #5393 sanity sweep posted a fresh hypothesis: the local CPU (Lunar Lake) has `vaes / sha_ni / vpclmulqdq / avx_vnni` while GHA free-tier Xeons typically lack these. If the libKGEN JIT emits one of these intrinsics in the crashing path (e.g. `string_slice._strip` SIMD search, or a `KGEN_CompilerRT_GetOrCreateGlobalIndexed` codegen path), the runner will UD2 / SIGILL where the local CPU runs the fast path. Dumping the bytes at `$pc` is the cheapest way to confirm or rule out this theory.

## Test plan

- [ ] Workflow YAML still parses (verified locally with `python3 -c 'import yaml; yaml.safe_load(...)'`)
- [ ] Next dispatch of `Repro modular/modular#6413` that captures a core attaches a `*-symbolicated.log` with `info registers`, `x/16i $pc`, and a `disassemble` block visible alongside the existing backtrace section
- [ ] If the opcode at `$pc` is one of the listed advanced ISA extensions, file that as the prime suspect with Modular

Refs: #5382, #5393, modular/modular#6413