### PR TITLE
ci(forensic): add bare-podman-run reproducer workflow for modular#6413

### DIFF
--- a/.github/workflows/probe-cpu-on-gha.yml
+++ b/.github/workflows/probe-cpu-on-gha.yml
@@ -65,10 +65,15 @@ jobs:
           path: /tmp/podman-image-cache
           key: ${{ steps.key.outputs.key }}
 
-      - name: Skip Mojo probe if cache miss
+      - name: Hard fail if cache miss
         if: steps.cache.outputs.cache-hit != 'true'
+        env:
+          CACHE_KEY: ${{ steps.key.outputs.key }}
         run: |
-          echo "::warning::No cached container image — Mojo probe skipped. (Run extract-cached-image.yml or comprehensive-tests first.)"
+          echo "[probe-cpu-on-gha] ERROR: no cached container image" >&2
+          echo "  expected key: ${CACHE_KEY}" >&2
+          echo "  run extract-cached-image.yml or comprehensive-tests on this branch first" >&2
+          exit 1
 
       - name: Start podman socket + load image
         if: steps.cache.outputs.cache-hit == 'true'

--- a/.github/workflows/probe-cpu-on-gha.yml
+++ b/.github/workflows/probe-cpu-on-gha.yml
@@ -1,0 +1,103 @@
+name: Probe CPU Features on GHA
+
+# Runs three orthogonal CPU-feature probes on a GHA `ubuntu-latest` runner:
+# 1. /proc/cpuinfo flags (kernel-mediated view)
+# 2. C probe: direct cpuid + xgetbv + __builtin_cpu_supports
+# 3. Mojo probe: sys.info.has_avx512f() etc.
+#
+# Goal for modular/modular#6413: prove (or disprove) that Mojo's CPU
+# detection sees AVX-512 silicon on a host where the kernel-mediated view
+# does not. The crash signatures + AMD EPYC 9V74 Zen 4 hypervisor topology
+# imply this is the bug; this workflow makes the proof concrete.
+#
+# Manual dispatch only.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
+        with:
+          fetch-depth: 1
+
+      - name: Kernel-mediated CPU view (/proc/cpuinfo + lscpu + getauxval)
+        run: |
+          echo "════════════════════ /proc/cpuinfo first CPU (host) ════════════════════"
+          awk '/^processor/{c++; if(c>1)exit} {print}' /proc/cpuinfo
+          echo
+          echo "════════════════════ Relevant flag filter (kernel view) ════════════════════"
+          grep -m1 ^flags /proc/cpuinfo | tr ' ' '\n' \
+            | grep -E '^(avx512[a-z0-9_]*|avx_vnni|avx|avx2|fma|f16c|sse4_[12]|vaes|sha_ni|movdir64b|gfni|vpclmulqdq|serialize|amx_)$' \
+            | sort -u | tr '\n' ' '
+          echo
+          echo
+          echo "════════════════════ lscpu (host) ════════════════════"
+          lscpu
+
+      - name: Build + run C probe (direct cpuid + xgetbv + __builtin_cpu_supports)
+        run: |
+          gcc -O2 -o /tmp/cpu_features_probe \
+            repro/cpuid-probes/cpu_features_probe.c
+          /tmp/cpu_features_probe
+
+      - name: Compute cache key
+        id: key
+        env:
+          DOCKERFILE_HASH: ${{ hashFiles('Dockerfile', 'pixi.toml', 'pixi.lock') }}
+        run: |
+          UID_VAL=$(id -u)
+          key="container-image-uid${UID_VAL}-${DOCKERFILE_HASH}"
+          echo "Cache key: ${key}"
+          echo "key=${key}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached container image
+        id: cache
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57  # v4
+        with:
+          path: /tmp/podman-image-cache
+          key: ${{ steps.key.outputs.key }}
+
+      - name: Skip Mojo probe if cache miss
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          echo "::warning::No cached container image — Mojo probe skipped. (Run extract-cached-image.yml or comprehensive-tests first.)"
+
+      - name: Start podman socket + load image
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: |
+          if ! systemctl --user start podman.socket; then
+            echo "warn: 'systemctl --user start podman.socket' failed (may already be running)" >&2
+          fi
+          echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+          podman load -i /tmp/podman-image-cache/dev.tar
+
+      - name: Mojo sys.info probe inside container
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: |
+          podman run --rm --userns=keep-id \
+            -v "$(pwd):/workspace:Z" -w /workspace \
+            --ulimit core=-1 \
+            projectodyssey:dev \
+            bash -c '
+              echo "════════════════════ /proc/cpuinfo flags (inside container) ════════════════════"
+              grep -m1 ^flags /proc/cpuinfo | tr " " "\n" \
+                | grep -E "^(avx512[a-z0-9_]*|avx_vnni|avx|avx2|fma|f16c|sse4_[12]|vaes|sha_ni)$" \
+                | sort -u | tr "\n" " "
+              echo
+              echo
+              echo "════════════════════ Mojo sys.info CPU detection ════════════════════"
+              pixi run mojo run repro/cpuid-probes/probe_cpu.mojo
+            '
+
+      - name: Summary
+        run: |
+          echo "::notice::Three views captured: kernel /proc/cpuinfo, direct cpuid via C, Mojo sys.info."
+          echo "::notice::If C probe shows cpuid(7,0).ebx[16] (AVX-512F) = 1 AND xgetbv[5..7] = 0 AND Mojo has_avx512f() = True, the bug is confirmed: Mojo reads silicon CPUID without checking OS-enabled XCR0."

