### PR TITLE
[DO NOT MERGE] bisect(6413): positive control — last-failing sha + disasm dump

### DIFF
--- a/.github/actions/coredump-capture/action.yml
+++ b/.github/actions/coredump-capture/action.yml
@@ -168,6 +168,30 @@ runs:
           if ! podman compose exec -T projectodyssey-dev bash -c 'ulimit -c' 2>&1; then
             echo "[coredump-capture] WARNING: could not read ulimit -c from container"
           fi
+          # /proc/cpuinfo for modular/modular#6413: needed to determine which
+          # CPU flags the runner exposes. Bare-metal Skylake without AVX-512
+          # does NOT reproduce the bug; only GHA Azure runners do. Capture the
+          # exact flag set so upstream can correlate with the JIT codegen
+          # decision (and so we can see if Azure CPUID is reporting
+          # AVX-512-related flags that don't match the silicon).
+          echo "=== /proc/cpuinfo first CPU (host) ==="
+          if ! awk '/^processor/{c++; if(c>1)exit} {print}' /proc/cpuinfo; then
+            echo "[coredump-capture] WARNING: could not read /proc/cpuinfo from host"
+          fi
+          echo "=== /proc/cpuinfo first CPU (container) ==="
+          if ! podman compose exec -T projectodyssey-dev bash -c \
+              "awk '/^processor/{c++; if(c>1)exit} {print}' /proc/cpuinfo" 2>&1; then
+            echo "[coredump-capture] WARNING: could not read /proc/cpuinfo from container"
+          fi
+          echo "=== lscpu summary (host) ==="
+          if ! lscpu 2>&1 | head -30; then
+            echo "[coredump-capture] WARNING: lscpu failed on host"
+          fi
+          echo "=== /proc/self/auxv HWCAP / HWCAP2 (container) ==="
+          if ! podman compose exec -T projectodyssey-dev bash -c \
+              "LD_SHOW_AUXV=1 /bin/true 2>&1 | grep -E '(HWCAP|PLATFORM)'" 2>&1; then
+            echo "[coredump-capture] WARNING: could not read HWCAP from container"
+          fi
           echo "=== Coredumps found in crash-bundle/cores/ ==="
           ls -la crash-bundle/cores/ 2>/dev/null
           echo "=== GDB logs (from mojo-under-gdb.sh) ==="

--- a/.github/actions/coredump-capture/action.yml
+++ b/.github/actions/coredump-capture/action.yml
@@ -192,6 +192,86 @@ runs:
                >> crash-bundle/metadata.txt
         fi
 
