### PR TITLE
[DO NOT MERGE] bisect(6413): revert Group A (#5381 + #5387) to test as crash fix

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -76,35 +76,6 @@ jobs:
           fi
           echo 'OK: no "continue-on-error: true" found'
 
-      - name: "Reject advisory annotation pattern"
-        run: |
-          set -euo pipefail
-          mapfile -t files < <(git ls-files -- '.github/workflows/*.yml' '.github/workflows/*.yaml')
-          # The advisory-annotation pattern in workflow run blocks is morally
-          # equivalent to continue-on-error: true: it lets a tool fail without
-          # failing the CI step. Per HomericIntelligence/Odysseus#282 (Bucket F),
-          # every tool must be fail-fast. The only legitimate annotation is
-          # informational text not tied to a tool's exit code — those should
-          # use echo "WARN:" to stdout instead.
-          declare -a scan_files=()
-          for f in "${files[@]}"; do
-            # Exempt this workflow file (heredoc would otherwise self-match).
-            case "$f" in
-              .github/workflows/_required.yml) continue ;;
-            esac
-            scan_files+=("$f")
-          done
-          if [ "${#scan_files[@]}" -eq 0 ]; then
-            echo "No files to scan"
-            exit 0
-          fi
-          if grep -nF '::warning::' "${scan_files[@]}"; then
-            echo ""
-            echo '::error::Found advisory annotations above. Make the underlying tool fail-fast or use echo "WARN:" to stdout. See HomericIntelligence/Odysseus#282.'
-            exit 1
-          fi
-          echo 'OK: no advisory annotations found'
-
   # ── 1. lint ────────────────────────────────────────────────────────────────
   lint:
     name: lint
@@ -268,33 +239,17 @@ jobs:
       - name: Run pip-audit against pyproject.toml dependencies
         id: pip-audit
         run: |
-          # Fail-fast pip-audit per HomericIntelligence/Odysseus#282 (Bucket F).
-          # Both wrappers (editable install + pip-audit) were advisory `::warning::`
-          # patterns that let CVE findings pass silently. Now:
-          #   - The editable install is required (a real build-backend failure
-          #     means the audit cannot evaluate project deps; fix the metadata).
-          #   - pip-audit exits non-zero on findings and blocks the PR.
-          #
-          # Pre-existing transitive-dep CVEs are tracked in #5386 and explicitly
-          # allowlisted below with `--ignore-vuln`. Each allowlist entry must be
-          # removed once the underlying package is upgraded.
+          # Scan project dependencies. pip-audit results are advisory (findings in the
+          # runner environment such as pip itself do not reflect project risk).
           set -euo pipefail
           pip install setuptools wheel
-          pip install -e . --no-deps
-          pip-audit --skip-editable \
-            --ignore-vuln CVE-2026-41425 \
-            --ignore-vuln CVE-2026-42215 \
-            --ignore-vuln CVE-2026-42284 \
-            --ignore-vuln CVE-2026-44244 \
-            --ignore-vuln GHSA-mv93-w799-cj2w \
-            --ignore-vuln CVE-2026-33079 \
-            --ignore-vuln CVE-2026-44708 \
-            --ignore-vuln CVE-2026-44896 \
-            --ignore-vuln CVE-2026-44897 \
-            --ignore-vuln CVE-2026-1703 \
-            --ignore-vuln CVE-2026-3219 \
-            --ignore-vuln CVE-2026-6357 \
-            --ignore-vuln CVE-2025-71176
+          # Editable install is best-effort: some pyproject.toml layouts (e.g.
+          # missing build backend metadata in dev branches) cannot be installed
+          # editable. Surface the failure as a warning so the audit step still runs.
+          if ! pip install -e . --no-deps; then
+            echo "::warning::editable install failed — running pip-audit on requirements only"
+          fi
+          pip-audit --skip-editable || echo "::warning::pip-audit found vulnerabilities — review manually"
 
       - name: Post pip-audit summary
         if: always()
@@ -484,10 +439,7 @@ jobs:
           if [ -f pixi.lock ]; then
             pixi install --locked
           else
-            # Informational stdout WARN (not a ::warning:: advisory): this branch
-            # does not gate a tool exit — pixi install will still run, just
-            # without lock-pinning. Per HomericIntelligence/Odysseus#282 Bucket F.
-            echo "WARN: pixi.toml present but pixi.lock missing — running unlocked"
+            echo "::warning::pixi.toml present but pixi.lock missing — running unlocked"
             pixi install
           fi
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -264,15 +264,11 @@ jobs:
             exit 1
           fi
           # Best-effort copy: the file may be absent when the benchmark exited
-          # early. Surface the failure as an informational `WARN:` line on
-          # stdout (the workflow-annotation form is forbidden per
-          # HomericIntelligence/Odysseus#282 Bucket F — advisory annotations
-          # that gate a tool exit are equivalent to continue-on-error). This
-          # branch does not block the step; the summary downstream will
-          # document the missing data.
+          # early. Surface the failure as a warning so reviewers see why the
+          # summary step downstream produces no data.
           if ! podman cp "$CONTAINER_ID:/tmp/benchmark-results/simd-output.txt" \
                          "benchmark-results/simd-output.txt" 2>/dev/null; then
-            echo "WARN: SIMD benchmark output not found in container — summary will be empty"
+            echo "::warning::SIMD benchmark output not found in container — summary will be empty"
           fi
 
       - name: Generate benchmark summary

--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -235,17 +235,14 @@ jobs:
   test-mojo-comprehensive:
     needs: [mojo-compilation, validate-test-coverage]
     runs-on: ubuntu-latest
-    # Fanned out into 6 parallel matrix jobs (one per `group`). modular/modular#6433
-    # — Mojo's unconditional ~3.6 GB virtual address reservation per invocation —
-    # was fixed upstream and confirmed in the nightly the project is pinned to
-    # (1.0.0b2.dev2026050805, postdates JoeLoser's fix in modular@99c4bfc9d6).
-    # Each matrix entry is its own GHA runner, so virtual-address contention
-    # between jobs is impossible; within one runner this fan-out tests whether
-    # the per-process reservation is now small enough that this no longer matters.
-    # If JIT crashes return (modular/modular#6413), they will be captured by the
-    # coredump-capture action; modular/modular#6433 returning would manifest as
-    # OOM kills, not libKGEN signals.
-    timeout-minutes: 60
+    # All groups run sequentially in a single job to avoid the Mojo compiler's
+    # ~3.6 GB unconditional virtual address reservation (modular/modular#6433)
+    # exhausting the GHA free-tier runner's 7 GB RAM when multiple matrix jobs
+    # share the same machine. A matrix with max-parallel:1 still spawns separate
+    # jobs that can overlap during setup/teardown on the same runner; a single
+    # sequential job guarantees only one mojo process is ever running at once.
+    # Deterministic local reproducer: ulimit -v 3500000 && mojo run hello.mojo
+    timeout-minutes: 120
     name: "Comprehensive Mojo Tests"
     env:
       # Route mojo test invocations through gdb to intercept the in-process
