### PR TITLE
[DO NOT MERGE] bisect(6413): revert justfile+examples from #5389 (compose preserved)

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -102,10 +102,7 @@ jobs:
   mojo-compilation:
     needs: [mojo-syntax-check]
     runs-on: ubuntu-latest
-    # 30 min: `just ci-build` now actually compiles 46 example/benchmark
-    # binaries in addition to the shared package (#5389). Previously this
-    # was a 1-file no-op, so 10 min was sufficient.
-    timeout-minutes: 30
+    timeout-minutes: 10
     name: "Mojo Package Compilation"
 
     steps:
@@ -832,10 +829,7 @@ jobs:
   build-validation:
     needs: [mojo-syntax-check]
     runs-on: ubuntu-latest
-    # 30 min: `just build` + `just package` now compile the full shared
-    # package and 46 example/benchmark binaries (#5389). Previously the
-    # build recipe was a 1-file no-op, so 10 min was sufficient.
-    timeout-minutes: 30
+    timeout-minutes: 10
     name: "Build Validation"
 
     steps:

--- a/benchmarks/bench_matmul.mojo
+++ b/benchmarks/bench_matmul.mojo
@@ -33,7 +33,7 @@ Output:
 
 from shared.utils.arg_parser import ArgumentParser
 from shared.tensor.any_tensor import AnyTensor, zeros, ones
-from std.time import perf_counter_ns
+from time import perf_counter_ns
 from std.collections import List
 
 