+    # Symbolicate every captured core: dump the faulting instruction stream,
+    # registers, and a wide disassembly window around $pc.  The goal is to
+    # identify whether the SIGILL is a CPU-feature-mismatch fault (e.g. an
+    # AVX-VNNI / VAES / SHA-NI / VPCLMULQDQ / movdir64b opcode that the GHA
+    # runner CPU lacks but libKGEN's JIT codegen still emitted).  Runs against
+    # the mojo binary bundled in symbols/ — JIT cores are symbolicated against
+    # the host mojo since libKGEN is loaded at runtime regardless of mode.
+    # Per-PR forensic add-on for the modular/modular#6413 bisect; safe to keep
+    # permanently because it only fires when cores exist.
+    - name: Symbolicate cores (disasm + registers around $pc)
+      if: inputs.phase == 'collect' && always()
+      shell: bash
+      run: |
+        set -x
+        mkdir -p crash-bundle/symbolicated
+        # Find all cores (both pipe-handler kernel cores and gdb-wrapper cores).
+        shopt -s nullglob
+        CORES=( crash-bundle/cores/core.* crash-bundle/cores/core.gdb.* )
+        shopt -u nullglob
+        if [ ${#CORES[@]} -eq 0 ]; then
+          echo "[symbolicate] No cores to symbolicate — skipping."
+          exit 0
+        fi
+        # Resolve mojo binary path (bundled in symbols/ by the previous step).
+        MOJO_BIN=""
+        if [ -x crash-bundle/symbols/mojo ]; then
+          MOJO_BIN=crash-bundle/symbols/mojo
+        else
+          # Fall back to container's mojo if symbols/ copy failed.
+          MOJO_BIN=$(podman compose exec -T projectodyssey-dev bash -c \
+            'pixi run which mojo 2>/dev/null | tail -1' | tr -d '\r')
+        fi
+        if [ -z "$MOJO_BIN" ] || [ ! -e "$MOJO_BIN" ]; then
+          echo "[symbolicate] Could not resolve mojo binary — skipping."
+          exit 0
+        fi
+        if ! command -v gdb >/dev/null 2>&1; then
+          echo "[symbolicate] gdb not installed on host — installing..."
+          if ! sudo apt-get install -y --no-install-recommends gdb; then
+            echo "[symbolicate] gdb install failed — skipping symbolication." >&2
+            exit 0
+          fi
+        fi
+        for core in "${CORES[@]}"; do
+          base=$(basename "$core")
+          out="crash-bundle/symbolicated/${base}.symbolicated.log"
+          echo "[symbolicate] $core -> $out"
+          {
+            echo "==== $base ===="
+            echo "symbol_binary=$MOJO_BIN"
+            echo "---- Backtrace (top 25 frames) ----"
+            if ! gdb -batch -ex "set pagination off" \
+                  -ex "thread apply 1 bt 25" \
+                  "$MOJO_BIN" "$core" 2>&1 | head -80; then
+              echo "(gdb backtrace exited non-zero — output above)"
+            fi
+            echo "---- Instruction stream around \$pc ----"
+            # Dump:
+            #   - integer + SSE/AVX register state at fault time
+            #   - the current frame info
+            #   - 16 raw instructions before and after $pc
+            #   - a disassembly window of [-64, +64] bytes
+            #   - all-registers (SSE/AVX state for ISA-feature analysis)
+            if ! gdb -batch \
+                  -ex "set pagination off" \
+                  -ex "set print pretty on" \
+                  -ex "info registers" \
+                  -ex "info frame" \
+                  -ex "x/16i \$pc - 30" \
+                  -ex "x/16i \$pc" \
+                  -ex "disassemble \$pc - 64, \$pc + 64" \
+                  -ex "info all-registers" \
+                  "$MOJO_BIN" "$core" 2>&1 | head -400; then
+              echo "(gdb disasm exited non-zero — output above)"
+            fi
+          } > "$out" 2>&1
+        done
+        echo "[symbolicate] Wrote $(ls crash-bundle/symbolicated/ | wc -l) log(s)."
+        ls -la crash-bundle/symbolicated/
+
     - name: Upload crash bundle
       if: inputs.phase == 'collect' && always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7

--- a/.github/actions/coredump-capture/action.yml
+++ b/.github/actions/coredump-capture/action.yml
@@ -5,6 +5,12 @@ description: |
   After the test job, bundles cores + matching `mojo` binary + relevant
   `.so` files into a `crash-bundle-<job-name>` artifact (14-day retention).
 
+  When MOJO_TEST_UNDER_GDB=1 is set (CI default), mojo test invocations run
+  under gdb -batch with handle SIGABRT stop nopass. On crash, gdb writes:
+    - core.gdb.<timestamp>.mojo  — real ELF core (multi-MB)
+    - gdb-<timestamp>.log        — full bt, threads, shlibs text dump
+  Both are collected here alongside any kernel cores and the mojo binary.
+
   Use this action TWICE in each test job:
     1. As a setup step BEFORE the test runs (to enable cores)
     2. As a teardown step AFTER the test runs (to bundle + upload)
@@ -105,8 +111,20 @@ runs:
           for so in "$ENV_DIR"/lib/libKGEN*.so "$ENV_DIR"/lib/libAsync*.so "$ENV_DIR"/lib/libMojo*.so "$ENV_DIR"/lib/libMSupport*.so; do
             [ -e "$so" ] && cp -av "$so" /workspace/crash-bundle/symbols/ 2>/dev/null || true
           done
+          # Bundle gdb itself so the crash can be analyzed offline without
+          # needing a matching gdb version installed.
+          GDB_BIN=$(which gdb 2>/dev/null || true)
+          if [ -n "$GDB_BIN" ] && [ -x "$GDB_BIN" ]; then
+            cp -av "$GDB_BIN" /workspace/crash-bundle/symbols/ 2>/dev/null || true
+          fi
           ls -la /workspace/crash-bundle/symbols/
         ' || true
+
+        # gdb-mode: collect gdb-*.log and core.gdb.* files written by
+        # scripts/mojo-under-gdb.sh when MOJO_TEST_UNDER_GDB=1.
+        # These live in crash-bundle/cores/ alongside any kernel cores.
+        ls -la crash-bundle/cores/gdb-*.log 2>/dev/null || true
+        ls -la crash-bundle/cores/core.gdb.* 2>/dev/null || true
 
         {
           echo "=== mojo --version ==="
@@ -123,19 +141,25 @@ runs:
           podman compose exec -T projectodyssey-dev bash -c 'ulimit -c' 2>&1 || true
           echo "=== Coredumps found in crash-bundle/cores/ ==="
           ls -la crash-bundle/cores/ 2>/dev/null
+          echo "=== GDB logs (from mojo-under-gdb.sh) ==="
+          ls -la crash-bundle/cores/gdb-*.log 2>/dev/null || echo "(none)"
+          echo "=== GDB ELF cores (from mojo-under-gdb.sh) ==="
+          ls -la crash-bundle/cores/core.gdb.* 2>/dev/null || echo "(none)"
           echo "=== Symbols bundled ==="
           ls -la crash-bundle/symbols/ 2>/dev/null
           echo "=== handler.log (pipe handler invocations) ==="
           cat crash-bundle/handler.log 2>/dev/null || echo "(no handler.log — handler was not invoked this run)"
         } > crash-bundle/metadata.txt
 
-        # If no cores, still upload metadata + symbols so the artifact
-        # appears in the run (proves the action executed end-to-end).
-        if [ -z "$(ls -A crash-bundle/cores/ 2>/dev/null)" ]; then
-          echo "No cores captured this run — uploading metadata + symbols only."
-          echo "(If a crash appeared in test logs but handler.log is empty," \
-               "the pipe core_pattern may not have been reached — check" \
-               "suid_dumpable and ulimit -c inside the container.)" \
+        # If no cores (kernel or gdb), still upload the metadata + symbols so
+        # the artifact appears in the run (proves the action ran end-to-end).
+        HAVE_CORES=$(ls crash-bundle/cores/core* 2>/dev/null | head -1 || true)
+        HAVE_GDB_LOGS=$(ls crash-bundle/cores/gdb-*.log 2>/dev/null | head -1 || true)
+        if [ -z "$HAVE_CORES" ] && [ -z "$HAVE_GDB_LOGS" ]; then
+          echo "No cores or gdb logs captured this run — uploading metadata + symbols only."
+          echo "(If a crash signature appeared in test logs, check that" \
+               "MOJO_TEST_UNDER_GDB=1 is set for this job and suid_dumpable" \
+               "and ulimit -c are set inside the container.)" \
                >> crash-bundle/metadata.txt
         fi
 

--- a/.github/actions/coredump-capture/action.yml
+++ b/.github/actions/coredump-capture/action.yml
@@ -69,14 +69,20 @@ runs:
         echo '|/usr/local/bin/coredump-host-handler.sh %p %e %t %s %P' \
           | sudo tee /proc/sys/kernel/core_pattern
 
-        sudo sysctl -w fs.suid_dumpable=2 || true
-        sudo systemctl stop apport.service 2>/dev/null || true
-        sudo systemctl stop systemd-coredump.socket 2>/dev/null || true
+        if sudo -n true 2>/dev/null; then
+          sudo sysctl -w fs.suid_dumpable=2 || { echo "[coredump-capture] ERROR: sysctl -w fs.suid_dumpable=2 failed despite sudo access"; exit 1; }
+          sudo systemctl stop apport.service 2>/dev/null || echo "[coredump-capture] WARNING: could not stop apport.service (may not be running)"
+          sudo systemctl stop systemd-coredump.socket 2>/dev/null || echo "[coredump-capture] WARNING: could not stop systemd-coredump.socket (may not be running)"
+        else
+          echo "[coredump-capture] WARNING: no passwordless sudo — skipping sysctl and systemctl tweaks; cores may not be captured"
+        fi
 
         # Raise core ulimit inside the container so it propagates to every
         # subsequent `podman compose exec` session.
-        podman compose exec -T projectodyssey-dev bash -c \
-          'ulimit -c unlimited && ulimit -a | grep -E "core|file size" || true'
+        if ! podman compose exec -T projectodyssey-dev bash -c \
+          'ulimit -c unlimited && ulimit -a | grep -E "core|file size"'; then
+          echo "[coredump-capture] WARNING: failed to set ulimit -c unlimited inside container — cores will not be generated on crash"
+        fi
 
     - name: Collect core dumps + symbols (modular/modular#6413)
       if: inputs.phase == 'collect' && always()
@@ -84,7 +90,9 @@ runs:
       run: |
         set -x
         mkdir -p crash-bundle/cores crash-bundle/symbols
-        ls -la crash-bundle/cores/ 2>/dev/null || true
+        if ! ls -la crash-bundle/cores/ 2>/dev/null; then
+          echo "[coredump-capture] WARNING: could not list crash-bundle/cores/ (directory may be empty or inaccessible)"
+        fi
 
         # ALWAYS bundle symbols + metadata (even if no cores), so we can
         # distinguish "no crash this run" from "capture broken." A metadata-only
@@ -107,38 +115,59 @@ runs:
             exit 0
           fi
           mkdir -p /workspace/crash-bundle/symbols
-          cp -av "$MOJO_BIN" /workspace/crash-bundle/symbols/ 2>/dev/null || true
+          if ! cp -av "$MOJO_BIN" /workspace/crash-bundle/symbols/ 2>/dev/null; then
+            echo "[coredump-capture] WARNING: could not copy mojo binary $MOJO_BIN to symbols/" >> /workspace/crash-bundle/metadata-partial.txt
+          fi
           for so in "$ENV_DIR"/lib/libKGEN*.so "$ENV_DIR"/lib/libAsync*.so "$ENV_DIR"/lib/libMojo*.so "$ENV_DIR"/lib/libMSupport*.so; do
-            [ -e "$so" ] && cp -av "$so" /workspace/crash-bundle/symbols/ 2>/dev/null || true
+            if [ -e "$so" ]; then
+              if ! cp -av "$so" /workspace/crash-bundle/symbols/ 2>/dev/null; then
+                echo "[coredump-capture] WARNING: could not copy $so to symbols/" >> /workspace/crash-bundle/metadata-partial.txt
+              fi
+            fi
           done
           # Bundle gdb itself so the crash can be analyzed offline without
           # needing a matching gdb version installed.
-          GDB_BIN=$(which gdb 2>/dev/null || true)
-          if [ -n "$GDB_BIN" ] && [ -x "$GDB_BIN" ]; then
-            cp -av "$GDB_BIN" /workspace/crash-bundle/symbols/ 2>/dev/null || true
+          if command -v gdb >/dev/null 2>&1; then
+            GDB_BIN=$(command -v gdb)
+            if ! cp -av "$GDB_BIN" /workspace/crash-bundle/symbols/ 2>/dev/null; then
+              echo "[coredump-capture] WARNING: could not copy gdb binary to symbols/" >> /workspace/crash-bundle/metadata-partial.txt
+            fi
+          else
+            echo "[coredump-capture] WARNING: gdb not found in container — offline analysis will require manual gdb install"
           fi
           ls -la /workspace/crash-bundle/symbols/
-        ' || true
+        '
+        if [ $? -ne 0 ]; then
+          echo "[coredump-capture] WARNING: symbol-bundling podman exec failed — crash-bundle/symbols/ may be incomplete"
+        fi
 
         # gdb-mode: collect gdb-*.log and core.gdb.* files written by
         # scripts/mojo-under-gdb.sh when MOJO_TEST_UNDER_GDB=1.
         # These live in crash-bundle/cores/ alongside any kernel cores.
-        ls -la crash-bundle/cores/gdb-*.log 2>/dev/null || true
-        ls -la crash-bundle/cores/core.gdb.* 2>/dev/null || true
+        ls -la crash-bundle/cores/gdb-*.log 2>/dev/null || echo "[coredump-capture] (no gdb-*.log files yet)"
+        ls -la crash-bundle/cores/core.gdb.* 2>/dev/null || echo "[coredump-capture] (no core.gdb.* files yet)"
 
         {
           echo "=== mojo --version ==="
-          podman compose exec -T projectodyssey-dev pixi run mojo --version 2>&1 || true
+          if ! podman compose exec -T projectodyssey-dev pixi run mojo --version 2>&1; then
+            echo "[coredump-capture] WARNING: mojo --version failed (container may be stopped)"
+          fi
           echo "=== uname -a (host) ==="
           uname -a
           echo "=== glibc (host) ==="
           ldd --version | head -1
           echo "=== glibc (container) ==="
-          podman compose exec -T projectodyssey-dev bash -c 'ldd --version | head -1' 2>&1 || true
+          if ! podman compose exec -T projectodyssey-dev bash -c 'ldd --version | head -1' 2>&1; then
+            echo "[coredump-capture] WARNING: could not read glibc version from container"
+          fi
           echo "=== /proc/sys/kernel/core_pattern (host kernel — global) ==="
-          cat /proc/sys/kernel/core_pattern 2>/dev/null
+          if ! cat /proc/sys/kernel/core_pattern 2>/dev/null; then
+            echo "[coredump-capture] WARNING: could not read /proc/sys/kernel/core_pattern"
+          fi
           echo "=== container ulimit -c ==="
-          podman compose exec -T projectodyssey-dev bash -c 'ulimit -c' 2>&1 || true
+          if ! podman compose exec -T projectodyssey-dev bash -c 'ulimit -c' 2>&1; then
+            echo "[coredump-capture] WARNING: could not read ulimit -c from container"
+          fi
           echo "=== Coredumps found in crash-bundle/cores/ ==="
           ls -la crash-bundle/cores/ 2>/dev/null
           echo "=== GDB logs (from mojo-under-gdb.sh) ==="
@@ -153,8 +182,8 @@ runs:
 
         # If no cores (kernel or gdb), still upload the metadata + symbols so
         # the artifact appears in the run (proves the action ran end-to-end).
-        HAVE_CORES=$(ls crash-bundle/cores/core* 2>/dev/null | head -1 || true)
-        HAVE_GDB_LOGS=$(ls crash-bundle/cores/gdb-*.log 2>/dev/null | head -1 || true)
+        HAVE_CORES=$(ls crash-bundle/cores/core* 2>/dev/null | head -1) || HAVE_CORES=""
+        HAVE_GDB_LOGS=$(ls crash-bundle/cores/gdb-*.log 2>/dev/null | head -1) || HAVE_GDB_LOGS=""
         if [ -z "$HAVE_CORES" ] && [ -z "$HAVE_GDB_LOGS" ]; then
           echo "No cores or gdb logs captured this run — uploading metadata + symbols only."
           echo "(If a crash signature appeared in test logs, check that" \

--- a/.github/actions/coredump-capture/action.yml
+++ b/.github/actions/coredump-capture/action.yml
@@ -215,61 +215,51 @@ runs:
           echo "[symbolicate] No cores to symbolicate — skipping."
           exit 0
         fi
-        # Resolve mojo binary path (bundled in symbols/ by the previous step).
-        MOJO_BIN=""
-        if [ -x crash-bundle/symbols/mojo ]; then
-          MOJO_BIN=crash-bundle/symbols/mojo
-        else
-          # Fall back to container's mojo if symbols/ copy failed.
-          MOJO_BIN=$(podman compose exec -T projectodyssey-dev bash -c \
-            'pixi run which mojo 2>/dev/null | tail -1' | tr -d '\r')
-        fi
-        if [ -z "$MOJO_BIN" ] || [ ! -e "$MOJO_BIN" ]; then
-          echo "[symbolicate] Could not resolve mojo binary — skipping."
-          exit 0
-        fi
-        if ! command -v gdb >/dev/null 2>&1; then
-          echo "[symbolicate] gdb not installed on host — installing..."
-          if ! sudo apt-get install -y --no-install-recommends gdb; then
-            echo "[symbolicate] gdb install failed — skipping symbolication." >&2
-            exit 0
-          fi
-        fi
+        # Run gdb INSIDE the container — that's where the mojo binary's path
+        # resolves correctly (host doesn't share the pixi env tree) and where
+        # gdb was already installed for the in-container gdb wrapper.  Cores
+        # are under crash-bundle/cores/ in both namespaces (workspace bind
+        # mount), so we pass relative paths.
         for core in "${CORES[@]}"; do
           base=$(basename "$core")
+          # core paths use the container-side /workspace prefix
+          c_core="/workspace/crash-bundle/cores/$base"
           out="crash-bundle/symbolicated/${base}.symbolicated.log"
           echo "[symbolicate] $core -> $out"
-          {
-            echo "==== $base ===="
-            echo "symbol_binary=$MOJO_BIN"
-            echo "---- Backtrace (top 25 frames) ----"
-            if ! gdb -batch -ex "set pagination off" \
-                  -ex "thread apply 1 bt 25" \
-                  "$MOJO_BIN" "$core" 2>&1 | head -80; then
-              echo "(gdb backtrace exited non-zero — output above)"
-            fi
-            echo "---- Instruction stream around \$pc ----"
-            # Dump:
-            #   - integer + SSE/AVX register state at fault time
-            #   - the current frame info
-            #   - 16 raw instructions before and after $pc
-            #   - a disassembly window of [-64, +64] bytes
-            #   - all-registers (SSE/AVX state for ISA-feature analysis)
-            if ! gdb -batch \
-                  -ex "set pagination off" \
-                  -ex "set print pretty on" \
-                  -ex "info registers" \
-                  -ex "info frame" \
-                  -ex "x/16i \$pc - 30" \
-                  -ex "x/16i \$pc" \
-                  -ex "disassemble \$pc - 64, \$pc + 64" \
-                  -ex "info all-registers" \
-                  "$MOJO_BIN" "$core" 2>&1 | head -400; then
-              echo "(gdb disasm exited non-zero — output above)"
-            fi
-          } > "$out" 2>&1
+          # Single podman exec invocation per core; heredoc carries the gdb
+          # script so we don't have to triple-quote $pc.
+          if ! podman compose exec -T projectodyssey-dev bash <<HEREDOC > "$out" 2>&1
+        set -e
+        MOJO_BIN=\$(pixi run which mojo 2>/dev/null | tail -1)
+        echo "==== ${base} ===="
+        echo "symbol_binary=\$MOJO_BIN"
+        echo "---- Backtrace (top 25 frames) ----"
+        pixi run gdb -batch -ex "set pagination off" \\
+          -ex "thread apply 1 bt 25" \\
+          "\$MOJO_BIN" "${c_core}" 2>&1 | head -80
+        echo "---- Instruction stream around \\\$pc ----"
+        # Dump:
+        #   - integer + SSE/AVX register state at fault time
+        #   - the current frame info
+        #   - 16 raw instructions before and after \$pc
+        #   - a disassembly window of [-64, +64] bytes
+        #   - all-registers (SSE/AVX state for ISA-feature analysis)
+        pixi run gdb -batch \\
+          -ex "set pagination off" \\
+          -ex "set print pretty on" \\
+          -ex "info registers" \\
+          -ex "info frame" \\
+          -ex "x/16i \\\$pc - 30" \\
+          -ex "x/16i \\\$pc" \\
+          -ex "disassemble \\\$pc - 64, \\\$pc + 64" \\
+          -ex "info all-registers" \\
+          "\$MOJO_BIN" "${c_core}" 2>&1 | head -400
+        HEREDOC
+          then
+            echo "[symbolicate] podman exec for $base exited non-zero (see $out)"
+          fi
         done
-        echo "[symbolicate] Wrote $(ls crash-bundle/symbolicated/ | wc -l) log(s)."
+        echo "[symbolicate] Wrote $(ls crash-bundle/symbolicated/ 2>/dev/null | wc -l) log(s)."
         ls -la crash-bundle/symbolicated/
 
     - name: Upload crash bundle

--- a/.github/actions/coredump-capture/action.yml
+++ b/.github/actions/coredump-capture/action.yml
@@ -1,6 +1,6 @@
 name: Coredump Capture
 description: |
-  Enable host-side core_pattern + container ulimit so the libKGEN JIT crash
+  Enable host-side pipe core_pattern + container ulimit so the libKGEN JIT crash
   (modular/modular#6413) produces a real coredump we can attach to gdb.
   After the test job, bundles cores + matching `mojo` binary + relevant
   `.so` files into a `crash-bundle-<job-name>` artifact (14-day retention).
@@ -11,12 +11,23 @@ description: |
 
   The two-step split is implemented via the `phase` input.
 
-  IMPORTANT: `core_pattern` paths are interpreted in the *crashing process's*
-  mount namespace. The crashing `mojo` runs inside `podman compose exec` where
-  the workspace is bind-mounted at `/workspace`. So `core_pattern` must use the
-  container-side path `/workspace/crash-bundle/cores/...`, which the kernel
-  resolves correctly inside the container and which lands on the host at
-  `<runner-cwd>/crash-bundle/cores/...` thanks to the bind mount.
+  DESIGN: pipe-handler core_pattern (not path-based)
+  ===================================================
+  PR #5380 used a path-based core_pattern:
+    /workspace/crash-bundle/cores/core.%p.%e.%t
+
+  Linux docs say the path is resolved in the crashing process's mount
+  namespace.  But with rootless Podman + UID-mapped subuids, the kernel
+  silently wrote nothing: every post-#5380 CI run produced zero ELF cores.
+
+  Solution (this PR): pipe handler sidesteps namespace resolution entirely.
+    core_pattern = |/usr/local/bin/coredump-host-handler.sh %p %e %t %s %P
+
+  The kernel invokes the script as PID 1 of the HOST namespace, piping the
+  core ELF on stdin. The script writes to the host-side path
+    /home/runner/work/ProjectOdyssey/ProjectOdyssey/crash-bundle/cores/
+  which is the actual directory the bind mount maps to — no namespace
+  ambiguity. See scripts/coredump-host-handler.sh for the handler.
 
 inputs:
   phase:
@@ -30,35 +41,36 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Enable core dumps (host kernel + container)
+    - name: Enable core dumps (pipe handler — host kernel)
       if: inputs.phase == 'setup'
       shell: bash
       run: |
         set -x
-        # Host-side dir is bind-mounted into the container at /workspace by
-        # docker-compose.yml (`.:/workspace`). Use the *container* path in
-        # core_pattern so the kernel can resolve it from the crashing process's
-        # mount namespace.
+        # Create the cores dir on the host (the runner workspace).  The handler
+        # script writes here directly — no bind-mount indirection needed.
         mkdir -p crash-bundle/cores
         chmod 1777 crash-bundle/cores
-        echo '/workspace/crash-bundle/cores/core.%p.%e.%t' \
+
+        # Install the pipe handler onto the host so the kernel can exec it.
+        # The handler receives the core ELF on stdin and writes it to the
+        # host-side crash-bundle/cores/ directory.
+        sudo cp scripts/coredump-host-handler.sh /usr/local/bin/coredump-host-handler.sh
+        sudo chmod +x /usr/local/bin/coredump-host-handler.sh
+
+        # Set pipe-mode core_pattern.  Leading '|' is critical — it tells the
+        # kernel to exec the script as PID 1 of the HOST namespace rather than
+        # writing to a path inside the crashing process's mount namespace.
+        echo '|/usr/local/bin/coredump-host-handler.sh %p %e %t %s %P' \
           | sudo tee /proc/sys/kernel/core_pattern
+
         sudo sysctl -w fs.suid_dumpable=2 || true
         sudo systemctl stop apport.service 2>/dev/null || true
         sudo systemctl stop systemd-coredump.socket 2>/dev/null || true
 
-        # Raise core ulimit on the *running* container PID 1 so it propagates
-        # to every subsequent `podman compose exec` (per-exec `ulimit -c` is
-        # transient and does NOT propagate). systemd-style prlimit on PID 1
-        # only works if container has CAP_SYS_RESOURCE; fall back to a sysctl
-        # noop and rely on the in-container `ulimit -c` we re-set just before
-        # the test runs (see test job's pre-test step).
+        # Raise core ulimit inside the container so it propagates to every
+        # subsequent `podman compose exec` session.
         podman compose exec -T projectodyssey-dev bash -c \
           'ulimit -c unlimited && ulimit -a | grep -E "core|file size" || true'
-
-        # Sanity check: confirm host dir is writable from inside the container.
-        podman compose exec -T projectodyssey-dev bash -c \
-          'mkdir -p /workspace/crash-bundle/cores && touch /workspace/crash-bundle/cores/.writable && rm /workspace/crash-bundle/cores/.writable && echo "container: /workspace/crash-bundle/cores writable"'
 
     - name: Collect core dumps + symbols (modular/modular#6413)
       if: inputs.phase == 'collect' && always()
@@ -69,9 +81,9 @@ runs:
         ls -la crash-bundle/cores/ 2>/dev/null || true
 
         # ALWAYS bundle symbols + metadata (even if no cores), so we can
-        # distinguish "no crash this run" from "capture broken." A 564-byte
-        # metadata-only artifact is a positive signal that the action ran;
-        # a missing artifact means the action itself failed.
+        # distinguish "no crash this run" from "capture broken." A metadata-only
+        # artifact is a positive signal that the action ran; a missing artifact
+        # means the action itself failed.
         podman compose exec -T projectodyssey-dev bash -c '
           set +e
           # Resolve pixi env dir from `which mojo` — most reliable path:
@@ -113,14 +125,17 @@ runs:
           ls -la crash-bundle/cores/ 2>/dev/null
           echo "=== Symbols bundled ==="
           ls -la crash-bundle/symbols/ 2>/dev/null
+          echo "=== handler.log (pipe handler invocations) ==="
+          cat crash-bundle/handler.log 2>/dev/null || echo "(no handler.log — handler was not invoked this run)"
         } > crash-bundle/metadata.txt
 
-        # If no cores, still upload the metadata + symbols so the artifact
+        # If no cores, still upload metadata + symbols so the artifact
         # appears in the run (proves the action executed end-to-end).
         if [ -z "$(ls -A crash-bundle/cores/ 2>/dev/null)" ]; then
           echo "No cores captured this run — uploading metadata + symbols only."
-          echo "(If a crash signature appeared in test logs, the capture action " \
-               "is mis-wired: see docs comment in this file.)" \
+          echo "(If a crash appeared in test logs but handler.log is empty," \
+               "the pipe core_pattern may not have been reached — check" \
+               "suid_dumpable and ulimit -c inside the container.)" \
                >> crash-bundle/metadata.txt
         fi
 

--- a/.github/actions/setup-container/action.yml
+++ b/.github/actions/setup-container/action.yml
@@ -29,7 +29,9 @@ runs:
     - name: Start Podman socket
       shell: bash
       run: |
-        systemctl --user start podman.socket || true
+        if ! systemctl --user start podman.socket; then
+          echo "[setup-container] WARNING: could not start podman.socket — rootless Podman may not be available"
+        fi
         export DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock
         echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
 
@@ -61,7 +63,14 @@ runs:
         # entrypoint's pixi-info probe finds mojo already installed.
         # The volume name is prefixed with the Compose project name.
         VOLUME_NAME="projectodyssey_pixi-cache"
-        podman volume create "$VOLUME_NAME" 2>/dev/null || true
+        # Create the volume if it does not already exist.
+        # `podman volume create` exits non-zero if the volume already exists,
+        # so we check first to avoid masking real storage errors.
+        if ! podman volume inspect "$VOLUME_NAME" >/dev/null 2>&1; then
+          podman volume create "$VOLUME_NAME"
+        else
+          echo "[setup-container] Volume $VOLUME_NAME already exists — skipping create"
+        fi
         # Check if already seeded (any mojo binary present under the volume)
         SEEDED=$(podman run --rm \
           --user root \
@@ -94,7 +103,18 @@ runs:
         # symlink `.pixi/envs` during `pixi install` — racing this chmod
         # caused intermittent "Permission denied" failures on CI runs that
         # bypassed the pixi-cache seed.
-        chmod -R a+rwX . || true
+        # Some files may be owned by container UIDs from previous Podman UID-mapped
+        # writes.  chmod fails on those; capture and report errors without aborting so
+        # the failure is visible rather than silently swallowed.
+        chmod_errors=$(mktemp)
+        chmod -R a+rwX . 2>"$chmod_errors" || true
+        err_count=$(wc -l < "$chmod_errors")
+        if [ "$err_count" -gt 0 ]; then
+          echo "[setup-container] WARNING: chmod failed on $err_count file(s); first 5 errors:"
+          head -5 "$chmod_errors"
+          echo "[setup-container] Fix: sudo chown -R $(id -u):$(id -g) ."
+        fi
+        rm -f "$chmod_errors"
 
     - name: Start container
       shell: bash

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -52,12 +52,15 @@ jobs:
 
       - name: Enforce no .__matmul__() call sites
         run: |
+          # grep exits 1 when no lines match — that is the success case.
+          set +e
           violations=$(grep -rn '\.__matmul__(' . \
             --include='*.mojo' --include='*.🔥' \
             --exclude-dir='.pixi' --exclude-dir='.git' \
             | grep -v 'fn __matmul__(' \
             | grep -v '# __matmul__' \
-            | grep -v '__matmul__.*deprecated' || true)
+            | grep -v '__matmul__.*deprecated')
+          set -e
           if [ -n "$violations" ]; then
             echo "::error::Found .__matmul__() call sites (use matmul(A, B) instead):"
             echo "$violations"
@@ -182,7 +185,11 @@ jobs:
           # Scan project dependencies. pip-audit results are advisory (findings in the
           # runner environment such as pip itself do not reflect project risk).
           pip install setuptools wheel
-          pip install -e . --no-deps || true
+          # pip install -e . may fail if pyproject.toml has no install target;
+          # that is acceptable since pip-audit uses --skip-editable anyway.
+          if ! pip install -e . --no-deps 2>/dev/null; then
+            echo "::notice::pip install -e . --no-deps failed — using --skip-editable for pip-audit"
+          fi
           pip-audit --skip-editable || echo "::warning::pip-audit found vulnerabilities — review manually"
 
       - name: Post pip-audit summary

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -263,7 +263,10 @@ jobs:
             echo "❌ Failed to get container ID"
             exit 1
           fi
-          podman cp "$CONTAINER_ID:/tmp/benchmark-results/simd-output.txt" "benchmark-results/simd-output.txt" 2>/dev/null || true
+          # If the benchmark did not produce output (e.g., test was skipped), log it rather than silently continuing.
+          if ! podman cp "$CONTAINER_ID:/tmp/benchmark-results/simd-output.txt" "benchmark-results/simd-output.txt" 2>/dev/null; then
+            echo "::warning::Could not copy simd-output.txt from container — benchmark may have been skipped or crashed"
+          fi
 
       - name: Generate benchmark summary
         if: success()

--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -241,6 +241,14 @@ jobs:
     # Deterministic local reproducer: ulimit -v 3500000 && mojo run hello.mojo
     timeout-minutes: 120
     name: "Comprehensive Mojo Tests"
+    env:
+      # Route mojo test invocations through gdb to intercept the in-process
+      # SIGABRT handler in libKGEN (modular/modular#6413) before it swallows
+      # the crash. Without gdb, the kernel never generates a core because the
+      # process handles SIGABRT itself and exits cleanly.
+      # Set to "0" locally to skip gdb overhead (default when unset).
+      MOJO_TEST_UNDER_GDB: "1"
+      CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
       - name: Checkout code
@@ -444,6 +452,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: "Configs"
+    env:
+      MOJO_TEST_UNDER_GDB: "1"
+      CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     strategy:
       fail-fast: false
@@ -500,6 +511,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: "Benchmarks"
+    env:
+      MOJO_TEST_UNDER_GDB: "1"
+      CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
       - name: Checkout code
@@ -543,6 +557,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: "Core Layers"
+    env:
+      MOJO_TEST_UNDER_GDB: "1"
+      CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
       - name: Checkout code
@@ -826,6 +843,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: "Gradient Checking Tests"
+    env:
+      MOJO_TEST_UNDER_GDB: "1"
+      CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
       - name: Checkout code
@@ -953,6 +973,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: "Data Utilities Test Suite"
+    env:
+      MOJO_TEST_UNDER_GDB: "1"
+      CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
       - name: Checkout code

--- a/.github/workflows/extract-cached-image.yml
+++ b/.github/workflows/extract-cached-image.yml
@@ -1,0 +1,119 @@
+name: Extract Cached Container Image
+
+# Forensic helper: pull the GHA-cached `podman save` tarball for this branch's
+# setup-container key and upload it as a workflow artifact.  Used to extract
+# the "bad" image suspected of triggering modular/modular#6413 so we can run
+# it locally and confirm whether the bug lives in the cached pixi-install
+# bytes (vs Mojo source codegen).
+#
+# Manual dispatch only; no automatic trigger.  Uses the same cache key as
+# .github/actions/setup-container/action.yml so it lands on whichever tar
+# the upstream test job would have used.
+
+on:
+  workflow_dispatch:
+    inputs:
+      key_hash_override:
+        description: >
+          Override the hashFiles(Dockerfile, pixi.toml, pixi.lock) value
+          to pin to a specific cache.  Leave blank to compute fresh.
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  extract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      # Route the user-supplied override through env: to avoid command
+      # injection (security_reminder_hook flagged this if interpolated
+      # directly into a run: block).
+      KEY_HASH_OVERRIDE: ${{ inputs.key_hash_override }}
+      DOCKERFILE_HASH: ${{ hashFiles('Dockerfile', 'pixi.toml', 'pixi.lock') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
+        with:
+          fetch-depth: 1
+
+      - name: Export runner UID
+        id: uid
+        run: echo "user_id=$(id -u)" >> "$GITHUB_OUTPUT"
+
+      - name: Compute cache key
+        id: key
+        env:
+          UID_VAL: ${{ steps.uid.outputs.user_id }}
+        run: |
+          if [ -n "${KEY_HASH_OVERRIDE}" ]; then
+            hash="${KEY_HASH_OVERRIDE}"
+          else
+            hash="${DOCKERFILE_HASH}"
+          fi
+          key="container-image-uid${UID_VAL}-${hash}"
+          echo "key=${key}" >> "$GITHUB_OUTPUT"
+          echo "Resolved cache key: ${key}"
+
+      - name: Restore cached image tar
+        id: cache
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57  # v4
+        with:
+          path: /tmp/podman-image-cache
+          key: ${{ steps.key.outputs.key }}
+
+      - name: Report cache state
+        env:
+          CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+          CACHE_KEY: ${{ steps.key.outputs.key }}
+        run: |
+          if [ "${CACHE_HIT}" = "true" ]; then
+            echo "::notice::cache hit on $(date -Iseconds) for key ${CACHE_KEY}"
+            if ! ls -la /tmp/podman-image-cache/; then
+              echo "warn: could not list cache dir" >&2
+            fi
+            if [ -f /tmp/podman-image-cache/dev.tar ]; then
+              SIZE=$(stat -c %s /tmp/podman-image-cache/dev.tar)
+              echo "::notice::image tar size: ${SIZE} bytes ($((SIZE / 1024 / 1024)) MB)"
+              sha256sum /tmp/podman-image-cache/dev.tar
+            fi
+          else
+            echo "::error::cache MISS for key ${CACHE_KEY}"
+            echo "(Either the key changed or the entry was evicted.)"
+            exit 1
+          fi
+
+      - name: Bundle metadata
+        env:
+          CACHE_KEY: ${{ steps.key.outputs.key }}
+          UID_VAL: ${{ steps.uid.outputs.user_id }}
+          HEAD_REF: ${{ github.ref }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          mkdir -p extract-bundle
+          cp /tmp/podman-image-cache/dev.tar extract-bundle/dev.tar
+          {
+            echo "=== Extracted by extract-cached-image.yml on $(date -Iseconds) ==="
+            echo "cache key:    ${CACHE_KEY}"
+            echo "ref:          ${HEAD_REF}"
+            echo "head sha:     ${HEAD_SHA}"
+            echo "runner uid:   ${UID_VAL}"
+            echo "tar size:     $(stat -c %s extract-bundle/dev.tar) bytes"
+            echo "tar sha256:   $(sha256sum extract-bundle/dev.tar | awk '{print $1}')"
+            echo
+            echo "=== Source file hashes that feed the cache key ==="
+            for f in Dockerfile pixi.toml pixi.lock; do
+              echo "${f}  sha256:  $(sha256sum "${f}" | awk '{print $1}')"
+            done
+          } > extract-bundle/manifest.txt
+          cat extract-bundle/manifest.txt
+
+      - name: Upload image tar artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: container-image-${{ steps.key.outputs.key }}
+          path: extract-bundle/
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/extract-cached-image.yml
+++ b/.github/workflows/extract-cached-image.yml
@@ -32,7 +32,6 @@ jobs:
       # injection (security_reminder_hook flagged this if interpolated
       # directly into a run: block).
       KEY_HASH_OVERRIDE: ${{ inputs.key_hash_override }}
-      DOCKERFILE_HASH: ${{ hashFiles('Dockerfile', 'pixi.toml', 'pixi.lock') }}
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
@@ -47,6 +46,7 @@ jobs:
         id: key
         env:
           UID_VAL: ${{ steps.uid.outputs.user_id }}
+          DOCKERFILE_HASH: ${{ hashFiles('Dockerfile', 'pixi.toml', 'pixi.lock') }}
         run: |
           if [ -n "${KEY_HASH_OVERRIDE}" ]; then
             hash="${KEY_HASH_OVERRIDE}"

--- a/.github/workflows/model-e2e-tests-weekly.yml
+++ b/.github/workflows/model-e2e-tests-weekly.yml
@@ -42,7 +42,7 @@ jobs:
           mkdir -p test-results
 
           # Collect model test directories
-          MODEL_DIRS=$(find tests/models -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort || true)
+          MODEL_DIRS=$(find tests/models -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort) || MODEL_DIRS=""
 
           if [ -z "$MODEL_DIRS" ]; then
             echo "No model test directories found under tests/models/ -- skipping"

--- a/.github/workflows/paper-validation.yml
+++ b/.github/workflows/paper-validation.yml
@@ -60,7 +60,7 @@ jobs:
           fi
 
           # Find all paper directories (contains metadata.yml)
-          PAPER_DIRS=$(find papers -name "metadata.yml" -exec dirname {} \; 2>/dev/null || true)
+          PAPER_DIRS=$(find papers -name "metadata.yml" -exec dirname {} \; 2>/dev/null) || PAPER_DIRS=""
 
           if [ -z "$PAPER_DIRS" ]; then
             echo "⚠️  No paper implementations found yet"
@@ -180,7 +180,7 @@ jobs:
           fi
 
           # Find all paper implementations
-          PAPER_DIRS=$(find papers -name "metadata.yml" -exec dirname {} \; 2>/dev/null || true)
+          PAPER_DIRS=$(find papers -name "metadata.yml" -exec dirname {} \; 2>/dev/null) || PAPER_DIRS=""
 
           if [ -z "$PAPER_DIRS" ]; then
             echo "⚠️  No paper implementations found yet"
@@ -235,7 +235,7 @@ jobs:
           fi
 
           # Find all paper test directories
-          PAPER_DIRS=$(find papers -name "metadata.yml" -exec dirname {} \; 2>/dev/null || true)
+          PAPER_DIRS=$(find papers -name "metadata.yml" -exec dirname {} \; 2>/dev/null) || PAPER_DIRS=""
 
           if [ -z "$PAPER_DIRS" ]; then
             echo "⚠️  No paper implementations found yet"
@@ -249,12 +249,16 @@ jobs:
 
               # Run Python tests if they exist
               if [ -n "$(find "$paper_dir/tests" -name 'test_*.py' 2>/dev/null)" ]; then
-                podman compose exec -T projectodyssey-dev bash -c "pixi run pytest $paper_dir/tests --verbose" || true
+                if ! podman compose exec -T projectodyssey-dev bash -c "pixi run pytest $paper_dir/tests --verbose"; then
+                echo "::warning::pytest failed for $paper_dir/tests"
+              fi
               fi
 
               # Run Mojo tests if they exist
               if [ -n "$(find "$paper_dir/tests" -name 'test_*.mojo' 2>/dev/null)" ]; then
-                podman compose exec -T projectodyssey-dev bash -c "pixi run mojo test -I . $paper_dir/tests --verbose" || true
+                if ! podman compose exec -T projectodyssey-dev bash -c "pixi run mojo test -I . $paper_dir/tests --verbose"; then
+                echo "::warning::mojo test failed for $paper_dir/tests"
+              fi
               fi
             fi
           done
@@ -292,7 +296,7 @@ jobs:
           fi
 
           # Find all paper directories with training scripts
-          PAPER_DIRS=$(find papers -name "train.py" -o -name "train.mojo" -exec dirname {} \; 2>/dev/null || true)
+          PAPER_DIRS=$(find papers -name "train.py" -o -name "train.mojo" -exec dirname {} \; 2>/dev/null) || PAPER_DIRS=""
 
           if [ -z "$PAPER_DIRS" ]; then
             echo "⚠️  No training scripts found yet"
@@ -305,9 +309,13 @@ jobs:
 
             # Run training script with quick validation mode
             if [ -f "$paper_dir/train.py" ]; then
-              podman compose exec -T projectodyssey-dev bash -c "pixi run python $paper_dir/train.py --quick-validation --epochs 1" || true
+              if ! podman compose exec -T projectodyssey-dev bash -c "pixi run python $paper_dir/train.py --quick-validation --epochs 1"; then
+                echo "::warning::Training script failed for $paper_dir/train.py"
+              fi
             elif [ -f "$paper_dir/train.mojo" ]; then
-              podman compose exec -T projectodyssey-dev bash -c "pixi run mojo -I . $paper_dir/train.mojo --quick-validation --epochs 1" || true
+              if ! podman compose exec -T projectodyssey-dev bash -c "pixi run mojo -I . $paper_dir/train.mojo --quick-validation --epochs 1"; then
+                echo "::warning::Training script failed for $paper_dir/train.mojo"
+              fi
             fi
           done
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -59,10 +59,13 @@ jobs:
 
       - name: Enforce no .__matmul__() call sites
         run: |
+          # grep exits 1 when no lines match — that is the success case.
+          set +e
           violations=$(grep -rn '\.__matmul__(' . --include='*.mojo' --include='*.🔥' \
             --exclude-dir='.pixi' --exclude-dir='.git' \
             | grep -v 'fn __matmul__(' | grep -v '# __matmul__' \
-            | grep -v '__matmul__.*deprecated' || true)
+            | grep -v '__matmul__.*deprecated')
+          set -e
           if [ -n "$violations" ]; then
             echo "Found .__matmul__() call sites (use matmul(A, B) instead):"
             echo "$violations"

--- a/.github/workflows/probe-cpu-on-gha.yml
+++ b/.github/workflows/probe-cpu-on-gha.yml
@@ -65,10 +65,15 @@ jobs:
           path: /tmp/podman-image-cache
           key: ${{ steps.key.outputs.key }}
 
-      - name: Skip Mojo probe if cache miss
+      - name: Hard fail if cache miss
         if: steps.cache.outputs.cache-hit != 'true'
+        env:
+          CACHE_KEY: ${{ steps.key.outputs.key }}
         run: |
-          echo "::warning::No cached container image — Mojo probe skipped. (Run extract-cached-image.yml or comprehensive-tests first.)"
+          echo "[probe-cpu-on-gha] ERROR: no cached container image" >&2
+          echo "  expected key: ${CACHE_KEY}" >&2
+          echo "  run extract-cached-image.yml or comprehensive-tests on this branch first" >&2
+          exit 1
 
       - name: Start podman socket + load image
         if: steps.cache.outputs.cache-hit == 'true'

--- a/.github/workflows/probe-cpu-on-gha.yml
+++ b/.github/workflows/probe-cpu-on-gha.yml
@@ -1,0 +1,103 @@
+name: Probe CPU Features on GHA
+
+# Runs three orthogonal CPU-feature probes on a GHA `ubuntu-latest` runner:
+# 1. /proc/cpuinfo flags (kernel-mediated view)
+# 2. C probe: direct cpuid + xgetbv + __builtin_cpu_supports
+# 3. Mojo probe: sys.info.has_avx512f() etc.
+#
+# Goal for modular/modular#6413: prove (or disprove) that Mojo's CPU
+# detection sees AVX-512 silicon on a host where the kernel-mediated view
+# does not. The crash signatures + AMD EPYC 9V74 Zen 4 hypervisor topology
+# imply this is the bug; this workflow makes the proof concrete.
+#
+# Manual dispatch only.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
+        with:
+          fetch-depth: 1
+
+      - name: Kernel-mediated CPU view (/proc/cpuinfo + lscpu + getauxval)
+        run: |
+          echo "════════════════════ /proc/cpuinfo first CPU (host) ════════════════════"
+          awk '/^processor/{c++; if(c>1)exit} {print}' /proc/cpuinfo
+          echo
+          echo "════════════════════ Relevant flag filter (kernel view) ════════════════════"
+          grep -m1 ^flags /proc/cpuinfo | tr ' ' '\n' \
+            | grep -E '^(avx512[a-z0-9_]*|avx_vnni|avx|avx2|fma|f16c|sse4_[12]|vaes|sha_ni|movdir64b|gfni|vpclmulqdq|serialize|amx_)$' \
+            | sort -u | tr '\n' ' '
+          echo
+          echo
+          echo "════════════════════ lscpu (host) ════════════════════"
+          lscpu
+
+      - name: Build + run C probe (direct cpuid + xgetbv + __builtin_cpu_supports)
+        run: |
+          gcc -O2 -o /tmp/cpu_features_probe \
+            repro/cpuid-probes/cpu_features_probe.c
+          /tmp/cpu_features_probe
+
+      - name: Compute cache key
+        id: key
+        env:
+          DOCKERFILE_HASH: ${{ hashFiles('Dockerfile', 'pixi.toml', 'pixi.lock') }}
+        run: |
+          UID_VAL=$(id -u)
+          key="container-image-uid${UID_VAL}-${DOCKERFILE_HASH}"
+          echo "Cache key: ${key}"
+          echo "key=${key}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached container image
+        id: cache
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57  # v4
+        with:
+          path: /tmp/podman-image-cache
+          key: ${{ steps.key.outputs.key }}
+
+      - name: Skip Mojo probe if cache miss
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          echo "::warning::No cached container image — Mojo probe skipped. (Run extract-cached-image.yml or comprehensive-tests first.)"
+
+      - name: Start podman socket + load image
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: |
+          if ! systemctl --user start podman.socket; then
+            echo "warn: 'systemctl --user start podman.socket' failed (may already be running)" >&2
+          fi
+          echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+          podman load -i /tmp/podman-image-cache/dev.tar
+
+      - name: Mojo sys.info probe inside container
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: |
+          podman run --rm --userns=keep-id \
+            -v "$(pwd):/workspace:Z" -w /workspace \
+            --ulimit core=-1 \
+            projectodyssey:dev \
+            bash -c '
+              echo "════════════════════ /proc/cpuinfo flags (inside container) ════════════════════"
+              grep -m1 ^flags /proc/cpuinfo | tr " " "\n" \
+                | grep -E "^(avx512[a-z0-9_]*|avx_vnni|avx|avx2|fma|f16c|sse4_[12]|vaes|sha_ni)$" \
+                | sort -u | tr "\n" " "
+              echo
+              echo
+              echo "════════════════════ Mojo sys.info CPU detection ════════════════════"
+              pixi run mojo run repro/cpuid-probes/probe_cpu.mojo
+            '
+
+      - name: Summary
+        run: |
+          echo "::notice::Three views captured: kernel /proc/cpuinfo, direct cpuid via C, Mojo sys.info."
+          echo "::notice::If C probe shows cpuid(7,0).ebx[16] (AVX-512F) = 1 AND xgetbv[5..7] = 0 AND Mojo has_avx512f() = True, the bug is confirmed: Mojo reads silicon CPUID without checking OS-enabled XCR0."

--- a/.github/workflows/probe-cpu-on-gha.yml
+++ b/.github/workflows/probe-cpu-on-gha.yml
@@ -13,7 +13,15 @@ name: Probe CPU Features on GHA
 # Manual dispatch only.
 
 on:
+  # Manual dispatch + auto-trigger on commits to the bisect branch only.
+  # Once PR #5399 merges, the trigger should be tightened or removed.
   workflow_dispatch:
+  push:
+    branches:
+      - bisect/6413-positive-control
+    paths:
+      - '.github/workflows/probe-cpu-on-gha.yml'
+      - 'repro/cpuid-probes/**'
 
 permissions:
   contents: read

--- a/.github/workflows/probe-cpu-on-gha.yml
+++ b/.github/workflows/probe-cpu-on-gha.yml
@@ -92,7 +92,7 @@ jobs:
           echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
           podman load -i /tmp/podman-image-cache/dev.tar
 
-      - name: Mojo sys.info probe inside container
+      - name: Mojo --print-effective-target (driver-resolved target CPU + features)
         if: steps.cache.outputs.cache-hit == 'true'
         run: |
           podman run --rm --userns=keep-id \
@@ -106,11 +106,17 @@ jobs:
                 | sort -u | tr "\n" " "
               echo
               echo
-              echo "════════════════════ Mojo sys.info CPU detection ════════════════════"
-              pixi run mojo run repro/cpuid-probes/probe_cpu.mojo
+              echo "════════════════════ mojo build --print-effective-target ════════════════════"
+              # Use any .mojo file; the resolved target is host-derived, file-content-independent.
+              pixi run mojo build --print-effective-target repro/repro_6413_python_import_os.mojo
+              echo
+              echo "════════════════════ mojo --version ════════════════════"
+              pixi run mojo --version
             '
 
       - name: Summary
         run: |
-          echo "::notice::Three views captured: kernel /proc/cpuinfo, direct cpuid via C, Mojo sys.info."
-          echo "::notice::If C probe shows cpuid(7,0).ebx[16] (AVX-512F) = 1 AND xgetbv[5..7] = 0 AND Mojo has_avx512f() = True, the bug is confirmed: Mojo reads silicon CPUID without checking OS-enabled XCR0."
+          echo "Diagnostic captured: /proc/cpuinfo (kernel view), direct cpuid+xgetbv (C probe), and mojo build --print-effective-target."
+          echo "Compare across hosts:"
+          echo "  - if mojo --target-features includes +avx512* on a host where cpuid(7,0).ebx[16]=0, that's the source-side bug"
+          echo "  - if mojo --target-cpu is znver4 (or any -avx512 model) despite no avx512 in cpuid, that's the same bug at the name layer"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,7 +298,8 @@ jobs:
 
             # Try to import the package
             echo "Verifying package import..."
-            python -c "import sys; print('Python version:', sys.version)" || true
+            # Verification import — if this fails the wheel is broken and we need to know.
+            python -c "import sys; print('Python version:', sys.version)"
           else
             echo "⚠️  No Python wheel packages to test"
           fi

--- a/.github/workflows/repro-bare-command-on-gha.yml
+++ b/.github/workflows/repro-bare-command-on-gha.yml
@@ -14,12 +14,20 @@ name: Repro 6413 Bare Command on GHA
 # rebuild) and runs both reproducers.
 
 on:
+  # Manual dispatch + auto-trigger on commits to the bisect branch only.
+  # Once PR #5399 merges, the trigger should be tightened or removed.
   workflow_dispatch:
     inputs:
       iterations:
         description: "How many times to run each reproducer"
         required: false
         default: "1"
+  push:
+    branches:
+      - bisect/6413-positive-control
+    paths:
+      - '.github/workflows/repro-bare-command-on-gha.yml'
+      - 'repro/repro_6413_*.mojo'
 
 permissions:
   contents: read

--- a/.github/workflows/repro-bare-command-on-gha.yml
+++ b/.github/workflows/repro-bare-command-on-gha.yml
@@ -1,0 +1,133 @@
+name: Repro 6413 Bare Command on GHA
+
+# Run the EXACT same `podman run` command we're testing locally, on a GHA
+# Azure runner, to confirm the command shape matters less than the
+# environment. Loads the same dev.tar that gets uploaded by
+# extract-cached-image.yml, mounts the workspace the same way, runs the same
+# `pixi run mojo run repro/...mojo` invocations.
+#
+# Hypothesis: if the GHA runner crashes here AND the local hosts don't, the
+# variable is the runner CPU/hypervisor — same image, same command, same
+# binary, just different silicon underneath.
+#
+# Manual dispatch only. Pulls the cached image fresh from the GHA cache (no
+# rebuild) and runs both reproducers.
+
+on:
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: "How many times to run each reproducer"
+        required: false
+        default: "1"
+
+permissions:
+  contents: read
+
+jobs:
+  bare-repro:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # Route user input through env: to avoid command injection.
+      ITERATIONS: ${{ inputs.iterations }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
+        with:
+          fetch-depth: 1
+
+      - name: Export runner UID
+        id: uid
+        run: echo "user_id=$(id -u)" >> "$GITHUB_OUTPUT"
+
+      - name: Compute cache key (same as setup-container)
+        id: key
+        env:
+          UID_VAL: ${{ steps.uid.outputs.user_id }}
+          DOCKERFILE_HASH: ${{ hashFiles('Dockerfile', 'pixi.toml', 'pixi.lock') }}
+        run: |
+          key="container-image-uid${UID_VAL}-${DOCKERFILE_HASH}"
+          echo "key=${key}" >> "$GITHUB_OUTPUT"
+          echo "Resolved cache key: ${key}"
+
+      - name: Restore cached image tar
+        id: cache
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57  # v4
+        with:
+          path: /tmp/podman-image-cache
+          key: ${{ steps.key.outputs.key }}
+
+      - name: Report cache state
+        env:
+          CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+          CACHE_KEY: ${{ steps.key.outputs.key }}
+        run: |
+          if [ "${CACHE_HIT}" = "true" ]; then
+            echo "::notice::cache hit for key ${CACHE_KEY}"
+            SIZE=$(stat -c %s /tmp/podman-image-cache/dev.tar 2>/dev/null || echo "?")
+            echo "::notice::image tar size: ${SIZE} bytes"
+            sha256sum /tmp/podman-image-cache/dev.tar
+          else
+            echo "::error::cache MISS for key ${CACHE_KEY}"
+            echo "(no prior setup-container run cached this key)"
+            exit 1
+          fi
+
+      - name: Show runner CPU info
+        run: |
+          echo "=== runner uname ==="
+          uname -a
+          echo
+          echo "=== runner /proc/cpuinfo first CPU ==="
+          awk '/^processor/{c++; if(c>1)exit} {print}' /proc/cpuinfo
+          echo
+          echo "=== runner relevant flags ==="
+          grep -m1 flags /proc/cpuinfo | tr ' ' '\n' \
+            | grep -E '^(avx512[a-z_0-9]*|avx_vnni|avx|fma|f16c|sse4_[12]|vaes|sha_ni|movdir64b|gfni|vpclmulqdq|serialize)$' \
+            | sort -u | tr '\n' ' '
+          echo
+
+      - name: Start podman socket
+        run: |
+          if ! systemctl --user start podman.socket; then
+            echo "warn: 'systemctl --user start podman.socket' failed (may already be running)" >&2
+          fi
+          echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+
+      - name: Load image from cache tar
+        run: |
+          podman load -i /tmp/podman-image-cache/dev.tar
+          podman images projectodyssey:dev
+
+      - name: Run Site B reproducer (Python.import_module) — bare command
+        run: |
+          set +e
+          for i in $(seq 1 "${ITERATIONS}"); do
+            echo "════════ Site B iteration ${i}/${ITERATIONS} ════════"
+            podman run --rm --userns=keep-id \
+              -v "$(pwd):/workspace:Z" -w /workspace \
+              --ulimit core=-1 \
+              projectodyssey:dev \
+              bash -c 'pixi run mojo run repro/repro_6413_python_import_os.mojo 2>&1'
+            EXIT=$?
+            echo "--- iteration ${i} exit=${EXIT} ---"
+          done
+
+      - name: Run Site A reproducer (assert_almost_equal) — bare command
+        run: |
+          set +e
+          for i in $(seq 1 "${ITERATIONS}"); do
+            echo "════════ Site A iteration ${i}/${ITERATIONS} ════════"
+            podman run --rm --userns=keep-id \
+              -v "$(pwd):/workspace:Z" -w /workspace \
+              --ulimit core=-1 \
+              projectodyssey:dev \
+              bash -c 'pixi run mojo run -I /workspace repro/repro_6413_assert_almost_equal.mojo 2>&1'
+            EXIT=$?
+            echo "--- iteration ${i} exit=${EXIT} ---"
+          done
+
+      - name: Summary
+        run: |
+          echo "::notice::repro complete. If any iteration crashed with SIGILL, the bug is reproducible with the bare podman command on a GHA runner — confirming the variable is the runner CPU, not the test harness."

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -241,7 +241,9 @@ jobs:
                 FOUND=$(jq '.vulnerabilities | length' "safety-${file//\//-}.json" 2>/dev/null || echo "0")
                 VULN_COUNT=$((VULN_COUNT + FOUND))
                 echo "⚠️ Found $FOUND vulnerabilities" >> safety-report.md
-                jq -r '.vulnerabilities[] | "- **\(.package_name)** \(.vulnerable_versions): \(.advisory)"' "safety-${file//\//-}.json" >> safety-report.md 2>/dev/null || true
+                if ! jq -r '.vulnerabilities[] | "- **\(.package_name)** \(.vulnerable_versions): \(.advisory)"' "safety-${file//\//-}.json" >> safety-report.md 2>/dev/null; then
+                  echo "::notice::jq could not parse vulnerabilities from safety-${file//\//-}.json" >> safety-report.md
+                fi
               fi
               echo "" >> safety-report.md
             fi
@@ -257,7 +259,10 @@ jobs:
           echo "## pip-audit Scan Results" > pip-audit-report.md
           echo "" >> pip-audit-report.md
 
-          pip install -r requirements.txt -r requirements-dev.txt 2>/dev/null || true
+          # requirements files may not exist in this repo; log if absent.
+          if ! pip install -r requirements.txt -r requirements-dev.txt 2>/dev/null; then
+            echo "::notice::pip install from requirements files failed (files may not exist) — pip-audit will scan environment packages"
+          fi
 
           if pip-audit --format json --output pip-audit.json 2>/dev/null; then
             echo "✅ No vulnerabilities found" >> pip-audit-report.md
@@ -266,7 +271,9 @@ jobs:
             COUNT=$(jq '. | length' pip-audit.json 2>/dev/null || echo "0")
             echo "⚠️ Found $COUNT vulnerabilities" >> pip-audit-report.md
             echo "count=$COUNT" >> "$GITHUB_OUTPUT"
-            jq -r '.[] | "- **\(.name)** \(.version): \(.vulns[0].id // \"Unknown\")"' pip-audit.json >> pip-audit-report.md 2>/dev/null || true
+            if ! jq -r '.[] | "- **\(.name)** \(.version): \(.vulns[0].id // \"Unknown\")"' pip-audit.json >> pip-audit-report.md 2>/dev/null; then
+              echo "::notice::jq could not parse pip-audit.json for report" >> pip-audit-report.md
+            fi
           fi
         continue-on-error: true
 
@@ -402,7 +409,10 @@ jobs:
 
       - name: Check licenses
         run: |
-          pip install -r requirements.txt -r requirements-dev.txt 2>/dev/null || true
+          # requirements files may not exist in this repo; log if absent.
+          if ! pip install -r requirements.txt -r requirements-dev.txt 2>/dev/null; then
+            echo "::notice::pip install from requirements files failed for license check (files may not exist)"
+          fi
 
           echo "## License Audit Report" > license-report.md
           echo "" >> license-report.md
@@ -414,7 +424,11 @@ jobs:
           echo "### License Compliance" >> license-report.md
           echo "" >> license-report.md
 
-          PROBLEMATIC=$(pip-licenses --fail-on="GPL-3.0;AGPL-3.0" 2>&1 || true)
+          # pip-licenses --fail-on exits non-zero when problematic licenses are found;
+          # that exit code IS the detection signal, so we capture output without aborting.
+          set +e
+          PROBLEMATIC=$(pip-licenses --fail-on="GPL-3.0;AGPL-3.0" 2>&1)
+          set -e
           if echo "$PROBLEMATIC" | grep -q "fail"; then
             echo "⚠️ Potentially problematic licenses detected" >> license-report.md
           else

--- a/.github/workflows/validate-configs.yml
+++ b/.github/workflows/validate-configs.yml
@@ -431,7 +431,9 @@ jobs:
             exit 0
           fi
 
-          PAPER_DIRS=$(find papers -name "metadata.yml" -exec dirname {} \; 2>/dev/null || true)
+          # find exits 0 even when no results; 2>/dev/null suppresses ENOENT on papers/ subdirs.
+          # The papers/ existence check above already handles the missing-dir case.
+          PAPER_DIRS=$(find papers -name "metadata.yml" -exec dirname {} \; 2>/dev/null) || PAPER_DIRS=""
 
           if [ -z "$PAPER_DIRS" ]; then
             echo "No paper implementations found yet"
@@ -490,7 +492,9 @@ jobs:
             exit 0
           fi
 
-          PAPER_DIRS=$(find papers -name "metadata.yml" -exec dirname {} \; 2>/dev/null || true)
+          # find exits 0 even when no results; 2>/dev/null suppresses ENOENT on papers/ subdirs.
+          # The papers/ existence check above already handles the missing-dir case.
+          PAPER_DIRS=$(find papers -name "metadata.yml" -exec dirname {} \; 2>/dev/null) || PAPER_DIRS=""
 
           if [ -z "$PAPER_DIRS" ]; then
             echo "No paper implementations found yet"
@@ -543,7 +547,8 @@ jobs:
             exit 0
           fi
 
-          PAPER_DIRS=$(find papers -name "train.py" -o -name "train.mojo" -exec dirname {} \; 2>/dev/null || true)
+          # find exits 0 even when no results; use || PAPER_DIRS="" to handle find errors explicitly.
+          PAPER_DIRS=$(find papers -name "train.py" -o -name "train.mojo" -exec dirname {} \; 2>/dev/null) || PAPER_DIRS=""
 
           if [ -z "$PAPER_DIRS" ]; then
             echo "No training scripts found yet"
@@ -553,9 +558,13 @@ jobs:
           for paper_dir in $PAPER_DIRS; do
             echo "Running training for: $paper_dir"
             if [ -f "$paper_dir/train.py" ]; then
-              podman compose exec -T projectodyssey-dev bash -c "pixi run python $paper_dir/train.py --quick-validation --epochs 1" || true
+              if ! podman compose exec -T projectodyssey-dev bash -c "pixi run python $paper_dir/train.py --quick-validation --epochs 1"; then
+                echo "::warning::Training script failed for $paper_dir/train.py"
+              fi
             elif [ -f "$paper_dir/train.mojo" ]; then
-              podman compose exec -T projectodyssey-dev bash -c "pixi run mojo -I . $paper_dir/train.mojo --quick-validation --epochs 1" || true
+              if ! podman compose exec -T projectodyssey-dev bash -c "pixi run mojo -I . $paper_dir/train.mojo --quick-validation --epochs 1"; then
+                echo "::warning::Training script failed for $paper_dir/train.mojo"
+              fi
             fi
           done
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
       - id: no-matmul-call-sites
         name: Enforce no .__matmul__() call sites
         description: Ban .__matmul__( call sites in Mojo files (use matmul(A, B) instead). Ref #3215
-        entry: bash -c 'violations=$(grep -rn "\.__matmul__(" . --include="*.mojo" --include="*.🔥" --exclude-dir=".pixi" --exclude-dir=".git" | grep -v "fn __matmul__(" | grep -v "# __matmul__" | grep -v "__matmul__.*deprecated" || true); if [ -n "$violations" ]; then echo "Found .__matmul__() call sites (use matmul(A, B) instead):"; echo "$violations"; exit 1; fi'
+        entry: bash -c 'set +e; violations=$(grep -rn "\.__matmul__(" . --include="*.mojo" --include="*.🔥" --exclude-dir=".pixi" --exclude-dir=".git" | grep -v "fn __matmul__(" | grep -v "# __matmul__" | grep -v "__matmul__.*deprecated"); set -e; if [ -n "$violations" ]; then echo "Found .__matmul__() call sites (use matmul(A, B) instead):"; echo "$violations"; exit 1; fi'
         language: system
         pass_filenames: false
         always_run: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y \
     wget \
     uuid \
     sudo \
+    gdb \
     && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub CLI (gh) as root

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -56,7 +56,11 @@ unset _prefix
 # ---------------------------------------------------------------------------
 _ensure_writable() {
     for dir in "$@"; do
-        mkdir -p "$dir" 2>/dev/null || sudo -n mkdir -p "$dir" 2>/dev/null || true
+        if ! mkdir -p "$dir" 2>/dev/null; then
+            if ! sudo -n mkdir -p "$dir" 2>/dev/null; then
+                echo "[entrypoint] WARNING: could not create $dir (neither as user nor via sudo)" >&2
+            fi
+        fi
         # If we own the directory already, nothing to do.
         if [ -w "$dir" ]; then
             continue
@@ -64,8 +68,11 @@ _ensure_writable() {
         # chmod only succeeds if we already own the directory.
         # When the workspace is bind-mounted as root:root, fall back to
         # sudo chown -R on the specific subdir only (never the whole workspace).
-        chmod u+w "$dir" 2>/dev/null || \
-            sudo -n chown -R "$(id -u):$(id -g)" "$dir" 2>/dev/null || true
+        if ! chmod u+w "$dir" 2>/dev/null; then
+            if ! sudo -n chown -R "$(id -u):$(id -g)" "$dir" 2>/dev/null; then
+                echo "[entrypoint] WARNING: $dir is not writable and chown failed — some operations may fail" >&2
+            fi
+        fi
     done
 }
 
@@ -85,7 +92,9 @@ _ensure_writable \
 # ---------------------------------------------------------------------------
 if [ -d ".git" ] && [ ! -f ".git/hooks/pre-commit" ]; then
     echo "Installing pre-commit git hooks..."
-    pixi run pre-commit install --install-hooks 2>/dev/null || true
+    if ! pixi run pre-commit install --install-hooks 2>/dev/null; then
+        echo "[entrypoint] WARNING: pre-commit install failed — git hooks will not run until fixed" >&2
+    fi
 fi
 
 exec "$@"

--- a/docs/dev/mojo-jit-crash-workaround.md
+++ b/docs/dev/mojo-jit-crash-workaround.md
@@ -151,6 +151,83 @@ higher memory pressure than a single test file produces. The targeted import fix
 the correct defensive measure -- it reduces compilation footprint by ~95% per test file,
 which lowers the probability of hitting the JIT buffer overflow regardless of environment.
 
+## GDB Wrapper: Capturing Real ELF Cores (modular/modular#6413)
+
+PRs #5380 and #5382 wired up host-side `core_pattern` (path-based then pipe-based) but
+produced **zero core files** across all CI runs even when the libKGEN JIT crash signature
+appeared in test logs:
+
+```text
+libKGENCompilerRTShared.so+0x6ef7b → +0x6c156 → +0x6fc27
+mojo: error: execution crashed
+```
+
+Root cause: libKGEN registers an in-process SIGABRT handler that catches the abort, prints
+its own 3-frame post-handler trace, and exits cleanly. The kernel never generates a core for
+a process that handles its own fatal signal.
+
+### The Fix: `scripts/mojo-under-gdb.sh`
+
+Mojo test invocations are wrapped in `gdb -batch` with:
+
+- `handle SIGABRT stop nopass` — gdb intercepts the signal BEFORE libKGEN's handler runs
+- `generate-core-file` — dumps a real ELF core on the stopped inferior
+- `bt full`, `info threads`, `info sharedlibrary` — captures rich text context to a log
+
+This produces two files per crash in `crash-bundle/cores/`:
+
+- `core.gdb.<timestamp>.mojo` — real ELF core (multi-MB, readable by gdb offline)
+- `gdb-<timestamp>.log` — full pre-signal backtrace + threads + shared library map
+
+### Using the Wrapper Locally
+
+The wrapper is **disabled by default** (`MOJO_TEST_UNDER_GDB` defaults to 0 so local dev
+runs mojo directly with no overhead).
+
+To reproduce a crash locally with gdb capture:
+
+```bash
+# One test file
+MOJO_TEST_UNDER_GDB=1 just test-group tests/shared/core \
+    "test_gradient_checking_basic.mojo"
+
+# The wrapper writes to crash-bundle/cores/ by default
+ls crash-bundle/cores/
+# core.gdb.<ts>.mojo   (ELF core)
+# gdb-<ts>.log         (text backtrace)
+```
+
+To completely bypass the wrapper when gdb is unavailable:
+
+```bash
+MOJO_UNDER_GDB=0 MOJO_TEST_UNDER_GDB=1 just test-group ...
+# or simply omit MOJO_TEST_UNDER_GDB (defaults to 0)
+```
+
+### Analyzing a Captured Core
+
+```bash
+# Download crash-bundle artifact from the GitHub Actions run
+cd crash-bundle/
+gdb symbols/mojo cores/core.gdb.<timestamp>.mojo
+# Inside gdb:
+(gdb) bt
+(gdb) info threads
+(gdb) frame N   # navigate to the faulting frame
+```
+
+The `gdb-<timestamp>.log` text file contains the same information without needing a
+local gdb installation.
+
+### CI Configuration
+
+`MOJO_TEST_UNDER_GDB=1` is set in the `env:` block of all Mojo test jobs in
+`.github/workflows/comprehensive-tests.yml`. Build-only jobs are unaffected.
+
+The coredump-capture composite action (`.github/actions/coredump-capture/action.yml`)
+collects both kernel cores and gdb-written files, and bundles gdb itself into
+`crash-bundle/symbols/` for offline analysis.
+
 ## References
 
 - [Issue #5108](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5108) -- JIT crash comprehensive tracking

--- a/justfile
+++ b/justfile
@@ -76,7 +76,16 @@ _run cmd:
 			# (modular/modular#6413). Pairs with the host-side core_pattern in
 			# .github/actions/coredump-capture/action.yml.
 			HOME_FIXUP='if [ ! -w "$HOME" ]; then export HOME="/tmp/mojo-home-$(id -u)"; mkdir -p "$HOME/.modular" "$HOME/.pixi"; fi; ulimit -c unlimited 2>/dev/null || true;'
-			podman compose exec -e USER_ID={{USER_ID}} -e GROUP_ID={{GROUP_ID}} -T {{podman_service}} bash -c "$HOME_FIXUP {{cmd}}"
+			# Forward CI/coredump env vars into the container. Without these
+			# -e passthroughs, MOJO_TEST_UNDER_GDB / CRASH_BUNDLE_DIR set on
+			# the GHA runner are NOT visible to the bash recipe inside the
+			# container, so the gdb wrapper would be silently skipped.
+			podman compose exec \
+				-e USER_ID={{USER_ID}} -e GROUP_ID={{GROUP_ID}} \
+				-e MOJO_TEST_UNDER_GDB \
+				-e MOJO_UNDER_GDB \
+				-e CRASH_BUNDLE_DIR \
+				-T {{podman_service}} bash -c "$HOME_FIXUP {{cmd}}"
 		fi
 	else
 		echo "Error: Podman compose container '{{podman_service}}' is not running."

--- a/justfile
+++ b/justfile
@@ -75,7 +75,7 @@ _run cmd:
 			# and we need real cores when the libKGEN JIT crashes
 			# (modular/modular#6413). Pairs with the host-side core_pattern in
 			# .github/actions/coredump-capture/action.yml.
-			HOME_FIXUP='if [ ! -w "$HOME" ]; then export HOME="/tmp/mojo-home-$(id -u)"; mkdir -p "$HOME/.modular" "$HOME/.pixi"; fi; ulimit -c unlimited 2>/dev/null || true;'
+			HOME_FIXUP='if [ ! -w "$HOME" ]; then export HOME="/tmp/mojo-home-$(id -u)"; mkdir -p "$HOME/.modular" "$HOME/.pixi"; fi; if ! ulimit -c unlimited 2>/dev/null; then echo "[run-in-container] WARNING: ulimit -c unlimited failed — cores will not be generated on crash" >&2; fi;'
 			# Forward CI/coredump env vars into the container. Without these
 			# -e passthroughs, MOJO_TEST_UNDER_GDB / CRASH_BUNDLE_DIR set on
 			# the GHA runner are NOT visible to the bash recipe inside the
@@ -122,7 +122,17 @@ podman-up:
     @# user cannot write to host-owned files. Make the workspace world-writable
     @# so `just build`, test fixtures, and pre-commit can create output files.
     @# (Safe: ephemeral dev machine; matches what the CI setup-container action does.)
-    @chmod -R a+rwX . || true
+    @# Some files may be owned by container UIDs from prior Podman UID-mapped writes.
+    @# chmod fails on those; capture errors so we can report them without aborting.
+    @chmod_errors=$(mktemp); \
+     chmod -R a+rwX . 2>"$chmod_errors" || true; \
+     err_count=$(wc -l < "$chmod_errors"); \
+     if [ "$err_count" -gt 0 ]; then \
+       echo "[podman-up] WARNING: chmod failed on $err_count file(s); first 5 errors:"; \
+       head -5 "$chmod_errors"; \
+       echo "[podman-up] Run: sudo chown -R \$(id -u):\$(id -g) . to fix permanently."; \
+     fi; \
+     rm -f "$chmod_errors"
 
 # Stop Podman development environment
 podman-down:
@@ -535,7 +545,9 @@ bootstrap:
 
     # Step 4: GLIBC compatibility check
     echo "==> Checking GLIBC compatibility..."
-    just check-glibc 2>/dev/null || true
+    if ! just check-glibc 2>/dev/null; then \
+        echo "[bootstrap] WARNING: check-glibc reported incompatibility — use Podman for Mojo tests"; \
+    fi
     echo ""
 
     echo "Bootstrap complete! Next steps:"
@@ -609,7 +621,11 @@ pre-commit-all:
 check-matmul-calls:
     #!/usr/bin/env bash
     set -e
-    violations=$(grep -rn "\.__matmul__(" . --include="*.mojo" --include="*.🔥" --exclude-dir=".pixi" --exclude-dir=".git" | grep -v "fn __matmul__(" | grep -v "# __matmul__" | grep -v "__matmul__.*deprecated" || true)
+    # grep returns exit code 1 when no lines match — that is the success case here.
+    # Use set +e / set -e to avoid aborting on the no-match exit code.
+    set +e
+    violations=$(grep -rn "\.__matmul__(" . --include="*.mojo" --include="*.🔥" --exclude-dir=".pixi" --exclude-dir=".git" | grep -v "fn __matmul__(" | grep -v "# __matmul__" | grep -v "__matmul__.*deprecated")
+    set -e
     if [ -n "$violations" ]; then
         echo "Found .__matmul__() call sites (use matmul(A, B) instead):"
         echo "$violations"
@@ -678,7 +694,9 @@ _test-group-inner path pattern:
 
     # Enable core dumps so the libKGEN JIT crash (modular/modular#6413)
     # produces a real coredump we can attach to gdb. No-op outside CI.
-    ulimit -c unlimited 2>/dev/null || true
+    if ! ulimit -c unlimited 2>/dev/null; then
+        echo "[_test-group-inner] WARNING: ulimit -c unlimited failed — cores will not be generated on crash" >&2
+    fi
 
     echo "=================================================="
     echo "Testing: {{path}}"
@@ -728,7 +746,9 @@ _test-group-inner path pattern:
             echo "Running: $test_file"
             test_count=$((test_count + 1))
 
-            ulimit -v unlimited 2>/dev/null || true
+            if ! ulimit -v unlimited 2>/dev/null; then
+                echo "[_test-group-inner] WARNING: ulimit -v unlimited failed — virtual memory limit remains in place" >&2
+            fi
             test_exit=0
             if [ "${MOJO_TEST_UNDER_GDB:-0}" = "1" ]; then
                 bash "$REPO_ROOT/scripts/mojo-under-gdb.sh" "$CORE_DIR" \
@@ -958,7 +978,8 @@ status:
 clean:
     @echo "Cleaning..."
     @rm -rf build/ dist/ htmlcov/ .pytest_cache/ .coverage
-    @find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+    @# rm -rf already swallows ENOENT. Any remaining errors (EACCES, EBUSY) are printed.
+    @find . -type d -name "__pycache__" | xargs -r rm -rf
     @echo "Clean complete"
 
 # Clean everything including Podman containers

--- a/justfile
+++ b/justfile
@@ -109,8 +109,15 @@ _ensure_build_dir mode:
 # ==============================================================================
 
 # Start Podman development environment
+#
+# docker-compose substitutes ${USER_ID}/${GROUP_ID} in docker-compose.yml from
+# its OWN environment, not from just's template vars. Without explicit
+# `USER_ID=... GROUP_ID=...` exports on the same line, the variables expand to
+# empty strings and the container would get `user: ":"` (invalid), causing
+# the compose call to fail or create a stuck container in an invalid state.
 podman-up:
-    @podman compose up -d {{podman_service}}
+    @USER_ID={{USER_ID}} GROUP_ID={{GROUP_ID}} USER_NAME=${USER_NAME:-dev} \
+        podman compose up -d {{podman_service}}
     @# Rootless Podman UID-maps the bind-mounted workspace so the container
     @# user cannot write to host-owned files. Make the workspace world-writable
     @# so `just build`, test fixtures, and pre-commit can create output files.
@@ -119,7 +126,8 @@ podman-up:
 
 # Stop Podman development environment
 podman-down:
-    @podman compose down
+    @USER_ID={{USER_ID}} GROUP_ID={{GROUP_ID}} USER_NAME=${USER_NAME:-dev} \
+        podman compose down
 
 # Build Podman images
 podman-build:

--- a/justfile
+++ b/justfile
@@ -693,6 +693,11 @@ _test-group-inner path pattern:
         exit 1
     fi
 
+    # gdb wrapper path: set MOJO_TEST_UNDER_GDB=1 in CI to intercept the
+    # in-process SIGABRT handler in libKGEN before it swallows the crash
+    # (modular/modular#6413). Default 0 so local dev runs mojo directly.
+    CORE_DIR="${CRASH_BUNDLE_DIR:-${REPO_ROOT}/crash-bundle/cores}"
+
     # Run each test file
     for test_file in $test_files; do
         if [ -f "$test_file" ]; then
@@ -701,13 +706,20 @@ _test-group-inner path pattern:
             test_count=$((test_count + 1))
 
             ulimit -v unlimited 2>/dev/null || true
-            pixi run mojo --Werror -debug-level=line-tables -I "$REPO_ROOT" -I . "$test_file" || test_exit=$?
-            if [ "${test_exit:-0}" -eq 0 ]; then
+            test_exit=0
+            if [ "${MOJO_TEST_UNDER_GDB:-0}" = "1" ]; then
+                bash "$REPO_ROOT/scripts/mojo-under-gdb.sh" "$CORE_DIR" \
+                    --Werror -debug-level=line-tables -I "$REPO_ROOT" -I . "$test_file" \
+                    || test_exit=$?
+            else
+                pixi run mojo --Werror -debug-level=line-tables -I "$REPO_ROOT" -I . "$test_file" \
+                    || test_exit=$?
+            fi
+            if [ "${test_exit}" -eq 0 ]; then
                 passed_count=$((passed_count + 1))
             else
                 failed_count=$((failed_count + 1))
                 failed_tests="$failed_tests\n  - $test_file"
-                test_exit=0
             fi
         fi
     done

--- a/justfile
+++ b/justfile
@@ -80,11 +80,17 @@ _run cmd:
 			# -e passthroughs, MOJO_TEST_UNDER_GDB / CRASH_BUNDLE_DIR set on
 			# the GHA runner are NOT visible to the bash recipe inside the
 			# container, so the gdb wrapper would be silently skipped.
+			#
+			# NOTE: docker-compose (cli-plugin) rejects bare `-e VARNAME`
+			# (without `=value`) with "badly formed, must be key=value" — we
+			# must build the args conditionally with explicit values.
+			EXTRA_ENV=()
+			if [ -n "${MOJO_TEST_UNDER_GDB-}" ]; then EXTRA_ENV+=(-e "MOJO_TEST_UNDER_GDB=${MOJO_TEST_UNDER_GDB}"); fi
+			if [ -n "${MOJO_UNDER_GDB-}" ];      then EXTRA_ENV+=(-e "MOJO_UNDER_GDB=${MOJO_UNDER_GDB}"); fi
+			if [ -n "${CRASH_BUNDLE_DIR-}" ];    then EXTRA_ENV+=(-e "CRASH_BUNDLE_DIR=${CRASH_BUNDLE_DIR}"); fi
 			podman compose exec \
 				-e USER_ID={{USER_ID}} -e GROUP_ID={{GROUP_ID}} \
-				-e MOJO_TEST_UNDER_GDB \
-				-e MOJO_UNDER_GDB \
-				-e CRASH_BUNDLE_DIR \
+				"${EXTRA_ENV[@]}" \
 				-T {{podman_service}} bash -c "$HOME_FIXUP {{cmd}}"
 		fi
 	else

--- a/notes/mojo-cpu-detection-source-review.md
+++ b/notes/mojo-cpu-detection-source-review.md
@@ -1,0 +1,321 @@
+# Mojo CPU / Target-Feature Detection — Open-Source Source Review
+
+**Context**: Tracking the AVX-512-on-non-AVX-512-CPU crash from modular/modular#6413
+(GHA Azure runners, suspected AMD Zen 4 under Hyper-V where the hypervisor masks
+the AVX-512 CPUID bits). This review answers: *where in the open-source
+modular/modular tree does Mojo's CPU/target-feature detection live, and which
+path could plausibly cause the JIT to emit AVX-512 on a CPU whose kernel/CPUID
+view reports no AVX-512?*
+
+**Repository**: <https://github.com/modular/modular> (branch `main`, fetched 2026-05-12)
+
+**Repo layout (top-level)**: `bazel/`, `docs/`, `max/`, `mojo/`, `tools/`,
+`utils/`, `.github/`, `.cursor/rules/`. The compiler driver / JIT runtime
+(`libKGENCompilerRTShared.so`, the `mojo` binary) is **not** in the open-source
+tree — only the **stdlib** (`mojo/stdlib/std/`) and documentation are open.
+
+---
+
+## TL;DR
+
+1. **The Mojo stdlib does zero runtime CPU detection.** Every feature check
+   (`has_avx512f`, `has_avx2`, `has_vnni`, …) resolves at *compile time* against
+   a `!kgen.target` MLIR attribute via the KGEN intrinsic
+   `#kgen.param.expr<target_has_feature, …>`. There is no `cpuid`, no
+   `xgetbv`, no `/proc/cpuinfo` parse, no HWCAP read, no
+   `__builtin_cpu_supports` anywhere in `mojo/stdlib/std/sys/`.
+2. **The `!kgen.target` attribute is populated by the closed-source compiler
+   driver**, not by stdlib. That driver — referenced in the open-source docs as
+   `CLOptions.h:118` — initializes its target-features list from
+   `getHostCPUFeatures()`, which is LLVM's
+   [`llvm::sys::getHostCPUFeatures()`](https://llvm.org/doxygen/namespacellvm_1_1sys.html).
+3. **LLVM's `getHostCPUFeatures()` on x86 does *not* consult the kernel's
+   masked CPUID view**: it issues the `cpuid` instruction directly (and
+   `xgetbv` for XSAVE). Under a hypervisor that *correctly* masks AVX-512 bits
+   in CPUID, LLVM would observe the mask and stay correct. **But** LLVM has a
+   long history of x86 family/model fingerprinting fallbacks (in
+   `Host.cpp::getHostCPUName`) that map Zen-family family/model numbers to a
+   named CPU (e.g. `znver4`), and `znver4` carries a *fixed* feature list that
+   includes `+avx512f,+avx512vl,…` regardless of what CPUID's feature leaves
+   reported. That is the most plausible upstream root cause: **CPU-name
+   fingerprinting overrides the masked feature view**.
+4. The Mojo documentation itself explicitly flags `CLOptions.h:118 →
+   getHostCPUFeatures()` as the source of a known related leak bug
+   (**MOCO-3686**, the "host features leak to LLVM" issue).
+5. **No `MOJO_*` or `KGEN_*` environment variable to override CPU detection** is
+   documented. The user-facing override is the build flag
+   `--target-cpu=<name>` / `--target-features="-avx512f,…"`, which only helps
+   for AOT builds — not for the in-process JIT that crashes in
+   `libKGENCompilerRTShared.so`.
+
+---
+
+## 1. Stdlib feature-check surface (open source)
+
+### `mojo/stdlib/std/sys/info.mojo`
+
+This is the file that *every* AVX-512 path in your crash traces ultimately
+queries (`shared/...` → `math.abs` → `SIMD.__abs__` → `CompilationTarget.has_avx512f()`).
+
+URL: <https://github.com/modular/modular/blob/main/mojo/stdlib/std/sys/info.mojo>
+
+Key definitions (line numbers approximate; file is ~1386 lines):
+
+```mojo
+# The compile-time target handle — a KGEN attribute, NOT a runtime value
+comptime _TargetType = __mlir_type.`!kgen.target`
+
+@always_inline("nodebug")
+def _current_target() -> _TargetType:
+    return __mlir_attr.`#kgen.param.expr<current_target> : !kgen.target`
+
+struct CompilationTarget[value: _TargetType = _current_target()](
+    TrivialRegisterPassable
+):
+    @staticmethod
+    def _has_feature[name: StaticString]() -> Bool:
+        return __mlir_attr[
+            `#kgen.param.expr<target_has_feature,`,
+            Self.value,
+            `,`,
+            _get_kgen_string[name](),
+            `> : i1`,
+        ]
+
+    @staticmethod
+    def has_avx512f() -> Bool:  # ~line 449
+        """Returns True if the host system has AVX512, otherwise returns False."""
+        return Self._has_feature["avx512f"]()
+```
+
+**Verdict for stdlib**: Correct in isolation. `target_has_feature` is a pure
+compile-time MLIR query; the value it returns is entirely determined by
+whatever feature set the compiler driver baked into the `!kgen.target`
+attribute when the IR module was created. The stdlib cannot lie about
+AVX-512 unless the driver told it to.
+
+### Sibling files searched (no CPU detection found)
+
+| File | Verdict |
+| --- | --- |
+| `mojo/stdlib/std/sys/_assembly.mojo` | Generic `inlined_assembly` wrapper. No `cpuid`/`xgetbv`. |
+| `mojo/stdlib/std/sys/intrinsics.mojo` | LLVM intrinsics (gather/scatter/prefetch, AMDGPU). No CPU detection. |
+| `mojo/stdlib/std/sys/_build.mojo` | Build-type (debug/release) only. |
+| `mojo/stdlib/std/sys/_libc.mojo` | libc bindings, no `getauxval`/HWCAP. |
+| `mojo/stdlib/std/sys/defines.mojo` | Compile-time `#kgen.param.expr` defines. |
+| `mojo/stdlib/std/sys/compile.mojo` | Build-info bridge to KGEN. |
+
+No occurrence of `cpuid`, `xgetbv`, `__builtin_cpu_supports`, `getauxval`,
+`HWCAP`, `/proc/cpuinfo`, `getHostCPUName`, `getAcceleratorArchOrEmpty`, or
+`detect_target_cpu` anywhere in `mojo/stdlib/`.
+
+---
+
+## 2. The smoking gun: `CLOptions.h:118` (closed source, but documented)
+
+Despite being closed source, the compiler driver is explicitly referenced in
+the open-source docs:
+
+### `mojo/docs/code/tools/README-Compilation-Targets.md`
+
+URL: <https://github.com/modular/modular/blob/main/mojo/docs/code/tools/README-Compilation-Targets.md>
+
+The "Known issue (MOCO-3686)" section says, verbatim:
+
+> **Known issue (MOCO-3686):** All three tests emit hundreds of warnings about
+> unrecognized features (ARM features from the M4 host leaking to the x86 LLVM
+> backend). Multi-threaded compilation causes interleaved warning output.
+> Output files are correct despite the warnings.
+>
+> **Root cause:** `CLOptions.h:118` initializes `targetFeatures` to
+> `getHostCPUFeatures()`. The `--march`/`--mcpu` path routes through
+> `getMArchFeatures()` which computes the correct features, but the stale
+> host defaults leak to LLVM before the override takes effect.
+>
+> No user-facing workaround exists:
+>
+> - `--disable-warnings` does not suppress them (LLVM-level, not Mojo-level
+>   warnings).
+> - `--target-features=""` with `--mcpu` does not clear them (empty string
+>   bypasses the mixing check but doesn't overwrite the default).
+> - `--target-features="<anything>"` with `--mcpu` triggers the mixing error.
+
+**Interpretation for the Zen-4-under-Hyper-V bug**:
+
+- `CLOptions.h:118 → targetFeatures = getHostCPUFeatures()` is the *single
+  point* at which the host's feature set enters Mojo. If
+  `getHostCPUFeatures()` returns a list containing `+avx512f,+avx512vl,…` on a
+  host whose CPUID has the AVX-512 bits masked off, **Mojo's JIT will see
+  AVX-512 as available and emit the instructions** — which is exactly what we
+  observe (`vpternlogd`, `{1to4}` broadcast, `%k1` opmask masked moves).
+- The documented MOCO-3686 leak is a *related* but distinct bug (cross-compile
+  feature leak). For the JIT-on-host case, no `--march`/`--mcpu` override is
+  applied, so the host-derived `targetFeatures` is the **final** value used
+  for code generation. No "stale leak" needed — it's the primary path.
+
+---
+
+## 3. Why `getHostCPUFeatures()` can be wrong on Zen 4 + Hyper-V
+
+`getHostCPUFeatures` is the LLVM function
+`llvm::sys::getHostCPUFeatures()` (declared in
+`llvm/include/llvm/TargetParser/Host.h`, implemented in
+`llvm/lib/TargetParser/Host.cpp`). The Mojo driver almost certainly uses it
+directly (the docs use the LLVM name verbatim and no Mojo-specific shim is
+referenced).
+
+The relevant x86 code path in upstream LLVM:
+
+1. **`__cpuid` / `__get_cpuid_count`** — issues raw `cpuid` instructions
+   directly (inline asm). On Hyper-V with AVX-512 masked, leaf 7 sub-leaf 0
+   `EBX/ECX/EDX` bits for AVX-512F/VL/BW/DQ/VBMI/VNNI are zero. Good so far.
+2. **`getHostCPUName()`** — *separately* determines a CPU name (e.g. `znver4`,
+   `skylake-avx512`) by reading **family/model/stepping** from CPUID leaf 1
+   `EAX` and matching against a hard-coded table:
+   - AMD family `0x19` model `0x10–0x1F`, `0x60–0x7F`, `0xA0–0xAF` → `znver4`.
+     See `Host.cpp::getAMDProcessorTypeAndSubtype` in upstream LLVM
+     (<https://github.com/llvm/llvm-project/blob/main/llvm/lib/TargetParser/Host.cpp>).
+   - **Family/model are not maskable by Hyper-V's standard CPUID masking** — the
+     hypervisor masks *feature* leaves to hide AVX-512 from naive software,
+     but it does not change the chip's reported family/model/stepping.
+3. **`getHostCPUFeatures` then merges**: it takes the CPUID feature bits **and**
+   the implicit features attached to the CPU name. When `znver4` is selected,
+   LLVM's `X86TargetParser` table assigns it the *static* feature list
+   `+avx512f,+avx512vl,+avx512bw,+avx512dq,+avx512cd,+avx512vnni,+avx512vbmi,
+   +avx512vbmi2,+avx512bitalg,+avx512vpopcntdq,+avx512bf16,+avx512fp16,…`. That
+   list is **not gated on the kernel's CPUID feature view**.
+
+The exact upstream call path:
+`llvm::sys::getHostCPUFeatures` (`Host.cpp`) → `sys::getHostCPUName` →
+`getAMDProcessorTypeAndSubtype` → returns `"znver4"` → caller looks up
+`znver4` in `X86TargetParser.cpp::Processors[]` → static feature list
+includes all AVX-512* extensions.
+
+That's the mechanism by which the JIT can emit AVX-512 on a CPU whose
+kernel/CPUID feature leaves say "no AVX-512".
+
+**Verification hint** for whoever picks this up: run `cpuid -1 -l 1 -s 0` in
+the failing container; if `EAX` decodes to AMD family `0x19` model in the
+Genoa range while leaf 7 has the AVX-512 bits cleared, the hypothesis is
+confirmed and the bug is upstream LLVM's CPU-name fingerprinting overriding
+the masked feature view.
+
+---
+
+## 4. Other detection paths checked
+
+### `getAcceleratorArchOrEmpty` / `_accelerator_arch`
+
+`info.mojo` line ~701–707 exposes `_accelerator_arch()` for GPU/accelerator
+targets. It also resolves via `#kgen.param.expr<…>` — purely compile-time
+metadata; nothing reads PCI IDs or `nvidia-smi` from stdlib. Not relevant
+to the SIGILL.
+
+### Environment variables
+
+| Variable | Effect | Found in |
+| --- | --- | --- |
+| `MOJO_*` for CPU override | **None documented** | (no hits in stdlib or docs) |
+| `KGEN_*` for CPU override | **None documented** | (no hits in stdlib or docs) |
+| LLVM-native: `LLVM_HOST_CPU_FEATURES` | *Not honored by LLVM* — there is no upstream env-var override for `getHostCPUFeatures`. Confirmed by reading `Host.cpp`. | — |
+
+The only override surface exposed to users is the CLI:
+`--target-cpu=<name>`, `--target-features="±feat,±feat"`,
+`--march=<name>`, `--mcpu=<name>`, `--target-triple=<triple>`. None of these
+are picked up by the **in-process JIT** that crashes in
+`libKGENCompilerRTShared.so` — they're parsed by the `mojo build` /
+`mojo run` driver and applied to AOT module compilation. Test runs invoked
+through `mojo` (`mojo run ...` / `mojo test`-style hand-rolled `def main`)
+inherit the driver-derived `!kgen.target`, so the flags *would* propagate —
+**worth testing** as a workaround: set
+`MOJO_TARGET_FEATURES="-avx512f,-avx512vl,-avx512bw,-avx512dq,-avx512cd,-avx512vnni,-avx512vbmi,-avx512vbmi2,-avx512bitalg,-avx512vpopcntdq,-avx512bf16,-avx512fp16"`
+or pass `--target-features=...` to `mojo run` to force-disable AVX-512.
+
+There is also no observable "force AVX-512" / "skip detection" env-var; the
+inverse path (forcing AVX-512 *on*) requires explicit
+`--target-features="+avx512f"`.
+
+### `--print-effective-target`
+
+Documented as the debug command:
+
+```bash
+mojo build --print-effective-target
+```
+
+This is the **single most useful diagnostic** for the GHA crash: run it
+inside the failing container and confirm whether the `cpu`/`features` line
+reports `znver4` + AVX-512. If it does, the upstream-LLVM fingerprinting
+hypothesis is confirmed at the Mojo layer.
+
+---
+
+## 5. Cross-reference with crash signatures
+
+The faulting instructions captured (per
+`notes/modular-6413-avx512-finding.md`):
+
+| Site | Instruction | Feature implied |
+| --- | --- | --- |
+| `string_slice._strip` | `vpbroadcastb %eax,%xmm0` | AVX-512BW + AVX-512VL (EVEX-encoded `vpbroadcastb` to XMM) |
+| `math.abs` | `vandps {1to4},…` | AVX-512F (embedded broadcast `{1toN}`) |
+| `philox._single_round` | `vpternlogd` | AVX-512F |
+| `_swisstable.match_h2` | `vpcmpeqb %zmm…, %k1` or `vpbroadcastb …, %zmm0` | AVX-512BW |
+| `activation._relu_backward_op` | `vcmpltss …, %k1` + `vmovdqa64 %zmm0` | AVX-512F |
+
+All five live behind the same compile-time guard chain:
+
+```text
+shared/* → math.abs / SIMD ops
+      └─ SIMD.__abs__ (mojo/stdlib/std/builtin/simd.mojo)
+           └─ CompilationTarget.has_avx512f()        ← info.mojo line 449
+                └─ __mlir_attr.target_has_feature["avx512f"]   ← KGEN intrinsic
+                     └─ !kgen.target attribute                  ← driver-populated
+                          └─ getHostCPUFeatures()               ← CLOptions.h:118
+                               └─ llvm::sys::getHostCPUFeatures   ← UPSTREAM LLVM
+                                    └─ family/model → znver4 → fixed feature list
+```
+
+Every site is consistent with `target_has_feature["avx512f"]` returning **true**
+when the kernel's CPUID view says **false** — i.e. the driver populated the
+`!kgen.target` attribute from a `getHostCPUFeatures()` that fingerprinted
+the CPU as Zen 4 and inherited that family's static AVX-512 feature set.
+
+---
+
+## 6. Recommendations for the upstream issue
+
+1. **Ask Modular to confirm `CLOptions.h:118`** uses raw
+   `llvm::sys::getHostCPUFeatures()` (not a Mojo-specific wrapper that
+   re-validates against the kernel view) — this is implied by the docs but
+   should be stated explicitly.
+2. **Ask Modular to add a kernel-view sanity check**: after calling
+   `getHostCPUFeatures()`, cross-check AVX-512 bits against
+   `/proc/cpuinfo` flags or `getauxval(AT_HWCAP2)` on Linux. If the kernel
+   view says no AVX-512 but the LLVM-derived list says yes, **strip**
+   AVX-512 from `targetFeatures` and log a warning. This is the standard
+   workaround for the LLVM Zen-fingerprinting issue (GCC and recent LLVM
+   versions have been adding similar guards).
+3. **Ask Modular to honor `MOJO_TARGET_FEATURES` / `MOJO_TARGET_CPU`
+   environment variables** for the in-process JIT, not just the AOT driver.
+   Today there's no way to override the JIT's feature set without rebuilding.
+4. **Document `--print-effective-target` as the first-line diagnostic** for
+   "wrong instructions emitted" reports.
+
+---
+
+## 7. Files referenced (with URLs)
+
+| Path | URL | Role |
+| --- | --- | --- |
+| `mojo/stdlib/std/sys/info.mojo` | <https://github.com/modular/modular/blob/main/mojo/stdlib/std/sys/info.mojo> | Compile-time feature queries (`has_avx512f`, `CompilationTarget`, `_current_target`). No runtime detection. |
+| `mojo/stdlib/std/sys/_assembly.mojo` | <https://github.com/modular/modular/blob/main/mojo/stdlib/std/sys/_assembly.mojo> | Generic `inlined_assembly`. No CPU detection. |
+| `mojo/stdlib/std/sys/intrinsics.mojo` | <https://github.com/modular/modular/blob/main/mojo/stdlib/std/sys/intrinsics.mojo> | LLVM intrinsics. No CPU detection. |
+| `mojo/stdlib/std/sys/_build.mojo` | <https://github.com/modular/modular/blob/main/mojo/stdlib/std/sys/_build.mojo> | Debug/release build detection only. |
+| `mojo/stdlib/std/sys/defines.mojo` | <https://github.com/modular/modular/blob/main/mojo/stdlib/std/sys/defines.mojo> | `#kgen.param.expr` defines. |
+| `mojo/docs/code/tools/README-Compilation-Targets.md` | <https://github.com/modular/modular/blob/main/mojo/docs/code/tools/README-Compilation-Targets.md> | **Names `CLOptions.h:118` + `getHostCPUFeatures()` as the host-feature entry point.** |
+| `mojo/docs/tools/compilation.mdx` (rendered) | <https://mojolang.org/docs/tools/compilation/> | User-facing flag docs; documents `--print-effective-target`. |
+| *(closed source)* `CLOptions.h` | not in repo | Compiler-driver option parsing; initializes `targetFeatures = getHostCPUFeatures()` at line 118. |
+| *(closed source)* `libKGENCompilerRTShared.so` | not in repo | In-process JIT runtime where the SIGILL fires. Consumes the `!kgen.target` attribute populated from `CLOptions.h`. |
+| *(upstream)* `llvm/lib/TargetParser/Host.cpp` | <https://github.com/llvm/llvm-project/blob/main/llvm/lib/TargetParser/Host.cpp> | `getHostCPUFeatures`, `getHostCPUName`, `getAMDProcessorTypeAndSubtype` — the likely upstream root cause. |
+| *(upstream)* `llvm/lib/TargetParser/X86TargetParser.cpp` | <https://github.com/llvm/llvm-project/blob/main/llvm/lib/TargetParser/X86TargetParser.cpp> | Static feature lists per CPU name (e.g. `znver4` → AVX-512*). |

--- a/repro/cpuid-probes/README.md
+++ b/repro/cpuid-probes/README.md
@@ -40,7 +40,7 @@ podman run --rm --userns=keep-id \
 
 ## Expected outcomes
 
-| Host | /proc/cpuinfo avx512f | cpuid(7,0).ebx[16] | xgetbv(0)[5..7] | builtin avx512f | mojo `has_avx512f()` |
+| Host | `/proc/cpuinfo` avx512f | `cpuid(7,0).ebx[16]` | `xgetbv(0)[5..7]` | `builtin avx512f` | `mojo has_avx512f()` |
 | --- | --- | --- | --- | --- | --- |
 | Local Intel without AVX-512 | 0 | 0 | n/a | 0 | **expected 0** |
 | Local Intel with AVX-512 (e.g. Tiger Lake) | 1 | 1 | 1 | 1 | **expected 1** |

--- a/repro/cpuid-probes/README.md
+++ b/repro/cpuid-probes/README.md
@@ -1,0 +1,68 @@
+# CPU detection probes for modular/modular#6413
+
+Three orthogonal probes that together pin down where Mojo's CPU detection is
+diverging from the kernel's view on AMD-EPYC-under-Hyper-V GHA runners.
+
+| Probe | What it asks |
+| --- | --- |
+| `/proc/cpuinfo` flags | What does the kernel allow user-space to see? |
+| `cpu_features_probe` (C, direct `cpuid` + `xgetbv`) | What does the silicon report, and what XCR0 has the OS enabled? |
+| `__builtin_cpu_supports` | What does compiler-rt say? |
+| `probe_cpu.mojo` (`sys.info.has_avx512f` etc.) | What does Mojo's stdlib advertise? |
+
+If `probe_cpu.mojo` reports `has_avx512f() = True` on the GHA runner while `/proc/cpuinfo`
+shows no `avx512f` flag, that's the source-side smoking gun: Mojo's detection bypasses
+the kernel-mediated view and lights up the AVX-512 codegen path.
+
+## Build & run inside the cached image
+
+```bash
+podman run --rm --userns=keep-id \
+  -v "$(pwd):/workspace:Z" -w /workspace --ulimit core=-1 \
+  projectodyssey:dev \
+  bash -c '
+    set -e
+    echo "════════════════════ /proc/cpuinfo (kernel view) ════════════════════"
+    grep -m1 ^flags /proc/cpuinfo | tr " " "\n" | grep -E "^(avx512[a-z0-9_]*|avx_vnni|avx|avx2|fma|f16c|sse4_[12]|vaes|sha_ni)$" | sort -u
+
+    echo
+    echo "════════════════════ C probe (cpuid + xgetbv + __builtin_cpu_supports) ════════════════════"
+    cd repro/cpuid-probes
+    gcc -O2 -o /tmp/cpu_features_probe cpu_features_probe.c
+    /tmp/cpu_features_probe
+
+    echo
+    echo "════════════════════ Mojo probe (sys.info) ════════════════════"
+    cd /workspace
+    pixi run mojo run repro/cpuid-probes/probe_cpu.mojo
+'
+```
+
+## Expected outcomes
+
+| Host | /proc/cpuinfo avx512f | cpuid(7,0).ebx[16] | xgetbv(0)[5..7] | builtin avx512f | mojo `has_avx512f()` |
+| --- | --- | --- | --- | --- | --- |
+| Local Intel without AVX-512 | 0 | 0 | n/a | 0 | **expected 0** |
+| Local Intel with AVX-512 (e.g. Tiger Lake) | 1 | 1 | 1 | 1 | **expected 1** |
+| GHA EPYC under Hyper-V (suspected bug) | 0 | **1** (silicon!) | **0** (OS not enabled) | **?** | **?** |
+
+The interesting columns are the last three on the GHA row. If `cpuid(7,0).ebx[16]` is 1 but
+`xgetbv(0)[5..7]` is 0, the hypervisor is exposing AVX-512 silicon to the guest's `cpuid`
+instruction without the OS enabling XSAVE state for it. Whether `__builtin_cpu_supports`
+and Mojo see that depends on which API path each consults:
+
+- `cpuid` directly → sees AVX-512 → wrong codegen
+- `__builtin_cpu_supports` → modern compiler-rt checks both `cpuid` AND `xgetbv` → safe
+- `getauxval(AT_HWCAP*)` → kernel view → safe
+- Parsing `/proc/cpuinfo` → kernel view → safe
+
+## Why this matters
+
+If the C probe shows `cpuid(7,0).ebx[16] = 1` AND `xgetbv(0)[5..7] = 0` AND `mojo
+has_avx512f() = True`, we have the smoking gun: Mojo's `sys.info.has_avx512f` is
+consulting raw CPUID rather than the OS-enabled XCR0. The fix is to gate AVX-512
+detection on `xgetbv & (1<<5 | 1<<6 | 1<<7) == 0xe0`, which is what
+[the Linux kernel documentation prescribes][1] for AVX-512 use.
+
+[1]: https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html
+     (see Vol. 1 §13.3, "Detection of XSAVE Feature Support")

--- a/repro/cpuid-probes/README.md
+++ b/repro/cpuid-probes/README.md
@@ -61,8 +61,7 @@ and Mojo see that depends on which API path each consults:
 If the C probe shows `cpuid(7,0).ebx[16] = 1` AND `xgetbv(0)[5..7] = 0` AND `mojo
 has_avx512f() = True`, we have the smoking gun: Mojo's `sys.info.has_avx512f` is
 consulting raw CPUID rather than the OS-enabled XCR0. The fix is to gate AVX-512
-detection on `xgetbv & (1<<5 | 1<<6 | 1<<7) == 0xe0`, which is what
-[the Linux kernel documentation prescribes][1] for AVX-512 use.
-
-[1]: https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html
-     (see Vol. 1 §13.3, "Detection of XSAVE Feature Support")
+detection on `xgetbv & (1<<5 | 1<<6 | 1<<7) == 0xe0`, which is the canonical
+sequence prescribed by Intel SDM Vol. 1 §13.3, "Detection of XSAVE Feature Support"
+(search the Intel SDM PDF on intel.com — the page is anti-bot-protected so we do
+not link it directly).

--- a/repro/cpuid-probes/cpu_features_probe.c
+++ b/repro/cpuid-probes/cpu_features_probe.c
@@ -1,0 +1,185 @@
+// Direct CPU feature probe — written in C to bypass any abstraction layer.
+//
+// Goal for modular/modular#6413: determine whether the JIT's CPU detection
+// would see AVX-512 capabilities on a host where the kernel reports none.
+//
+// Build:
+//   gcc -O2 -o cpu_features_probe cpu_features_probe.c
+//
+// Run inside the cached Podman image to see what bytes Mojo's underlying
+// codegen detection routines would see.
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/auxv.h>
+
+#ifdef __x86_64__
+#include <cpuid.h>
+#include <immintrin.h>
+#endif
+
+// HWCAP2 bits relevant to x86 AVX-512 (matches kernel/include/asm/hwcap.h
+// or fallback if your headers don't define them). On x86 Linux, AT_HWCAP2
+// carries XSAVE / FSGSBASE / etc. AVX-512 itself is advertised via the
+// 'flags' field in /proc/cpuinfo more reliably than via HWCAP on x86.
+// We print AT_HWCAP / AT_HWCAP2 / AT_PLATFORM regardless and let the
+// reader compare.
+
+static void print_auxv(void) {
+    printf("--- getauxval (kernel-mediated view) ---\n");
+    unsigned long h1 = getauxval(AT_HWCAP);
+    unsigned long h2 = getauxval(AT_HWCAP2);
+    const char *plat = (const char *)getauxval(AT_PLATFORM);
+    printf("  AT_HWCAP:    0x%lx\n", h1);
+    printf("  AT_HWCAP2:   0x%lx\n", h2);
+    printf("  AT_PLATFORM: %s\n", plat ? plat : "(null)");
+}
+
+#ifdef __x86_64__
+
+// CPUID leaf 1: ECX bit 26 = XSAVE, bit 27 = OSXSAVE, bit 28 = AVX
+//               EDX bit 25 = SSE, bit 26 = SSE2
+// CPUID leaf 7,0: EBX bit 5  = AVX2
+//                 EBX bit 16 = AVX-512F
+//                 EBX bit 17 = AVX-512DQ
+//                 EBX bit 21 = AVX-512IFMA
+//                 EBX bit 30 = AVX-512BW
+//                 EBX bit 31 = AVX-512VL
+//                 ECX bit 1  = AVX-512_VBMI
+//                 ECX bit 11 = AVX-512_VNNI
+// CPUID leaf 7,1: EAX bit 4  = AVX-VNNI
+//                 EAX bit 23 = AVX-IFMA
+// CPUID leaf D,0: EAX = XCR0 mask of supported XSAVE features (from silicon, NOT
+//                 from kernel's allowed view). Bits 5/6/7 = opmask, hi256, hi16_zmm.
+
+static void print_cpuid_direct(void) {
+    unsigned int eax, ebx, ecx, edx;
+
+    printf("--- direct cpuid (bypasses kernel masking, sees silicon) ---\n");
+
+    // Vendor + base info
+    __cpuid(0, eax, ebx, ecx, edx);
+    char vendor[13];
+    memcpy(vendor, &ebx, 4);
+    memcpy(vendor + 4, &edx, 4);
+    memcpy(vendor + 8, &ecx, 4);
+    vendor[12] = 0;
+    printf("  cpuid(0): max_basic_leaf=%u  vendor=\"%s\"\n", eax, vendor);
+
+    // Brand string (leaves 0x80000002–0x80000004)
+    char brand[49] = {0};
+    for (int i = 0; i < 3; i++) {
+        __cpuid(0x80000002 + i, eax, ebx, ecx, edx);
+        memcpy(brand + i * 16 + 0, &eax, 4);
+        memcpy(brand + i * 16 + 4, &ebx, 4);
+        memcpy(brand + i * 16 + 8, &ecx, 4);
+        memcpy(brand + i * 16 + 12, &edx, 4);
+    }
+    printf("  cpuid(0x80000002..4) brand: \"%s\"\n", brand);
+
+    // Leaf 1
+    __cpuid(1, eax, ebx, ecx, edx);
+    printf("  cpuid(1): family=%u model=%u stepping=%u  ext_family=%u ext_model=%u\n",
+           (eax >> 8) & 0xf, (eax >> 4) & 0xf, eax & 0xf,
+           (eax >> 20) & 0xff, (eax >> 16) & 0xf);
+    printf("  cpuid(1).ecx: AVX=%d  XSAVE=%d  OSXSAVE=%d  AES=%d  PCLMUL=%d  FMA=%d\n",
+           !!(ecx & (1u << 28)), !!(ecx & (1u << 26)), !!(ecx & (1u << 27)),
+           !!(ecx & (1u << 25)), !!(ecx & (1u << 1)),  !!(ecx & (1u << 12)));
+
+    // Leaf 7, subleaf 0
+    __cpuid_count(7, 0, eax, ebx, ecx, edx);
+    printf("  cpuid(7,0).ebx: AVX2=%d  AVX512F=%d  AVX512DQ=%d  AVX512IFMA=%d  AVX512CD=%d\n",
+           !!(ebx & (1u << 5)),  !!(ebx & (1u << 16)), !!(ebx & (1u << 17)),
+           !!(ebx & (1u << 21)), !!(ebx & (1u << 28)));
+    printf("  cpuid(7,0).ebx: AVX512BW=%d  AVX512VL=%d  SHA=%d\n",
+           !!(ebx & (1u << 30)), !!(ebx & (1u << 31)), !!(ebx & (1u << 29)));
+    printf("  cpuid(7,0).ecx: AVX512VBMI=%d  AVX512VBMI2=%d  AVX512VNNI=%d  AVX512BITALG=%d  VAES=%d  VPCLMULQDQ=%d\n",
+           !!(ecx & (1u << 1)),  !!(ecx & (1u << 6)),  !!(ecx & (1u << 11)),
+           !!(ecx & (1u << 12)), !!(ecx & (1u << 9)),  !!(ecx & (1u << 10)));
+    printf("  cpuid(7,0).edx: AVX512_4VNNIW=%d  AVX512_4FMAPS=%d  AVX512_VP2INTERSECT=%d\n",
+           !!(edx & (1u << 2)),  !!(edx & (1u << 3)),  !!(edx & (1u << 8)));
+
+    // Leaf 7, subleaf 1
+    __cpuid_count(7, 1, eax, ebx, ecx, edx);
+    printf("  cpuid(7,1).eax: AVX_VNNI=%d  AVX_IFMA=%d  AVX512_BF16=%d\n",
+           !!(eax & (1u << 4)),  !!(eax & (1u << 23)), !!(eax & (1u << 5)));
+
+    // Leaf D, subleaf 0: XCR0 supported by silicon
+    __cpuid_count(0xd, 0, eax, ebx, ecx, edx);
+    printf("  cpuid(0xd,0).eax (silicon XCR0 mask): 0x%x\n", eax);
+    printf("    bit  0 (x87)    = %d\n", !!(eax & (1u << 0)));
+    printf("    bit  1 (SSE)    = %d\n", !!(eax & (1u << 1)));
+    printf("    bit  2 (AVX)    = %d\n", !!(eax & (1u << 2)));
+    printf("    bit  3 (BNDREGS)= %d\n", !!(eax & (1u << 3)));
+    printf("    bit  4 (BNDCSR) = %d\n", !!(eax & (1u << 4)));
+    printf("    bit  5 (AVX-512 opmask)  = %d\n", !!(eax & (1u << 5)));
+    printf("    bit  6 (AVX-512 hi256)   = %d\n", !!(eax & (1u << 6)));
+    printf("    bit  7 (AVX-512 hi16_zmm)= %d\n", !!(eax & (1u << 7)));
+
+    // OSXSAVE indicates the OS has done XCR0 setup
+    __cpuid(1, eax, ebx, ecx, edx);
+    int osxsave = !!(ecx & (1u << 27));
+    printf("  OSXSAVE=%d %s\n", osxsave,
+           osxsave ? "(OS has enabled XSAVE)" : "(OS has NOT enabled XSAVE — direct AVX use will fault)");
+
+    if (osxsave) {
+        // Read actual XCR0 the OS has configured
+        unsigned int xcr0_lo, xcr0_hi;
+        __asm__ volatile("xgetbv" : "=a"(xcr0_lo), "=d"(xcr0_hi) : "c"(0));
+        unsigned long long xcr0 = ((unsigned long long)xcr0_hi << 32) | xcr0_lo;
+        printf("  xgetbv(0) (OS-enabled XCR0): 0x%llx\n", xcr0);
+        printf("    bit  0 (x87)    = %d\n", !!(xcr0 & (1ull << 0)));
+        printf("    bit  1 (SSE)    = %d\n", !!(xcr0 & (1ull << 1)));
+        printf("    bit  2 (AVX)    = %d\n", !!(xcr0 & (1ull << 2)));
+        printf("    bit  5 (AVX-512 opmask)  = %d\n", !!(xcr0 & (1ull << 5)));
+        printf("    bit  6 (AVX-512 hi256)   = %d\n", !!(xcr0 & (1ull << 6)));
+        printf("    bit  7 (AVX-512 hi16_zmm)= %d\n", !!(xcr0 & (1ull << 7)));
+        printf("    ↑ If silicon (cpuid 0xd,0) has AVX-512 bits set but xgetbv (OS-enabled XCR0)\n");
+        printf("    ↑ does NOT, then any code path that consults raw cpuid for codegen decisions\n");
+        printf("    ↑ will incorrectly emit AVX-512 — kernel cannot save the registers.\n");
+    }
+}
+
+// __builtin_cpu_supports: what compiler-rt sees.
+// Note: gcc requires a string LITERAL — can't loop. The named features must
+// be ones gcc recognizes; older gcc rejects names like "avxvnni".
+#define BCS(name) printf("  %-14s = %d\n", name, __builtin_cpu_supports(name))
+static void print_builtin_cpu_supports(void) {
+    printf("--- __builtin_cpu_supports (compiler-rt) ---\n");
+    __builtin_cpu_init();
+    BCS("sse");
+    BCS("sse2");
+    BCS("sse3");
+    BCS("ssse3");
+    BCS("sse4.1");
+    BCS("sse4.2");
+    BCS("avx");
+    BCS("avx2");
+    BCS("fma");
+    BCS("avx512f");
+    BCS("avx512dq");
+    BCS("avx512bw");
+    BCS("avx512vl");
+    BCS("avx512cd");
+    BCS("avx512vnni");
+    BCS("avx512vbmi");
+    BCS("avx512ifma");
+}
+#undef BCS
+
+#endif // __x86_64__
+
+int main(void) {
+    print_auxv();
+    printf("\n");
+#ifdef __x86_64__
+    print_cpuid_direct();
+    printf("\n");
+    print_builtin_cpu_supports();
+#else
+    printf("(non-x86 build — only auxv probe ran)\n");
+#endif
+    return 0;
+}

--- a/repro/cpuid-probes/probe_cpu.mojo
+++ b/repro/cpuid-probes/probe_cpu.mojo
@@ -1,0 +1,66 @@
+# Mojo-side CPU feature probe for modular/modular#6413.
+#
+# Run inside the cached projectodyssey:dev container alongside the
+# cpu_features_probe.c output to compare what Mojo sees vs what
+# the kernel/__builtin_cpu_supports/direct cpuid sees.
+#
+# Goal: identify whether Mojo's stdlib exposes any way to detect
+# the CPU features it will use for SIMD codegen, and whether that
+# detection routine sees AVX-512 on a host where /proc/cpuinfo
+# does not advertise it.
+#
+# Run:
+#   pixi run mojo run repro/cpuid-probes/probe_cpu.mojo
+
+
+from sys.info import (
+    has_avx,
+    has_avx2,
+    has_avx512f,
+    has_fma,
+    has_intel_amx_bf16,
+    has_intel_amx_int8,
+    has_neon,
+    has_sse2,
+    has_sse3,
+    has_sse4_1,
+    has_sse4_2,
+    has_vnni,
+    is_apple_silicon,
+    is_neoverse_n1,
+    is_x86,
+    num_logical_cores,
+    num_performance_cores,
+    simdbitwidth,
+    simdwidthof,
+)
+
+
+def main():
+    print("=== Mojo sys.info CPU detection ===")
+    print("is_x86()           =", is_x86())
+    print("has_sse2()         =", has_sse2())
+    print("has_sse3()         =", has_sse3())
+    print("has_sse4_1()       =", has_sse4_1())
+    print("has_sse4_2()       =", has_sse4_2())
+    print("has_avx()          =", has_avx())
+    print("has_avx2()         =", has_avx2())
+    print("has_fma()          =", has_fma())
+    print("has_avx512f()      =", has_avx512f())
+    print("has_vnni()         =", has_vnni())
+    print("has_intel_amx_bf16=", has_intel_amx_bf16())
+    print("has_intel_amx_int8=", has_intel_amx_int8())
+    print("has_neon()         =", has_neon())
+    print("is_apple_silicon() =", is_apple_silicon())
+    print("is_neoverse_n1()   =", is_neoverse_n1())
+    print()
+    print("=== SIMD width (the JIT will pick this) ===")
+    print("simdbitwidth()                =", simdbitwidth())
+    print("simdwidthof[DType.float32]()  =", simdwidthof[DType.float32]())
+    print("simdwidthof[DType.float64]()  =", simdwidthof[DType.float64]())
+    print("simdwidthof[DType.int32]()    =", simdwidthof[DType.int32]())
+    print("simdwidthof[DType.int8]()     =", simdwidthof[DType.int8]())
+    print()
+    print("=== logical cores ===")
+    print("num_logical_cores()           =", num_logical_cores())
+    print("num_performance_cores()       =", num_performance_cores())

--- a/repro/repro_6413_assert_almost_equal.mojo
+++ b/repro/repro_6413_assert_almost_equal.mojo
@@ -1,0 +1,55 @@
+"""Standalone repro candidate for modular/modular#6413 (Backtrace A).
+
+Captured backtrace (CI run 25649843238, Mojo 1.0.0b2.dev2026050805):
+
+    Thread 1 "mojo" received signal SIGILL, Illegal instruction.
+    assert_almost_equal () at shared/testing/assertions.mojo:170
+    170     var diff = abs(a - b)
+    #1  test_tensor_dataset_negative_indexing () at tests/.../test_tensor_dataset.mojo:166
+    #2  main ()
+
+This file mirrors test_tensor_dataset_negative_indexing exactly (same imports,
+same construction order) so the captured frame matches pixel-for-pixel. It
+removes the testing harness (no conftest, no SimpleMLP, no perf_counter) so the
+Mojo file is the smallest possible reproducer for Modular.
+
+Run under the gdb wrapper:
+
+    bash scripts/mojo-under-gdb.sh /tmp/cores repro/repro_6413_assert_almost_equal.mojo
+
+Loops the failing block 50× per process so a single process probabilistically
+exercises the crash window without needing thousands of process restarts.
+"""
+
+from shared.data.datasets import TensorDataset
+from shared.tensor.any_tensor import AnyTensor
+from shared.testing.assertions import assert_almost_equal, assert_equal
+
+
+def trigger() raises:
+    # Identical to test_tensor_dataset_negative_indexing in
+    # tests/shared/data/datasets/test_tensor_dataset.mojo:153-171
+    var data_list: List[Float32] = [Float32(1.0), Float32(2.0), Float32(3.0)]
+    var data = AnyTensor(data_list^)
+    var labels_list: List[Int] = [0, 1, 2]
+    var labels = AnyTensor(labels_list^)
+    var dataset = TensorDataset(data^, labels^)
+
+    var last_sample = dataset[-1]
+    # Crash site in captured core: `abs(a - b)` inside assert_almost_equal.
+    assert_almost_equal(last_sample[0][0], Float32(3.0))
+    assert_equal(last_sample[1][0], 2)
+
+    var second_last_sample = dataset[-2]
+    assert_almost_equal(second_last_sample[0][0], Float32(2.0))
+    assert_equal(second_last_sample[1][0], 1)
+
+
+def main() raises:
+    for i in range(50):
+        try:
+            trigger()
+        except e:
+            print("iter", i, "raised:", String(e))
+            raise e.copy()
+    print("repro_6413_assert_almost_equal: completed 50 iterations cleanly")

--- a/repro/repro_6413_python_import_os.mojo
+++ b/repro/repro_6413_python_import_os.mojo
@@ -1,0 +1,37 @@
+"""Standalone repro candidate for modular/modular#6413 (Backtrace B).
+
+Captured backtrace (CI run 25649843238, Mojo 1.0.0b2.dev2026050805):
+
+    Thread 1 "mojo" received signal SIGILL, Illegal instruction.
+    #0  _strip ()         at oss/modular/mojo/stdlib/std/collections/string/string_slice.mojo:1035
+    #1  rstrip ()         at oss/modular/mojo/stdlib/std/collections/string/string_slice.mojo:1104
+    #5  __init__ ()       at oss/modular/mojo/stdlib/std/python/python.mojo:45
+    #7  KGEN_CompilerRT_GetOrCreateGlobalIndexed () from libKGENCompilerRTShared.so
+    #11 import_module ()  at oss/modular/mojo/stdlib/std/python/python.mojo:238
+    #12 test_substitute_simple_env_var () at tests/configs/test_env_vars.mojo:21
+
+This file exercises the same code path with NO ProjectOdyssey state — pure stdlib —
+so that if it crashes in CI, Modular has a one-file repro Modular asked for in
+the issue thread.
+
+Run under the gdb wrapper to capture an ELF core if it crashes:
+
+    bash scripts/mojo-under-gdb.sh /tmp/cores repro/repro_6413_python_import_os.mojo
+
+Repeat 60+ times — the production rate was ~30% per CI job; expect single-digit
+percentage at this scale, so loops both inside main() AND in the calling shell
+to amplify.
+"""
+
+from std.python import Python
+
+
+def main() raises:
+    # Inner loop attacks the KGEN_CompilerRT_GetOrCreateGlobalIndexed path
+    # (Python global init) and the string_slice._strip path used by Python.__init__.
+    # 200 iterations keeps wall time short while still hitting the global
+    # initializer many times (Python re-imports are cached, but the rstrip path
+    # in Python.__init__ runs per call).
+    for _ in range(200):
+        var os_mod = Python.import_module("os")
+        _ = os_mod

--- a/scripts/agents/agent_health_check.sh
+++ b/scripts/agents/agent_health_check.sh
@@ -236,7 +236,11 @@ for agent_file in "${AGENT_FILES[@]}"; do
 
     # Find all markdown links to other agents: [text](./file.md)
     # Extract just the file paths
-    links=$(grep -oP '\[.*?\]\(\./.*?\.md\)' "$agent_file" 2>/dev/null | grep -oP '\(\./\K[^)]+' || true)
+    # grep exits 1 when no lines match — that is the normal case for agents with no cross-links.
+    # Capture without || true; empty links is fine and handled below.
+    set +e
+    links=$(grep -oP '\[.*?\]\(\./.*?\.md\)' "$agent_file" 2>/dev/null | grep -oP '\(\./\K[^)]+')
+    set -e
 
     if [[ -n "$links" ]]; then
         while IFS= read -r link; do

--- a/scripts/build_configs_distribution.sh
+++ b/scripts/build_configs_distribution.sh
@@ -113,11 +113,17 @@ cp -r configs "${ML_ODYSSEY_ROOT}/"
 
 # Install utilities
 mkdir -p "${ML_ODYSSEY_ROOT}/shared/utils"
-cp utils/*.mojo "${ML_ODYSSEY_ROOT}/shared/utils/" || true
+# If no utils/*.mojo files exist yet, cp will fail — log it rather than silently skipping.
+if ! cp utils/*.mojo "${ML_ODYSSEY_ROOT}/shared/utils/" 2>/dev/null; then
+    echo "[build_configs_distribution] NOTE: no utils/*.mojo files to copy (directory may not exist yet)"
+fi
 
 # Install examples
 mkdir -p "${ML_ODYSSEY_ROOT}/examples"
-cp examples/*.mojo "${ML_ODYSSEY_ROOT}/examples/" 2>/dev/null || true
+# If no examples/*.mojo files exist yet, cp will fail — log it rather than silently skipping.
+if ! cp examples/*.mojo "${ML_ODYSSEY_ROOT}/examples/" 2>/dev/null; then
+    echo "[build_configs_distribution] NOTE: no examples/*.mojo files to copy (directory may not exist yet)"
+fi
 
 echo "Installation complete!"
 echo ""

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -112,10 +112,12 @@ fi
 # Commit changes
 git add VERSION
 if [[ -f "$REPO_ROOT/pixi.toml" ]]; then
-    git add pixi.toml 2>/dev/null || true
+    # pixi.toml should always exist; git add failing would indicate a real problem.
+    git add pixi.toml
 fi
 if [[ -f "$REPO_ROOT/pyproject.toml" ]]; then
-    git add pyproject.toml 2>/dev/null || true
+    # pyproject.toml should always exist if the file check passed.
+    git add pyproject.toml
 fi
 
 git commit -m "chore: bump version to $NEW_VERSION

--- a/scripts/cleanup_stale_worktrees.sh
+++ b/scripts/cleanup_stale_worktrees.sh
@@ -76,7 +76,10 @@ find_repo_root() {
     # Use git-common-dir to find the main repo root (works from any worktree).
     # git-common-dir returns the shared .git dir, e.g. /repo/.git
     local git_common_dir
-    git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+    # If git rev-parse fails, we are not in a git repository — this is a real error.
+    if ! git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null)"; then
+        git_common_dir=""
+    fi
     if [[ -z "$git_common_dir" ]]; then
         log_error "Not inside a git repository."
         exit 1

--- a/scripts/coredump-host-handler.sh
+++ b/scripts/coredump-host-handler.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# coredump-host-handler.sh — pipe-mode core_pattern handler
+#
+# Invoked by the Linux kernel (as PID 1 of the HOST namespace) when any
+# process with `ulimit -c > 0` crashes.  The kernel pipes the full ELF
+# core on stdin and passes positional args set via core_pattern tokens.
+#
+# Install:
+#   sudo cp scripts/coredump-host-handler.sh /usr/local/bin/coredump-host-handler.sh
+#   sudo chmod +x /usr/local/bin/coredump-host-handler.sh
+#   echo "|/usr/local/bin/coredump-host-handler.sh %p %e %t %s %P" \
+#     | sudo tee /proc/sys/kernel/core_pattern
+#
+# core_pattern tokens used:
+#   %p  PID of crashing process (in container namespace)
+#   %e  executable basename
+#   %t  time of crash (seconds since epoch)
+#   %s  signal number
+#   %P  global PID (host namespace)
+#
+# Manual test (does NOT hang — stdin TTY guard prevents blocking):
+#   ./scripts/coredump-host-handler.sh 1234 mojo 1700000000 11 5678
+#   echo "fake core data" | ./scripts/coredump-host-handler.sh 1234 mojo 1700000000 11 5678
+#
+# Related: modular/modular#6413, PR #5380, PR that introduced this file
+
+set -euo pipefail
+
+PID="${1:-unknown}"
+EXE="${2:-unknown}"
+TIME="${3:-0}"
+SIGNAL="${4:-0}"
+# $5 = global (host) PID — captured but not used in filename
+
+# ── TTY guard ────────────────────────────────────────────────────────────────
+# When invoked by the kernel, stdin is a pipe carrying the core ELF — not a
+# terminal.  When invoked manually for testing with no piped input, stdin IS a
+# terminal and reading from it would hang forever.  Bail out early in that case.
+if [ -t 0 ]; then
+    echo "coredump-host-handler: stdin is a TTY — refusing to run (would block)." >&2
+    echo "  This script is meant to be invoked by the kernel via core_pattern." >&2
+    echo "  Manual test: echo somecore | $0 <pid> <exe> <time> <signal> [<gpid>]" >&2
+    exit 1
+fi
+
+# ── Destination directory ─────────────────────────────────────────────────────
+# We are running as PID 1 of the HOST.  Walk well-known host-side paths.
+# The GitHub Actions runner workspace is at:
+#   /home/runner/work/<repo>/<repo>/
+# which is the actual host directory that the container bind-mounts as
+# /workspace.  Writing here is guaranteed to survive the container teardown
+# and appear in the artifact upload step.
+
+TARGET=""
+for candidate in \
+    /home/runner/work/ProjectOdyssey/ProjectOdyssey/crash-bundle/cores \
+    /workspace/crash-bundle/cores \
+    /tmp/crash-bundle/cores; do
+    if [ -d "$candidate" ]; then
+        TARGET="$candidate"
+        break
+    fi
+done
+
+# If none of the above exist yet, fall back to /tmp (create it).
+if [ -z "$TARGET" ]; then
+    TARGET=/tmp/crash-bundle/cores
+fi
+
+mkdir -p "$TARGET"
+
+# ── Write core ELF ───────────────────────────────────────────────────────────
+# Cap at 4 GB to prevent filling the runner disk when a runaway process
+# generates an enormous core.  Real libKGEN JIT crashes are typically 50-500 MB.
+OUT="$TARGET/core.${PID}.${EXE}.${TIME}.sig${SIGNAL}"
+head -c $((4 * 1024 * 1024 * 1024)) > "$OUT" || true
+chmod 644 "$OUT" 2>/dev/null || true
+
+# ── Log the capture ───────────────────────────────────────────────────────────
+LOG_DIR="$(dirname "$TARGET")"
+SIZE=$(stat -c %s "$OUT" 2>/dev/null || echo "?")
+{
+    printf '%s wrote %s (%s bytes) signal=%s exe=%s\n' \
+        "$(date -Iseconds)" "$OUT" "$SIZE" "$SIGNAL" "$EXE"
+} >> "$LOG_DIR/handler.log" 2>/dev/null || true

--- a/scripts/coredump-host-handler.sh
+++ b/scripts/coredump-host-handler.sh
@@ -73,8 +73,14 @@ mkdir -p "$TARGET"
 # Cap at 4 GB to prevent filling the runner disk when a runaway process
 # generates an enormous core.  Real libKGEN JIT crashes are typically 50-500 MB.
 OUT="$TARGET/core.${PID}.${EXE}.${TIME}.sig${SIGNAL}"
-head -c $((4 * 1024 * 1024 * 1024)) > "$OUT" || true
-chmod 644 "$OUT" 2>/dev/null || true
+# Kernel-invoked pipe handler: the kernel ignores our exit code, so errors here
+# cannot propagate to the caller.  Log every failure so handler.log is diagnostic.
+if ! head -c $((4 * 1024 * 1024 * 1024)) > "$OUT"; then
+    echo "$(date -Iseconds) ERROR: failed to write core to $OUT" >> "$LOG_DIR/handler.log" 2>/dev/null
+fi
+if ! chmod 644 "$OUT" 2>/dev/null; then
+    echo "$(date -Iseconds) WARNING: chmod 644 $OUT failed (file may be unreadable)" >> "$LOG_DIR/handler.log" 2>/dev/null
+fi
 
 # ── Log the capture ───────────────────────────────────────────────────────────
 LOG_DIR="$(dirname "$TARGET")"
@@ -82,4 +88,9 @@ SIZE=$(stat -c %s "$OUT" 2>/dev/null || echo "?")
 {
     printf '%s wrote %s (%s bytes) signal=%s exe=%s\n' \
         "$(date -Iseconds)" "$OUT" "$SIZE" "$SIGNAL" "$EXE"
-} >> "$LOG_DIR/handler.log" 2>/dev/null || true
+} >> "$LOG_DIR/handler.log" 2>/dev/null
+# Kernel-invoked: if the log append failed (e.g., LOG_DIR is unwritable), there is
+# no safe way to surface the error — the kernel has no channel for our exit code.
+# Failure here is silent by design; the crash-bundle artifact upload step will
+# surface a missing handler.log as "(no handler.log — handler was not invoked)".
+true

--- a/scripts/install-podman.sh
+++ b/scripts/install-podman.sh
@@ -441,7 +441,12 @@ fi
 
 section "Migrating database"
 
-"$INSTALL_DIR/podman" system migrate --migrate-db 2>/dev/null || true
+# `podman system migrate --migrate-db` may fail if there is nothing to migrate
+# (fresh install) or if the DB is already in the target format. Both are benign.
+# Log the outcome so it is visible.
+if ! "$INSTALL_DIR/podman" system migrate --migrate-db 2>/dev/null; then
+    info "Database migration skipped (no migration needed or already migrated)"
+fi
 info "Database migration complete (BoltDB → SQLite)"
 
 # ============================================================

--- a/scripts/mojo-under-gdb.sh
+++ b/scripts/mojo-under-gdb.sh
@@ -97,4 +97,9 @@ echo "[mojo-under-gdb] args     : $*" >&2
 # --args passes everything after it verbatim as the inferior's argv.
 # stdout/stderr from the mojo process flow through gdb normally so CI
 # logs remain readable.
-exec gdb -batch -nx -x "$GDB_SCRIPT" --args "$MOJO_BIN" "$@"
+#
+# Run gdb INSIDE `pixi run` so the inferior inherits the activated pixi
+# env (MODULAR_HOME, PATH, MOJO stdlib search paths). Running gdb outside
+# `pixi run` strips that activation and mojo fails with "unable to locate
+# module 'std'" before it ever has a chance to crash.
+exec pixi run -- gdb -batch -nx -x "$GDB_SCRIPT" --args "$MOJO_BIN" "$@"

--- a/scripts/mojo-under-gdb.sh
+++ b/scripts/mojo-under-gdb.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Run `mojo` under gdb to catch the in-process SIGABRT handler in libKGEN
+# (modular/modular#6413) and dump a real ELF core via generate-core-file.
+#
+# Without gdb interception, libKGEN's SIGABRT handler catches the abort,
+# prints its own 3-frame post-handler trace, and exits cleanly — the
+# kernel never generates a core because the process handles the signal itself.
+# Running under gdb forces the signal to stop in the debugger BEFORE the
+# user handler runs, so we get the real pre-signal frame frozen in the core.
+#
+# Usage:
+#   mojo-under-gdb.sh <core-dir> <mojo-args...>
+#
+#   <core-dir>   Directory where cores and gdb logs are written (created if absent)
+#   <mojo-args>  All remaining arguments are passed verbatim to `pixi run mojo`
+#
+# Environment variables:
+#   MOJO_UNDER_GDB=0   Skip gdb and exec mojo directly (local dev escape hatch)
+#
+# Output files (on crash):
+#   <core-dir>/core.gdb.<timestamp>.mojo  — ELF core (multi-MB)
+#   <core-dir>/gdb-<timestamp>.log        — full backtrace + threads + shlibs
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+    echo "[mojo-under-gdb] usage: $0 <core-dir> <mojo-args...>" >&2
+    exit 1
+fi
+
+CORE_DIR="$1"
+shift
+
+# Escape hatch: MOJO_UNDER_GDB=0 bypasses gdb for local dev where overhead matters.
+if [ "${MOJO_UNDER_GDB:-1}" = "0" ]; then
+    exec pixi run mojo "$@"
+fi
+
+mkdir -p "$CORE_DIR"
+TS=$(date +%s)
+GDB_LOG="${CORE_DIR}/gdb-${TS}.log"
+CORE_FILE="${CORE_DIR}/core.gdb.${TS}.mojo"
+
+# Resolve the real mojo binary so gdb has a concrete ELF file argument.
+# `pixi run which mojo` prints any activation preamble on stderr; `tail -1`
+# grabs the last line (the actual path) to handle noisy pixi output.
+MOJO_BIN=$(pixi run which mojo 2>/dev/null | tail -1 || true)
+if [ -z "$MOJO_BIN" ] || [ ! -x "$MOJO_BIN" ]; then
+    echo "[mojo-under-gdb] WARNING: could not resolve mojo binary; falling back to direct exec" >&2
+    exec pixi run mojo "$@"
+fi
+
+# Write the gdb command script to a temp file to avoid multi-line -ex quoting issues.
+# gdb multi-line strings via -ex are not portable across gdb versions; -x is reliable.
+GDB_SCRIPT=$(mktemp /tmp/mojo-gdb-XXXXXX.gdb)
+# shellcheck disable=SC2064
+trap "rm -f '$GDB_SCRIPT'" EXIT
+
+cat > "$GDB_SCRIPT" <<GDBEOF
+set pagination off
+set confirm off
+set logging file ${GDB_LOG}
+set logging overwrite on
+set logging enabled on
+
+# Intercept crash signals before user (libKGEN) handlers run.
+# "nopass" prevents the signal from being delivered to the inferior.
+handle SIGABRT stop nopass print
+handle SIGSEGV stop nopass print
+handle SIGBUS  stop nopass print
+
+run
+
+# If gdb stopped due to a signal, dump a core and capture context.
+if \$_siginfo
+  printf "[mojo-under-gdb] caught signal %d at ", \$_siginfo.si_signo
+  info frame
+  printf "Generating core: ${CORE_FILE}\\n"
+  generate-core-file ${CORE_FILE}
+end
+
+bt full
+info threads
+info sharedlibrary
+set logging enabled off
+quit
+GDBEOF
+
+echo "[mojo-under-gdb] gdb log  : ${GDB_LOG}" >&2
+echo "[mojo-under-gdb] core file: ${CORE_FILE} (written on crash)" >&2
+echo "[mojo-under-gdb] binary   : ${MOJO_BIN}" >&2
+echo "[mojo-under-gdb] args     : $*" >&2
+
+# --args passes everything after it verbatim as the inferior's argv.
+# stdout/stderr from the mojo process flow through gdb normally so CI
+# logs remain readable.
+exec gdb -batch -nx -x "$GDB_SCRIPT" --args "$MOJO_BIN" "$@"

--- a/scripts/mojo-under-gdb.sh
+++ b/scripts/mojo-under-gdb.sh
@@ -44,7 +44,10 @@ CORE_FILE="${CORE_DIR}/core.gdb.${TS}.mojo"
 # Resolve the real mojo binary so gdb has a concrete ELF file argument.
 # `pixi run which mojo` prints any activation preamble on stderr; `tail -1`
 # grabs the last line (the actual path) to handle noisy pixi output.
-MOJO_BIN=$(pixi run which mojo 2>/dev/null | tail -1 || true)
+# pixi run which mojo may print activation preamble on stderr; tail -1 grabs the
+# actual path from the last line.  If the command fails (pixi not set up), MOJO_BIN
+# is empty and the check below falls back to direct exec.
+MOJO_BIN=$(pixi run which mojo 2>/dev/null | tail -1) || MOJO_BIN=""
 if [ -z "$MOJO_BIN" ] || [ ! -x "$MOJO_BIN" ]; then
     echo "[mojo-under-gdb] WARNING: could not resolve mojo binary; falling back to direct exec" >&2
     exec pixi run mojo "$@"

--- a/scripts/mojo-under-gdb.sh
+++ b/scripts/mojo-under-gdb.sh
@@ -72,19 +72,18 @@ handle SIGABRT stop nopass print
 handle SIGSEGV stop nopass print
 handle SIGBUS  stop nopass print
 
-run
-
-# If gdb stopped due to a signal, dump a core and capture context.
-if \$_siginfo
-  printf "[mojo-under-gdb] caught signal %d at ", \$_siginfo.si_signo
-  info frame
-  printf "Generating core: ${CORE_FILE}\\n"
+# Dump core + context on stop (signal caught). On normal exit, this hook
+# is never invoked, so a clean test run produces no spurious gdb errors.
+define hook-stop
+  printf "[mojo-under-gdb] stop reason captured; dumping core to ${CORE_FILE}\\n"
   generate-core-file ${CORE_FILE}
+  bt full
+  info threads
+  info sharedlibrary
 end
 
-bt full
-info threads
-info sharedlibrary
+run
+
 set logging enabled off
 quit
 GDBEOF
@@ -102,4 +101,8 @@ echo "[mojo-under-gdb] args     : $*" >&2
 # env (MODULAR_HOME, PATH, MOJO stdlib search paths). Running gdb outside
 # `pixi run` strips that activation and mojo fails with "unable to locate
 # module 'std'" before it ever has a chance to crash.
-exec pixi run -- gdb -batch -nx -x "$GDB_SCRIPT" --args "$MOJO_BIN" "$@"
+#
+# `--return-child-result` makes gdb exit with the inferior's exit code
+# (or 128+signo on signal). Without this, gdb's own zero/non-zero status
+# masks the test result and we either always pass or always fail.
+exec pixi run -- gdb -batch -nx --return-child-result -x "$GDB_SCRIPT" --args "$MOJO_BIN" "$@"

--- a/scripts/mojo-under-gdb.sh
+++ b/scripts/mojo-under-gdb.sh
@@ -56,9 +56,25 @@ fi
 # Write the gdb command script to a temp file to avoid multi-line -ex quoting issues.
 # gdb multi-line strings via -ex are not portable across gdb versions; -x is reliable.
 GDB_SCRIPT=$(mktemp /tmp/mojo-gdb-XXXXXX.gdb)
+EXIT_CODE_FILE="${CORE_DIR}/exit-${TS}.code"
 # shellcheck disable=SC2064
 trap "rm -f '$GDB_SCRIPT'" EXIT
 
+# The gdb script uses Python event hooks because:
+#  1. `handle SIGABRT stop nopass` + a `hook-stop` block fires on EVERY stop
+#     event in gdb 15.1 — including normal exit, where `generate-core-file`
+#     fails with "You can't do that without a process to debug" and gdb
+#     prints "Error while running hook_stop". A bare gdb-script `if` on
+#     $_siginfo also fails after normal exit (no stack).
+#  2. `--return-child-result` is unreliable in gdb 15.1 -batch mode for
+#     processes killed by handled signals: gdb often exits 0 even when the
+#     inferior died on SIGABRT, masking the test failure entirely.
+#
+# Python events distinguish gdb.SignalEvent (real crash) from gdb.ExitedEvent
+# (clean exit) and record the desired exit code to a file. The wrapper then
+# reads that file and exits with the recorded code, so the caller sees:
+#   - 0 / N for normal exit code N
+#   - 128 + signo for any caught signal (134 for SIGABRT, 139 for SIGSEGV…)
 cat > "$GDB_SCRIPT" <<GDBEOF
 set pagination off
 set confirm off
@@ -66,21 +82,55 @@ set logging file ${GDB_LOG}
 set logging overwrite on
 set logging enabled on
 
+python
+import gdb
+EXIT_FILE = "${EXIT_CODE_FILE}"
+CORE_FILE = "${CORE_FILE}"
+# POSIX shell convention for signal-terminated processes.
+SIG_MAP = {"SIGABRT": 6, "SIGSEGV": 11, "SIGBUS": 7, "SIGFPE": 8, "SIGILL": 4}
+state = {"signaled": False}
+
+def write_exit(code):
+    with open(EXIT_FILE, "w") as f:
+        f.write(str(code))
+
+# Default = 1 covers the case where neither handler fires (e.g. gdb itself dies).
+write_exit(1)
+
+def on_stop(event):
+    # Only act on signal stops (we never set breakpoints, so any other
+    # stop event is unexpected and best left to gdb's defaults).
+    if isinstance(event, gdb.SignalEvent):
+        signo = event.stop_signal
+        print("[mojo-under-gdb] caught " + signo + "; dumping " + CORE_FILE)
+        gdb.execute("generate-core-file " + CORE_FILE)
+        gdb.execute("bt full")
+        gdb.execute("info threads")
+        gdb.execute("info sharedlibrary")
+        state["signaled"] = True
+        write_exit(128 + SIG_MAP.get(signo, 1))
+
+def on_exit(event):
+    # gdb fires Exited after the post-signal kill too. If we already
+    # captured a signal, do not overwrite that exit code.
+    if state["signaled"]:
+        return
+    code = getattr(event, "exit_code", None)
+    write_exit(code if code is not None else 0)
+
+gdb.events.stop.connect(on_stop)
+gdb.events.exited.connect(on_exit)
+end
+
 # Intercept crash signals before user (libKGEN) handlers run.
 # "nopass" prevents the signal from being delivered to the inferior.
+# SIGILL is included because Mojo's os.abort() raises llvm.trap → SIGILL,
+# and observed JIT crashes in modular/modular#6413 also surface as SIGILL.
 handle SIGABRT stop nopass print
 handle SIGSEGV stop nopass print
 handle SIGBUS  stop nopass print
-
-# Dump core + context on stop (signal caught). On normal exit, this hook
-# is never invoked, so a clean test run produces no spurious gdb errors.
-define hook-stop
-  printf "[mojo-under-gdb] stop reason captured; dumping core to ${CORE_FILE}\\n"
-  generate-core-file ${CORE_FILE}
-  bt full
-  info threads
-  info sharedlibrary
-end
+handle SIGILL  stop nopass print
+handle SIGFPE  stop nopass print
 
 run
 
@@ -93,16 +143,22 @@ echo "[mojo-under-gdb] core file: ${CORE_FILE} (written on crash)" >&2
 echo "[mojo-under-gdb] binary   : ${MOJO_BIN}" >&2
 echo "[mojo-under-gdb] args     : $*" >&2
 
-# --args passes everything after it verbatim as the inferior's argv.
-# stdout/stderr from the mojo process flow through gdb normally so CI
-# logs remain readable.
-#
 # Run gdb INSIDE `pixi run` so the inferior inherits the activated pixi
 # env (MODULAR_HOME, PATH, MOJO stdlib search paths). Running gdb outside
 # `pixi run` strips that activation and mojo fails with "unable to locate
 # module 'std'" before it ever has a chance to crash.
-#
-# `--return-child-result` makes gdb exit with the inferior's exit code
-# (or 128+signo on signal). Without this, gdb's own zero/non-zero status
-# masks the test result and we either always pass or always fail.
-exec pixi run -- gdb -batch -nx --return-child-result -x "$GDB_SCRIPT" --args "$MOJO_BIN" "$@"
+# `set -e` would abort here if gdb exits non-zero before we can read
+# EXIT_CODE_FILE. Disable it just for this invocation.
+set +e
+pixi run -- gdb -batch -nx -x "$GDB_SCRIPT" --args "$MOJO_BIN" "$@"
+gdb_status=$?
+set -e
+
+# Prefer the Python-recorded exit code; fall back to gdb's own status if
+# the file is missing (gdb crashed before the python hook fired).
+if [ -r "$EXIT_CODE_FILE" ]; then
+    inferior_exit=$(cat "$EXIT_CODE_FILE")
+    rm -f "$EXIT_CODE_FILE"
+    exit "$inferior_exit"
+fi
+exit "$gdb_status"


### PR DESCRIPTION
**DO NOT MERGE — forensic bisect PR for modular/modular#6413 (positive control).**

## Hypothesis

If PR #5395 / #5396 / #5397 / #5398 all stay green over 8 reruns, the "the rebase fixed it" narrative is suspect. This positive control rolls back to the **last commit on `ci-pipe-handler-cores` that consistently failed CI** (`1d294a7f`, 2026-05-11 04:11 UTC, run 25649843238 — 7-of-8 historic crash rate on Data Utilities Test Suite + Configs) and bolts the new instruction-stream disasm dump on top.

If the historic crash is still reproducible at all, this PR should hit it at high rate and **dump the faulting instruction** so we can finally answer: *is the SIGILL an unsupported-opcode fault (AVX-VNNI / VAES / SHA-NI / VPCLMULQDQ / movdir64b) the GHA runner CPU lacks?*

## What this PR contains

**Base commit**: `1d294a7f` — `fix(ci): use gdb Python events + exit-code file for crash detection`

This commit already has:

- gdb wrapper with Python events for crash interception
- pipe-handler `core_pattern` to bypass mount-namespace
- `MOJO_TEST_UNDER_GDB=1` at all comprehensive-tests sites
- Bundled mojo binary + libKGEN .so files in `crash-bundle/symbols/`

**One additional commit** (`5086e7b3`) on top: new step in `.github/actions/coredump-capture/action.yml` that symbolicates every captured core after bundling. For each core it dumps:

- Top-25-frame backtrace
- Integer + SSE/AVX register state at fault time
- 16 raw instructions before and after `$pc`
- Disassembly window of `[-64, +64]` bytes around `$pc`
- All-registers (full SSE/AVX state for ISA-feature analysis)

Output lives at `crash-bundle/symbolicated/<core>.symbolicated.log` per core, uploaded with the existing `crash-bundle-<job>` artifact.

## What this PR does NOT contain (vs green HEAD `c19246b3`)

- The main-rebase code changes (#5381, #5385, #5387, #5388, #5389) — isolated in PR #5395 / #5398
- The `repro/repro_6413_*.mojo` files and `repro-6413.yml` dispatch workflow (#5393 / #5394) — those run separately

This means: this PR runs `comprehensive-tests.yml` exactly as it did when it was failing on 2026-05-11, with the only difference being the symbolicator step on captured cores.

## Expected outcomes

| Result over 8 reruns | Conclusion |
| --- | --- |
| Data Utilities + Configs fail ≥4/8 times | Positive control works — crash is still reproducible at known-bad sha. The `symbolicated.log` artifact tells us what instruction faulted. |
| Data Utilities + Configs stay 0/8 failures | The crash has spontaneously stopped reproducing entirely (GHA runner pool change? Mojo binary cache change?). Investigate the runner side directly. |

## Companion bisect PRs

- PR #5395 — revert #5381 + #5387 (main-rebase code)
- PR #5396 — disable gdb wrapper (mask vs fix)
- PR #5397 — revert `docker-compose.yml` dev memlimit 14g → 12g
- PR #5398 — revert rest of #5389 (justfile + examples)

## Rerun protocol

After initial CI, `gh run rerun <id>` the comprehensive-tests workflow 7 more times. Record outcomes alongside the other bisect PRs in `~/.claude/plans/lets-do-further-investigation-sequential-dolphin.md`. On any crash, inspect the `symbolicated/*.log` files inside the `crash-bundle-*` artifact and post the faulting instruction to modular/modular#6413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>