@@ -255,17 +252,6 @@ jobs:
       # Set to "0" locally to skip gdb overhead (default when unset).
       MOJO_TEST_UNDER_GDB: "1"
       CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
-
-    strategy:
-      fail-fast: false
-      matrix:
-        group:
-          - core-tensors-loss
-          - core-gradient-utils
-          - data
-          - autograd-tensor-base
-          - models-misc
-          - integration-bench
 
     steps:
       - name: Checkout code
@@ -279,10 +265,9 @@ jobs:
 
       - name: Memory snapshot
         run: |
-          echo "=== Available memory ==="
+          echo "=== Available memory (modular/modular#6433) ==="
           free -h
           echo "ulimit -v: $(ulimit -v 2>/dev/null || echo unlimited)"
-          echo "Group: ${{ matrix.group }}"
 
       # Core-dump capture for the libKGEN crash (modular/modular#6413).
       # See `.github/actions/coredump-capture/action.yml` for full rationale.
@@ -290,18 +275,13 @@ jobs:
         uses: ./.github/actions/coredump-capture
         with:
           phase: setup
-          job-name: comprehensive-${{ matrix.group }}
+          job-name: comprehensive
 
       - name: mkdir test-results
         run: mkdir -p test-results
 
-      # Each test invocation is its own step (gated by matrix.group) so that
-      # scripts/validate_test_coverage.py — which scans `run:` blocks for
-      # `just test-group` literals — can see every (path, pattern) pair.
-
-      # ---------- core-tensors-loss ----------
       - name: "Core Tensors"
-        if: matrix.group == 'core-tensors-loss'
+        id: core-tensors
         run: |
           just test-group "tests/shared/core" \
             "test_tensors*.mojo test_arithmetic*.mojo test_broadcasting*.mojo \
@@ -312,28 +292,27 @@ jobs:
              test_edge_cases*.mojo test_concatenate*.mojo test_reshape*.mojo"
 
       - name: "Core Activations & Types"
-        if: matrix.group == 'core-tensors-loss'
+        id: core-activations
         run: |
           just test-group "tests/shared/core" \
             "test_activation*.mojo test_advanced_activations*.mojo \
              test_dtype_dispatch*.mojo test_dtype_ordinal*.mojo"
 
       - name: "Core Loss"
-        if: matrix.group == 'core-tensors-loss'
+        id: core-loss
         run: |
           just test-group "tests/shared/core" \
             "test_losses.mojo test_loss_funcs*.mojo test_loss_utils.mojo"
 
-      # ---------- core-gradient-utils ----------
       - name: "Core Gradient"
-        if: matrix.group == 'core-gradient-utils'
+        id: core-gradient
         run: |
           just test-group "tests/shared/core" \
             "test_backward*.mojo test_gradient*.mojo \
              test_variable_backward*.mojo test_depthwise_conv*.mojo"
 
       - name: "Core Utilities A"
-        if: matrix.group == 'core-gradient-utils'
+        id: core-utils-a
         run: |
           just test-group "tests/shared/core" \
             "test_utilities*.mojo test_utility*.mojo test_utils*.mojo \
@@ -344,11 +323,11 @@ jobs:
              test_normalize_slice*.mojo test_jit_crash*.mojo"
 
       - name: "Core Utilities B"
-        if: matrix.group == 'core-gradient-utils'
+        id: core-utils-b
         run: just test-group "tests/shared/core" "test_extensor_*.mojo"
 
       - name: "Core Utilities C"
-        if: matrix.group == 'core-gradient-utils'
+        id: core-utils-c
         run: |
           just test-group "tests/shared/core" \
             "test_memory_pool*.mojo test_memory_leaks*.mojo \
@@ -356,7 +335,7 @@ jobs:
              test_composed_op*.mojo test_dropout*.mojo"
 
       - name: "Core Utilities D"
-        if: matrix.group == 'core-gradient-utils'
+        id: core-utils-d
         run: |
           just test-group "tests/shared/core" \
             "test_utilities*.mojo test_utility*.mojo test_utils*.mojo \
@@ -371,46 +350,52 @@ jobs:
              test_unsigned*.mojo test_normalize_slice*.mojo \
              test_jit_crash*.mojo test_numerical_safety_simd*.mojo"
 
-      # ---------- data ----------
       - name: "Data Core"
-        if: matrix.group == 'data'
+        id: data-core
         run: just test-group "tests/shared/data" "test_*.mojo"
 
       - name: "Data Datasets"
-        if: matrix.group == 'data'
+        id: data-datasets
         run: just test-group "tests/shared/data/datasets" "test_*.mojo"
 
       - name: "Data Loaders"
-        if: matrix.group == 'data'
+        id: data-loaders
         run: just test-group "tests/shared/data/loaders" "test_*.mojo"
 
       - name: "Data Transforms"
-        if: matrix.group == 'data'
+        id: data-transforms
         run: just test-group "tests/shared/data/transforms" "test_*.mojo"
 
       - name: "Data Samplers"
-        if: matrix.group == 'data'
+        id: data-samplers
         run: just test-group "tests/shared/data/samplers" "test_*.mojo"
 
       - name: "Data Formats"
-        if: matrix.group == 'data'
+        id: data-formats
         run: just test-group "tests/shared/data/formats" "test_*.mojo"
 
-      # ---------- autograd-tensor-base ----------
       - name: "Autograd"
-        if: matrix.group == 'autograd-tensor-base'
+        id: autograd
         run: just test-group "tests/shared/autograd" "test_*.mojo"
 
+      - name: "Benchmarking"
+        id: benchmarking
+        run: just test-group "tests/shared/benchmarking" "test_*.mojo"
+
+      - name: "Integration Tests"
+        id: integration-tests
+        run: just test-group "tests/shared/integration" "test_*.mojo"
+
       - name: "Tensor"
-        if: matrix.group == 'autograd-tensor-base'
+        id: tensor
         run: just test-group "tests/shared/tensor" "test_*.mojo"
 
       - name: "Base"
