### PR TITLE
[DO NOT MERGE] bisect(6413): revert docker-compose dev memlimit 14g→12g

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,12 +36,10 @@ services:
     # cgroups v1 hosts will silently ignore these — that's fine; on cgroups v2
     # they enforce.
     #
-    # Sanitizer note: `just build tsan` and `just build asan` cause the Mojo
-    # compiler to allocate ~3-6 GB per invocation (modular/modular#6433).
-    # Build sweeps under TSAN may hit OOM if other processes are competing for
-    # memory; on memory-constrained hosts run with explicit swap or a higher
-    # limit, e.g. ODYSSEY_MEM_LIMIT=24g just podman-up.
-    mem_limit: ${ODYSSEY_MEM_LIMIT:-14g}
+    # BISECT/6413: reverted from 14g to 12g (PR #5389's projectodyssey-dev
+    # bump). Tests whether the +2 GB headroom on the dev service silenced
+    # the libKGEN JIT crash. CI uses projectodyssey-dev (see justfile:8).
+    mem_limit: ${ODYSSEY_MEM_LIMIT:-12g}
     cpus: ${ODYSSEY_CPU_LIMIT:-6.0}
     # Allow unlimited core dumps so the libKGEN JIT crash
     # (modular/modular#6413) actually writes a core file. Per-exec `ulimit -c


### PR DESCRIPTION
**DO NOT MERGE — forensic bisect PR for modular/modular#6413.**

## Hypothesis

The +2 GB memory headroom on the `projectodyssey-dev` container (introduced in PR #5389 as part of the justfile/build restructure) silenced the libKGEN JIT crash.

**Why this matters:** CI tests run inside `projectodyssey-dev` (see `justfile:8` — `podman_service := "projectodyssey-dev"`). Mojo reserves ~3.6 GB VmPeak per JIT invocation (modular/modular#6433, upstream-fixed in `1.0.0b2.dev2026050805`). Even with that fix, multi-process JIT activity can be memory-bound on the GHA runner; the +2 GB container ceiling could provide just enough headroom to avoid an in-process allocation failure that surfaces as SIGILL via libKGEN's in-process signal handler.

## What this PR does

Single-line change at `docker-compose.yml:42`:

```yaml
- mem_limit: ${ODYSSEY_MEM_LIMIT:-14g}
+ mem_limit: ${ODYSSEY_MEM_LIMIT:-12g}
```

All other PR #5389 deltas (justfile rewrite, benchmarks, examples, `tests/shared/test_imports.mojo`) preserved at green HEAD. The `projectodyssey-ci` and `projectodyssey-prod` services keep their 24g limits — those are unused by CI tests.

## What this PR preserves

Per user requirement that every bisect PR keep gdb register/disasm dump active:

- ✅ `MOJO_TEST_UNDER_GDB: \"1\"` at all 6 workflow sites
- ✅ `scripts/mojo-under-gdb.sh`
- ✅ `scripts/coredump-host-handler.sh` (pipe handler)
- ✅ disasm/register-dump symbolicator in `coredump-capture` action

## Companion PR (parallel)

`bisect/6413-revert-justfile-5389` — tests the rest of PR #5389 (justfile + examples + workflow timeout) while compose stays at 14g.

## Expected outcomes

| Result over 8 reruns | Conclusion |
| --- | --- |
| Data Utilities + Configs fail ≥4/8 times | Compose memlimit was the fix → root cause is memory-pressure-sensitive |
| Data Utilities + Configs stay 0/8 failures | Memlimit is irrelevant → fix is in the rest of #5389 (companion PR) or in PR1/PR2 candidates |

## Rerun protocol

After initial CI, `gh run rerun <id>` the comprehensive-tests workflow 7 more times. Record outcomes in the per-PR table at `~/.claude/plans/lets-do-further-investigation-sequential-dolphin.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>