@@ -622,7 +622,7 @@ def run_benchmarks[
 def main() raises:
     """Main benchmark driver."""
     # Check for help flags
-    from std.sys import argv
+    from sys import argv
 
     var args = argv()
     for i in range(len(args)):

--- a/benchmarks/bench_simd.mojo
+++ b/benchmarks/bench_simd.mojo
@@ -24,7 +24,7 @@ from shared.core.arithmetic_simd import (
     multiply_simd,
     divide_simd,
 )
-from std.time import perf_counter_ns
+from time import perf_counter_ns
 
 
 def benchmark_operation[

--- a/benchmarks/scripts/compare_results.mojo
+++ b/benchmarks/scripts/compare_results.mojo
@@ -18,7 +18,7 @@ Output:
 """
 
 from std.sys import argv
-from std.python import Python
+from python import Python
 
 
 # ============================================================================
@@ -123,43 +123,37 @@ def atof(s: String) -> Float64:
     var bytes = s.as_bytes()
 
     # Handle negative numbers
-    if len(bytes) > 0 and bytes[0] == UInt8(ord("-")):
+    if len(bytes) > 0 and bytes[0] == ord("-"):
         sign = -1.0
         i = 1
 
     # Parse integer part
     while (
         i < len(bytes)
-        and bytes[i] != UInt8(ord("."))
-        and bytes[i] != UInt8(ord("e"))
-        and bytes[i] != UInt8(ord("E"))
+        and bytes[i] != ord(".")
+        and bytes[i] != ord("e")
+        and bytes[i] != ord("E")
     ):
         result = result * 10.0 + Float64(Int(bytes[i]) - ord("0"))
         i += 1
 
     # Parse decimal part
-    if i < len(bytes) and bytes[i] == UInt8(ord(".")):
+    if i < len(bytes) and bytes[i] == ord("."):
         i += 1
         var decimal_place: Float64 = 0.1
-        while (
-            i < len(bytes)
-            and bytes[i] != UInt8(ord("e"))
-            and bytes[i] != UInt8(ord("E"))
-        ):
+        while i < len(bytes) and bytes[i] != ord("e") and bytes[i] != ord("E"):
             result = result + Float64(Int(bytes[i]) - ord("0")) * decimal_place
             decimal_place = decimal_place * 0.1
             i += 1
 
     # Parse exponent (scientific notation)
-    if i < len(bytes) and (
-        bytes[i] == UInt8(ord("e")) or bytes[i] == UInt8(ord("E"))
-    ):
+    if i < len(bytes) and (bytes[i] == ord("e") or bytes[i] == ord("E")):
         i += 1
         var exp_sign = 1
-        if i < len(bytes) and bytes[i] == UInt8(ord("-")):
+        if i < len(bytes) and bytes[i] == ord("-"):
             exp_sign = -1
             i += 1
-        elif i < len(bytes) and bytes[i] == UInt8(ord("+")):
+        elif i < len(bytes) and bytes[i] == ord("+"):
             i += 1
 
         var exponent = 0
@@ -333,13 +327,13 @@ def atoi(s: String) -> Int:
     var s_bytes = s.as_bytes()
 
     # Handle negative numbers
-    if len(s_bytes) > 0 and s_bytes[0] == UInt8(ord("-")):
+    if len(s_bytes) > 0 and s_bytes[0] == ord("-"):
         sign = -1
         i = 1
 
     # Parse digits
     while i < len(s_bytes):
-        if s_bytes[i] >= UInt8(ord("0")) and s_bytes[i] <= UInt8(ord("9")):
+        if s_bytes[i] >= ord("0") and s_bytes[i] <= ord("9"):
             result = result * 10 + (Int(s_bytes[i]) - ord("0"))
         i += 1
 

--- a/benchmarks/scripts/run_benchmarks.mojo
+++ b/benchmarks/scripts/run_benchmarks.mojo
@@ -13,8 +13,8 @@ Output:
 """
 
 from std.sys import argv
-from std.time import perf_counter_ns
-from std.python import Python
+from time import perf_counter_ns
+from python import Python
 
 
 # ============================================================================
@@ -183,10 +183,9 @@ def measure_benchmark[
     """Measure a benchmark's performance.
 
     Parameters:
-        FuncType: Type of the benchmark function.
+        func: Benchmark function to measure.
 
     Args:
-        func: Benchmark function to measure.
         name: Name of the benchmark.
         description: Description of what benchmark measures.
         iterations: Number of iterations to run.

--- a/docs/dev/mojo-jit-crash-capture-core.md
+++ b/docs/dev/mojo-jit-crash-capture-core.md
@@ -99,11 +99,11 @@ USER_ID=$(id -u) GROUP_ID=$(id -g) podman compose exec -T projectodyssey-dev bas
 
 Expected outcomes:
 
-| Test result    | wrapper exit                                                    | Files in `/tmp/cores/`                |
-| -------------- | --------------------------------------------------------------- | ------------------------------------- |
-| Pass           | `0`                                                             | `gdb-<ts>.log` only                   |
-| Fail (non-0)   | The test's exit code                                            | `gdb-<ts>.log` only                   |
-| Crash (signal) | `128 + signo` (e.g. 132 = SIGILL, 134 = SIGABRT, 139 = SIGSEGV) | `gdb-<ts>.log` + `core.gdb.<ts>.mojo` |
+| Test result   | wrapper exit | Files in `/tmp/cores/`                          |
+| ------------- | ------------ | ----------------------------------------------- |
+| Pass          | `0`          | `gdb-<ts>.log` only                             |
+| Fail (non-0)  | The test's exit code | `gdb-<ts>.log` only                     |
+| Crash (signal)| `128 + signo` (e.g. 132 = SIGILL, 134 = SIGABRT, 139 = SIGSEGV) | `gdb-<ts>.log` + `core.gdb.<ts>.mojo` |
 
 ### 3. Inspect the gdb log first
 

--- a/examples/mobilenetv1_cifar10/inference.mojo
+++ b/examples/mobilenetv1_cifar10/inference.mojo
@@ -34,7 +34,7 @@ def evaluate_model(
     var correct_per_class = List[Int]()
     var total_per_class = List[Int]()
 
-    for _ in range(10):
+    for i in range(10):
         correct_per_class.append(0)
         total_per_class.append(0)
 

--- a/examples/mojo_patterns/simd_example.mojo
+++ b/examples/mojo_patterns/simd_example.mojo
@@ -9,7 +9,7 @@ See documentation: docs/core/mojo-patterns.md
 """
 
 from std.algorithm import vectorize
-from std.sys.info import simd_width_of
+from sys.info import simd_width_of
 from shared.tensor.any_tensor import AnyTensor
 
 

--- a/examples/mojo_patterns/trait_example.mojo
+++ b/examples/mojo_patterns/trait_example.mojo
@@ -42,7 +42,8 @@ struct Tensor(Copyable, ImplicitlyCopyable):
 
     def __del__(deinit self):
         """Destructor to free gradient pointer."""
-        self._grad_ptr.free()
+        if self._grad_ptr:
+            self._grad_ptr.free()
 
     def get_grad(self) -> Tensor:
         """Get gradient as a Tensor (stub - returns zero tensor of same size).

--- a/justfile
+++ b/justfile
@@ -263,13 +263,11 @@ _build-inner mode="debug":
     # Configuration
     # ------------------------------------------------------------
 
-    MODE="{{mode}}"             # debug | release | test | ci | asan | tsan
+    MODE="{{mode}}"             # debug | release | test | ci
     REPO_ROOT="$(pwd)"
     STRICT="--Werror"
 
-    # tsan needs single-job execution to work around modular/modular#6413
-    # (libKGEN JIT crashes under thread sanitizer with parallel codegen).
-    JOBS=""
+    FAIL_ON_ERROR=1
 
     case "$MODE" in
         debug)
@@ -284,16 +282,9 @@ _build-inner mode="debug":
         ci)
             FLAGS="-g1 $STRICT"
             ;;
-        asan)
-            FLAGS="-g1 --sanitize address $STRICT"
-            ;;
-        tsan)
-            FLAGS="-g1 --sanitize thread $STRICT"
-            JOBS="-j1"
-            ;;
         *)
             echo "❌ Unknown mode: $MODE"
-            echo "Valid modes: debug | release | test | ci | asan | tsan"
+            echo "Valid modes: debug | release | test | ci"
             exit 1
             ;;
     esac
@@ -303,114 +294,61 @@ _build-inner mode="debug":
 
     echo "🔨 Building Mojo files"
     echo "Mode:  $MODE"
-    echo "Flags: $FLAGS${JOBS:+ $JOBS}"
+    echo "Flags: $FLAGS"
     echo "Out:   $BUILD_DIR"
     echo
 
     # ------------------------------------------------------------
-    # Phase A: Package the shared library
+    # Build
     # ------------------------------------------------------------
-    # shared/ is a library (no main() entry points) — must be compiled with
-    # `mojo package`, not file-by-file `mojo build`. This is the same logic
-    # as `_package-inner`; we inline it here so `just build` produces a
-    # complete artifact set in one invocation.
 
-    # `mojo package` only accepts a small subset of compiler flags
-    # (no -g / --no-optimization / -O3 / --sanitize). Pass STRICT only.
-    echo "→ Packaging shared library"
-    pixi run mojo package $STRICT -I "$REPO_ROOT" shared \
-        -o "$BUILD_DIR/ProjectOdyssey-shared.mojopkg"
-
-    # ------------------------------------------------------------
-    # Phase B: AOT-compile every executable (examples, benchmarks, papers)
-    # ------------------------------------------------------------
-    # Sanitizer modes skip Phase B: the Mojo compiler under ASAN/TSAN
-    # allocates 3-6 GB per invocation (modular/modular#6433), so sweeping
-    # 46 binaries OOMs hosts with <32 GB RAM. Sanitizers are valuable for
-    # runtime race/leak detection in tests, not for compile-time validation
-    # of example binaries. Use `just test-mojo-asan` / `just test-mojo-tsan`
-    # to exercise sanitizers against the test suite.
-    if [ "$MODE" = "asan" ] || [ "$MODE" = "tsan" ]; then
-        echo
-        echo "✅ Sanitizer build complete (shared package only)"
-        echo "  shared package: $BUILD_DIR/ProjectOdyssey-shared.mojopkg"
-        echo "  Run sanitized tests: just test-mojo-${MODE}"
-        exit 0
-    fi
-
-    # `-Xlinker -lm` is required for files that transitively use libm
-    # symbols (fmaxf, sincos, etc.). Mirrors `_test-group-asan-inner` at
-    # justfile:791 which already uses this flag successfully.
-    #
-    # set -euo pipefail aborts on the first failed compile. No silent
-    # FAIL_ON_ERROR=0 escape hatch — Werror means Werror.
-
-    # Collect candidate files, then keep only those with a main() entry
-    # point. `grep -l ... -- file1 file2 ...` (single invocation) is more
-    # robust than `xargs -I{} grep` — xargs treats a no-match exit 1 as a
-    # child failure (exit 123). `|| true` swallows the no-match exit code.
-    CANDIDATES=$(
-        {
-            find examples -name "*.mojo" \
-                -not -path "*/.*" \
-                -not -name "__init__.mojo" \
-                -not -name "model.mojo"
-            find benchmarks -name "*.mojo" \
-                -not -path "*/.*" \
-                -not -name "__init__.mojo"
-            find papers -path "*/examples/*.mojo" \
-                -not -path "*/.*" \
-                -not -name "__init__.mojo"
-        } 2>/dev/null | sort -u
-    )
-    EXEC_FILES=""
-    if [ -n "$CANDIDATES" ]; then
-        EXEC_FILES=$(echo "$CANDIDATES" | tr '\n' '\0' \
-            | xargs -0 grep -lE "^fn main|^def main" 2>/dev/null || true)
-    fi
-
-    # Disable -e for the per-file loop so a single failure doesn't abort
-    # the whole sweep — collect failures, report at end, exit non-zero if any.
-    set +e
-    BUILT=0
     FAILED=0
-    FAILED_FILES=""
-    while IFS= read -r file; do
-        [ -z "$file" ] && continue
-        # Flatten path → unique binary name: examples/foo/bar.mojo → examples_foo_bar
-        rel="${file#./}"
-        out_name="${rel%.mojo}"
-        out_name="${out_name//\//_}"
-        out="$BUILD_DIR/$out_name"
 
-        echo "→ Building: $file"
-        if pixi run mojo build $FLAGS ${JOBS:-} -I "$REPO_ROOT" \
-                -Xlinker -lm "$file" -o "$out" 2>&1; then
-            BUILT=$((BUILT + 1))
-        else
-            FAILED=$((FAILED + 1))
-            FAILED_FILES="${FAILED_FILES}\n  - $file"
-        fi
-    done <<< "$EXEC_FILES"
-    set -e
+    find . \
+        \( -path "./.pixi" -o -path "./worktrees" -o -path "./.worktrees" \) -prune -o \
+        \( \
+            -name "*.mojo" \
+            -not -path "./.claude/*" \
+            -not -path "./tests/*" \
+            -not -path "./shared/*" \
+            -not -path "./examples/*" \
+            -not -path "./benchmarks/*" \
+            -not -path "./.templates/*" \
+            -not -path "./papers/_template/*" \
+            -not -path "./notes/*" \
+            -not -path "./repro/*" \
+            -not -name "test_*.mojo" \
+            -not -name "model.mojo" \
+            -not -name "__init__.mojo" \
+            -not -name "repro_*.mojo" \
+        \) -print \
+        | while read -r file; do
+            out="$BUILD_DIR/$(basename "$file" .mojo)"
+            echo "→ Building: $file"
+
+            if ! pixi run mojo build $FLAGS -I "$REPO_ROOT" "$file" -o "$out" 2>&1; then
+                echo "❌ Failed: $file"
+                FAILED=1
+                if [[ "$FAIL_ON_ERROR" -eq 1 ]]; then
+                    exit 1
+                fi
+            fi
+        done
 
     # ------------------------------------------------------------
     # Summary
     # ------------------------------------------------------------
 
-    echo
-    echo "=================================================="
-    echo "Build summary ($MODE)"
-    echo "=================================================="
-    echo "  shared package: $BUILD_DIR/ProjectOdyssey-shared.mojopkg"
-    echo "  executables:    $BUILT built, $FAILED failed"
-    if [ "$FAILED" -gt 0 ]; then
+    if [[ "$FAILED" -eq 1 ]]; then
         echo
-        echo "❌ Failed files:"
-        echo -e "$FAILED_FILES"
-        exit 1
+        echo "⚠️  Build completed with errors"
+        echo "Outputs in $BUILD_DIR"
+        [[ "$FAIL_ON_ERROR" -eq 1 ]] && exit 1
+    else
+        echo
+        echo "✅ Build successful"
+        echo "Outputs in $BUILD_DIR"
     fi
-    echo "✅ Build successful"
 
 # Build debug version
 build-debug: (build "debug")
@@ -418,19 +356,11 @@ build-debug: (build "debug")
 # Build release version
 build-release: (build "release")
 
-# Build with AddressSanitizer
-build-asan: (build "asan")
-
-# Build with ThreadSanitizer (uses -j1, modular/modular#6413 workaround)
-build-tsan: (build "tsan")
-
 # Build all modes
 build-all:
     @just build debug
     @just build release
     @just build test
-    @just build asan
-    @just build tsan
 
 # CI: Build and validate all Mojo code (entry points + shared library)
 ci-build:
@@ -969,74 +899,6 @@ _test-group-asan-inner path pattern:
 test-mojo:
     @just _run "just _test-mojo-inner"
 
-# Run all Mojo tests under AddressSanitizer (memory errors, leaks, UAF)
-test-mojo-asan:
-    @just _run "just _test-mojo-sanitized-inner address"
-
-# Run all Mojo tests under ThreadSanitizer (data races).
-# Uses -j1 codegen (modular/modular#6413 workaround). Note: each compile is
-# ~5min and holds 3-6GB; on memory-limited hosts, prefer `test-group-asan`
-# on individual groups.
-test-mojo-tsan:
-    @just _run "just _test-mojo-sanitized-inner thread"
-
-[private]
-_test-mojo-sanitized-inner sanitizer:
-    #!/usr/bin/env bash
-    set -e
-    REPO_ROOT="$(pwd)"
-    SANITIZER="{{sanitizer}}"
-    SAN_FLAGS="--sanitize $SANITIZER"
-    # Match the JIT-crash workaround used in `_build-inner` for tsan
-    JOBS=""
-    if [ "$SANITIZER" = "thread" ]; then
-        JOBS="-j1"
-    fi
-    echo "Running all Mojo tests with --sanitize $SANITIZER..."
-
-    # Walk tree recursively via `find` — bash's `tests/**/*.mojo` without
-    # `shopt -s globstar` only matches one level deep, silently skipping
-    # ~85% of the test suite.
-    mapfile -t test_files < <(
-        find tests -name "test_*.mojo" \
-            -not -path "*/__init__.mojo" \
-            -not -path "tests/helpers/fixtures.mojo" \
-            -not -path "tests/helpers/utils.mojo" \
-            -not -path "tests/conftest.mojo" \
-            | sort
-    )
-
-    test_count=${#test_files[@]}
-    failed=0
-    failed_tests=""
-    for test_file in "${test_files[@]}"; do
-        [ ! -f "$test_file" ] && continue
-
-        BINARY=$(mktemp /tmp/mojo-san-XXXXXX)
-        echo "Testing ($SANITIZER): $test_file"
-        if pixi run mojo build $SAN_FLAGS --Werror $JOBS \
-                -I "$REPO_ROOT" -I . -Xlinker -lm \
-                "$test_file" -o "$BINARY" 2>&1 \
-           && "$BINARY" 2>&1; then
-            : # passed
-        else
-            failed=$((failed + 1))
-            failed_tests="$failed_tests\n  - $test_file"
-        fi
-        rm -f "$BINARY"
-    done
-
-    if [ $test_count -eq 0 ]; then
-        echo "❌ ERROR: No Mojo test files found in tests/"
-        exit 1
-    fi
-    if [ $failed -gt 0 ]; then
-        echo "❌ $failed tests failed under --sanitize $SANITIZER:"
-        echo -e "$failed_tests"
-        exit 1
-    fi
-    echo "✅ All $test_count tests passed under --sanitize $SANITIZER"
-
 [private]
 _test-mojo-inner:
     #!/usr/bin/env bash
@@ -1044,42 +906,44 @@ _test-mojo-inner:
     REPO_ROOT="$(pwd)"
     echo "Running all Mojo tests..."
 
-    # `find` walks the tree recursively; bash's `tests/**/*.mojo` glob
-    # without `shopt -s globstar` only matches one level deep, which would
-    # silently skip ~98% of the test suite. Use `find` for correctness.
-    mapfile -t test_files < <(
-        find tests -name "test_*.mojo" \
-            -not -path "*/__init__.mojo" \
-            -not -path "tests/helpers/fixtures.mojo" \
-            -not -path "tests/helpers/utils.mojo" \
-            -not -path "tests/conftest.mojo" \
-            | sort
-    )
+    # Count test files
+    test_count=0
+    for test_file in tests/**/*.mojo; do
+        [[ "$(basename "$test_file")" == "__init__.mojo" ]] && continue
+        [[ "$(basename "$test_file")" == "conftest.mojo" ]] && continue
+        [[ "$test_file" == "tests/helpers/fixtures.mojo" ]] && continue
+        [[ "$test_file" == "tests/helpers/utils.mojo" ]] && continue
+        [ -f "$test_file" ] && test_count=$((test_count + 1))
+    done
 
-    test_count=${#test_files[@]}
-    if [ "$test_count" -eq 0 ]; then
+    if [ $test_count -eq 0 ]; then
         echo "❌ ERROR: No Mojo test files found in tests/"
         echo "   This usually means the directory is empty or test files were renamed."
         exit 1
     fi
 
-    echo "Found $test_count test files"
     failed=0
-    failed_tests=""
-    for test_file in "${test_files[@]}"; do
-        echo "Testing: $test_file"
-        if ! pixi run mojo --Werror -I "$REPO_ROOT" -I . "$test_file"; then
-            failed=$((failed + 1))
-            failed_tests="$failed_tests\n  - $test_file"
+    for test_file in tests/**/*.mojo; do
+        # Skip non-test library files (no main function)
+        if [[ "$(basename "$test_file")" == "__init__.mojo" ]] || \
+           [[ "$(basename "$test_file")" == "conftest.mojo" ]] || \
+           [[ "$test_file" == "tests/helpers/fixtures.mojo" ]] || \
+           [[ "$test_file" == "tests/helpers/utils.mojo" ]]; then
+            continue
+        fi
+        if [ -f "$test_file" ]; then
+            echo "Testing: $test_file"
+            if ! pixi run mojo --Werror -I "$REPO_ROOT" -I . "$test_file"; then
+                failed=1
+            fi
         fi
     done
 
-    if [ "$failed" -gt 0 ]; then
-        echo "❌ $failed of $test_count tests failed:"
-        echo -e "$failed_tests"
+    if [ $failed -eq 1 ]; then
+        echo "❌ Some tests failed"
         exit 1
     fi
-    echo "✅ All $test_count tests passed"
+    echo "✅ All tests passed"
 
 # ==============================================================================
 # Utility

--- a/tests/shared/test_imports.mojo
+++ b/tests/shared/test_imports.mojo
@@ -63,6 +63,7 @@ from shared import (
     AdamW,
     LICENSE,
     RMSprop,
+    SGD,
     VERSION,
     core,
     data,
@@ -178,13 +179,9 @@ def test_training_optimizers_imports() raises:
 
 
 def test_shared_optimizer_imports() raises:
-    """Test that Adam, AdamW, AdaGrad, RMSprop are importable from shared package.
+    """Test that SGD, Adam, AdamW, AdaGrad, RMSprop are importable from shared package.
 
     Covers Issue #3745: AdaGrad and RMSprop exposed as top-level shared imports.
-    Note: SGD is intentionally imported via `shared.training` instead — the
-    `shared` package surfaces two `SGD` declarations (autograd's optimizer
-    struct and training's wrapper), so a bare `from shared import SGD`
-    is ambiguous under --Werror.
     """
     print("✓ Shared optimizer imports test passed")
 


### PR DESCRIPTION
**DO NOT MERGE — forensic bisect PR for modular/modular#6413.**

## Hypothesis

PR #5389 ("make `just build` actually compile everything") rewrote the justfile build/test recipes (311-line delta), changed several example/benchmark Mojo files, and bumped the workflow test timeout 10 → 30 min. One of those non-compose changes may have silenced the libKGEN JIT crash by altering how mojo is invoked, which test files compile under STRICT, or build ordering.

## What this PR does

Reverts all #5389 deltas EXCEPT `docker-compose.yml` (which is isolated in companion PR #5397). Files reverted to pre-#5389 (parent `adb4c35c`):

- `justfile` (recipe rewrite, 278-line delta)
- `.github/workflows/comprehensive-tests.yml` (10-line: timeout-minutes + related)
- `benchmarks/*` (4 files, 43-line delta total)
- `examples/*` (3 files, minor)
- `docs/dev/mojo-jit-crash-capture-core.md` (doc)
- `tests/shared/test_imports.mojo` (7-line)

## What this PR preserves

- ✅ `docker-compose.yml` memlimits at green HEAD (14g/24g/24g) — that's PR3's variable
- ✅ All gdb-wrapper plumbing (`MOJO_TEST_UNDER_GDB: \"1\"` at all 6 sites, `scripts/mojo-under-gdb.sh`, pipe handler, disasm symbolicator)
- ✅ All post-#5389 fixes (`e3e0de83`, `9d452948`, `5eaf8ad9`, etc.) preserved via `-X ours` conflict resolution

## Companion PR (parallel)

`bisect/6413-revert-compose-memlimit` (PR #5397) — tests the +2 GB dev memlimit alone.

## Expected outcomes

| Result over 8 reruns | Conclusion |
| --- | --- |
| Data Utilities + Configs fail ≥4/8 times | A non-compose change in #5389 was the fix → next step is to bisect within this revert (justfile vs workflow vs test_imports.mojo vs examples) |
| Data Utilities + Configs stay 0/8 failures | The rest of #5389 is irrelevant → fix is in compose memlimit (PR #5397) or in PR1/PR2 candidates |

## Rerun protocol

After initial CI, `gh run rerun <id>` the comprehensive-tests workflow 7 more times. Record outcomes in the per-PR table at `~/.claude/plans/lets-do-further-investigation-sequential-dolphin.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>