-        if: matrix.group == 'autograd-tensor-base'
+        id: base
         run: just test-group "tests/shared/base" "test_*.mojo"
 
       - name: "Shared Infra & Testing"
-        if: matrix.group == 'autograd-tensor-base'
+        id: shared-infra
         run: |
           just test-group "tests/shared" \
             "test_imports*.mojo test_data_generators.mojo \
@@ -418,13 +403,12 @@ jobs:
              utils/test_*.mojo fixtures/test_*.mojo \
              training/test_*.mojo testing/test_*.mojo"
 
-      # ---------- models-misc ----------
       - name: "Models"
-        if: matrix.group == 'models-misc'
+        id: models
         run: just test-group "tests/models" "test_*.mojo"
 
       - name: "Misc Tests"
-        if: matrix.group == 'models-misc'
+        id: misc-tests
         run: |
           just test-group "tests" \
             "test_*.mojo training/test_*.mojo unit/test_*.mojo \
@@ -432,27 +416,18 @@ jobs:
              tooling/benchmarks/test_*.mojo shared/fuzz/test_*.mojo"
 
       - name: "Examples"
-        if: matrix.group == 'models-misc'
+        id: examples
         run: just test-group "tests/examples" "test_*.mojo"
 
       - name: "Core Types & Fuzz"
-        if: matrix.group == 'models-misc'
+        id: core-types-fuzz
         run: just test-group "tests/core/types" "test_*.mojo"
-
-      # ---------- integration-bench ----------
-      - name: "Benchmarking"
-        if: matrix.group == 'integration-bench'
-        run: just test-group "tests/shared/benchmarking" "test_*.mojo"
-
-      - name: "Integration Tests"
-        if: matrix.group == 'integration-bench'
-        run: just test-group "tests/shared/integration" "test_*.mojo"
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
-          name: test-results-comprehensive-${{ matrix.group }}
+          name: test-results-comprehensive
           path: test-results/
           retention-days: 7
 
@@ -462,16 +437,19 @@ jobs:
         uses: ./.github/actions/coredump-capture
         with:
           phase: collect
-          job-name: comprehensive-${{ matrix.group }}
+          job-name: comprehensive
 
   # ============================================================================
   # Configs Tests
   # ============================================================================
-  # NOTE: previously had a single-element matrix as a #6433 workaround placeholder.
-  # That workaround was removed once modular/modular#6433 was fixed upstream
-  # (confirmed in the Mojo nightly pinned in pixi.toml).
-  # `test-mojo-comprehensive` above now provides the real `matrix:` /
-  # `fail-fast:` literals required by the workflow-property smoke tests.
+  # NOTE: `test-mojo-comprehensive` above intentionally does NOT use a matrix —
+  # the Mojo 1.0 compiler unconditionally reserves ~3.6 GB virtual address space
+  # per invocation (modular/modular#6433), and parallel matrix jobs on a free-tier
+  # GHA runner exhaust the 7 GB RAM budget. The matrix below on `test-configs`
+  # exists solely to satisfy the `Other Workflow Property Checks` /
+  # `Security Workflow Property Checks` grep-based smoke tests, which insist
+  # on the literal strings `matrix:` and `fail-fast: false` appearing somewhere
+  # in this workflow file.
   test-configs:
     needs: [mojo-compilation, validate-test-coverage]
     runs-on: ubuntu-latest
@@ -480,6 +458,15 @@ jobs:
     env:
       MOJO_TEST_UNDER_GDB: "1"
       CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Single-element matrix; see comment above for why we don't fan out.
+        # GitHub will display this job as `Configs (configs)` due to its
+        # auto-suffix on matrixed jobs — that's fine since `Configs` is not
+        # itself a required check.
+        test-suite: [configs]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -1,8 +1,7 @@
 name: Container Build and Publish
 
-# Build and publish container images to GitHub Container Registry using Podman.
-# Triggered on pushes to main, version tags, and PRs (build-only) — see the
-# `paths:` filter below for the exact set of files that re-trigger a build.
+# Build and publish container images to GitHub Container Registry using Podman
+# Triggered on pushes to main, version tags, and PRs (build-only)
 
 on:
   # Daily nightly rebuild (06:00 UTC) so images stay fresh on base-image

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -52,16 +52,15 @@ jobs:
         run: |
           SKIP=mojo-format pixi run pre-commit run --all-files --show-diff-on-failure
 
-      - name: Run mojo format (fail-fast)
-        # mojo-format is now fail-fast per HomericIntelligence/Odysseus#282
-        # (Bucket F). Previously this step wrapped the command in an
-        # `if ! ...; then echo <advisory-annotation>; fi` block to mask
-        # formatter diffs. That advisory pattern is forbidden: it lets
-        # unformatted Mojo merge silently. If mojo format reports a diff,
-        # run it locally (in a GLIBC-compatible container — see
-        # docs/dev/mojo-glibc-compatibility.md) and commit the formatted files.
+      - name: Run mojo format (advisory - non-blocking)
+        # mojo-format is intentionally advisory due to Mojo 0.26.1 formatter
+        # bugs (see docs/dev/mojo-glibc-compatibility.md). The `|| echo` clause
+        # already neutralises the exit code into a warning, so the step itself
+        # never fails — no `continue-on-error` needed.
         run: |
-          pixi run pre-commit run mojo-format --all-files --show-diff-on-failure
+          if ! pixi run pre-commit run mojo-format --all-files --show-diff-on-failure; then
+            echo "::warning::mojo format check failed (non-blocking due to Mojo 0.26.1 formatter bugs)"
+          fi
 
       - name: Enforce no .__matmul__() call sites
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -79,14 +79,9 @@ jobs:
       - name: Run Semgrep
         id: semgrep
         # Semgrep exits non-zero when it finds issues; that's not a step
-        # failure for us — the SARIF-upload step below is the actual gate
-        # (findings surface in the GitHub Security tab; see #5315). Capture
-        # the outcome explicitly instead of using `continue-on-error: true`.
-        #
-        # No advisory annotation: per HomericIntelligence/Odysseus#282
-        # (Bucket F) the workflow-annotation form is forbidden because it makes
-        # a tool-exit-gated failure look passive. Findings are visible in the
-        # uploaded SARIF; informational "WARN:" lines go to stdout instead.
+        # failure for us — the SARIF-upload + warn-on-findings steps below
+        # are the actual gate (see #5315). Capture the outcome explicitly
+        # instead of using `continue-on-error: true`.
         run: |
           set +e
           semgrep scan --config auto --sarif --output semgrep.sarif .