--- a/.github/workflows/repro-bare-command-on-gha.yml
+++ b/.github/workflows/repro-bare-command-on-gha.yml
@@ -1,0 +1,133 @@
+name: Repro 6413 Bare Command on GHA
+
+# Run the EXACT same `podman run` command we're testing locally, on a GHA
+# Azure runner, to confirm the command shape matters less than the
+# environment. Loads the same dev.tar that gets uploaded by
+# extract-cached-image.yml, mounts the workspace the same way, runs the same
+# `pixi run mojo run repro/...mojo` invocations.
+#
+# Hypothesis: if the GHA runner crashes here AND the local hosts don't, the
+# variable is the runner CPU/hypervisor — same image, same command, same
+# binary, just different silicon underneath.
+#
+# Manual dispatch only. Pulls the cached image fresh from the GHA cache (no
+# rebuild) and runs both reproducers.
+
+on:
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: "How many times to run each reproducer"
+        required: false
+        default: "1"
+
+permissions:
+  contents: read
+
+jobs:
+  bare-repro:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # Route user input through env: to avoid command injection.
+      ITERATIONS: ${{ inputs.iterations }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
+        with:
+          fetch-depth: 1
+
+      - name: Export runner UID
+        id: uid
+        run: echo "user_id=$(id -u)" >> "$GITHUB_OUTPUT"
+
+      - name: Compute cache key (same as setup-container)
+        id: key
+        env:
+          UID_VAL: ${{ steps.uid.outputs.user_id }}
+          DOCKERFILE_HASH: ${{ hashFiles('Dockerfile', 'pixi.toml', 'pixi.lock') }}
+        run: |
+          key="container-image-uid${UID_VAL}-${DOCKERFILE_HASH}"
+          echo "key=${key}" >> "$GITHUB_OUTPUT"
+          echo "Resolved cache key: ${key}"
+
+      - name: Restore cached image tar
+        id: cache
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57  # v4
+        with:
+          path: /tmp/podman-image-cache
+          key: ${{ steps.key.outputs.key }}
+
+      - name: Report cache state
+        env:
+          CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+          CACHE_KEY: ${{ steps.key.outputs.key }}
+        run: |
+          if [ "${CACHE_HIT}" = "true" ]; then
+            echo "::notice::cache hit for key ${CACHE_KEY}"
+            SIZE=$(stat -c %s /tmp/podman-image-cache/dev.tar 2>/dev/null || echo "?")
+            echo "::notice::image tar size: ${SIZE} bytes"
+            sha256sum /tmp/podman-image-cache/dev.tar
+          else
+            echo "::error::cache MISS for key ${CACHE_KEY}"
+            echo "(no prior setup-container run cached this key)"
+            exit 1
+          fi
+
+      - name: Show runner CPU info
+        run: |
+          echo "=== runner uname ==="
+          uname -a
+          echo
+          echo "=== runner /proc/cpuinfo first CPU ==="
+          awk '/^processor/{c++; if(c>1)exit} {print}' /proc/cpuinfo
+          echo
+          echo "=== runner relevant flags ==="
+          grep -m1 flags /proc/cpuinfo | tr ' ' '\n' \
+            | grep -E '^(avx512[a-z_0-9]*|avx_vnni|avx|fma|f16c|sse4_[12]|vaes|sha_ni|movdir64b|gfni|vpclmulqdq|serialize)$' \
+            | sort -u | tr '\n' ' '
+          echo
+
+      - name: Start podman socket
+        run: |
+          if ! systemctl --user start podman.socket; then
+            echo "warn: 'systemctl --user start podman.socket' failed (may already be running)" >&2
+          fi
+          echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+
+      - name: Load image from cache tar
+        run: |
+          podman load -i /tmp/podman-image-cache/dev.tar
+          podman images projectodyssey:dev
+
+      - name: Run Site B reproducer (Python.import_module) — bare command
+        run: |
+          set +e
+          for i in $(seq 1 "${ITERATIONS}"); do
+            echo "════════ Site B iteration ${i}/${ITERATIONS} ════════"
+            podman run --rm --userns=keep-id \
+              -v "$(pwd):/workspace:Z" -w /workspace \
+              --ulimit core=-1 \
+              projectodyssey:dev \
+              bash -c 'pixi run mojo run repro/repro_6413_python_import_os.mojo 2>&1'
+            EXIT=$?
+            echo "--- iteration ${i} exit=${EXIT} ---"
+          done
+
+      - name: Run Site A reproducer (assert_almost_equal) — bare command
+        run: |
+          set +e
+          for i in $(seq 1 "${ITERATIONS}"); do
+            echo "════════ Site A iteration ${i}/${ITERATIONS} ════════"
+            podman run --rm --userns=keep-id \
+              -v "$(pwd):/workspace:Z" -w /workspace \
+              --ulimit core=-1 \
+              projectodyssey:dev \
+              bash -c 'pixi run mojo run -I /workspace repro/repro_6413_assert_almost_equal.mojo 2>&1'
+            EXIT=$?
+            echo "--- iteration ${i} exit=${EXIT} ---"
+          done
+
+      - name: Summary
+        run: |
+          echo "::notice::repro complete. If any iteration crashed with SIGILL, the bug is reproducible with the bare podman command on a GHA runner — confirming the variable is the runner CPU, not the test harness."

--- a/repro/cpuid-probes/README.md
+++ b/repro/cpuid-probes/README.md
@@ -40,7 +40,7 @@ podman run --rm --userns=keep-id \
 
 ## Expected outcomes
 
-| Host | /proc/cpuinfo avx512f | cpuid(7,0).ebx[16] | xgetbv(0)[5..7] | builtin avx512f | mojo `has_avx512f()` |
+| Host | `/proc/cpuinfo` avx512f | `cpuid(7,0).ebx[16]` | `xgetbv(0)[5..7]` | `builtin avx512f` | `mojo has_avx512f()` |
 | --- | --- | --- | --- | --- | --- |
 | Local Intel without AVX-512 | 0 | 0 | n/a | 0 | **expected 0** |
 | Local Intel with AVX-512 (e.g. Tiger Lake) | 1 | 1 | 1 | 1 | **expected 1** |

--- a/repro/cpuid-probes/README.md
+++ b/repro/cpuid-probes/README.md
@@ -1,0 +1,68 @@
+# CPU detection probes for modular/modular#6413
+
+Three orthogonal probes that together pin down where Mojo's CPU detection is
+diverging from the kernel's view on AMD-EPYC-under-Hyper-V GHA runners.
+
+| Probe | What it asks |
+| --- | --- |
+| `/proc/cpuinfo` flags | What does the kernel allow user-space to see? |
+| `cpu_features_probe` (C, direct `cpuid` + `xgetbv`) | What does the silicon report, and what XCR0 has the OS enabled? |
+| `__builtin_cpu_supports` | What does compiler-rt say? |
+| `probe_cpu.mojo` (`sys.info.has_avx512f` etc.) | What does Mojo's stdlib advertise? |
+
+If `probe_cpu.mojo` reports `has_avx512f() = True` on the GHA runner while `/proc/cpuinfo`
+shows no `avx512f` flag, that's the source-side smoking gun: Mojo's detection bypasses
+the kernel-mediated view and lights up the AVX-512 codegen path.
+
+## Build & run inside the cached image
+
+```bash
+podman run --rm --userns=keep-id \
+  -v "$(pwd):/workspace:Z" -w /workspace --ulimit core=-1 \
+  projectodyssey:dev \
+  bash -c '
+    set -e
+    echo "════════════════════ /proc/cpuinfo (kernel view) ════════════════════"
+    grep -m1 ^flags /proc/cpuinfo | tr " " "\n" | grep -E "^(avx512[a-z0-9_]*|avx_vnni|avx|avx2|fma|f16c|sse4_[12]|vaes|sha_ni)$" | sort -u
+
+    echo
+    echo "════════════════════ C probe (cpuid + xgetbv + __builtin_cpu_supports) ════════════════════"
+    cd repro/cpuid-probes
+    gcc -O2 -o /tmp/cpu_features_probe cpu_features_probe.c
+    /tmp/cpu_features_probe
+
+    echo
+    echo "════════════════════ Mojo probe (sys.info) ════════════════════"
+    cd /workspace
+    pixi run mojo run repro/cpuid-probes/probe_cpu.mojo
+'
+```
+
+## Expected outcomes
+
+| Host | /proc/cpuinfo avx512f | cpuid(7,0).ebx[16] | xgetbv(0)[5..7] | builtin avx512f | mojo `has_avx512f()` |
+| --- | --- | --- | --- | --- | --- |
+| Local Intel without AVX-512 | 0 | 0 | n/a | 0 | **expected 0** |
+| Local Intel with AVX-512 (e.g. Tiger Lake) | 1 | 1 | 1 | 1 | **expected 1** |
+| GHA EPYC under Hyper-V (suspected bug) | 0 | **1** (silicon!) | **0** (OS not enabled) | **?** | **?** |
+
+The interesting columns are the last three on the GHA row. If `cpuid(7,0).ebx[16]` is 1 but
+`xgetbv(0)[5..7]` is 0, the hypervisor is exposing AVX-512 silicon to the guest's `cpuid`
+instruction without the OS enabling XSAVE state for it. Whether `__builtin_cpu_supports`
+and Mojo see that depends on which API path each consults:
+
+- `cpuid` directly → sees AVX-512 → wrong codegen
+- `__builtin_cpu_supports` → modern compiler-rt checks both `cpuid` AND `xgetbv` → safe
+- `getauxval(AT_HWCAP*)` → kernel view → safe
+- Parsing `/proc/cpuinfo` → kernel view → safe
+
+## Why this matters
+
+If the C probe shows `cpuid(7,0).ebx[16] = 1` AND `xgetbv(0)[5..7] = 0` AND `mojo
+has_avx512f() = True`, we have the smoking gun: Mojo's `sys.info.has_avx512f` is
+consulting raw CPUID rather than the OS-enabled XCR0. The fix is to gate AVX-512
+detection on `xgetbv & (1<<5 | 1<<6 | 1<<7) == 0xe0`, which is what
+[the Linux kernel documentation prescribes][1] for AVX-512 use.
+
+[1]: https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html
+     (see Vol. 1 §13.3, "Detection of XSAVE Feature Support")

--- a/repro/cpuid-probes/README.md
+++ b/repro/cpuid-probes/README.md
@@ -61,8 +61,7 @@ and Mojo see that depends on which API path each consults:
 If the C probe shows `cpuid(7,0).ebx[16] = 1` AND `xgetbv(0)[5..7] = 0` AND `mojo
 has_avx512f() = True`, we have the smoking gun: Mojo's `sys.info.has_avx512f` is
 consulting raw CPUID rather than the OS-enabled XCR0. The fix is to gate AVX-512
-detection on `xgetbv & (1<<5 | 1<<6 | 1<<7) == 0xe0`, which is what
-[the Linux kernel documentation prescribes][1] for AVX-512 use.
-
-[1]: https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html
-     (see Vol. 1 §13.3, "Detection of XSAVE Feature Support")
+detection on `xgetbv & (1<<5 | 1<<6 | 1<<7) == 0xe0`, which is the canonical
+sequence prescribed by Intel SDM Vol. 1 §13.3, "Detection of XSAVE Feature Support"
+(search the Intel SDM PDF on intel.com — the page is anti-bot-protected so we do
+not link it directly).

--- a/repro/cpuid-probes/cpu_features_probe.c
+++ b/repro/cpuid-probes/cpu_features_probe.c
@@ -1,0 +1,185 @@
+// Direct CPU feature probe — written in C to bypass any abstraction layer.
+//
+// Goal for modular/modular#6413: determine whether the JIT's CPU detection
+// would see AVX-512 capabilities on a host where the kernel reports none.
+//
+// Build:
+//   gcc -O2 -o cpu_features_probe cpu_features_probe.c
+//
+// Run inside the cached Podman image to see what bytes Mojo's underlying
+// codegen detection routines would see.
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/auxv.h>
+
+#ifdef __x86_64__
+#include <cpuid.h>
+#include <immintrin.h>
+#endif
+
+// HWCAP2 bits relevant to x86 AVX-512 (matches kernel/include/asm/hwcap.h
+// or fallback if your headers don't define them). On x86 Linux, AT_HWCAP2
+// carries XSAVE / FSGSBASE / etc. AVX-512 itself is advertised via the
+// 'flags' field in /proc/cpuinfo more reliably than via HWCAP on x86.
+// We print AT_HWCAP / AT_HWCAP2 / AT_PLATFORM regardless and let the
+// reader compare.
+
+static void print_auxv(void) {
+    printf("--- getauxval (kernel-mediated view) ---\n");
+    unsigned long h1 = getauxval(AT_HWCAP);
+    unsigned long h2 = getauxval(AT_HWCAP2);
+    const char *plat = (const char *)getauxval(AT_PLATFORM);
+    printf("  AT_HWCAP:    0x%lx\n", h1);
+    printf("  AT_HWCAP2:   0x%lx\n", h2);
+    printf("  AT_PLATFORM: %s\n", plat ? plat : "(null)");
+}
+
+#ifdef __x86_64__
+
+// CPUID leaf 1: ECX bit 26 = XSAVE, bit 27 = OSXSAVE, bit 28 = AVX
+//               EDX bit 25 = SSE, bit 26 = SSE2
+// CPUID leaf 7,0: EBX bit 5  = AVX2
+//                 EBX bit 16 = AVX-512F
+//                 EBX bit 17 = AVX-512DQ
+//                 EBX bit 21 = AVX-512IFMA
+//                 EBX bit 30 = AVX-512BW
+//                 EBX bit 31 = AVX-512VL
+//                 ECX bit 1  = AVX-512_VBMI
+//                 ECX bit 11 = AVX-512_VNNI
+// CPUID leaf 7,1: EAX bit 4  = AVX-VNNI
+//                 EAX bit 23 = AVX-IFMA
+// CPUID leaf D,0: EAX = XCR0 mask of supported XSAVE features (from silicon, NOT
+//                 from kernel's allowed view). Bits 5/6/7 = opmask, hi256, hi16_zmm.
+
+static void print_cpuid_direct(void) {
+    unsigned int eax, ebx, ecx, edx;
+
+    printf("--- direct cpuid (bypasses kernel masking, sees silicon) ---\n");
+
+    // Vendor + base info
+    __cpuid(0, eax, ebx, ecx, edx);
+    char vendor[13];
+    memcpy(vendor, &ebx, 4);
+    memcpy(vendor + 4, &edx, 4);
+    memcpy(vendor + 8, &ecx, 4);
+    vendor[12] = 0;
+    printf("  cpuid(0): max_basic_leaf=%u  vendor=\"%s\"\n", eax, vendor);
+
+    // Brand string (leaves 0x80000002–0x80000004)
+    char brand[49] = {0};
+    for (int i = 0; i < 3; i++) {
+        __cpuid(0x80000002 + i, eax, ebx, ecx, edx);
+        memcpy(brand + i * 16 + 0, &eax, 4);
+        memcpy(brand + i * 16 + 4, &ebx, 4);
+        memcpy(brand + i * 16 + 8, &ecx, 4);
+        memcpy(brand + i * 16 + 12, &edx, 4);
+    }
+    printf("  cpuid(0x80000002..4) brand: \"%s\"\n", brand);
+
+    // Leaf 1
+    __cpuid(1, eax, ebx, ecx, edx);
+    printf("  cpuid(1): family=%u model=%u stepping=%u  ext_family=%u ext_model=%u\n",
+           (eax >> 8) & 0xf, (eax >> 4) & 0xf, eax & 0xf,
+           (eax >> 20) & 0xff, (eax >> 16) & 0xf);
+    printf("  cpuid(1).ecx: AVX=%d  XSAVE=%d  OSXSAVE=%d  AES=%d  PCLMUL=%d  FMA=%d\n",
+           !!(ecx & (1u << 28)), !!(ecx & (1u << 26)), !!(ecx & (1u << 27)),
+           !!(ecx & (1u << 25)), !!(ecx & (1u << 1)),  !!(ecx & (1u << 12)));
+
+    // Leaf 7, subleaf 0
+    __cpuid_count(7, 0, eax, ebx, ecx, edx);
+    printf("  cpuid(7,0).ebx: AVX2=%d  AVX512F=%d  AVX512DQ=%d  AVX512IFMA=%d  AVX512CD=%d\n",
+           !!(ebx & (1u << 5)),  !!(ebx & (1u << 16)), !!(ebx & (1u << 17)),
+           !!(ebx & (1u << 21)), !!(ebx & (1u << 28)));
+    printf("  cpuid(7,0).ebx: AVX512BW=%d  AVX512VL=%d  SHA=%d\n",
+           !!(ebx & (1u << 30)), !!(ebx & (1u << 31)), !!(ebx & (1u << 29)));
+    printf("  cpuid(7,0).ecx: AVX512VBMI=%d  AVX512VBMI2=%d  AVX512VNNI=%d  AVX512BITALG=%d  VAES=%d  VPCLMULQDQ=%d\n",
+           !!(ecx & (1u << 1)),  !!(ecx & (1u << 6)),  !!(ecx & (1u << 11)),
+           !!(ecx & (1u << 12)), !!(ecx & (1u << 9)),  !!(ecx & (1u << 10)));
+    printf("  cpuid(7,0).edx: AVX512_4VNNIW=%d  AVX512_4FMAPS=%d  AVX512_VP2INTERSECT=%d\n",
+           !!(edx & (1u << 2)),  !!(edx & (1u << 3)),  !!(edx & (1u << 8)));
+
+    // Leaf 7, subleaf 1
+    __cpuid_count(7, 1, eax, ebx, ecx, edx);
+    printf("  cpuid(7,1).eax: AVX_VNNI=%d  AVX_IFMA=%d  AVX512_BF16=%d\n",
+           !!(eax & (1u << 4)),  !!(eax & (1u << 23)), !!(eax & (1u << 5)));
+
+    // Leaf D, subleaf 0: XCR0 supported by silicon
+    __cpuid_count(0xd, 0, eax, ebx, ecx, edx);
+    printf("  cpuid(0xd,0).eax (silicon XCR0 mask): 0x%x\n", eax);
+    printf("    bit  0 (x87)    = %d\n", !!(eax & (1u << 0)));
+    printf("    bit  1 (SSE)    = %d\n", !!(eax & (1u << 1)));
+    printf("    bit  2 (AVX)    = %d\n", !!(eax & (1u << 2)));
+    printf("    bit  3 (BNDREGS)= %d\n", !!(eax & (1u << 3)));
+    printf("    bit  4 (BNDCSR) = %d\n", !!(eax & (1u << 4)));
+    printf("    bit  5 (AVX-512 opmask)  = %d\n", !!(eax & (1u << 5)));
+    printf("    bit  6 (AVX-512 hi256)   = %d\n", !!(eax & (1u << 6)));
+    printf("    bit  7 (AVX-512 hi16_zmm)= %d\n", !!(eax & (1u << 7)));
+
+    // OSXSAVE indicates the OS has done XCR0 setup
+    __cpuid(1, eax, ebx, ecx, edx);
+    int osxsave = !!(ecx & (1u << 27));
+    printf("  OSXSAVE=%d %s\n", osxsave,
+           osxsave ? "(OS has enabled XSAVE)" : "(OS has NOT enabled XSAVE — direct AVX use will fault)");
+
+    if (osxsave) {
+        // Read actual XCR0 the OS has configured
+        unsigned int xcr0_lo, xcr0_hi;
+        __asm__ volatile("xgetbv" : "=a"(xcr0_lo), "=d"(xcr0_hi) : "c"(0));
+        unsigned long long xcr0 = ((unsigned long long)xcr0_hi << 32) | xcr0_lo;
+        printf("  xgetbv(0) (OS-enabled XCR0): 0x%llx\n", xcr0);
+        printf("    bit  0 (x87)    = %d\n", !!(xcr0 & (1ull << 0)));
+        printf("    bit  1 (SSE)    = %d\n", !!(xcr0 & (1ull << 1)));
+        printf("    bit  2 (AVX)    = %d\n", !!(xcr0 & (1ull << 2)));
+        printf("    bit  5 (AVX-512 opmask)  = %d\n", !!(xcr0 & (1ull << 5)));
+        printf("    bit  6 (AVX-512 hi256)   = %d\n", !!(xcr0 & (1ull << 6)));
+        printf("    bit  7 (AVX-512 hi16_zmm)= %d\n", !!(xcr0 & (1ull << 7)));
+        printf("    ↑ If silicon (cpuid 0xd,0) has AVX-512 bits set but xgetbv (OS-enabled XCR0)\n");
+        printf("    ↑ does NOT, then any code path that consults raw cpuid for codegen decisions\n");
+        printf("    ↑ will incorrectly emit AVX-512 — kernel cannot save the registers.\n");
+    }
+}
+
+// __builtin_cpu_supports: what compiler-rt sees.
+// Note: gcc requires a string LITERAL — can't loop. The named features must
+// be ones gcc recognizes; older gcc rejects names like "avxvnni".
+#define BCS(name) printf("  %-14s = %d\n", name, __builtin_cpu_supports(name))
+static void print_builtin_cpu_supports(void) {
+    printf("--- __builtin_cpu_supports (compiler-rt) ---\n");
+    __builtin_cpu_init();
+    BCS("sse");
+    BCS("sse2");
+    BCS("sse3");
+    BCS("ssse3");
+    BCS("sse4.1");
+    BCS("sse4.2");
+    BCS("avx");
+    BCS("avx2");
+    BCS("fma");
+    BCS("avx512f");
+    BCS("avx512dq");
+    BCS("avx512bw");
+    BCS("avx512vl");
+    BCS("avx512cd");
+    BCS("avx512vnni");
+    BCS("avx512vbmi");
+    BCS("avx512ifma");
+}
+#undef BCS
+
+#endif // __x86_64__
+
+int main(void) {
+    print_auxv();
+    printf("\n");
+#ifdef __x86_64__
+    print_cpuid_direct();
+    printf("\n");
+    print_builtin_cpu_supports();
+#else
+    printf("(non-x86 build — only auxv probe ran)\n");
+#endif
+    return 0;
+}

--- a/repro/cpuid-probes/probe_cpu.mojo
+++ b/repro/cpuid-probes/probe_cpu.mojo
@@ -1,0 +1,66 @@
+# Mojo-side CPU feature probe for modular/modular#6413.
+#
+# Run inside the cached projectodyssey:dev container alongside the
+# cpu_features_probe.c output to compare what Mojo sees vs what
+# the kernel/__builtin_cpu_supports/direct cpuid sees.
+#
+# Goal: identify whether Mojo's stdlib exposes any way to detect
+# the CPU features it will use for SIMD codegen, and whether that
+# detection routine sees AVX-512 on a host where /proc/cpuinfo
+# does not advertise it.
+#
+# Run:
+#   pixi run mojo run repro/cpuid-probes/probe_cpu.mojo
+
+
+from sys.info import (
+    has_avx,
+    has_avx2,
+    has_avx512f,
+    has_fma,
+    has_intel_amx_bf16,
+    has_intel_amx_int8,
+    has_neon,
+    has_sse2,
+    has_sse3,
+    has_sse4_1,
+    has_sse4_2,
+    has_vnni,
+    is_apple_silicon,
+    is_neoverse_n1,
+    is_x86,
+    num_logical_cores,
+    num_performance_cores,
+    simdbitwidth,
+    simdwidthof,
+)
+
+
+def main():
+    print("=== Mojo sys.info CPU detection ===")
+    print("is_x86()           =", is_x86())
+    print("has_sse2()         =", has_sse2())
+    print("has_sse3()         =", has_sse3())
+    print("has_sse4_1()       =", has_sse4_1())
+    print("has_sse4_2()       =", has_sse4_2())
+    print("has_avx()          =", has_avx())
+    print("has_avx2()         =", has_avx2())
+    print("has_fma()          =", has_fma())
+    print("has_avx512f()      =", has_avx512f())
+    print("has_vnni()         =", has_vnni())
+    print("has_intel_amx_bf16=", has_intel_amx_bf16())
+    print("has_intel_amx_int8=", has_intel_amx_int8())
+    print("has_neon()         =", has_neon())
+    print("is_apple_silicon() =", is_apple_silicon())
+    print("is_neoverse_n1()   =", is_neoverse_n1())
+    print()
+    print("=== SIMD width (the JIT will pick this) ===")
+    print("simdbitwidth()                =", simdbitwidth())
+    print("simdwidthof[DType.float32]()  =", simdwidthof[DType.float32]())
+    print("simdwidthof[DType.float64]()  =", simdwidthof[DType.float64]())
+    print("simdwidthof[DType.int32]()    =", simdwidthof[DType.int32]())
+    print("simdwidthof[DType.int8]()     =", simdwidthof[DType.int8]())
+    print()
+    print("=== logical cores ===")
+    print("num_logical_cores()           =", num_logical_cores())
+    print("num_performance_cores()       =", num_performance_cores())


### PR DESCRIPTION
Adds a manual-dispatch workflow `.github/workflows/repro-bare-command-on-gha.yml` that
runs the modular/modular#6413 reproducers using the bare `podman run` command (same shape
as our local testing on epimetheus + this laptop).

Purpose: validate whether the bug requires the full test harness
(comprehensive-tests.yml + justfile + setup-container action) or just the bare command
shape. If SIGILL reproduces here with `podman run ... pixi run mojo run repro/*.mojo`,
then the variable is purely the runner CPU, not the harness.

Workflow is manual-dispatch-only, no auto-trigger. Auto-merge so it's available on main
for `gh workflow run --ref` dispatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)