### PR TITLE
[DO NOT MERGE] bisect(6413): disable gdb wrapper to test mask-vs-fix

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -253,7 +253,7 @@ jobs:
       # the crash. Without gdb, the kernel never generates a core because the
       # process handles SIGABRT itself and exits cleanly.
       # Set to "0" locally to skip gdb overhead (default when unset).
-      MOJO_TEST_UNDER_GDB: "1"
+      MOJO_TEST_UNDER_GDB: "0"  # bisect/6413: disabled to test mask-vs-fix hypothesis
       CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     strategy:
@@ -478,7 +478,7 @@ jobs:
     timeout-minutes: 15
     name: "Configs"
     env:
-      MOJO_TEST_UNDER_GDB: "1"
+      MOJO_TEST_UNDER_GDB: "0"  # bisect/6413: disabled to test mask-vs-fix hypothesis
       CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
@@ -528,7 +528,7 @@ jobs:
     timeout-minutes: 15
     name: "Benchmarks"
     env:
-      MOJO_TEST_UNDER_GDB: "1"
+      MOJO_TEST_UNDER_GDB: "0"  # bisect/6413: disabled to test mask-vs-fix hypothesis
       CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
@@ -574,7 +574,7 @@ jobs:
     timeout-minutes: 15
     name: "Core Layers"
     env:
-      MOJO_TEST_UNDER_GDB: "1"
+      MOJO_TEST_UNDER_GDB: "0"  # bisect/6413: disabled to test mask-vs-fix hypothesis
       CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
@@ -863,7 +863,7 @@ jobs:
     timeout-minutes: 15
     name: "Gradient Checking Tests"
     env:
-      MOJO_TEST_UNDER_GDB: "1"
+      MOJO_TEST_UNDER_GDB: "0"  # bisect/6413: disabled to test mask-vs-fix hypothesis
       CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
@@ -993,7 +993,7 @@ jobs:
     timeout-minutes: 15
     name: "Data Utilities Test Suite"
     env:
-      MOJO_TEST_UNDER_GDB: "1"
+      MOJO_TEST_UNDER_GDB: "0"  # bisect/6413: disabled to test mask-vs-fix hypothesis
       CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:


### PR DESCRIPTION
**DO NOT MERGE — forensic bisect PR for modular/modular#6413.**

## Hypothesis

The gdb wrapper added by PR #5382 may have **masked** the libKGEN JIT crash rather than fixed it. Under `gdb -batch` with `py-events install`, signal disposition changes — gdb intercepts SIGILL/SIGABRT before libKGEN's in-process handler. If that interception changes observable behavior, the crash signature could appear to vanish without the bug being fixed.

## What this PR does

Sets `MOJO_TEST_UNDER_GDB: "0"` at all 6 sites in `.github/workflows/comprehensive-tests.yml`. The `_test-group-inner` justfile recipe falls back to plain `pixi run mojo` when the env var is `"0"`.

## What this PR preserves (per user requirement)

The post-crash gdb register/instruction dump must remain active so any kernel core that drops produces full forensic data:

- ✅ `scripts/coredump-host-handler.sh` (pipe-handler core_pattern install)
- ✅ `core_pattern = \|/usr/local/bin/coredump-host-handler.sh ...` host setup
- ✅ disasm/register-dump symbolicator in `coredump-capture` action (runs on any captured core)
- ✅ `scripts/mojo-under-gdb.sh` (script remains in repo, just not invoked)

Cores will now be captured via the pipe handler (kernel-level, post-mortem) rather than via gdb-batch (live, at signal time). The disasm symbolicator processes either kind transparently.

## Expected outcomes

| Result over 8 reruns | Conclusion |
| --- | --- |
| Data Utilities + Configs fail ≥4/8 times (cores captured by pipe handler) | gdb wrapper was masking the bug → reopen modular#6413 investigation |
| Data Utilities + Configs stay 0/8 failures | gdb wrapper is innocent → the actual fix is elsewhere; run companion PR (bisect/6413-revert-main-rebase) |

## Companion PR

`bisect/6413-revert-main-rebase` (tests whether the main-rebase code changes were the fix).

## Rerun protocol

After initial CI completes, `gh run rerun <id>` the `comprehensive-tests.yml` workflow 7 more times. Record outcomes in the table at `~/.claude/plans/lets-do-further-investigation-sequential-dolphin.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>