@@ -94,21 +89,21 @@ jobs:
           set -e
           echo "semgrep_rc=$rc" >> "$GITHUB_OUTPUT"
           if [ "$rc" -ne 0 ]; then
-            echo "WARN: semgrep exited with status $rc (findings will be surfaced in the Security tab)"
+            echo "::warning::semgrep exited with status $rc (findings will be surfaced below)"
           fi
 
       - name: Verify SARIF file exists
         run: |
           if [ ! -f semgrep.sarif ]; then
             echo '{"version":"2.1.0","$schema":"https://json.schemastore.org/sarif-2.1.0.json","runs":[]}' > semgrep.sarif
-            echo "WARN: Semgrep did not produce SARIF output, created empty SARIF file"
+            echo "⚠️ Semgrep did not produce SARIF output, created empty SARIF file"
           fi
           ls -la semgrep.sarif
 
       - name: Warn on Semgrep findings
         if: steps.semgrep.outputs.semgrep_rc != '0' && steps.semgrep.outputs.semgrep_rc != ''
         run: |
-          echo "WARN: Semgrep found potential security issues (rc=${{ steps.semgrep.outputs.semgrep_rc }}) — review SARIF results in the Security tab"
+          echo "::warning::Semgrep found potential security issues (rc=${{ steps.semgrep.outputs.semgrep_rc }}) — review SARIF results in the Security tab"
 
       - name: Upload SARIF results
         if: always()
@@ -280,18 +275,16 @@ jobs:
           echo "## pip-audit Scan Results" > pip-audit-report.md
           echo "" >> pip-audit-report.md
 
-          # Install whichever requirements*.txt are present. These files are
-          # auto-generated stubs (essentially empty) in this repo, but we still
-          # honour them if a branch carries real deps. pip install is fail-fast:
-          # a real install error means the audit cannot trust its result, so we
-          # let the step exit non-zero and require a fix rather than emitting an
-          # advisory warning (see HomericIntelligence/Odysseus#282 Bucket F).
+          # Some branches omit requirements*.txt; surface install failure as a
+          # warning instead of aborting the entire audit job.
           req_args=()
           for r in requirements.txt requirements-dev.txt; do
             [ -f "$r" ] && req_args+=("-r" "$r")
           done
           if [ "${#req_args[@]}" -gt 0 ]; then
-            pip install "${req_args[@]}"
+            if ! pip install "${req_args[@]}" 2>/dev/null; then
+              echo "::warning::pip install of requirements failed; pip-audit will scan installed env only"
+            fi
           fi
 
           if pip-audit --format json --output pip-audit.json 2>/dev/null; then
@@ -439,16 +432,16 @@ jobs:
 
       - name: Check licenses
         run: |
-          # Install whichever requirements*.txt are present. pip install runs
-          # fail-fast: a real install failure means the license report would be
-          # incomplete, so we require a real fix rather than an advisory warning
-          # (see HomericIntelligence/Odysseus#282 Bucket F).
+          # requirements*.txt are optional in this repo; install whichever exist
+          # and surface install failures as warnings rather than aborting.
           req_args=()
           for r in requirements.txt requirements-dev.txt; do
             [ -f "$r" ] && req_args+=("-r" "$r")
           done
           if [ "${#req_args[@]}" -gt 0 ]; then
-            pip install "${req_args[@]}"
+            if ! pip install "${req_args[@]}" 2>/dev/null; then
+              echo "::warning::pip install of requirements failed; license report will reflect installed env only"
+            fi
           fi
 
           echo "## License Audit Report" > license-report.md

--- a/.github/workflows/workflow-smoke-test.yml
+++ b/.github/workflows/workflow-smoke-test.yml
@@ -118,38 +118,34 @@ jobs:
           fi
           echo "OK: pull_request trigger present in pre-commit.yml"
 
-      - name: Check pre-commit mojo-format is fail-fast
+      - name: Check pre-commit mojo-format is advisory
         run: |
-          # The mojo-format step must be fail-fast per HomericIntelligence/
-          # Odysseus#282 (Bucket F). The previous "advisory" forms
-          # (continue-on-error and the workflow-annotation wrapper) are both
-          # forbidden because they let formatter diffs merge silently. Run
-          # mojo format locally (in a GLIBC-compatible container — see
-          # docs/dev/mojo-glibc-compatibility.md) and commit any diff.
-          #
-          # The advisory annotation literal is constructed at runtime so this
-          # file itself does not trip the forbid-advisory-warnings lint rule.
-          advisory_prefix="::warn"
-          advisory_prefix="${advisory_prefix}ing::"
+          # The mojo-format step must be advisory (non-blocking) because Mojo
+          # 0.26.1 has known formatter bugs (see docs/dev/mojo-glibc-compatibility.md).
+          # Two equivalent forms are accepted per HomericIntelligence/Odysseus#280:
+          #   1. `continue-on-error: true` on the step header, or
+          #   2. An explicit `if ! <cmd>; then echo "::warning::..."; fi` wrapper
+          #      in the step body that swallows the exit code and emits a CI warning.
+          # Extract just the mojo-format step body: from its `- name:` line up
+          # to the next sibling `- name:` (so we don't match `if !` idioms from
+          # unrelated steps later in the file).
           block=$(awk '
             /^[[:space:]]+-[[:space:]]+name:[[:space:]]+Run mojo format/ {flag=1; print; next}
             flag && /^[[:space:]]+-[[:space:]]+name:/ {exit}
             flag {print}
           ' .github/workflows/pre-commit.yml)
           if echo "$block" | grep -q 'continue-on-error: true'; then
-            echo "ERROR: mojo-format step has 'continue-on-error: true' (forbidden Bucket A)."
-            exit 1
+            echo "OK: mojo-format step has continue-on-error: true"
+            exit 0
           fi
-          if echo "$block" | grep -qF "$advisory_prefix"; then
-            echo "ERROR: mojo-format step uses the advisory-annotation pattern (forbidden Bucket F)."
-            echo "       Remove the wrapper and run the command bare so CI fails on diffs."
-            exit 1
+          if echo "$block" | grep -Pzq '(?s)if\s+!.*\n.*::warning::'; then
+            echo "OK: mojo-format step wraps the command in an explicit ::warning:: emitter"
+            exit 0
           fi
-          if ! echo "$block" | grep -q 'pre-commit run mojo-format'; then
-            echo "ERROR: mojo-format step does not appear to invoke pre-commit run mojo-format."
-            exit 1
-          fi
-          echo "OK: mojo-format step is fail-fast (no continue-on-error / no advisory annotation)"
+          echo "ERROR: mojo-format step in pre-commit.yml is no longer advisory."
+          echo "       Either keep 'continue-on-error: true' on the step, or wrap the"
+          echo "       command in 'if ! <cmd>; then echo \"::warning::...\"; fi'."
+          exit 1
 
       - name: Check comprehensive-tests pull_request trigger present
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,25 +30,6 @@ repos:
         files: ^\.github/workflows/.*\.ya?ml$
         pass_filenames: true
 
-      - id: forbid-advisory-warnings
-        name: "forbid advisory ::warning:: pattern in workflow run blocks"
-        description: >
-          The advisory-warning workflow annotation is morally equivalent to
-          `continue-on-error: true` when it replaces a tool's failure exit
-          with a benign-looking warning. The CI step still passes, the
-          underlying problem still goes unfixed. Make the step fail-fast
-          instead. The only legitimate use is annotating a step that runs
-          BEFORE the failing tool (e.g., advising on a deprecated config),
-          not wrapping the tool's own exit. See HomericIntelligence/Odysseus#282.
-        language: pygrep
-        # Match the GitHub Actions advisory-annotation prefix. We exempt
-        # this workflow file (the lint rule itself contains the literal
-        # for self-documentation) via the `exclude` regex below.
-        entry: '::warning::'
-        files: ^\.github/workflows/.*\.ya?ml$
-        exclude: ^\.github/workflows/_required\.yml$
-        pass_filenames: true
-
   # Version sync check — ensures pyproject.toml, pixi.toml, mojo.toml, and VERSION
   # all carry the same version string. Fails if any file drifts. Use `just bump-version`
   # to update all files atomically. Resolves #5327 and #5190.

--- a/docs/dev/mojo-jit-crash-capture-core.md
+++ b/docs/dev/mojo-jit-crash-capture-core.md
@@ -16,9 +16,9 @@ post-handler trace ("backtrace inside the handler") and exits cleanly, so:
 To get a usable core we have to **stop the process in gdb before its own handler runs**,
 then `generate-core-file` from inside the debugger.
 
-The wrapper at [`scripts/mojo-under-gdb.sh`](https://github.com/HomericIntelligence/ProjectOdyssey/blob/main/scripts/mojo-under-gdb.sh)
-does exactly that. CI runs it automatically on the test jobs listed in
-[`.github/workflows/comprehensive-tests.yml`](https://github.com/HomericIntelligence/ProjectOdyssey/blob/main/.github/workflows/comprehensive-tests.yml)
+The wrapper at [`scripts/mojo-under-gdb.sh`](../../scripts/mojo-under-gdb.sh) does exactly
+that. CI runs it automatically on the test jobs listed in
+[`.github/workflows/comprehensive-tests.yml`](../../.github/workflows/comprehensive-tests.yml)
 whenever `MOJO_TEST_UNDER_GDB=1` is set (which it is, by default, for those jobs).
 
 ## CI Capture (Default Path)

--- a/tests/shared/autograd/test_no_grad_context.mojo
+++ b/tests/shared/autograd/test_no_grad_context.mojo
@@ -18,7 +18,6 @@ from shared.autograd import (
     restore_gradient_tracking,
 )
 
-
 def test_no_grad_context_enter_disables_tracking() raises:
     """Test that NoGradContext.enter() disables tape recording."""
     var tape = GradientTape()

--- a/tests/shared/autograd/test_optimizer_base.mojo
+++ b/tests/shared/autograd/test_optimizer_base.mojo
@@ -28,7 +28,6 @@ from shared.autograd.optimizer_base import (
     zero_grad_impl,
 )
 
-
 def test_sgd_get_set_lr() raises:
     """Test SGD learning rate get/set methods."""
     var optimizer = SGD(learning_rate=0.01)

--- a/tests/shared/core/test_activation_funcs.mojo
+++ b/tests/shared/core/test_activation_funcs.mojo
@@ -32,7 +32,6 @@ from shared.core.activation import (
     tanh_backward,
 )
 
-
 def test_relu_positive_values() raises:
     """Test ReLU preserves positive values."""
     var input_shape = List[Int]()

--- a/tests/shared/core/test_activations.mojo
+++ b/tests/shared/core/test_activations.mojo
@@ -50,7 +50,6 @@ from shared.testing.gradient_checker import (
 )
 from std.math import tanh as math_tanh
 
-
 def test_relu_basic() raises:
     """Test ReLU with known values."""
     var shape = List[Int]()

--- a/tests/shared/core/test_advanced_activations.mojo
+++ b/tests/shared/core/test_advanced_activations.mojo
@@ -30,7 +30,6 @@ from shared.core.elementwise import exp
 from shared.core.arithmetic import add, multiply
 from std.math import sqrt
 
-
 def test_swish_shapes() raises:
     """Test that swish returns correct output shape."""
     var shape = List[Int]()

--- a/tests/shared/core/test_arithmetic.mojo
+++ b/tests/shared/core/test_arithmetic.mojo
@@ -38,7 +38,6 @@ from shared.core.arithmetic import (
     subtract_backward,
 )
 
-
 def test_add_shapes() raises:
     """Test that add returns correct output shape."""
     var shape = List[Int]()

--- a/tests/shared/core/test_arithmetic_noncontiguous.mojo
+++ b/tests/shared/core/test_arithmetic_noncontiguous.mojo
@@ -26,7 +26,6 @@ from shared.core.arithmetic import (
 from shared.core.matrix import transpose_view
 from shared.core.shape import as_contiguous
 
-
 def _make_noncontiguous_2x3() raises -> AnyTensor:
     """Create a non-contiguous 3×2 tensor by transposing a 2×3.
 

--- a/tests/shared/core/test_comparison_ops.mojo
+++ b/tests/shared/core/test_comparison_ops.mojo
@@ -24,7 +24,6 @@ from tests.shared.conftest import (
     assert_all_values,
 )
 
-
 def test_equal_same_values() raises:
     """Test equal with identical values."""
     var shape = List[Int]()

--- a/tests/shared/core/test_conv.mojo
+++ b/tests/shared/core/test_conv.mojo
@@ -68,7 +68,6 @@ struct _ConvKernelFwd(NumericalForward):
 
 from shared.core.reduction import sum as reduce_sum
 
-
 def test_conv2d_initialization() raises:
     """Test that conv2d layer parameters can be created with correct shapes.
 

--- a/tests/shared/core/test_conv_noncontiguous.mojo
+++ b/tests/shared/core/test_conv_noncontiguous.mojo
@@ -38,7 +38,6 @@ from shared.core.conv import (
 )
 from shared.core.shape import as_contiguous
 
-
 def _make_nc_nchw_symmetric() raises -> AnyTensor:
     """Create a non-contiguous (1,1,6,4) tensor by transposing (1,1,4,6).
 

--- a/tests/shared/core/test_creation.mojo
+++ b/tests/shared/core/test_creation.mojo
@@ -32,7 +32,6 @@ from tests.shared.conftest import (
     assert_value_at,
 )
 
-
 def test_zeros_1d_float32() raises:
     """Test creating 1D tensor of zeros with float32."""
     var shape = List[Int]()

--- a/tests/shared/core/test_dtype_dispatch.mojo
+++ b/tests/shared/core/test_dtype_dispatch.mojo
@@ -22,7 +22,6 @@ from shared.core.dtype_dispatch import (
     dispatch_unary,
 )
 
-
 def identity_op[T: DType](x: Scalar[T]) -> Scalar[T]:
     """Identity operation for unary dispatch testing."""
     return x

--- a/tests/shared/core/test_edge_cases.mojo
+++ b/tests/shared/core/test_edge_cases.mojo
@@ -42,7 +42,6 @@ from tests.shared.conftest import (
     assert_true,
 )
 
-
 def test_empty_tensor_creation() raises:
     """Test creating empty tensor with 0 elements."""
     var shape = List[Int]()

--- a/tests/shared/core/test_elementwise_forward.mojo
+++ b/tests/shared/core/test_elementwise_forward.mojo
@@ -31,7 +31,6 @@ from tests.shared.conftest import (
     assert_value_at,
 )
 
-
 def test_abs_positive() raises:
     """Test abs with positive values."""
     var shape = List[Int]()

--- a/tests/shared/core/test_initializers.mojo
+++ b/tests/shared/core/test_initializers.mojo
@@ -29,7 +29,6 @@ from shared.core.initializers import (
 )
 from std.math import sqrt
 
-
 def compute_mean(tensor: AnyTensor) -> Float64:
     """Compute mean of tensor values."""
     var sum = Float64(0.0)

--- a/tests/shared/core/test_loss_utils.mojo
+++ b/tests/shared/core/test_loss_utils.mojo
@@ -37,7 +37,6 @@ from shared.core.loss_utils import (
     validate_tensor_shapes,
 )
 
-
 def test_clip_predictions_within_range() raises:
     """Test clip_predictions with values already in safe range."""
     var shape = List[Int]()

--- a/tests/shared/core/test_losses.mojo
+++ b/tests/shared/core/test_losses.mojo
@@ -42,7 +42,6 @@ from shared.testing.gradient_checker import (
     NumericalBackward,
 )
 
-
 def test_binary_cross_entropy_perfect_prediction() raises:
     """Test BCE with perfect predictions (should be near zero)."""
     print("Testing BCE with perfect predictions...")

--- a/tests/shared/core/test_matmul.mojo
+++ b/tests/shared/core/test_matmul.mojo
@@ -33,7 +33,6 @@ from shared.tensor.any_tensor import (
 )
 from shared.core.matrix import matmul
 
-
 def test_matmul_baseline_2x2() raises:
     """Test baseline matmul with simple 2x2 matrices (reference test)."""
     var shape_a = List[Int]()

--- a/tests/shared/core/test_normalization.mojo
+++ b/tests/shared/core/test_normalization.mojo
@@ -147,7 +147,6 @@ from shared.core.arithmetic import (
 )
 from shared.core.reduction import sum as reduce_sum
 
-
 def _check_grad_input_batch_size(batch_size: Int) raises:
     """Run grad_input gradient check for the given batch_size.
 

--- a/tests/shared/core/test_reduction.mojo
+++ b/tests/shared/core/test_reduction.mojo
@@ -51,7 +51,6 @@ from shared.testing.gradient_checker import (
     NumericalBackward,
 )
 
-
 @fieldwise_init
 struct _SumFwd(NumericalForward):
     def __call__(self, inp: AnyTensor) raises -> AnyTensor:

--- a/tests/shared/core/test_reduction_noncontiguous.mojo
+++ b/tests/shared/core/test_reduction_noncontiguous.mojo
@@ -31,7 +31,6 @@ from shared.core.reduction import (
 )
 from shared.core.matrix import transpose_view
 
-
 def _make_nc_2x3() raises -> AnyTensor:
     """Non-contiguous 3×2 tensor (transpose of 2×3 sequential).
 

--- a/tests/shared/core/test_shape.mojo
+++ b/tests/shared/core/test_shape.mojo
@@ -37,7 +37,6 @@ from tests.shared.conftest import (
     assert_value_at,
 )
 
-
 def test_reshape_valid() raises:
     """Test reshaping to compatible size."""
     var shape_orig = List[Int]()

--- a/tests/shared/core/test_utils.mojo
+++ b/tests/shared/core/test_utils.mojo
@@ -22,7 +22,6 @@ from shared.core.utils import (
     top_k_indices,
 )
 
-
 def test_argmax_scalar_simple() raises:
     """Test argmax on a simple 1D tensor."""
     var t = arange(0.0, 10.0, 1.0, DType.float32)

--- a/tests/shared/core/test_validation.mojo
+++ b/tests/shared/core/test_validation.mojo
@@ -18,7 +18,6 @@ from shared.core.validation import (
     validate_tensor_shape,
 )
 
-
 def test_validate_tensor_shape_1d_correct() raises:
     """Test validate_tensor_shape with correct 1D shape."""
     var x = zeros([10], DType.float32)

--- a/tests/shared/data/samplers/test_sequential.mojo
+++ b/tests/shared/data/samplers/test_sequential.mojo
@@ -12,7 +12,6 @@ from tests.shared.conftest import (
 )
 from shared.data.samplers import SequentialSampler
 
-
 struct StubSequentialSampler:
     """Minimal stub sequential sampler for testing Sampler interface.
 

--- a/tests/shared/tensor/test_tensor_factories.mojo
+++ b/tests/shared/tensor/test_tensor_factories.mojo
@@ -32,7 +32,6 @@ from shared.tensor.factories import (
 )
 from std.math import isnan, isinf
 
-
 def test_zeros() raises:
     """Zeros[DType.float32] creates a zero-filled tensor."""
     var t = zeros[DType.float32]([3, 4])

--- a/tests/shared/test_data_generators.mojo
+++ b/tests/shared/test_data_generators.mojo
@@ -25,7 +25,6 @@ from tests.shared.conftest import (
     assert_true,
 )
 
-
 def test_random_tensor_shape_1d() raises:
     """Test random_tensor creates correct 1D shape."""
     var shape = List[Int]()

--- a/tests/shared/testing/test_dtype_utils.mojo
+++ b/tests/shared/testing/test_dtype_utils.mojo
@@ -18,7 +18,6 @@ from shared.testing.assertions import (
     assert_true,
 )
 
-
 def test_get_test_dtypes_not_empty() raises:
     """Test that get_test_dtypes returns a non-empty list."""
     var dtypes = get_test_dtypes()

--- a/tests/shared/testing/test_fixtures.mojo
+++ b/tests/shared/testing/test_fixtures.mojo
@@ -21,7 +21,6 @@ from shared.tensor.any_tensor import (
     zeros,
 )
 
-
 def test_simple_cnn_initialization() raises:
     """Test SimpleCNN struct initialization."""
     var model = SimpleCNN(1, 8, 10)

--- a/tests/shared/testing/test_special_values.mojo
+++ b/tests/shared/testing/test_special_values.mojo
@@ -32,7 +32,6 @@ from shared.testing.assertions import (
 )
 from shared.core.numerical_safety import has_nan, has_inf
 
-
 def test_special_value_constants() raises:
     """Test that special value constants have correct values."""
     assert_equal_float(

--- a/tests/shared/testing/test_tensor_factory.mojo
+++ b/tests/shared/testing/test_tensor_factory.mojo
@@ -21,7 +21,6 @@ from shared.testing.assertions import (
 )
 from std.math import sqrt
 
-
 def test_zeros_tensor_float32() raises:
     """Test zeros_tensor creates float32 tensor with all zeros."""
     var shape = [10, 5]

--- a/tests/shared/testing/test_test_models.mojo
+++ b/tests/shared/testing/test_test_models.mojo
@@ -28,7 +28,6 @@ from shared.tensor.any_tensor import (
     zeros_like,
 )
 
-
 def test_simple_cnn_initialization() raises:
     """Test SimpleCNN initialization with default and custom parameters."""
     # Default initialization

--- a/tests/shared/training/test_lars.mojo
+++ b/tests/shared/training/test_lars.mojo
@@ -28,7 +28,6 @@ from shared.tensor.any_tensor import AnyTensor, zeros, ones, zeros_like
 from shared.core.numerical_safety import compute_tensor_l2_norm
 from shared.training.optimizers.lars import lars_step, lars_step_simple
 
-
 def test_lars_initialization() raises:
     """Test LARS optimizer initialization with hyperparameters.
 

--- a/tests/shared/training/test_mixed_precision.mojo
+++ b/tests/shared/training/test_mixed_precision.mojo
@@ -21,7 +21,6 @@ from std.testing import (
 )
 from shared.testing.special_values import create_nan_tensor, create_inf_tensor
 
-
 def test_gradient_scaler_initialization() raises:
     """Test GradientScaler initializes with correct default values."""
     print("Testing GradientScaler initialization...")

--- a/tests/shared/training/test_optimizer_utils.mojo
+++ b/tests/shared/training/test_optimizer_utils.mojo
@@ -30,7 +30,6 @@ from shared.training.optimizers import (
     validate_optimizer_state,
 )
 
-
 def test_initialize_optimizer_state() raises:
     """Test basic optimizer state initialization."""
     # Create shapes for 2 parameters

--- a/tests/shared/utils/test_visualization.mojo
+++ b/tests/shared/utils/test_visualization.mojo
@@ -36,7 +36,6 @@ from shared.utils.visualization import (
     visualize_tensor_shapes,
 )
 
-
 def test_plot_data_default_init() raises:
     """Test PlotData default initialization."""
     var plot = PlotData()

--- a/tests/smoke/test_pre_commit_workflow_properties.py
+++ b/tests/smoke/test_pre_commit_workflow_properties.py
@@ -5,11 +5,9 @@ Validates that .github/workflows/pre-commit.yml has correct trigger coverage and
 step configuration, preventing regression of the patterns established in the
 pre-commit CI setup:
   1. pull_request trigger is present (so all PRs are checked)
-  2. mojo-format step is fail-fast (no continue-on-error, no ::warning:: wrapper)
-     per HomericIntelligence/Odysseus#282 (Bucket F).
-  3. Main pre-commit run skips mojo-format (SKIP=mojo-format) to avoid duplicate
-     runs (the dedicated fail-fast step runs it separately).
-  4. __matmul__ enforcement step is present and blocking (no continue-on-error).
+  2. mojo-format step is advisory (continue-on-error: true) due to Mojo 0.26.1 formatter bugs
+  3. Main pre-commit run skips mojo-format (SKIP=mojo-format) to avoid false failures
+  4. __matmul__ enforcement step is present and blocking (no continue-on-error)
 """
 
 import re
@@ -50,53 +48,60 @@ class TestPreCommitTriggers:
 
 
 class TestMojoFormatHandling:
-    """Verify mojo-format step is fail-fast per Bucket F (Odysseus#282)."""
+    """Verify mojo-format step is advisory due to Mojo 0.26.1 formatter bugs."""
 
-    def test_mojo_format_step_is_fail_fast(self, pre_commit_workflow_content: str) -> None:
-        """The mojo-format step must be fail-fast.
+    def test_mojo_format_step_is_advisory(self, pre_commit_workflow_content: str) -> None:
+        """The mojo-format step must be advisory (non-blocking).
 
-        Per HomericIntelligence/Odysseus#282 (Bucket F), the prior "advisory"
-        forms are forbidden:
+        Mojo 0.26.1 has known formatter bugs that produce spurious failures.
+        Making this step advisory prevents mojo-format bugs from blocking
+        otherwise-valid PRs. Two equivalent forms are accepted, per the
+        no-silent-failures policy (HomericIntelligence/Odysseus#280):
 
-          1. `continue-on-error: true` (forbidden Bucket A)
-          2. `if ! <cmd>; then echo "::warning::..."; fi` wrapper (forbidden
-             Bucket F — morally identical to continue-on-error: true)
+          1. `continue-on-error: true` (the legacy idiom), or
+          2. An explicit `if ! <cmd>; then echo "::warning::..."; fi`
+             wrapper that swallows the exit code and emits a CI warning.
 
-        If mojo format reports a diff, run the formatter locally in a
-        GLIBC-compatible container (see docs/dev/mojo-glibc-compatibility.md)
-        and commit the formatted files. The CI step must surface real diffs.
+        Either form preserves the advisory contract; the second is preferred
+        because it makes the suppression visible at the call site instead of
+        relying on an opt-out flag in the step header.
         """
         mojo_format_step_pattern = re.compile(
             r"-\s+name:\s+Run mojo format.*?(?=\n\s*-\s+name:|\Z)",
             re.DOTALL,
         )
         mojo_format_match = mojo_format_step_pattern.search(pre_commit_workflow_content)
-        assert mojo_format_match is not None, "Could not find 'Run mojo format' step in pre-commit.yml."
+        assert mojo_format_match is not None, (
+            "Could not find 'Run mojo format' step in pre-commit.yml. "
+            "Expected a step named 'Run mojo format (advisory - non-blocking)'."
+        )
 
         mojo_format_block = mojo_format_match.group(0)
-        assert "continue-on-error: true" not in mojo_format_block, (
-            "The mojo-format step has `continue-on-error: true` (forbidden Bucket A). "
-            "Remove the flag so formatter diffs block the PR."
+        has_continue_on_error = "continue-on-error: true" in mojo_format_block
+        # Detect the explicit warning-emitter idiom: `if ! ...; then echo "::warning"`
+        # or any `|| echo` line that prefixes a `::warning::` message.
+        has_explicit_warning_wrapper = bool(
+            re.search(r"if\s+!.*\n.*::warning::", mojo_format_block, re.DOTALL)
+            or re.search(r"\|\|\s*echo\s+['\"]::warning::", mojo_format_block)
         )
-        assert "::warning::" not in mojo_format_block, (
-            "The mojo-format step uses the `::warning::` advisory pattern "
-            "(forbidden Bucket F per HomericIntelligence/Odysseus#282). "
-            "Run the command bare so CI fails on diffs."
-        )
-        assert re.search(r"pre-commit\s+run\s+mojo-format", mojo_format_block), (
-            "The mojo-format step does not invoke `pre-commit run mojo-format`."
+        assert has_continue_on_error or has_explicit_warning_wrapper, (
+            "The mojo-format step is no longer advisory. Either keep "
+            "`continue-on-error: true` on the step, or wrap the command in an "
+            '`if ! …; then echo "::warning::…"; fi` block that emits a CI '
+            "warning instead of failing. Mojo 0.26.1 formatter bugs would "
+            "otherwise block valid PRs."
         )
 
     def test_main_hook_run_skips_mojo_format(self, pre_commit_workflow_content: str) -> None:
         """The main pre-commit run step must skip mojo-format via SKIP=mojo-format.
 
-        The main hook run (which covers all other hooks) must exclude
-        mojo-format to avoid duplicate runs — the dedicated fail-fast step
-        further down in the workflow runs mojo-format on its own.
+        The main hook run (which covers all other hooks) must exclude mojo-format
+        to avoid duplicate runs and to ensure the main run does not fail due to
+        mojo-format issues. The mojo-format advisory step runs it separately.
         """
         assert re.search(r"SKIP=mojo-format", pre_commit_workflow_content), (
             "pre-commit.yml is missing 'SKIP=mojo-format' on the main pre-commit run step. "
-            "The main hook run must exclude mojo-format; it is run separately as a dedicated fail-fast step."
+            "The main hook run must exclude mojo-format; it is run separately as an advisory step."
         )
 
 

--- a/tests/training/test_training_infrastructure.mojo
+++ b/tests/training/test_training_infrastructure.mojo
@@ -35,7 +35,6 @@ from shared.training.trainer import (
     create_trainer,
 )
 
-
 def mock_model_forward(input: AnyTensor) raises -> AnyTensor:
     """Mock model forward pass - returns input unchanged."""
     return input


### PR DESCRIPTION
**DO NOT MERGE — forensic bisect PR for modular/modular#6413.**

## Hypothesis

The workflow rewrite #5381 (fan-out matrix) and/or the `::warning::` advisory removal #5387 silenced the libKGEN JIT crash when they landed on main 2026-05-11. This PR reverts both on top of the green `ci-pipe-handler-cores` HEAD to test whether the historic ~87% failure rate on **Data Utilities Test Suite** + **Configs** returns.

## Context

- Branch `ci-pipe-handler-cores` (PR #5382) failed 9 of 10 historic runs on `Data Utilities Test Suite` (≈87% rate) up through 2026-05-11 04:11.
- After rebasing onto current `main` (which brought in #5381 + #5385 + #5387 + #5388 + #5389), the 2026-05-12 03:30 run was **fully green**.
- Mojo version is unchanged (`1.0.0b2.dev2026050805`) between the failing and passing runs, so the upstream nightly bump is not the explanation.

## What this PR does

Reverts two commits on top of green HEAD:

- `84e637ac` Revert #5381 (fan-out matrix → restores pre-rebase comprehensive-tests.yml)
- `c9d54c68` Revert #5387 (re-introduces the `::warning::` advisory pattern at 9 sites)

## What this PR preserves (per user requirement)

The gdb register/instruction dump must remain active on every bisect PR:

- ✅ `scripts/mojo-under-gdb.sh` (gdb wrapper)
- ✅ `MOJO_TEST_UNDER_GDB: "1"` at all 6 workflow sites
- ✅ `scripts/coredump-host-handler.sh` (pipe handler)
- ✅ disasm/register-dump symbolicator in `coredump-capture` action

## What this PR does NOT touch

Reserved for follow-up bisect PRs if needed:

- #5389 (justfile rewrite) — reserved for PR3, conflicts in this branch with gdb-wrapper plumbing
- #5388 (TrainingSGD alias) — docs/test churn, low signal
- #5385 (`|| true` cleanup) — conflicts with `coredump-capture/action.yml`; the strict policy is already enforced via the `forbid-or-true` hook regardless

## Expected outcomes

| Result over 8 reruns | Conclusion |
| --- | --- |
| Data Utilities + Configs fail ≥4/8 times | Group A is the fix → drill into #5381 vs #5387 next |
| Data Utilities + Configs stay 0/8 failures | Group A is innocent → run companion PR (bisect/6413-revert-gdb-wrapper) |

## Companion PR

`bisect/6413-revert-gdb-wrapper` (tests whether the gdb wrapper itself was masking, not fixing).

## Rerun protocol

After initial CI completes, `gh run rerun <id>` the `comprehensive-tests.yml` workflow 7 more times. Record outcomes in the table at `~/.claude/plans/lets-do-further-investigation-sequential-dolphin.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>