### PR TITLE
docs(blog): day 187 — phantom bugs in the CI machines

### DIFF
--- a/notes/blog/05-12-2026/README.md
+++ b/notes/blog/05-12-2026/README.md
@@ -1,4 +1,4 @@
-# Day One Hundred Eighty-Seven: The AVX-512 Phantom in the Hypervisor
+# Day One Hundred Eighty-Seven: Phantom Bugs in the CI Machines
 
 ```text
 model name        : AMD EPYC 9V74 80-Core Processor

--- a/notes/blog/05-12-2026/README.md
+++ b/notes/blog/05-12-2026/README.md
@@ -113,12 +113,11 @@ on April 20. The first comment I posted on 6413 with *real cores* was
 **May 11**. The first ISA analysis was **May 12**. The AMD EPYC reveal
 was **May 13**.
 
-Between April 12 and May 8, I did not know this crash was a SIGILL. I did
-not know it was AVX-512. I did not know it was a code-generation problem
-in the compiler. I knew exactly one thing: `mojo` exited non-zero inside
-the container, intermittently, on a subset of the test jobs, with no
-useful output. The crashpad emitted `__fortify_fail_abort` in
-`libKGENCompilerRTShared.so` and no other context. That is what I had to
+Between April 12 and May 8, I had nothing to go on but the crashpad: a
+non-zero exit out of `mojo` inside the container, intermittently, on a
+subset of test jobs, the single string `__fortify_fail_abort` inside
+`libKGENCompilerRTShared.so`, and no other context. No backtrace I could
+trust. No register state. No deterministic input. That is what I had to
 work with for four weeks.
 
 Through all of April, I treated this as a **flaky JIT** — the same family
@@ -246,11 +245,11 @@ under both stock Mojo and Mojo-with-targeted-imports, and wake up to
 finding 200 passes and zero crashes. The thing I needed — a *single*
 local reproduction — did not arrive.
 
-I did not, at any point in this stretch, think *"this is a code-generation
-bug."* The crash signature kept saying `__fortify_fail_abort`. Fortify is
-a runtime guard against overflowing string buffers. Every prior libKGEN
+The crash signature kept saying `__fortify_fail_abort`. Fortify is a
+runtime guard against overflowing string buffers. Every prior libKGEN
 flake the workaround document had cataloged was framed as a JIT memory
-problem. The mental model was set.
+problem. The mental model was set, and nothing in the data I could
+collect locally pushed back against it.
 
 ### Four weeks of work that didn't crack it
 
@@ -421,17 +420,16 @@ generates a real ELF core. Libkgen's handler never runs.
 
 This wrapper became the centerpiece of
 [`docs/dev/mojo-jit-crash-capture-core.md`](../../../docs/dev/mojo-jit-crash-capture-core.md).
-The first real cores arrived on May 11. **They showed SIGILL, not
-SIGABRT.** That single bit — *"the silicon refused to decode this
-instruction"* rather than *"glibc detected a buffer overflow"* — falsified
-a month of working assumptions in one line. Fortify generates SIGABRT.
-SIGILL means *the bytes the JIT emitted are not legal x86 on this CPU*.
-That is not a JIT load problem. That is a code-generation problem.
+The first real cores arrived on May 11. What they showed did not match
+the working model I had been operating under for a month. The details
+of *what* they showed, and how each follow-on theory in turn failed to
+explain it, are the next chapter.
 
-End of Chapter 2: I had spent April acting as if this were a heap or
-scheduling flake in the runtime, and I had spent that month being wrong
-about what I was looking at. On May 11, for the first time, I could see
-what was actually happening. Now I had to figure out *what it was*.
+End of Chapter 2: for the first time since April 12, I had data I could
+trust. The cores were on disk, the registers were captured at the
+moment of fault, and the symbol table was intact. The investigation
+moved from *"why does this crash sometimes"* to *"what does this crash
+actually say"*.
 
 ---
 

--- a/notes/blog/05-12-2026/README.md
+++ b/notes/blog/05-12-2026/README.md
@@ -566,7 +566,7 @@ binary is the same. The pixi.lock is the same. The Mojo source we ship is
 the same. The bug appears and disappears across container-image rebuilds.
 **Whatever is varying is not in the package; it is in the container.**
 
-### H6: a non-AVX CPU breaks the JIT
+### H6: the runner's CPU lacks something the JIT assumed it had
 
 By now the gdb wrapper had captured real cores from CI, and the
 disassembly around `$pc` was no longer just bytes — it was instructions

--- a/notes/blog/05-12-2026/README.md
+++ b/notes/blog/05-12-2026/README.md
@@ -10,12 +10,15 @@ Virtualization type : full
 That capture, pulled from `/proc/cpuinfo` inside a GitHub Actions container at
 06:31 on May 12, broke the investigation open.
 
-For thirty straight days I had been writing private notes that began with
-phrases like *"Intel Cascade Lake-class runner with AVX-512 disabled"* or
-*"some older Xeon SKU"*. Every hypothesis I had filed against
+For Months now, I have been hitting my head against a wall trying
+to make CI/CD green. Multiple bugs filed and fixed, yet getting nowhere. This final
+issue has been a marathon sprint over the past 6 days trying to track down a
+crash that ONLY occurs on github runners.  Every hypothesis I had filed against
 [modular/modular#6413](https://github.com/modular/modular/issues/6413)
 assumed an Intel CPU. Every cross-machine reproduction attempt was on Intel
-hardware. Every model in my head was Intel.
+hardware. Every model in my head was Intel. Intel Inside has been the marketing
+mantra for so long, I didn't even question that assumption that the CPU manufacturer
+could have been the clue.
 
 The runner was AMD. The runner had AVX-512 silicon. The hypervisor was hiding
 it. And the compiler was finding it anyway.
@@ -33,45 +36,29 @@ back to April.
 
 ---
 
-> **Note:** This is the longest post in the *Day N* series. It documents
-> a thirty-day investigation into the second of two crash signatures that
-> were blocking ProjectOdyssey CI. The investigation burned roughly
-> 2.0–2.4 M Claude tokens — about half a weekly Claude Max Pro budget — and
-> produced six new Mnemosyne skills, three upstream issue threads
-> ([#6412](https://github.com/modular/modular/issues/6412),
-> [#6413](https://github.com/modular/modular/issues/6413),
-> [#6445](https://github.com/modular/modular/issues/6445)),
-> and a four-layer CPU-feature-detection probe that is now part of the
-> standard toolkit. The root cause is deferred until Chapter 8 so the story
-> can be read in the order it actually happened. If you want the spoiler,
-> jump to Chapter 8 — but the dead ends are the point of the post.
-
----
-
 ## TL;DR
 
 CI was crashing inside `libKGENCompilerRTShared.so` at some unidentifiable
-instruction. The crash had been intermittent for over a month. Six different
-hypotheses — JIT volume overflow, tuple destructor UAF, ASAN-strict
-use-after-free, pixi cache content drift, a silent nightly republish, and
-*"every non-AVX-512 Intel CPU triggers it"* — were tested in sequence. All
-six were wrong. By the time the fourth was rejected the question had stopped
-being *"what is the crash?"* and become *"why is the crash invisible?"*
+instruction. For four weeks of April I treated it as a flaky JIT and
+chased a 100%-reproducible local test case I could hand upstream — the
+mitigation lineage runs through retry harnesses, container UID fixes,
+import-localization, job serialization, and ulimit bumps. None of it
+worked, because none of it was looking at the right failure. On May 10 I
+finally built core-dump capture that actually worked and a gdb ptrace
+wrapper that fired before libKGEN's in-process signal handler could
+swallow the crash. The first real cores arrived on May 11 and showed
+**SIGILL, not SIGABRT** — *the silicon refused to decode this
+instruction*, not glibc detecting a buffer overflow. That single bit
+falsified a month of working assumptions.
 
-Why was it invisible? Because every diagnostic layer agreed with every other
-diagnostic layer except one. The kernel said no AVX-512. The raw `cpuid`
-instruction said no AVX-512. The compiler-rt `__builtin_cpu_supports` said
-no AVX-512. But the *compiler* — the Mojo driver populating its
-`!kgen.target` MLIR attribute — said `znver4` and emitted twelve different
-AVX-512 features anyway. Finding *why* meant building four orthogonal
-probes, capturing ELF cores inside a container with gdb's ptrace
-interception running ahead of libKGEN's signal handler, surveying five
-physical machines over Tailscale, and finally reading the open-source
-`modular/modular` tree for the one line of documentation that names the
-closed-source mechanism.
+After that pivot, five more hypotheses fell in turn — tuple destructor
+UAF, ASAN-strict use-after-free, pixi cache content drift, a silent
+nightly republish, and *"every non-AVX-512 Intel CPU triggers it"*. By
+the time the fifth was rejected the question had stopped being *"what is
+the crash?"* and become *"why is the crash invisible?"* I HAD to solve
+it...
 
-The eventual root cause is a single design decision in upstream LLVM's
-`getHostCPUFeatures`. But you'll have to wait for the ride.
+And I did.
 
 ---
 
@@ -82,8 +69,8 @@ that had been blocking ProjectOdyssey CI for a month: virtual address space
 exhaustion in the Mojo JIT, filed as
 [modular/modular#6433](https://github.com/modular/modular/issues/6433),
 documented with a `ulimit -v` binary search and a one-command reproducer.
-That fix landed. Sixteen blocked PRs unstuck. CI went green for a day and a
-half.
+That fix landed. Sixteen blocked PRs unstuck. CI looked like it would finally
+go green.
 
 The second crash signature — internally labelled *"the libKGEN flake"* —
 did not go away. It kept firing, intermittently, on the `Data Utilities
@@ -93,7 +80,7 @@ stack trace was always the same noise: `__fortify_fail_abort` inside
 context the harness would let us see. The crash file contained 28 bytes of
 log output. None of it was useful.
 
-The reason it contained 28 bytes of log output was that libKGEN installs
+My current understanding is that the reason it contained 28 bytes of log output was that libKGEN installs
 its own SIGABRT/SIGILL handler at startup. When the JIT'd code dereferences
 a bad page or executes an instruction the silicon refuses, the kernel
 delivers a signal to the process, libKGEN's handler intercepts it, prints
@@ -109,69 +96,246 @@ the *symptom* matches: an unexplained, non-deterministic SIGABRT/SIGILL in
 a process whose handler swallows it before the kernel can record what
 happened.
 
-The plan at the start of May was modest: stop the handler from swallowing
-the signal, capture a real ELF core, look at the faulting instruction,
-move on. None of that turned out to be modest.
+The plan, going into April, was modest and — in retrospect — wrong: get
+CI/CD green by reducing the JIT's load until the flake stopped firing.
+The next month was spent acting on that plan. None of it worked. The
+shape of the bug was not what I thought.
 
 ---
 
-## Chapter 2: Building Infrastructure Before You Can Diagnose
+## Chapter 2: A Month of Chasing a 100% Reproducer
 
-The first ten days of May were spent making it *possible* to see the crash.
-Three pieces of infrastructure had to exist before any hypothesis could be
-tested.
+Look at the dates on
+[modular/modular#6413](https://github.com/modular/modular/issues/6413) and
+[modular/modular#6433](https://github.com/modular/modular/issues/6433).
+6413 was filed on **April 12**. 6433 was filed mid-month and closed out
+on April 20. The first comment I posted on 6413 with *real cores* was
+**May 11**. The first ISA analysis was **May 12**. The AMD EPYC reveal
+was **May 13**.
 
-### PR #5378 — extend core-dump capture across all CI jobs
+Between April 12 and May 8, I did not know this crash was a SIGILL. I did
+not know it was AVX-512. I did not know it was a code-generation problem
+in the compiler. I knew exactly one thing: `mojo` exited non-zero inside
+the container, intermittently, on a subset of the test jobs, with no
+useful output. The crashpad emitted `__fortify_fail_abort` in
+`libKGENCompilerRTShared.so` and no other context. That is what I had to
+work with for four weeks.
 
-The `coredump-capture` action existed in the repo, but only the
-`comprehensive-tests` workflow wired it in. The libKGEN flake fired on five
-distinct jobs (`Data Utilities`, `Configs`, `Core Layers`, `Models`, and
-`Optimizers`). [PR #5378](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5378)
-extended the action to every test workflow. This was cosmetic plumbing.
-What it *exposed*, after merging, was a much more interesting failure.
+Through all of April, I treated this as a **flaky JIT** — the same family
+of failure as `mojo-jit-crash-workaround.md` had been describing since
+March. The entire shape of the investigation was *"this is some kind of
+heap or scheduling flake in the JIT, and the way to defeat a flake is to
+find a 100% reproducible test case that triggers it on demand."*
 
-### PR #5380 — the silent-failure modes
+So that is what I tried to do.
 
-After PR #5378 we expected core dumps to start appearing as workflow
-artifacts. They did not. The capture step would run, succeed, exit 0, and
-upload an artifact containing the string `cores/` and nothing else.
+### The flaky-JIT mitigation lineage
 
-Two compounding bugs were in play. The first was a path-namespace bug: the
-host's `/proc/sys/kernel/core_pattern` was set to `/tmp/cores/core.%e.%p`,
-but `/tmp/cores/` on the host did not exist inside the rootless Podman
-container's mount namespace. The kernel, when delivering a signal to a
-process inside the container, would resolve the `core_pattern` path
-against the container's view, fail to find the directory, and *silently
-write nothing*. No error message. No stderr. Just a missing core.
+Months before the AVX-512 story starts, the same crash family had already
+provoked an escalating series of mitigations. None of them treated the
+crash as a code-generation bug; all of them treated it as a transient
+fault in a JIT pipeline that needed retries, smaller compilation units, or
+quieter test environments. In rough chronological order:
 
-The second bug compounded it: when the harness ran `ls cores/` and found
-the directory empty, the metadata-collection step would short-circuit with
-*"no cores to process"* and skip the upload entirely. There was no signal,
-anywhere, that the harness had failed to capture what it claimed it would
-capture.
+- [PR #3958 (Mar 7)](https://github.com/HomericIntelligence/ProjectOdyssey/pull/3958) —
+  *"document Mojo JIT crash workaround for libKGENCompilerRTShared.so"*
+- [PR #4744 (Mar 14)](https://github.com/HomericIntelligence/ProjectOdyssey/pull/4744) —
+  *"add retry logic for flaky JIT test groups"*
+- [PR #5161 (Mar 26)](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5161) —
+  *"mitigate Data test JIT crashes with targeted submodule imports"*
+- [PR #5167 (Mar 26)](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5167) —
+  *"eliminate per-element bitcast in gradient checker tight loops"*
+- [PR #5171 (Mar 26)](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5171) —
+  *"add per-file JIT crash retry for Mojo 0.26.1"*
 
-[PR #5380](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5380)
-fixed both. The first fix: switch to a pipe-handler `core_pattern`
-(`|/usr/local/bin/core-pipe-handler.sh %e %p %s`) that runs inside the
-container's PID/mount namespace and writes to a known-good path. The
-second fix: make the metadata step fail loudly when zero cores are
-produced — print a diagnostic, upload an empty-cores marker artifact, and
-exit non-zero so the surrounding job's status reflects the silent capture
+That is the prehistory. Each of these PRs assumes the same model of the
+bug — *the JIT is fragile under certain loads, and the fix is to relieve
+the load or retry through the failure* — and each of them is informed by
+no more than what the crashpad chose to print.
+
+### April 12 — the upstream issue is filed
+
+I opened
+[modular/modular#6413](https://github.com/modular/modular/issues/6413) on
+April 12 with the bug-report I could write at the time: *execution
+crashed in libKGENCompilerRTShared.so inside Docker containers, but not
+natively, on Mojo 0.26.3.* The issue's reproduction section literally
+says *"this crash occurs non-deterministically in CI Docker (~40-60% of
+runs have at least one crash)."* I attached the crashpad. I listed the
+~30 tests that had crashed at least once. The conjectured cause in the
+issue body was *"a buffer overflow detection in glibc's fortified string
+functions, triggered during JIT compilation rather than user code
+execution."* I would spend the next four weeks acting on that conjecture,
+and it was wrong.
+
+### April 12–20 — retry, serialize, localize
+
+Same day as the upstream filing,
+[PR #5243](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5243)
+wired `test-with-retry.sh` into `_test-group-inner` to handle JIT crashes
+at the harness level. The premise: if the JIT flakes 40% of the time on
+any given run, retrying any failing test once or twice converges the
+job's success rate to near-100%. That PR was never merged — concurrent
+work was already moving toward a *different* mitigation — but the
+philosophy embodied in it dominated the next eight days.
+
+Look at the merge dates and you can read the shape of the search:
+
+- [PR #5247 (Apr 20)](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5247) —
+  *"ADR-015 for flaky required CI checks + remove stale ADR-009 annotations"*
+- [PR #5252 (Apr 20)](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5252) —
+  *"fix container UID mismatch causing libKGENCompilerRTShared.so JIT crash"*
+- [PR #5254 (Apr 20)](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5254) —
+  *"remove test-with-retry.sh and direct-wire mojo invocation (ADR-015 Action 2)"*
+
+ADR-015 named the policy out loud: *"flaky required CI checks."* The
+mental model was the JIT crashes randomly, and the engineering response
+is to make our infrastructure tolerate randomness — better isolation, no
+shared state across tests, no retry sleights of hand.
+
+[PR #5252](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5252)
+is the most telling artifact of the period. Its title states that a
+container UID mismatch *causes* the JIT crash. The PR did fix a real UID
+mismatch and did reduce some kind of failure. But the libKGEN crashes
+kept happening after it merged. The hypothesis had been *"the runtime is
+crashing because permissions are wrong on a cache directory."* That's a
+plausible model — until the next CI run crashes anyway with no
+permissions touched.
+
+### April 20–22 — make the JIT footprint smaller
+
+The next hypothesis: the JIT crashes when its compile unit gets too large.
+A burst of import-localization PRs followed:
+
+- [PR #5256 (Apr 21)](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5256) —
+  *"localize heavy imports in activation.mojo to reduce JIT footprint"*
+- [PR #5258 (Apr 21)](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5258) —
+  *"localize shape/reduction imports to fix Data Utilities and Integration Tests JIT crashes"*
+- [PR #5259 (Apr 21)](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5259) —
+  *"localize shape import in reduction.mojo to eliminate 1371-line JIT footprint"*
+- [PR #5260 (Apr 21)](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5260) —
+  *"add Category 4 deterministic module-level import chain crash reproducers"*
+- [PR #5264 (Apr 21)](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5264) —
+  *"complete ADR-015 import audit + add targeted-import repro"*
+- [PR #5274 (Apr 22)](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5274) —
+  *"serialize mojo test jobs and lift virtual address limit"*
+
+These PRs are all working a single theory: the crash is JIT-load
+dependent, so reduce the load. Move imports closer to their use site so
+fewer modules compile together. Push the `ulimit -v` cap upward so the
+JIT has more headroom. Serialize the test jobs so two JIT sessions don't
+run concurrently and starve each other.
+
+PR #5260 in particular tried to give the upstream issue what it needed
+most: a *deterministic* reproducer. *"Category 4 deterministic
+module-level import chain crash reproducers"* — read the title. The whole
+point of that PR was *"if we can get this to fail 100% of the time on a
+small input, we can hand it off."* It didn't work locally. The crashes
+remained CI-only.
+
+### April 22 – May 1 — the long, quiet weeks of "just one more thing"
+
+After the import-localization wave, the merge cadence slowed and the
+investigation went quiet. The CI was *better*. Some jobs that crashed
+20% of the time now crashed 10%. ADR-015 had given me a vocabulary for
+*"accept the flake, narrow its blast radius."* I kept trying local
+reproductions. I tried different test orderings. I tried running each
+crashing test file 100 times in a tight loop on my laptop. I would log
+in to the laptop at 10pm, kick off a 200-iteration loop on `test_dropout`
+under both stock Mojo and Mojo-with-targeted-imports, and wake up to
+finding 200 passes and zero crashes. The thing I needed — a *single*
+local reproduction — did not arrive.
+
+I did not, at any point in this stretch, think *"this is a code-generation
+bug."* The crash signature kept saying `__fortify_fail_abort`. Fortify is
+a runtime guard against overflowing string buffers. Every prior libKGEN
+flake the workaround document had cataloged was framed as a JIT memory
+problem. The mental model was set.
+
+### May 8 — the pivot
+
+By the end of the first week of May, the import-localization mitigation
+had pushed the crash rate down but not to zero. PRs that touched
+unrelated code (like
+[PR #5363](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5363),
+a 33-issue consolidation merge) were still tripping the crash. The
+*Phase G* merge on May 5 produced
+[a particularly clear failure](https://github.com/modular/modular/issues/6413#issuecomment-from-may-10)
+that I reported back to 6413 on May 10 with the words *"same crash family
+confirmed in Mojo 1.0.0b2."*
+
+That post is when the investigation pivoted. The Modular engineer
+([dgurchenkov](https://github.com/modular/modular/issues/6413#issuecomment-4435794613))
+replied: *"For the repro steps... I don't quite understand this part. The
+repro section says it cannot reproduce natively."* They were politely
+asking what I was already painfully aware of: **without a reproducer,
+they could not help me.** A month of "make it less flaky" had hit a wall.
+
+So I stopped trying to suppress the symptoms and started trying to
+*observe* the failure properly. The next ten days — what the rest of this
+post is actually about — were spent building the diagnostic infrastructure
+I should have built on April 13 but did not, because for a month I did
+not believe I was looking at a compiler bug. I believed I was looking at
+a JIT load problem in our test harness.
+
+### The infrastructure I finally built (May 10–11)
+
+Three PRs, in quick succession, built the lens I had been missing. Each
+one assumed nothing about *what* the crash was. Each one only tried to
+let me *see* it.
+
+**[PR #5378 (May 10)](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5378) —
+extend core-dump capture across all CI jobs.** The `coredump-capture`
+action existed in the repo, but only the `comprehensive-tests` workflow
+wired it in. The libKGEN flake fired on five distinct jobs (`Data
+Utilities`, `Configs`, `Core Layers`, `Models`, and `Optimizers`). PR
+#5378 extended the action to every test workflow. This was cosmetic
+plumbing. What it *exposed*, after merging, was a much more interesting
 failure.
 
+**[PR #5380 (May 10)](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5380) —
+the silent-failure modes.** After #5378 I expected core dumps to start
+appearing as workflow artifacts. They did not. The capture step would
+run, succeed, exit 0, and upload an artifact containing the string
+`cores/` and nothing else.
+
+Two compounding bugs were in play. The first was a path-namespace bug:
+the host's `/proc/sys/kernel/core_pattern` was set to
+`/tmp/cores/core.%e.%p`, but `/tmp/cores/` on the host did not exist
+inside the rootless Podman container's mount namespace. The kernel, when
+delivering a signal to a process inside the container, would resolve the
+`core_pattern` path against the container's view, fail to find the
+directory, and *silently write nothing*. No error message. No stderr.
+Just a missing core.
+
+The second bug compounded it: when the harness ran `ls cores/` and found
+the directory empty, the metadata-collection step would short-circuit
+with *"no cores to process"* and skip the upload entirely. There was no
+signal, anywhere, that the harness had failed to capture what it claimed
+it would capture.
+
+PR #5380 fixed both. The first fix: switch to a pipe-handler
+`core_pattern` (`|/usr/local/bin/core-pipe-handler.sh %e %p %s`) that
+runs inside the container's PID/mount namespace and writes to a
+known-good path. The second fix: make the metadata step fail loudly when
+zero cores are produced — print a diagnostic, upload an empty-cores
+marker artifact, and exit non-zero so the surrounding job's status
+reflects the silent capture failure.
+
 This is the kind of bug that's invisible until you build the tool that
-would have caught it, then re-read the previous month of failures with the
-new tool's eyes and realize half of what you thought you knew came from
-falsified evidence.
+would have caught it, then re-read the previous month of failures with
+the new tool's eyes and realize half of what you thought you knew came
+from falsified evidence. Every one of the April mitigations had been
+designed against output the harness was already failing to capture.
 
-### PR #5382 — the gdb ptrace wrapper
-
-Even with cores writing to disk, libKGEN's userspace signal handler still
-won. The handler runs *inside* the process; the kernel delivers the signal
-to the process before any external observer (including the kernel's own
-core-dump path) sees the full unmodified register state at the moment of
-crash. The pipe-handler did fire, but what it received was the post-handler
-state, not the moment-of-fault state.
+**[PR #5382 (May 10)](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5382) —
+the gdb ptrace wrapper.** Even with cores writing to disk, libKGEN's
+userspace signal handler still won. The handler runs *inside* the
+process; the kernel delivers the signal to the process before any
+external observer (including the kernel's own core-dump path) sees the
+full unmodified register state at the moment of crash. The pipe-handler
+did fire, but what it received was the post-handler state, not the
+moment-of-fault state.
 
 The conceptual leap: wrap the `mojo` invocation in `gdb -batch` with
 ptrace-based interception, so gdb attaches before the JIT starts and
@@ -198,22 +362,32 @@ generates a real ELF core. Libkgen's handler never runs.
 
 This wrapper became the centerpiece of
 [`docs/dev/mojo-jit-crash-capture-core.md`](../../../docs/dev/mojo-jit-crash-capture-core.md).
-It was the difference between *"another flake"* and *"site A:
-`vandps (mem){1to4},%xmm3,%xmm3`."* Without that PR, none of the rest of
-this investigation happens.
+The first real cores arrived on May 11. **They showed SIGILL, not
+SIGABRT.** That single bit — *"the silicon refused to decode this
+instruction"* rather than *"glibc detected a buffer overflow"* — falsified
+a month of working assumptions in one line. Fortify generates SIGABRT.
+SIGILL means *the bytes the JIT emitted are not legal x86 on this CPU*.
+That is not a JIT load problem. That is a code-generation problem.
 
-End of Chapter 2: we could finally see the crash. Now we needed to
-understand what it was.
+End of Chapter 2: I had spent April acting as if this were a heap or
+scheduling flake in the runtime, and I had spent that month being wrong
+about what I was looking at. On May 11, for the first time, I could see
+what was actually happening. Now I had to figure out *what it was*.
 
 ---
 
 ## Chapter 3: Six Hypotheses, Six Dead Ends
 
-This chapter is the failure-and-tenacity heart of the post. The chapter is
-long because the investigation was long. Each subsection follows the same
-shape: *I thought X. I gathered Y. Z is why it was wrong.*
+Chapter 2 already buried one of these hypotheses by the time it ended:
+the *flaky-JIT-load* mental model that dominated all of April. I'm
+re-stating it as H1 here anyway, because the way it died — when the gdb
+wrapper showed SIGILL, not SIGABRT — is what made every subsequent
+hypothesis necessary. The next five (H2 through H6) are the *post-May-11*
+attempts to explain what a SIGILL inside libKGEN actually meant. Each
+follows the same shape: *I thought X. I gathered Y. Z is why it was
+wrong.*
 
-### H1: JIT volume / `__fortify_fail` overflow
+### H1: JIT volume / `__fortify_fail` overflow (April's whole month)
 
 The libKGEN crashpad output mentioned `__fortify_fail_abort`. That symbol
 appears when glibc's fortify-source machinery detects an overflowing

--- a/notes/blog/05-12-2026/README.md
+++ b/notes/blog/05-12-2026/README.md
@@ -29,7 +29,7 @@ back to April.
 **Project:** ML Odyssey
 **Date:** May 12, 2026
 **Branch:** `bisect/6413-positive-control`
-**Tags:** #mojo #debugging #ci #avx512 #hyper-v #amd-epyc #llvm #jit #cpu-fingerprinting #cross-cpu-survey #modular-bug
+**Tags:** #mojo #debugging #ci #llvm #jit #cross-cpu-survey #modular-bug
 
 ---
 
@@ -51,21 +51,23 @@ stack trace was always the same noise: `__fortify_fail_abort` inside
 context the harness would let us see. The crash file contained 28 bytes of
 log output. None of it was useful.
 
-My current understanding is that the reason it contained 28 bytes of log output was that libKGEN installs
-its own SIGABRT handler at startup. When the JIT'd code dereferences
-a bad page or address, the kernel
-delivers a signal to the process, libKGEN's handler intercepts it, prints
-its 28 bytes, and calls `_exit(134)`. The kernel never gets a chance to
-generate a core dump. **We had been debugging a crash whose stack trace
-was the handler, not the bug.**
+My current understanding is that the reason it contained 28 bytes of log
+output was that libKGEN installs its own signal handler at startup. When
+the runtime hits a fatal fault, the kernel delivers a signal to the
+process, libKGEN's handler intercepts it before anything else can,
+prints its 28 bytes, and calls `_exit(134)`. The kernel never gets a
+chance to generate a core dump. **We had been debugging a crash whose
+stack trace was the handler, not the bug.** Whatever the underlying
+fault actually was, the handler repainted it into the same 28-byte
+non-answer every time.
 
 At the close of Day 165 we had a workaround note about this in
 [`docs/dev/mojo-jit-crash-workaround.md`](../../../docs/dev/mojo-jit-crash-workaround.md)
-— it speculated about JIT volume thresholds and recommended retries. That
-document is now historical. Everything in it about the cause is wrong. Only
-the *symptom* matches: an unexplained, non-deterministic SIGABRT/SIGILL in
-a process whose handler swallows it before the kernel can record what
-happened.
+— it speculated about JIT volume thresholds and recommended retries.
+That document is now historical. Everything in it about the cause is
+wrong. Only the *symptom* matches: an unexplained, non-deterministic
+fatal fault in a process whose handler swallows it before the kernel
+can record what happened.
 
 The plan, going into April, was modest and — in retrospect — wrong: get
 CI/CD green by reducing the JIT's load until the flake stopped firing.
@@ -407,11 +409,12 @@ actually say"*.
 Chapter 2 already buried one of these hypotheses by the time it ended:
 the *flaky-JIT-load* mental model that dominated for months. I'm
 re-stating it as H1 here anyway, because the way it died — when the gdb
-wrapper showed SIGILL, not SIGABRT — is what made every subsequent
-hypothesis necessary. The next five (H2 through H6) are the *post-May-11*
-attempts to explain what a SIGILL inside libKGEN actually meant. Each
-follows the same shape: *I thought X. I gathered Y. Z is why it was
-wrong.*
+wrapper finally showed the hardware state at the moment of the fault,
+and that state did not match anything the flaky-JIT model predicted —
+is what made every subsequent hypothesis necessary. The next five (H2
+through H6) are the *post-May-11* attempts to explain what the captured
+hardware state was actually telling us. Each follows the same shape:
+*I thought X. I gathered Y. Z is why it was wrong.*
 
 ### H1: JIT volume / `__fortify_fail` overflow
 
@@ -438,16 +441,36 @@ mid-3.6 GB mark. H1 was the same kind of story, one layer deeper.
 
 [PR #5389](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5389)
 added `just build` modes for AddressSanitizer and ThreadSanitizer so we
-could re-run the failing tests under instrumentation. Twenty CI runs under
-ASAN. Zero ASAN reports. Real cores from the gdb wrapper, finally, showed
-the faulting signal was **SIGILL, not SIGABRT**. Fortify reports SIGABRT.
-SIGILL means *the silicon refused to decode this instruction*. That is a
-completely different failure class!
+could re-run the failing tests under instrumentation. Twenty CI runs
+under ASAN. Zero ASAN reports — no overflowing `memcpy`, no fortify
+trip, nothing the buffer-overflow theory predicted.
 
-Theory dead. The `__fortify_fail_abort` symbol in the original crashpad
-was libKGEN's own handler routing through fortify on its way to
-`_exit` — a red herring of the kind that exists only because the handler
-ran instead of the kernel. If this handler didn't switch the signal.... One can only guess how much quicker this would have been resolved.
+Then the gdb wrapper produced its first real cores, and the hardware
+state at the moment of the fault told a completely different story.
+A buffer overflow caught by fortify leaves a recognisable fingerprint:
+the program counter sits inside a libc string routine, the backtrace
+runs up through `__fortify_fail`, the fault is a deliberate abort the
+process raised on *itself* after detecting corruption. That is not
+what the cores showed. The captured `$pc` was not in libc at all — it
+was sitting on a single machine instruction inside JIT-compiled code,
+and the fault was the *hardware* rejecting that instruction, not
+software detecting bad data. The register file was intact. The stack
+was intact. There was no corruption to detect. The CPU had simply
+been handed bytes at `$pc` it would not execute.
+
+That is a completely different failure class. Fortify means *the
+program found bad data and gave up*. What the cores actually showed
+means *the processor was asked to run something it could not run*.
+The first is a memory-safety problem somewhere upstream. The second
+is a code-generation problem: somebody emitted those bytes.
+
+Theory dead. The `__fortify_fail_abort` symbol in the original
+crashpad was libKGEN's own handler on its exit path, not the cause —
+a red herring that existed only because the handler ran instead of
+the kernel. Had that handler not been there to repaint the
+crash, the very first core dump would have pointed straight at the
+faulting instruction, and this investigation would have been weeks
+shorter.
 
 ### H2: Tuple destructor use-after-free
 
@@ -476,10 +499,10 @@ If a destructor bug was responsible somewhere in the stack, ASAN with
 strict-UB would catch it. PR #5389's ASAN mode produced 115 instrumented
 CI runs across the failing job set. **Zero UAF reports. Zero stack-buffer-
 overflow reports. Zero heap-buffer-overflow reports.** The instrumented
-binaries crashed at the same rate as the uninstrumented ones, with the
-same SIGILL, at the same faulting instructions — but without any of the
-sanitizer signatures you would expect if the cause were a memory-safety
-bug in our Mojo code.
+binaries crashed at the same rate as the uninstrumented ones, faulting
+on the same rejected instructions at the same call sites — but without
+any of the sanitizer signatures you would expect if the cause were a
+memory-safety bug in our Mojo code.
 
 This was important. ASAN instruments code at compile time. Code that
 isn't instrumented (statically linked precompiled libraries) is not
@@ -559,7 +582,7 @@ day-to-day work on hermes, a Lunar Lake laptop with AVX2 + VNNI. The
 GHA runner — whatever it was, I had not yet bothered to check — was on
 the older end of the Azure pool. If the compiler was assuming a baseline
 SIMD level above what the runner could run, we'd see exactly this
-shape: green on the laptop, SIGILL in CI.
+shape: green on the laptop, failing in CI.
 
 The experiment was to take the exact failing container image, pull it
 to the laptop, and run the same reproducer locally. Same binary, same

--- a/notes/blog/05-12-2026/README.md
+++ b/notes/blog/05-12-2026/README.md
@@ -252,28 +252,36 @@ a runtime guard against overflowing string buffers. Every prior libKGEN
 flake the workaround document had cataloged was framed as a JIT memory
 problem. The mental model was set.
 
-### Why nothing changed for four weeks — and what made me finally look
+### Four weeks of work that didn't crack it
 
-There was a structural reason the April investigation stalled where it
-did. Two of the *other* upstream issues open against the project,
+I want to be careful not to make April sound like a stall. It wasn't. I
+was working the problem every day — running tests in long loops on the
+laptop, tweaking compile-unit shape, hunting for an input that would fail
+on demand. The PRs in the previous section are *every* one of those
+attempts that produced a code change worth merging. None of them
+reproduced the crash locally. None of them eliminated it in CI either.
+
+Part of what kept the search going in the direction it did was that two
+of the *other* upstream issues open against the project,
 [modular/modular#6412](https://github.com/modular/modular/issues/6412)
 (*"uncaught filesystem_error in `getAcceleratorArchOrEmpty()` when HOME
 is not traversable by running UID"*) and
 [modular/modular#6433](https://github.com/modular/modular/issues/6433)
 (*"mojo compiler reserves ~3.6 GB virtual address space unconditionally,
 causing OOM crashes on memory-constrained CI runners"*), each looked
-like they could plausibly explain the libKGEN failures. 6412 fit the
-container UID symptoms PR #5252 had been chasing. 6433 fit the JIT-load
-mental model the import-localization PRs were built on. **As long as
-those two issues were open, I had two perfectly good outstanding excuses
-for any libKGEN crash in CI**, and I could keep applying targeted
-workarounds without having to confront a third unknown.
+like they could plausibly account for some of what I was seeing. 6412
+fit the container UID symptoms PR #5252 had been chasing. 6433 fit the
+JIT-load mental model the import-localization PRs were built on. They
+shaped the search by making *load-and-environment* explanations feel
+like the right kind of explanation to test next.
 
 6412 closed on April 20. 6433 closed on May 6 — that's the *3.6 GB
-Virtual Ghost* from [Day 165](../04-20-2026/). The day 6433 closed, the
-libKGEN crash *should* have stopped, because the dominant outstanding
-explanation for it was gone. It did not stop. It kept firing on PRs that
-had nothing to do with virtual-memory exhaustion.
+Virtual Ghost* from [Day 165](../04-20-2026/). Both of those fixes did
+land in CI, and they did remove real failure modes. What they didn't do
+was stop the libKGEN crash. It kept firing on PRs that had nothing to
+do with virtual-memory exhaustion or HOME traversability. So whatever
+was left, it was a third thing, and I still didn't have a local
+reproducer to chase it with.
 
 ### AMD AI Dev Day, Beyond Summit, and the Mojo 1.0 beta decision
 

--- a/notes/blog/05-12-2026/README.md
+++ b/notes/blog/05-12-2026/README.md
@@ -20,9 +20,6 @@ hardware. Every model in my head was Intel. Intel Inside has been the marketing
 mantra for so long, I didn't even question that assumption that the CPU manufacturer
 could have been the clue.
 
-The runner was AMD. The runner had AVX-512 silicon. The hypervisor was hiding
-it. And the compiler was finding it anyway.
-
 To understand why that four-line block from `/proc/cpuinfo` was the moment
 everything pivoted — and why it took a month to capture it — you have to go
 back to April.
@@ -33,32 +30,6 @@ back to April.
 **Date:** May 12, 2026
 **Branch:** `bisect/6413-positive-control`
 **Tags:** #mojo #debugging #ci #avx512 #hyper-v #amd-epyc #llvm #jit #cpu-fingerprinting #cross-cpu-survey #modular-bug
-
----
-
-## TL;DR
-
-CI was crashing inside `libKGENCompilerRTShared.so` at some unidentifiable
-instruction. For four weeks of April I treated it as a flaky JIT and
-chased a 100%-reproducible local test case I could hand upstream — the
-mitigation lineage runs through retry harnesses, container UID fixes,
-import-localization, job serialization, and ulimit bumps. None of it
-worked, because none of it was looking at the right failure. On May 10 I
-finally built core-dump capture that actually worked and a gdb ptrace
-wrapper that fired before libKGEN's in-process signal handler could
-swallow the crash. The first real cores arrived on May 11 and showed
-**SIGILL, not SIGABRT** — *the silicon refused to decode this
-instruction*, not glibc detecting a buffer overflow. That single bit
-falsified a month of working assumptions.
-
-After that pivot, five more hypotheses fell in turn — tuple destructor
-UAF, ASAN-strict use-after-free, pixi cache content drift, a silent
-nightly republish, and *"every non-AVX-512 Intel CPU triggers it"*. By
-the time the fifth was rejected the question had stopped being *"what is
-the crash?"* and become *"why is the crash invisible?"* I HAD to solve
-it...
-
-And I did.
 
 ---
 
@@ -81,8 +52,8 @@ context the harness would let us see. The crash file contained 28 bytes of
 log output. None of it was useful.
 
 My current understanding is that the reason it contained 28 bytes of log output was that libKGEN installs
-its own SIGABRT/SIGILL handler at startup. When the JIT'd code dereferences
-a bad page or executes an instruction the silicon refuses, the kernel
+its own SIGABRT handler at startup. When the JIT'd code dereferences
+a bad page or address, the kernel
 delivers a signal to the process, libKGEN's handler intercepts it, prints
 its 28 bytes, and calls `_exit(134)`. The kernel never gets a chance to
 generate a core dump. **We had been debugging a crash whose stack trace
@@ -129,8 +100,8 @@ So that is what I tried to do.
 
 ### The flaky-JIT mitigation lineage
 
-Months before the AVX-512 story starts, the same crash family had already
-provoked an escalating series of mitigations. None of them treated the
+Months before the rest of this story starts, the same crash family had
+already provoked an escalating series of mitigations. None of them treated the
 crash as a code-generation bug; all of them treated it as a transient
 fault in a JIT pipeline that needed retries, smaller compilation units, or
 quieter test environments. In rough chronological order:
@@ -695,13 +666,21 @@ reproducer. Five hosts available.
 
 The fleet:
 
-| Host | CPU | Microarch | Year | SIMD | AVX-512? |
-| --- | --- | --- | --- | --- | --- |
-| `aeolus` | Intel i7-3820 | Sandy Bridge-E | 2012 | AVX1 | no |
-| `titan` | Intel i5-4440 | Haswell | 2013 | AVX2 | no |
-| `epimetheus` | Intel i5-6600K | Skylake (desktop) | 2015 | AVX2 | no |
-| `apollo` | Intel i7-8565U | Whiskey Lake | 2018 | AVX2 + VNNI | no |
-| `hermes` | Intel 258V | Lunar Lake | 2024 | AVX2 + VNNI | no |
+| Host | CPU | Microarch | Year | SIMD baseline |
+| --- | --- | --- | --- | --- |
+| `aeolus` | Intel i7-3820 | Sandy Bridge-E | 2012 | AVX |
+| `titan` | Intel i5-4440 | Haswell | 2013 | AVX2 |
+| `epimetheus` | Intel i5-6600K | Skylake (desktop) | 2015 | AVX2 |
+| `apollo` | Intel i7-8565U | Whiskey Lake | 2018 | AVX2 + VNNI |
+| `hermes` | Intel 258V | Lunar Lake | 2024 | AVX2 + VNNI |
+
+Twelve years of Intel microarchitecture, every SIMD baseline from
+Sandy Bridge through Lunar Lake — but every one of them topped out
+at AVX2. If the bug needed something *older* than AVX2, aeolus would
+catch it. If it needed something newer or weirder than what my
+laptop had, none of the others would help — but in that case the
+survey's *uniform* failure would tell us the bug needed something
+none of these chips had at all.
 
 The image was 760 MB. Tailscale moved it in about 90 seconds host-to-host.
 Total wall-clock from `podman save` on the GHA artifact to first
@@ -711,9 +690,8 @@ The protocol on each host was the same. Load the image. Run the bare
 podman command that the failing CI job runs. Wait for SIGILL or
 completion.
 
-**All five clean.** Sandy Bridge through Lunar Lake, no AVX-512 silicon
-in any of them, twelve years of Intel microarchitecture variety, *not one
-crash*.
+**All five clean.** Sandy Bridge through Lunar Lake, every machine
+ran the failing bytes without faulting, *not one crash*.
 
 That was the moment of pivot. I had predicted *at least one* of these
 machines would crash. None did. Either the bug was sensitive to something
@@ -752,30 +730,33 @@ flags            : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca
                    arat npt nrip_save vaes vpclmulqdq rdpid fsrm
 ```
 
-**There is no `avx512f` in that flag list.** There is no `avx512vl`,
-`avx512bw`, `avx512dq`, `avx512cd`, `avx512vnni`, `avx512vbmi`. The kernel
-sees no AVX-512 features at all.
+Two things jumped out of that flag list. First, this was not an
+Intel chip. The runner is AMD — `AuthenticAMD`, family 25 model 17,
+which is the Zen 4 microarchitecture (EPYC 9V74 is a Genoa-family
+server chip). Every assumption I had been making about CI's CPU was
+wrong: not just *"older Intel"* wrong, *Intel at all* wrong.
 
-But the silicon is Zen 4. AMD EPYC 9V74 is a Genoa-family chip. *Zen 4
-hardware natively supports the full AVX-512 stack.* The host the runner
-is sitting on top of is, on the metal, capable of running every
-AVX-512 instruction the cores were faulting on. And yet
-`/proc/cpuinfo` inside the runner — the guest kernel's curated view of
-its own CPU — was telling every consumer of CPU features that no
-AVX-512 existed here.
+Second, the runner is running under a hypervisor. `Hypervisor vendor :
+Microsoft` plus the `hypervisor` flag in the feature list says the
+guest kernel inside the runner is a VM sitting on top of Microsoft
+Hyper-V. The flag list in `/proc/cpuinfo` is what the *guest* kernel
+sees, after the hypervisor has had its way with the CPUID page on
+boot. That view is *curated*, not raw silicon.
 
-The cross-CPU survey had been designed to find an Intel SKU that
-reproduced the bug. What it found instead was that *no Intel SKU in my
-fleet could possibly reproduce the bug, because the bug requires
-silicon that has AVX-512 capability — and none of my Intel machines do*.
-The crash-host has AVX-512 capability that nothing in its software
-stack will admit to.
+So what the cross-CPU survey actually found was twofold: *no Intel
+SKU in my fleet could reproduce the bug*, because the bug requires
+features none of my Intel SIMD baselines have — and *the GHA runner
+is hardware nothing in my fleet resembles*. AMD Zen 4 server silicon,
+running under a hypervisor whose CPUID curation may or may not match
+the underlying metal, is the host where the JIT decided to emit
+whatever the captured cores contained.
 
-End of Chapter 5: the silicon has AVX-512. The kernel says it doesn't.
-The compiler is emitting AVX-512 anyway. Three layers of the system
-have to be examined to figure out which one is wrong — and *why*
-nobody other than the compiler is willing to acknowledge what the
-hardware actually is.
+End of Chapter 5: the runner is not what I had been assuming, the
+guest kernel's CPU view passes through Microsoft's curation before
+anyone sees it, and my Intel fleet had no chance of catching this.
+The next question — *what exactly are those crashing bytes asking
+for that none of these CPUs has?* — is the captured-cores question.
+That's the next chapter.
 
 ---
 

--- a/notes/blog/05-12-2026/README.md
+++ b/notes/blog/05-12-2026/README.md
@@ -1,0 +1,1020 @@
+# Day One Hundred Eighty-Seven: The AVX-512 Phantom in the Hypervisor
+
+```text
+model name        : AMD EPYC 9V74 80-Core Processor
+vendor_id         : AuthenticAMD
+Hypervisor vendor : Microsoft
+Virtualization type : full
+```
+
+That capture, pulled from `/proc/cpuinfo` inside a GitHub Actions container at
+06:31 on May 12, broke the investigation open.
+
+For thirty straight days I had been writing private notes that began with
+phrases like *"Intel Cascade Lake-class runner with AVX-512 disabled"* or
+*"some older Xeon SKU"*. Every hypothesis I had filed against
+[modular/modular#6413](https://github.com/modular/modular/issues/6413)
+assumed an Intel CPU. Every cross-machine reproduction attempt was on Intel
+hardware. Every model in my head was Intel.
+
+The runner was AMD. The runner had AVX-512 silicon. The hypervisor was hiding
+it. And the compiler was finding it anyway.
+
+To understand why that four-line block from `/proc/cpuinfo` was the moment
+everything pivoted — and why it took a month to capture it — you have to go
+back to April.
+
+---
+
+**Project:** ML Odyssey
+**Date:** May 12, 2026
+**Branch:** `bisect/6413-positive-control`
+**Tags:** #mojo #debugging #ci #avx512 #hyper-v #amd-epyc #llvm #jit #cpu-fingerprinting #cross-cpu-survey #modular-bug
+
+---
+
+> **Note:** This is the longest post in the *Day N* series. It documents
+> a thirty-day investigation into the second of two crash signatures that
+> were blocking ProjectOdyssey CI. The investigation burned roughly
+> 2.0–2.4 M Claude tokens — about half a weekly Claude Max Pro budget — and
+> produced six new Mnemosyne skills, three upstream issue threads
+> ([#6412](https://github.com/modular/modular/issues/6412),
+> [#6413](https://github.com/modular/modular/issues/6413),
+> [#6445](https://github.com/modular/modular/issues/6445)),
+> and a four-layer CPU-feature-detection probe that is now part of the
+> standard toolkit. The root cause is deferred until Chapter 8 so the story
+> can be read in the order it actually happened. If you want the spoiler,
+> jump to Chapter 8 — but the dead ends are the point of the post.
+
+---
+
+## TL;DR
+
+CI was crashing inside `libKGENCompilerRTShared.so` at some unidentifiable
+instruction. The crash had been intermittent for over a month. Six different
+hypotheses — JIT volume overflow, tuple destructor UAF, ASAN-strict
+use-after-free, pixi cache content drift, a silent nightly republish, and
+*"every non-AVX-512 Intel CPU triggers it"* — were tested in sequence. All
+six were wrong. By the time the fourth was rejected the question had stopped
+being *"what is the crash?"* and become *"why is the crash invisible?"*
+
+Why was it invisible? Because every diagnostic layer agreed with every other
+diagnostic layer except one. The kernel said no AVX-512. The raw `cpuid`
+instruction said no AVX-512. The compiler-rt `__builtin_cpu_supports` said
+no AVX-512. But the *compiler* — the Mojo driver populating its
+`!kgen.target` MLIR attribute — said `znver4` and emitted twelve different
+AVX-512 features anyway. Finding *why* meant building four orthogonal
+probes, capturing ELF cores inside a container with gdb's ptrace
+interception running ahead of libKGEN's signal handler, surveying five
+physical machines over Tailscale, and finally reading the open-source
+`modular/modular` tree for the one line of documentation that names the
+closed-source mechanism.
+
+The eventual root cause is a single design decision in upstream LLVM's
+`getHostCPUFeatures`. But you'll have to wait for the ride.
+
+---
+
+## Chapter 1: Where We Left Off
+
+[Day 165](../04-20-2026/) closed out the first of the two crash signatures
+that had been blocking ProjectOdyssey CI for a month: virtual address space
+exhaustion in the Mojo JIT, filed as
+[modular/modular#6433](https://github.com/modular/modular/issues/6433),
+documented with a `ulimit -v` binary search and a one-command reproducer.
+That fix landed. Sixteen blocked PRs unstuck. CI went green for a day and a
+half.
+
+The second crash signature — internally labelled *"the libKGEN flake"* —
+did not go away. It kept firing, intermittently, on the `Data Utilities
+Test Suite` and `Configs` jobs at something like a one-in-six rate. The
+stack trace was always the same noise: `__fortify_fail_abort` inside
+`libKGENCompilerRTShared.so`, no source location, no symbol, no register
+context the harness would let us see. The crash file contained 28 bytes of
+log output. None of it was useful.
+
+The reason it contained 28 bytes of log output was that libKGEN installs
+its own SIGABRT/SIGILL handler at startup. When the JIT'd code dereferences
+a bad page or executes an instruction the silicon refuses, the kernel
+delivers a signal to the process, libKGEN's handler intercepts it, prints
+its 28 bytes, and calls `_exit(134)`. The kernel never gets a chance to
+generate a core dump. **We had been debugging a crash whose stack trace
+was the handler, not the bug.**
+
+At the close of Day 165 we had a workaround note about this in
+[`docs/dev/mojo-jit-crash-workaround.md`](../../../docs/dev/mojo-jit-crash-workaround.md)
+— it speculated about JIT volume thresholds and recommended retries. That
+document is now historical. Everything in it about the cause is wrong. Only
+the *symptom* matches: an unexplained, non-deterministic SIGABRT/SIGILL in
+a process whose handler swallows it before the kernel can record what
+happened.
+
+The plan at the start of May was modest: stop the handler from swallowing
+the signal, capture a real ELF core, look at the faulting instruction,
+move on. None of that turned out to be modest.
+
+---
+
+## Chapter 2: Building Infrastructure Before You Can Diagnose
+
+The first ten days of May were spent making it *possible* to see the crash.
+Three pieces of infrastructure had to exist before any hypothesis could be
+tested.
+
+### PR #5378 — extend core-dump capture across all CI jobs
+
+The `coredump-capture` action existed in the repo, but only the
+`comprehensive-tests` workflow wired it in. The libKGEN flake fired on five
+distinct jobs (`Data Utilities`, `Configs`, `Core Layers`, `Models`, and
+`Optimizers`). [PR #5378](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5378)
+extended the action to every test workflow. This was cosmetic plumbing.
+What it *exposed*, after merging, was a much more interesting failure.
+
+### PR #5380 — the silent-failure modes
+
+After PR #5378 we expected core dumps to start appearing as workflow
+artifacts. They did not. The capture step would run, succeed, exit 0, and
+upload an artifact containing the string `cores/` and nothing else.
+
+Two compounding bugs were in play. The first was a path-namespace bug: the
+host's `/proc/sys/kernel/core_pattern` was set to `/tmp/cores/core.%e.%p`,
+but `/tmp/cores/` on the host did not exist inside the rootless Podman
+container's mount namespace. The kernel, when delivering a signal to a
+process inside the container, would resolve the `core_pattern` path
+against the container's view, fail to find the directory, and *silently
+write nothing*. No error message. No stderr. Just a missing core.
+
+The second bug compounded it: when the harness ran `ls cores/` and found
+the directory empty, the metadata-collection step would short-circuit with
+*"no cores to process"* and skip the upload entirely. There was no signal,
+anywhere, that the harness had failed to capture what it claimed it would
+capture.
+
+[PR #5380](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5380)
+fixed both. The first fix: switch to a pipe-handler `core_pattern`
+(`|/usr/local/bin/core-pipe-handler.sh %e %p %s`) that runs inside the
+container's PID/mount namespace and writes to a known-good path. The
+second fix: make the metadata step fail loudly when zero cores are
+produced — print a diagnostic, upload an empty-cores marker artifact, and
+exit non-zero so the surrounding job's status reflects the silent capture
+failure.
+
+This is the kind of bug that's invisible until you build the tool that
+would have caught it, then re-read the previous month of failures with the
+new tool's eyes and realize half of what you thought you knew came from
+falsified evidence.
+
+### PR #5382 — the gdb ptrace wrapper
+
+Even with cores writing to disk, libKGEN's userspace signal handler still
+won. The handler runs *inside* the process; the kernel delivers the signal
+to the process before any external observer (including the kernel's own
+core-dump path) sees the full unmodified register state at the moment of
+crash. The pipe-handler did fire, but what it received was the post-handler
+state, not the moment-of-fault state.
+
+The conceptual leap: wrap the `mojo` invocation in `gdb -batch` with
+ptrace-based interception, so gdb attaches before the JIT starts and
+catches signals *ahead of* libKGEN's handler.
+
+```bash
+gdb -batch \
+    -ex "handle SIGABRT stop nopass" \
+    -ex "handle SIGILL stop nopass" \
+    -ex "handle SIGSEGV stop nopass" \
+    -ex "run" \
+    -ex "bt" \
+    -ex "disassemble \$pc-32,\$pc+16" \
+    -ex "info registers" \
+    -ex "info all-registers" \
+    -ex "generate-core-file" \
+    --args mojo run "$@"
+```
+
+Ptrace gets first dibs on signal delivery. Gdb stops the process at the
+faulting instruction, prints the backtrace, disassembles the surrounding
+bytes, captures every register including the SIMD register file, and
+generates a real ELF core. Libkgen's handler never runs.
+
+This wrapper became the centerpiece of
+[`docs/dev/mojo-jit-crash-capture-core.md`](../../../docs/dev/mojo-jit-crash-capture-core.md).
+It was the difference between *"another flake"* and *"site A:
+`vandps (mem){1to4},%xmm3,%xmm3`."* Without that PR, none of the rest of
+this investigation happens.
+
+End of Chapter 2: we could finally see the crash. Now we needed to
+understand what it was.
+
+---
+
+## Chapter 3: Six Hypotheses, Six Dead Ends
+
+This chapter is the failure-and-tenacity heart of the post. The chapter is
+long because the investigation was long. Each subsection follows the same
+shape: *I thought X. I gathered Y. Z is why it was wrong.*
+
+### H1: JIT volume / `__fortify_fail` overflow
+
+The libKGEN crashpad output mentioned `__fortify_fail_abort`. That symbol
+appears when glibc's fortify-source machinery detects an overflowing
+`memcpy` / `strcpy` / similar. The natural reading: the JIT compiler is
+hitting a fortify-detected buffer overflow during heavy compilation. Day
+165 had been about virtual-memory exhaustion in the JIT; H1 was the same
+kind of story, one layer deeper.
+
+[PR #5389](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5389)
+added `just build` modes for AddressSanitizer and ThreadSanitizer so we
+could re-run the failing tests under instrumentation. Twenty CI runs under
+ASAN. Zero ASAN reports. Real cores from the gdb wrapper, finally, showed
+the faulting signal was **SIGILL, not SIGABRT**. Fortify reports SIGABRT.
+SIGILL means *the silicon refused to decode this instruction*. That is a
+completely different failure class.
+
+Theory dead. The `__fortify_fail_abort` symbol in the original crashpad
+was libKGEN's own handler routing through fortify on its way to
+`_exit` — a red herring of the kind that exists only because the handler
+ran instead of the kernel.
+
+### H2: Tuple destructor use-after-free
+
+[mojo#6187](https://github.com/modular/modular/issues/6187) — closed
+months earlier — had been a real destructor-ordering bug. The pattern was
+ASAP destruction firing on a tuple before a derived pointer finished using
+it. Maybe the libKGEN flake was the same pattern in a different
+neighborhood of the stdlib.
+
+Two hundred and seventy-six local runs on hermes (the development laptop,
+a Lunar Lake 258V) of every test file that had ever crashed in CI. Zero
+reproductions. Locally, with everything else identical, the crash refused
+to fire.
+
+That alone didn't kill H2. It could have been a rare destructor race that
+needed CI-load to surface. But H2 made no prediction the gdb-wrapper data
+contradicted *or* confirmed; it was an unfalsifiable hypothesis dressed as
+a falsifiable one. We didn't *reject* H2 here so much as set it aside as
+something we couldn't move on. That itself was useful data: whatever the
+bug was, *it didn't reproduce on my laptop*. The bug was hardware-coupled,
+or at least environment-coupled. We didn't know which yet.
+
+### H3: ASAN-strict / use-after-free in user code
+
+If a destructor bug was responsible somewhere in the stack, ASAN with
+strict-UB would catch it. PR #5389's ASAN mode produced 115 instrumented
+CI runs across the failing job set. **Zero UAF reports. Zero stack-buffer-
+overflow reports. Zero heap-buffer-overflow reports.** The instrumented
+binaries crashed at the same rate as the uninstrumented ones, with the
+same SIGILL, at the same faulting instructions — but without any of the
+sanitizer signatures you would expect if the cause were a memory-safety
+bug in our Mojo code.
+
+This was important. ASAN instruments code at compile time. Code that
+isn't instrumented (statically linked precompiled libraries) is not
+checked. `libKGENCompilerRTShared.so` ships precompiled, statically
+linked, *not* ASAN-instrumented. **If the bug were in any of the Mojo
+source we wrote, ASAN would have seen it. ASAN didn't see it. The bug
+lives in libKGEN itself, or upstream of libKGEN.**
+
+This shrank the hypothesis space considerably. It didn't tell us what was
+wrong; it told us where to stop looking.
+
+### H4: pixi-env cache content drift
+
+The next anomaly came from
+[PR #5382](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5382)
+itself. After it merged, it had been failing at roughly 87 % on the
+target jobs through commit `379cf40a`. After a routine rebase onto main,
+the same branch suddenly went 100 % green. No code changed in the
+rebase — just the merge base.
+
+The first theory was that `pixi install` is non-deterministic across hosts,
+that the GHA Ubuntu build VM produces a subtly different `pixi.lock`-
+resolved environment than developer machines, and that the cached
+container image had quietly absorbed different bytes during a recent
+re-publish. The hypothesis was specific: *the rebase invalidated the
+container cache key, the action rebuilt the image fresh, and the fresh
+image contained a fixed Mojo somehow.*
+
+This was falsifiable. We had the `pixi.lock` from before and after the
+rebase. Both files were byte-identical. The cached `mojo-1.0.0b2.dev2026050805-release.conda`
+artifact had sha256 `8b6f080d54b7c53185786a9a928afbfcf2fbb539d89c9d44da3b5b6700a8b6dc`
+on both sides. The *package contents* were not different.
+
+But the *image* was different. Three distinct cache-key suffixes were in
+active rotation in the GHA cache:
+
+| Cache key suffix | Image size | Used by |
+| --- | --- | --- |
+| `ab0290811d2e...` | 761 MB | PR #5399, #5393, #5394 (failing-era branches) |
+| `8f28e14581a4...` | 880 MB | PR #5395–#5398, PR #5382 post-rebase (green) |
+| `86502c66bbdd...` | 852 MB | `refs/heads/main` |
+
+The two images that *did the same thing* differed by 119 MB. Same Mojo
+package. Same pixi.lock. Different image content. Something in the
+container build process — outside Mojo, outside pixi — was non-determinism.
+
+We chased this for six hours. It became H4-prime in my notes. It mattered
+less than it seemed.
+
+### H5: Modular silently republished the nightly
+
+A parallel sub-theory: maybe Modular republished the `2026050805` nightly
+between Day 1 and Day 14 of the investigation with a fix, keeping the
+filename and shipping different bytes. The conda artifact sha256 ruled
+that out instantly — same hash on both sides. Modular did not republish.
+The Mojo binary in the failing-era image and the Mojo binary in the green
+image are byte-identical.
+
+That was the moment the investigation got really uncomfortable. The Mojo
+binary is the same. The pixi.lock is the same. The Mojo source we ship is
+the same. The bug appears and disappears across container-image rebuilds.
+**Whatever is varying is not in the package; it is in the container.**
+
+### H6: every non-AVX-512 Intel CPU triggers it
+
+By now the gdb wrapper had captured real cores. Five sites had emerged
+(see Chapter 6 for the full ISA inventory), all with AVX-512-only
+encodings. Site C2's `vmovss %xmm1{%k1}{z}` was the cleanest: `%k1` is
+an opmask register that does not exist before AVX-512F. The compiler had
+emitted an opmask-conditional move on a host whose kernel said it didn't
+have opmask registers.
+
+The obvious-looking hypothesis: *the compiler is emitting AVX-512 because
+it thinks the host has AVX-512. The host doesn't. Any older Intel SKU
+without AVX-512 — Skylake desktop, Whiskey Lake, Haswell, anything —
+should reproduce.* My laptop, hermes, is Lunar Lake (also no AVX-512). It
+didn't reproduce 276 times in a row. But maybe the bug was sensitive to
+CPU generation in some specific way; maybe a Skylake or a Haswell would
+hit it where Lunar Lake didn't.
+
+H6 was wrong in a particular way. It led to the cross-CPU survey. The
+survey falsified it. But the falsification turned out to be the most
+useful experiment of the investigation, because it produced the data that
+made the *real* hypothesis visible.
+
+End of Chapter 3: six theories, six rejections. Almost a month of work.
+The crashes continued.
+
+---
+
+## Chapter 4: The Bisect Protocol That Wasn't
+
+The week of May 11 began with one more attempt at clean falsification.
+Between the failing-era commit `379cf40a` on
+[PR #5382](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5382)
+and the green post-rebase commit, exactly five PRs had been merged:
+[#5381](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5381),
+[#5387](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5387),
+[#5388](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5388),
+[#5389](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5389),
+and [#5385](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5385).
+One of them, presumably, contained the fix. If we could identify *which*,
+we could understand the bug from the patch.
+
+I built a five-PR bisect protocol around 06:45 on May 12:
+
+- [PR #5395](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5395)
+  — revert Group A (`#5381` + `#5387`) and re-run target jobs eight times
+- [PR #5396](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5396)
+  — disable the gdb wrapper, to test mask-vs-fix
+- [PR #5397](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5397)
+  — revert the docker-compose dev memlimit change (14 G → 12 G)
+- [PR #5398](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5398)
+  — revert the `just build` + examples additions from PR #5389 (compose preserved)
+- [PR #5399](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5399)
+  — positive control: branch off the last-failing sha, add the symbolicator,
+    do not revert anything
+
+Per-PR protocol: re-run each target job eight times. Aggregate result over
+8 × 4 negative controls = 32 jobs. If any single revert flipped the
+failure rate back to ~87 %, we found the responsible PR. If all stayed
+green, no single revert mattered.
+
+By 07:33 the four negative controls had finished. **All four stayed green
+at 8/8.** Statistically, the probability of all 32 target jobs landing
+green by chance if the underlying failure rate were still 87 % is
+approximately P ≈ 2 × 10⁻²⁹. The bisect rejected the *"one of the five
+PRs contains the fix"* hypothesis with overwhelming confidence.
+
+The realization that crystallized over the next two coffees: we had been
+chasing **a GHA cache key**. The `setup-container` composite action keys
+its cache on `hashFiles('Dockerfile', 'pixi.toml', 'pixi.lock')`. A rebase
+that touched any of those three files — even just a no-op merge that
+re-saved them — produced a new hash, missed the cache, forced a fresh
+image build, and downloaded a fresh stdlib. The fresh image had different
+sha. That different sha was correlated with green CI. We had been treating
+that correlation as causation.
+
+What had actually changed? Nothing in our source. The Mojo binary, the
+stdlib, the pixi env — all byte-identical between the failing and green
+images, as far as anything we could measure was concerned. But something
+about the container build process itself was non-deterministic, and the
+non-determinism happened to land green on the rebase. We had no idea why.
+
+Six hours of cache theory, killed by the next experiment.
+
+---
+
+## Chapter 5: The Cross-CPU Survey
+
+The cross-CPU survey was designed to test H6. The premise: take the exact
+760 MB cached image tar from a failing CI run, save it with `podman save`,
+rsync it over Tailscale to five physical Intel machines I had access to,
+load it on each, and run the reproducer. If H6 was right, one or more of
+those machines would crash in the same place.
+
+The fleet:
+
+| Host | CPU | Microarch | Year | SIMD | AVX-512? |
+| --- | --- | --- | --- | --- | --- |
+| `aeolus` | Intel i7-3820 | Sandy Bridge-E | 2012 | AVX1 | no |
+| `titan` | Intel i5-4440 | Haswell | 2013 | AVX2 | no |
+| `epimetheus` | Intel i5-6600K | Skylake (desktop) | 2015 | AVX2 | no |
+| `apollo` | Intel i7-8565U | Whiskey Lake | 2018 | AVX2 + VNNI | no |
+| `hermes` | Intel 258V | Lunar Lake | 2024 | AVX2 + VNNI | no |
+
+The image was 760 MB. Tailscale moved it in about 90 seconds host-to-host.
+Total wall-clock from `podman save` on the GHA artifact to first
+reproduction attempt on aeolus: about twelve minutes per host.
+
+The protocol on each host was the same. Load the image. Run the bare
+podman command that the failing CI job runs. Wait for SIGILL or
+completion.
+
+**All five clean.** Sandy Bridge through Lunar Lake, no AVX-512 silicon
+in any of them, twelve years of Intel microarchitecture variety, *not one
+crash*.
+
+That was the moment of pivot. H6 predicted *at least one* of these
+machines would crash. None did. Either the bug was sensitive to something
+none of these machines had, or the bug was sensitive to something all of
+them lacked relative to the GHA runner.
+
+I had been assuming the GHA runner was an older Intel SKU. That assumption
+had never been tested. I had a workflow that ran on the runner and
+captured `/proc/cpuinfo` to the build log. That capture had been sitting
+in `actions/runs/25746055958/logs/` for a week and I had never opened it.
+
+I opened it.
+
+```text
+vendor_id        : AuthenticAMD
+cpu family       : 25
+model            : 17
+model name       : AMD EPYC 9V74 80-Core Processor
+stepping         : 1
+microcode        : 0xffffffff
+cpu MHz          : 2445.434
+Hypervisor vendor : Microsoft
+Virtualization type : full
+flags            : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca
+                   cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx
+                   mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good
+                   nopl tsc_reliable nonstop_tsc cpuid extd_apicid
+                   pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe
+                   popcnt aes xsave avx f16c rdrand hypervisor lahf_lm
+                   cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch
+                   osvw topoext invpcid_single vmmcall fsgsbase tsc_adjust
+                   bmi1 avx2 smep bmi2 invpcid rdseed adx smap clflushopt clwb
+                   sha_ni xsaveopt xsavec xgetbv1 xsaves clzero xsaveerptr
+                   arat npt nrip_save vaes vpclmulqdq rdpid fsrm
+```
+
+**There is no `avx512f` in that flag list.** There is no `avx512vl`,
+`avx512bw`, `avx512dq`, `avx512cd`, `avx512vnni`, `avx512vbmi`. The kernel
+sees no AVX-512 features at all.
+
+But the silicon is Zen 4. AMD EPYC 9V74 is a Genoa-family chip. *Zen 4
+hardware natively supports the full AVX-512 stack.* The hypervisor —
+Microsoft Hyper-V — masks the AVX-512 CPUID feature bits before they reach
+the guest kernel. The guest sees a Zen 4 chip without the AVX-512 silicon
+the underlying hardware actually has.
+
+The cross-CPU survey had been designed to find an Intel SKU that
+reproduced the bug. What it found instead was that *the bug requires an
+AMD chip with AVX-512 silicon, running under a hypervisor that masks the
+AVX-512 CPUID bits while leaving family/model/stepping untouched*. None
+of my five Intel machines could possibly reproduce it. They have no
+AVX-512 silicon to find.
+
+End of Chapter 5: AMD EPYC silicon does have AVX-512. The kernel says no
+AVX-512. The compiler emits AVX-512. Why is the kernel lying — or who is?
+
+---
+
+## Chapter 6: The Four ISA Crime Scenes
+
+With the gdb wrapper capturing real cores reliably, and with a
+companion symbolicator (`scripts/symbolicate-mojo-cores.sh`, which runs
+gdb *inside* the same container the binary was built in so the mojo
+binary's path resolves and DWARF info loads), four distinct faulting
+instructions appeared across captured crashes. A fifth turned out to be
+a variant of one of the first four.
+
+Each instruction is interesting in its own right because each is AVX-512
+in a *different* way. Together they rule out any explanation that hinges
+on a single misencoded instruction, or a peephole optimizer being one
+prefix byte off. The compiler emitted five distinct AVX-512 encodings
+across five distinct call sites. Five separate decisions to use AVX-512.
+Five separate confirmations of the same upstream behavior.
+
+| Site | Function | Faulting instruction | Why this is AVX-512 |
+| --- | --- | --- | --- |
+| A | `assert_almost_equal+48` (calls `abs()`) | `vandps (mem){1to4},%xmm3,%xmm3` | The `{1to4}` is an EVEX-encoded embedded broadcast modifier introduced in AVX-512F |
+| B | `_strip+68` (string slice) | `vmovdqa64 (mem),%zmm0` | `%zmm0` is a 512-bit register. It does not exist outside AVX-512. |
+| C1 | `next_uint32+178` (Philox PRNG round) | `vpternlogd $0x96,…,%xmm7` | No SSE/AVX/AVX2 form of `vpternlogd` exists |
+| C2 | `dispatch_binary+3024` (`_relu_backward_op`) | `vcmpltss → %k1`; then `vmovss {%k1}{z}` | `%k1` is an AVX-512F opmask register; the opmask register class did not exist before AVX-512 |
+| D | `_insert+4476` (swisstable `match_h2`) | `vpbroadcastb %eax,%xmm0` | The register-source form of `vpbroadcastb` is AVX-512BW; the memory-source form is AVX2 |
+
+### A short primer on the AVX-512 register file
+
+This primer lives in the post body, not behind a link, because the rest of
+the post depends on knowing which registers exist where.
+
+- `%xmm0..15` — 128-bit, SSE / AVX
+- `%ymm0..15` — 256-bit, AVX / AVX2
+- `%zmm0..31` — **512-bit, AVX-512F only**. There is no 256-bit-or-narrower
+  fallback that uses these register names. `%zmm` in disassembly is a
+  positive fingerprint: this binary depends on AVX-512F.
+- `%k0..7` — **opmask registers, AVX-512F only**. Used to predicate
+  per-lane SIMD operations. There is no pre-AVX-512 equivalent.
+- XSAVE state components: bit 5 (opmask), bit 6 (hi256), bit 7 (hi16_zmm).
+  These must be enabled in the OS-managed `XCR0` register before AVX-512
+  is safe to execute. Even on silicon with AVX-512 capability, if `XCR0`
+  doesn't have those bits set, the kernel hasn't reserved space to save
+  the AVX-512 register state on context switch — so executing an AVX-512
+  instruction is undefined. The canonical Intel guidance is to check
+  `cpuid(7,0).ebx[16]` (AVX-512F supported by silicon) *and*
+  `(xgetbv(0) & 0xe0) == 0xe0` (OS has enabled the state components),
+  both. See Intel SDM Volume 1 §13.3 *"Detection of XSAVE Feature
+  Support"*: <https://cdrdv2-public.intel.com/671436/253665-sdm-vol-1.pdf>.
+
+Hyper-V's standard CPUID-masking behavior, on the EPYC 9V74 fleet, clears
+the AVX-512 feature bits in CPUID leaf 7 sub-leaf 0, and clears bits 5/6/7
+of the host-reported XCR0. Both signals consistently say *"this CPU does
+not support AVX-512 for the purposes of guest execution."* The compiler
+that emits AVX-512 anyway is in violation of every protocol the kernel
+provides for detecting AVX-512 availability.
+
+End of Chapter 6: the kernel says no AVX-512. The hypervisor masks the
+CPUID view consistently. But the compiler emits AVX-512 anyway. *Where
+is the compiler getting its information?*
+
+---
+
+## Chapter 7: The Four-Layer Probe
+
+To answer *where is the compiler getting its information* required
+isolating each independent layer of the CPU-feature-detection stack and
+asking it the same question. If three layers agreed and one disagreed, we
+would know exactly which layer was wrong.
+
+Four probes, each with no dependency on the others:
+
+1. **Kernel view** — read `/proc/cpuinfo`, filter `flags` for `avx*`.
+   This is the kernel's curated view of CPU features, derived from CPUID
+   at boot and filtered by KVM/Hyper-V CPUID emulation.
+2. **Silicon-direct view** — a C program that issues raw `cpuid`
+   instructions and `xgetbv(0)` via inline assembly. Bypasses every
+   abstraction.
+3. **Compiler-rt view** — call `__builtin_cpu_supports("avx512f")`,
+   `__builtin_cpu_supports("avx512vl")`, etc. This is the standard
+   gcc/clang runtime CPU detection builtin, populated by libgcc's
+   `__cpu_features` ctor.
+4. **Driver-resolved view** — `mojo build --print-effective-target` on
+   a no-op `.mojo` file. This prints the Mojo driver's final
+   target-triple + target-cpu + target-features list — exactly what the
+   driver will hand to LLVM for codegen.
+
+The probe is committed at `repro/cpuid-probes/` on the
+`bisect/6413-positive-control` branch, along with a workflow
+(`probe-cpu-on-gha.yml`) that runs it on the GHA Azure runner via
+`workflow_dispatch`. The same probe also runs on every host in the
+cross-CPU fleet via Tailscale.
+
+The data flow that the probe maps out:
+
+```mermaid
+sequenceDiagram
+    participant Silicon
+    participant Hypervisor
+    participant Kernel
+    participant CompilerRT as compiler-rt
+    participant LLVM as LLVM (getHostCPUFeatures)
+    participant Mojo as Mojo Driver
+
+    Silicon->>Hypervisor: CPUID(7,0).ebx [AVX-512 bits]
+    Hypervisor-->>Kernel: masks bits 16/17/30/31 to 0
+    Kernel-->>CompilerRT: __builtin_cpu_supports("avx512f") = 0
+    Silicon->>Hypervisor: CPUID(1).eax family=25 model=17
+    Hypervisor-->>LLVM: family/model UNMASKED -> znver4
+    LLVM->>LLVM: X86TargetParser.Processors[znver4] = +avx512f,+vl,+bw,...
+    LLVM-->>Mojo: targetFeatures = host features UNION znver4 table
+    Mojo->>Mojo: target_has_feature["avx512f"] = TRUE
+    Note over Mojo: JIT emits vpternlogd / %zmm / %k1 / {1to4}
+    Mojo->>Silicon: executes AVX-512 encoded bytes
+    Silicon->>Kernel: SIGILL (XCR0 not enabled for AVX-512 state)
+```
+
+The probe run on hermes (Lunar Lake) was the control. All four layers
+agreed: no AVX-512, no `znver4`, no `avx512f` in `--print-effective-target`.
+Lunar Lake's static feature list in `X86TargetParser.cpp` does not include
+AVX-512, so the LLVM-side fingerprinting agrees with the silicon. Clean.
+
+The probe run on epimetheus (Skylake desktop) was the next control.
+Skylake desktop maps to `skylake` (not `skylake-avx512`) in the LLVM
+table; the `skylake` static feature list also does not include AVX-512.
+Clean.
+
+The probe run on the GHA EPYC 9V74 runner. **Layers 1–3 unanimously
+report no AVX-512.** `/proc/cpuinfo` has no avx512 flags; raw `cpuid(7,0)`
+returns zero in all AVX-512 bit positions; `__builtin_cpu_supports` for
+each AVX-512 feature returns 0. Layer 4 reports `--target-cpu znver4`
+with twelve distinct AVX-512 features in its target-features list:
+`+avx512f,+avx512vl,+avx512bw,+avx512dq,+avx512cd,+avx512vnni,+avx512vbmi,
++avx512vbmi2,+avx512bitalg,+avx512vpopcntdq,+avx512bf16,+avx512ifma`.
+
+Three layers agree. The compiler disagrees. The compiler is wrong.
+
+We now know exactly which layer holds the bug. We do not yet know *why*
+that layer holds the bug. For that we have to read the open-source tree.
+
+---
+
+## Chapter 8: The Smoking Gun in the Source
+
+A sub-agent was dispatched to do a source-code review of the
+`modular/modular` GitHub tree — specifically: *find every place where
+the Mojo stack reads CPU features at runtime, classify each, and identify
+which one populates the `!kgen.target` MLIR attribute*. The full review
+landed in
+[`notes/mojo-cpu-detection-source-review.md`](../../mojo-cpu-detection-source-review.md).
+The condensed version is below.
+
+### Step 1: the stdlib does no runtime CPU detection
+
+`mojo/stdlib/std/sys/info.mojo` is the file every AVX-512 path in our
+crash trace eventually queries. The relevant block:
+
+```mojo
+struct CompilationTarget[value: _TargetType = _current_target()](
+    TrivialRegisterPassable
+):
+    @staticmethod
+    def _has_feature[name: StaticString]() -> Bool:
+        return __mlir_attr[
+            `#kgen.param.expr<target_has_feature,`,
+            Self.value,
+            `,`,
+            _get_kgen_string[name](),
+            `> : i1`,
+        ]
+
+    @staticmethod
+    def has_avx512f() -> Bool:
+        return Self._has_feature["avx512f"]()
+```
+
+`target_has_feature` is a compile-time MLIR query. It cannot read CPUID.
+It cannot read `/proc/cpuinfo`. It resolves entirely against the
+`!kgen.target` attribute attached to the MLIR module. The stdlib is a
+faithful reporter of whatever the driver baked in.
+
+A complete sibling-file grep for `cpuid`, `xgetbv`, `__builtin_cpu_supports`,
+`getauxval`, `HWCAP`, `/proc/cpuinfo`, `getHostCPUName`, `getAcceleratorArchOrEmpty`
+across `mojo/stdlib/std/sys/` returns zero hits. **The stdlib cannot
+lie. It only repeats.**
+
+### Step 2: the driver populates `!kgen.target` from `getHostCPUFeatures()`
+
+The compiler driver — the binary that produces the MLIR module the stdlib
+operates on — is closed source. But it is referenced explicitly in the
+open-source docs at
+`mojo/docs/code/tools/README-Compilation-Targets.md` under *"Known issue
+(MOCO-3686)"*:
+
+> **Root cause:** `CLOptions.h:118` initializes `targetFeatures` to
+> `getHostCPUFeatures()`. The `--march`/`--mcpu` path routes through
+> `getMArchFeatures()` which computes the correct features, but the
+> stale host defaults leak to LLVM before the override takes effect.
+
+That naming is unambiguous: `getHostCPUFeatures()` is
+[`llvm::sys::getHostCPUFeatures()`](https://llvm.org/doxygen/namespacellvm_1_1sys.html),
+the upstream LLVM symbol. The driver imports it from LLVM. There is no
+Mojo-specific wrapper.
+
+### Step 3: `getHostCPUFeatures` on x86 has two parallel paths
+
+Reading the upstream LLVM source
+([`llvm/lib/TargetParser/Host.cpp`](https://github.com/llvm/llvm-project/blob/main/llvm/lib/TargetParser/Host.cpp)):
+
+1. **Raw CPUID read.** Issues `cpuid` directly via inline asm. Reads
+   leaf 7 sub-leaf 0 `ebx/ecx/edx` for feature bits. On the EPYC 9V74
+   under Hyper-V, every AVX-512 bit comes back zero.
+2. **CPU-name fingerprinting.** Separately calls `getHostCPUName()`,
+   which reads family / model / stepping from CPUID leaf 1 `eax` and
+   matches against a hard-coded table in
+   `getAMDProcessorTypeAndSubtype`. AMD family `0x19` model `0x10–0x1F`,
+   `0x60–0x7F`, `0xA0–0xAF` is `znver4`. **Hyper-V does not mask
+   family/model/stepping.** The fingerprinting returns `znver4`.
+
+The two paths are then **merged**. The function takes the CPUID feature
+bits (zero AVX-512) and the static feature list attached to the named
+CPU (`X86TargetParser.cpp::Processors["znver4"]` has the full AVX-512
+suite), and produces a union. The merge is not intersection-with-CPUID.
+The static list wins for any feature CPUID didn't explicitly say
+*"present"* or *"absent"* — and on a Hyper-V-masked Zen 4 guest, CPUID
+says *"absent"* for AVX-512, but the static-list merge ignores absence
+and adds AVX-512 anyway.
+
+That is the bug.
+
+### Stating the scope precisely
+
+The temptation here is to extrapolate: *every product that has ever
+shipped LLVM has shipped this bug.* That is not a claim the evidence
+supports. We have evidence for one driver, one LLVM version, one
+microarchitecture pair, one hypervisor.
+
+The maximum claim the evidence does support, stated carefully:
+
+> Any compiler driver that consumes `llvm::sys::getHostCPUFeatures()` —
+> or any equivalent path that combines CPU-name fingerprinting against
+> a static feature table with the CPUID feature-bit view, without
+> intersecting the result against the kernel-mediated CPUID feature
+> view — is exposed to wrong codegen whenever it runs in a
+> CPUID-masking environment such as Hyper-V. Microsoft's Hyper-V masks
+> AVX-512 *feature* bits but does not alter the family / model /
+> stepping fields that the fingerprinting reads. The Mojo 1.0.0b2
+> compiler driver, as documented in MOCO-3686, is one such consumer.
+
+That is everything we have proof of. The upstream LLVM behavior is the
+mechanism; whether every other LLVM-using driver in the world has the
+same issue depends on whether they *intersect* `getHostCPUFeatures`'s
+result against an independent kernel-view check before handing it to
+codegen. Most likely many do not. But we have no evidence about any
+specific product other than Mojo 1.0.0b2.
+
+The fix surface is small and well-defined. Either upstream LLVM changes
+`getHostCPUFeatures` to intersect the CPU-name-derived feature list
+against the CPUID feature view, or downstream consumers add a
+post-processing pass that does the intersection themselves. The Mojo
+team can do option 2 in days; option 1 is a large upstream change with
+broader implications.
+
+---
+
+## Chapter 9: Token Budget — A Note on Cost
+
+This investigation burned approximately **2.0–2.4 M tokens** across
+three overlapping Claude Code sessions:
+
+| Session id | Size | Turns | Window |
+| --- | --- | --- | --- |
+| `ed4137f5-…` | 230 KB jsonl | early | May 11, the earliest probe |
+| `35bf125d-…` | 2.7 MB jsonl | 365 | May 11–12 |
+| `b4253dc0-…` | 6.6 MB jsonl | 879 | May 11–13, primary session |
+
+That is roughly **50 % of a weekly Claude Max Pro budget** (estimated
+4–5 M tokens per week at the highest tier).
+
+What did the tokens buy?
+
+- Six new Mnemosyne skills, cross-linked at the end of this post.
+- Three upstream issue threads: `#6412` (filesystem error from
+  `getAcceleratorArchOrEmpty`), `#6413` (this AVX-512 codegen
+  mismatch, with nine substantive comments), and `#6445` (a
+  separately surfaced KGEN JIT buffer overflow).
+- Four captured ELF cores from the gdb wrapper, with full
+  symbolicator output.
+- A four-layer CPU-feature-detection probe — generalizable methodology
+  for any *"wrong instruction on this host"* report.
+- A five-host tailnet cross-CPU survey that falsified an entire
+  hypothesis class in one afternoon.
+- A source-side root cause traced to a specific documented line of
+  upstream LLVM, with the exact mechanism named.
+
+If you have been hesitant to spend serious model tokens on a single
+debugging investigation, this is the case for the case. The cost paid
+for durable skills, a confirmed upstream report with a reproducer, and
+a methodology that will pay forward across the next year of CPU-
+feature investigations. The dollar value of *"my CI is reliable
+again"* alone covers it.
+
+---
+
+## Chapter 10: Reproduce It Yourself
+
+The repro is self-contained. It requires Podman or Docker and a network
+connection.
+
+```bash
+# 1. Clone the repo and check out the positive-control branch
+git clone https://github.com/HomericIntelligence/ProjectOdyssey
+cd ProjectOdyssey
+git checkout bisect/6413-positive-control
+
+# 2. Build the container image locally (or pull from GHCR)
+podman compose build projectodyssey-dev
+# (~10 min first build; subsequent builds use the layer cache)
+
+# 3. Run the four-layer probe inside the cached image
+podman run --rm --userns=keep-id \
+  -v "$(pwd):/workspace:Z" -w /workspace \
+  --ulimit core=-1 \
+  projectodyssey:dev bash -c '
+    echo "=== Layer 1: kernel view ==="
+    grep -m1 ^flags /proc/cpuinfo | tr " " "\n" | grep ^avx
+    echo "=== Layer 2 + 3: silicon + compiler-rt ==="
+    gcc -O2 -o /tmp/probe repro/cpuid-probes/cpu_features_probe.c
+    /tmp/probe
+    echo "=== Layer 4: Mojo driver-resolved target ==="
+    pixi run mojo build --print-effective-target \
+        repro/repro_6413_python_import_os.mojo
+  '
+
+# 4. Attempt reproduction (only crashes on Hyper-V AMD Zen 4)
+podman run --rm --userns=keep-id \
+  -v "$(pwd):/workspace:Z" -w /workspace \
+  --ulimit core=-1 \
+  projectodyssey:dev \
+  bash -c 'pixi run mojo run repro/repro_6413_python_import_os.mojo'
+```
+
+On any Intel CPU without AVX-512 silicon (Sandy Bridge through Lunar
+Lake), Layers 1–4 will all agree on *"no AVX-512"* and the reproducer
+will exit clean. On a Hyper-V-hosted AMD Zen 4 (e.g., GHA
+`ubuntu-latest` Azure runners on the EPYC fleet), Layers 1–3 will
+report no AVX-512 but Layer 4 will report `--target-cpu znver4` with
+the twelve-feature AVX-512 list, and the reproducer will SIGILL inside
+`libKGENCompilerRTShared.so` with a faulting instruction encoded as
+`vmovdqa64 …,%zmm0` or similar.
+
+The reproducer file `repro/repro_6413_python_import_os.mojo` (committed
+on the `bisect/6413-positive-control` branch) is two lines: `from python import Python` then `def main(): _ =
+Python.import_module("os")`. The crash happens during the `_strip` call
+in the Python interop initialization path. There is nothing in the
+user-visible source about AVX-512 or SIMD.
+
+---
+
+## Lessons Learned
+
+A bulleted list. Most are recurring themes from prior posts in this
+series, but this investigation reinforced them with new weight.
+
+- **Six rejected hypotheses is a feature, not a failure.** Each one
+  tightened the search space. The investigation could not have reached
+  the AMD EPYC reveal without the wrong hypotheses preceding it. H1
+  showed the signal was SIGILL not SIGABRT. H3 ruled out user-code
+  memory bugs and pointed at libKGEN itself. H4 chased the cache and
+  ultimately discovered the image content was different even though
+  the package was identical. H6 motivated the cross-CPU survey, whose
+  *failure* to reproduce is what made the AMD/Hyper-V mechanism
+  visible. Without H1–H6 we would have looked at the EPYC 9V74
+  cpuinfo line and not known what to do with it.
+
+- **The four-layer probe is the first thing to run** for *"wrong
+  instruction on this host"* reports. If layers 1–3 (kernel,
+  silicon-direct, compiler-rt) agree and layer 4 (driver-resolved)
+  disagrees, the compiler is the bug surface. Save yourself a week.
+
+- **Cross-CPU surveys are cheap and high-signal.** Five physical
+  machines via Tailscale, the exact same image, the exact same
+  command — falsified an entire hypothesis class in one afternoon and
+  pointed at the actual mechanism by elimination.
+
+- **`cpuid` is not authoritative for codegen decisions.** OS-enabled
+  `XCR0` via `xgetbv` is the real source of truth for whether AVX-512
+  is safe to *execute*. Intel SDM Vol. 1 §13.3 is the canonical
+  reference; any compiler driver that doesn't check `XCR0` is wrong
+  in the same class of way that this bug is wrong.
+
+- **CI runner CPUs are not what your laptop is.** GitHub Actions
+  Azure runners include AMD EPYC silicon in the pool. *"My laptop is
+  Intel"* tells you nothing about your runner. Capture
+  `/proc/cpuinfo` and `cat /sys/class/dmi/id/sys_vendor` from CI
+  jobs as standard practice; it costs nothing and saves weeks.
+
+- **Build the infrastructure before you trust the data.** Two weeks
+  of the early investigation were spent on hypotheses whose
+  evidentiary base — libKGEN's 28-byte crashpad output — was actively
+  misleading. The gdb wrapper from PR #5382 was the moment the
+  investigation became real. Until then I was debugging the handler,
+  not the bug.
+
+- **Tenacity matters.** Wall-clock for this investigation across the
+  active sessions was roughly 75 hours. The breakthrough came at
+  hour 60+. If we'd stopped at *"six rejected hypotheses, we tried
+  hard enough"* — a defensible decision — we'd never have found it.
+  The temptation to mark something as unreproducible and move on is
+  strongest exactly at the point where the next experiment would
+  have produced the answer.
+
+---
+
+## References
+
+### This investigation's upstream issue thread
+
+[modular/modular#6413](https://github.com/modular/modular/issues/6413) —
+*"JIT emits AVX-512 instructions on a host without AVX-512 support"*,
+with the following substantive comments cited at their narrative moments
+above:
+
+- [Initial AVX-512 findings](https://github.com/modular/modular/issues/6413#issuecomment-4435784092)
+- [Cache content drift hypothesis](https://github.com/modular/modular/issues/6413#issuecomment-4435794613)
+- [Local reproducer recipe](https://github.com/modular/modular/issues/6413#issuecomment-4436157861)
+- [Skylake negative result](https://github.com/modular/modular/issues/6413#issuecomment-4436291160)
+- [Five-host tailnet survey](https://github.com/modular/modular/issues/6413#issuecomment-4436529846)
+- [AMD EPYC discovery](https://github.com/modular/modular/issues/6413#issuecomment-4436547360)
+- [Source code review](https://github.com/modular/modular/issues/6413#issuecomment-4436612117)
+- [cpuid probe falsifying earlier hypothesis](https://github.com/modular/modular/issues/6413#issuecomment-4436787785)
+- [Final smoking gun](https://github.com/modular/modular/issues/6413#issuecomment-4437508239)
+
+### Related upstream issues
+
+- [modular/modular#6412](https://github.com/modular/modular/issues/6412)
+  — `getAcceleratorArchOrEmpty` filesystem_error on rootless Podman
+- [modular/modular#6445](https://github.com/modular/modular/issues/6445)
+  — KGEN JIT buffer overflow, separately surfaced during this
+    investigation
+
+### External technical references
+
+- Intel SDM Vol. 1 §13.3 *Detection of XSAVE Feature Support*:
+  <https://cdrdv2-public.intel.com/671436/253665-sdm-vol-1.pdf> —
+  canonical reference for `cpuid + xgetbv` joint feature detection
+- LLVM `Host.cpp::getHostCPUFeatures`:
+  <https://github.com/llvm/llvm-project/blob/main/llvm/lib/TargetParser/Host.cpp>
+- LLVM `X86TargetParser.cpp::Processors[]`:
+  <https://github.com/llvm/llvm-project/blob/main/llvm/lib/TargetParser/X86TargetParser.cpp>
+- Mojo *Known issue MOCO-3686* docs:
+  <https://github.com/modular/modular/blob/main/mojo/docs/code/tools/README-Compilation-Targets.md>
+
+### ProjectOdyssey PRs that participated
+
+- [#5378](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5378)
+  — extend coredump-capture to all test jobs
+- [#5380](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5380)
+  — fix path-namespace and empty-cores silent-failure modes
+- [#5381](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5381)
+  — test matrix fan-out (later reverted as part of bisect)
+- [#5382](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5382)
+  — gdb ptrace wrapper for core capture
+- [#5385](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5385)
+  — refactor `|| true` workarounds; add forbid-suppressions guard
+- [#5387](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5387)
+  — forbid `::warning::` advisory pattern; flip 9 sites fail-fast
+- [#5388](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5388)
+  — alias `shared.training.SGD` to `TrainingSGD`
+- [#5389](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5389)
+  — `just build` compiles everything; add ASAN/TSAN modes
+- [#5393](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5393)
+  — failing-era branch retained for repro
+- [#5394](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5394)
+  — failing-era branch retained for repro
+- [#5395](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5395)
+  — bisect: revert Group A
+- [#5396](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5396)
+  — bisect: disable gdb wrapper to test mask-vs-fix
+- [#5397](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5397)
+  — bisect: revert docker-compose memlimit change
+- [#5398](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5398)
+  — bisect: revert justfile + examples additions from #5389
+- [#5399](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5399)
+  — bisect positive control: branch off last-failing sha + symbolicator
+- [#5401](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5401)
+  — bare-command repro + probe workflow
+
+### Internal repo artifacts
+
+- [`notes/modular-6413-avx512-finding.md`](../../modular-6413-avx512-finding.md)
+- [`notes/mojo-cpu-detection-source-review.md`](../../mojo-cpu-detection-source-review.md)
+- `repro/repro_6413_python_import_os.mojo` (on `bisect/6413-positive-control`)
+- `repro/repro_6413_assert_almost_equal.mojo` (on `bisect/6413-positive-control`)
+- [`docs/dev/mojo-jit-crash-capture-core.md`](../../../docs/dev/mojo-jit-crash-capture-core.md)
+- [`docs/dev/mojo-jit-crash-workaround.md`](../../../docs/dev/mojo-jit-crash-workaround.md)
+  (older theory, superseded by this post)
+
+### ProjectMnemosyne skills produced from this investigation
+
+- `mojo-jit-emits-avx512-on-non-avx512-cpu` v3.0.0
+- `multi-layer-cpu-feature-detection-mismatch-probe` v1.0.0
+- `cross-cpu-survey-gha-only-crash` v1.0.0
+- `extract-gha-container-image-cache-locally` v1.0.0
+- `symbolicate-mojo-cores-inside-container` v1.0.0
+- `mojo-print-effective-target-codegen-diagnostic` v1.0.0
+
+### Previous posts in this series
+
+- [Day 165 (modular#6433: the 3.6 GB virtual ghost)](../04-20-2026/)
+- [Day 62 (three weeks of firefighting)](../03-25-2026/)
+- [Day 61 (slice view bad-free)](../03-24-2026/)
+- [Day 53 (UnsafePointer.bitcast UAF)](../03-16-2026/)¹
+
+¹ The Day 53 post's H1 reads *"Day Fifty-Three"*, but its date
+(2026-03-16) is approximately 130 days after the project's first
+commit on 2025-11-07. The Day 53 numbering in that older post is an
+error; subsequent posts and this one use the 2025-11-07 baseline,
+under which 2026-04-20 is Day 165 and 2026-05-12 is Day 187. The
+older post has not been retroactively renumbered.

--- a/notes/blog/05-12-2026/README.md
+++ b/notes/blog/05-12-2026/README.md
@@ -109,9 +109,8 @@ Look at the dates on
 [modular/modular#6413](https://github.com/modular/modular/issues/6413) and
 [modular/modular#6433](https://github.com/modular/modular/issues/6433).
 6413 was filed on **April 12**. 6433 was filed mid-month and closed out
-on April 20. The first comment I posted on 6413 with *real cores* was
-**May 11**. The first ISA analysis was **May 12**. The AMD EPYC reveal
-was **May 13**.
+on April 20. The first comment I posted on 6413 with *real core dumps* was
+**May 11**.
 
 Between April 12 and May 8, I had nothing to go on but the crashpad: a
 non-zero exit out of `mojo` inside the container, intermittently, on a
@@ -161,7 +160,7 @@ crashed in libKGENCompilerRTShared.so inside Docker containers, but not
 natively, on Mojo 0.26.3.* The issue's reproduction section literally
 says *"this crash occurs non-deterministically in CI Docker (~40-60% of
 runs have at least one crash)."* I attached the crashpad. I listed the
-~30 tests that had crashed at least once. The conjectured cause in the
+tests that had crashed at least once. The conjectured cause in the
 issue body was *"a buffer overflow detection in glibc's fortified string
 functions, triggered during JIT compilation rather than user code
 execution."* I would spend the next four weeks acting on that conjecture,
@@ -188,7 +187,7 @@ Look at the merge dates and you can read the shape of the search:
   *"remove test-with-retry.sh and direct-wire mojo invocation (ADR-015 Action 2)"*
 
 ADR-015 named the policy out loud: *"flaky required CI checks."* The
-mental model was the JIT crashes randomly, and the engineering response
+mental model was the JIT crashes randomly, given its alpha nature, and the engineering response
 is to make our infrastructure tolerate randomness — better isolation, no
 shared state across tests, no retry sleights of hand.
 
@@ -254,7 +253,7 @@ collect locally pushed back against it.
 ### Four weeks of work that didn't crack it
 
 I want to be careful not to make April sound like a stall. It wasn't. I
-was working the problem every day — running tests in long loops on the
+was working the problem — running tests in long loops on the
 laptop, tweaking compile-unit shape, hunting for an input that would fail
 on demand. The PRs in the previous section are *every* one of those
 attempts that produced a code change worth merging. None of them
@@ -284,13 +283,13 @@ reproducer to chase it with.
 
 ### AMD AI Dev Day, Beyond Summit, and the Mojo 1.0 beta decision
 
-In parallel, the Mojo 1.0 beta had been released. I'd had a chance to
+On a side note, I'd had a chance to
 talk to several folks from Modular at AMD AI Dev Day and at the Beyond
-Summit 2025, and the conversations all pointed the same direction: 1.0
-was the line the project was being supported against, the workaround
-zoo accumulated during 0.26 was the *old* world, and a number of the
-JIT-side fragilities had been getting attention in the beta. I decided
-to upgrade.
+Summit 2025, and the conversations all pointed the same direction: Mojo 1.0
+was coming this summer. The workaround
+zoo that accumulated during 0.26 was temporary and needed to be resolved before 1.0 finalized.
+I decided to upgrade, when the beta gets released, so paused all work. The initial
+beta release dropped a few days after AMD AI Dev Day.
 
 That upgrade was not a trivial bump. It required a lot of changes across
 the codebase — new constructor signature (`out self` vs `mut self`),
@@ -332,9 +331,8 @@ adjacent excuses closed out.
 
 So I stopped trying to suppress the symptoms and started trying to
 *observe* the failure properly. The next ten days — what the rest of this
-post is actually about — were spent building the diagnostic infrastructure
-I should have built on April 13 but did not, because for a month I had
-two more comfortable explanations open against the same compiler.
+post is actually about — were spent building the diagnostic infrastructure 
+to solve the problem.
 
 ### The infrastructure I finally built (May 10–11)
 
@@ -436,7 +434,7 @@ actually say"*.
 ## Chapter 3: Six Hypotheses, Six Dead Ends
 
 Chapter 2 already buried one of these hypotheses by the time it ended:
-the *flaky-JIT-load* mental model that dominated all of April. I'm
+the *flaky-JIT-load* mental model that dominated for months. I'm
 re-stating it as H1 here anyway, because the way it died — when the gdb
 wrapper showed SIGILL, not SIGABRT — is what made every subsequent
 hypothesis necessary. The next five (H2 through H6) are the *post-May-11*
@@ -444,14 +442,28 @@ attempts to explain what a SIGILL inside libKGEN actually meant. Each
 follows the same shape: *I thought X. I gathered Y. Z is why it was
 wrong.*
 
-### H1: JIT volume / `__fortify_fail` overflow (April's whole month)
+### H1: JIT volume / `__fortify_fail` overflow
 
 The libKGEN crashpad output mentioned `__fortify_fail_abort`. That symbol
 appears when glibc's fortify-source machinery detects an overflowing
 `memcpy` / `strcpy` / similar. The natural reading: the JIT compiler is
-hitting a fortify-detected buffer overflow during heavy compilation. Day
-165 had been about virtual-memory exhaustion in the JIT; H1 was the same
-kind of story, one layer deeper.
+hitting a fortify-detected buffer overflow during heavy compilation.
+This was not the first time a libKGEN crash had been framed as a JIT
+resource problem on this project. The mitigation lineage going back to
+March —
+[PR #3958](https://github.com/HomericIntelligence/ProjectOdyssey/pull/3958)
+*(document Mojo JIT crash workaround)*,
+[PR #4744](https://github.com/HomericIntelligence/ProjectOdyssey/pull/4744)
+*(add retry logic for flaky JIT test groups)*,
+[PR #5161](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5161)
+*(targeted submodule imports to mitigate Data test JIT crashes)*,
+[PR #5171](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5171)
+*(per-file JIT crash retry for Mojo 0.26.1)* — had every one of them
+treated libKGEN signals as transient runtime faults in a JIT that
+needed less load, smaller compile units, or retries to converge.
+[Day 165](../04-20-2026/) and `modular/modular#6433` had even *confirmed*
+one specific JIT resource bug: virtual-memory exhaustion at the
+mid-3.6 GB mark. H1 was the same kind of story, one layer deeper.
 
 [PR #5389](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5389)
 added `just build` modes for AddressSanitizer and ThreadSanitizer so we
@@ -459,12 +471,12 @@ could re-run the failing tests under instrumentation. Twenty CI runs under
 ASAN. Zero ASAN reports. Real cores from the gdb wrapper, finally, showed
 the faulting signal was **SIGILL, not SIGABRT**. Fortify reports SIGABRT.
 SIGILL means *the silicon refused to decode this instruction*. That is a
-completely different failure class.
+completely different failure class!
 
 Theory dead. The `__fortify_fail_abort` symbol in the original crashpad
 was libKGEN's own handler routing through fortify on its way to
 `_exit` — a red herring of the kind that exists only because the handler
-ran instead of the kernel.
+ran instead of the kernel. If this handler didn't switch the signal.... One can only guess how much quicker this would have been resolved.
 
 ### H2: Tuple destructor use-after-free
 
@@ -514,7 +526,7 @@ The next anomaly came from
 [PR #5382](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5382)
 itself. After it merged, it had been failing at roughly 87 % on the
 target jobs through commit `379cf40a`. After a routine rebase onto main,
-the same branch suddenly went 100 % green. No code changed in the
+the same branch suddenly went *100%* green! No code changed in the
 rebase — just the merge base.
 
 The first theory was that `pixi install` is non-deterministic across hosts,
@@ -560,27 +572,42 @@ binary is the same. The pixi.lock is the same. The Mojo source we ship is
 the same. The bug appears and disappears across container-image rebuilds.
 **Whatever is varying is not in the package; it is in the container.**
 
-### H6: every non-AVX-512 Intel CPU triggers it
+### H6: a non-AVX CPU breaks the JIT
 
-By now the gdb wrapper had captured real cores. Five sites had emerged
-(see Chapter 6 for the full ISA inventory), all with AVX-512-only
-encodings. Site C2's `vmovss %xmm1{%k1}{z}` was the cleanest: `%k1` is
-an opmask register that does not exist before AVX-512F. The compiler had
-emitted an opmask-conditional move on a host whose kernel said it didn't
-have opmask registers.
+By now the gdb wrapper had captured real cores from CI, and the
+disassembly around `$pc` was no longer just bytes — it was instructions
+the silicon was refusing to decode. The chapters that follow will spend
+real time on which instructions those were. For now what mattered was
+the shape of the question they raised: the JIT had emitted bytes that
+the executing CPU could not run.
 
-The obvious-looking hypothesis: *the compiler is emitting AVX-512 because
-it thinks the host has AVX-512. The host doesn't. Any older Intel SKU
-without AVX-512 — Skylake desktop, Whiskey Lake, Haswell, anything —
-should reproduce.* My laptop, hermes, is Lunar Lake (also no AVX-512). It
-didn't reproduce 276 times in a row. But maybe the bug was sensitive to
-CPU generation in some specific way; maybe a Skylake or a Haswell would
-hit it where Lunar Lake didn't.
+The first hypothesis off that observation was a simple one:
+*maybe the JIT is making a CPU-feature assumption that my development
+hardware happens to satisfy and CI's hardware doesn't.* I run my
+day-to-day work on hermes, a Lunar Lake laptop with AVX2 + VNNI. The
+GHA runner — whatever it was, I had not yet bothered to check — was on
+the older end of the Azure pool. If the compiler was assuming a baseline
+SIMD level above what the runner could run, we'd see exactly this
+shape: green on the laptop, SIGILL in CI.
 
-H6 was wrong in a particular way. It led to the cross-CPU survey. The
-survey falsified it. But the falsification turned out to be the most
-useful experiment of the investigation, because it produced the data that
-made the *real* hypothesis visible.
+The experiment was to take the exact failing container image, pull it
+to the laptop, and run the same reproducer locally. Same binary, same
+stdlib, same library tree, same input — only the silicon changes. If
+the bug was a JIT-on-old-hardware mismatch, then on hermes the runtime
+would either fault in the same way (because the bug is hardware-agnostic
+inside the container) or succeed (because the laptop has whatever the
+GHA runner is missing). Either way, *one* of the two outcomes was a
+useful next data point.
+
+276 iterations on the laptop, in the failing image, against the
+deterministic reproducers from PR #5393. *Zero crashes.*
+
+That ruled the simplest version of H6 out, but it didn't fully kill the
+shape of the hypothesis. The laptop was newer than the CI runner had to
+be, not older. Maybe the bug was generation-specific in some narrower
+way — maybe an older Intel chip, a Haswell or a Skylake, would trip
+where Lunar Lake didn't. To answer that I needed more silicon than the
+one laptop. That experiment is Chapter 5.
 
 End of Chapter 3: six theories, six rejections. Almost a month of work.
 The crashes continued.
@@ -626,7 +653,7 @@ green by chance if the underlying failure rate were still 87 % is
 approximately P ≈ 2 × 10⁻²⁹. The bisect rejected the *"one of the five
 PRs contains the fix"* hypothesis with overwhelming confidence.
 
-The realization that crystallized over the next two coffees: we had been
+The realization that crystallized over the next two development periods: we had been
 chasing **a GHA cache key**. The `setup-container` composite action keys
 its cache on `hashFiles('Dockerfile', 'pixi.toml', 'pixi.lock')`. A rebase
 that touched any of those three files — even just a no-op merge that
@@ -647,11 +674,24 @@ Six hours of cache theory, killed by the next experiment.
 
 ## Chapter 5: The Cross-CPU Survey
 
-The cross-CPU survey was designed to test H6. The premise: take the exact
-760 MB cached image tar from a failing CI run, save it with `podman save`,
-rsync it over Tailscale to five physical Intel machines I had access to,
-load it on each, and run the reproducer. If H6 was right, one or more of
-those machines would crash in the same place.
+The cross-CPU survey extended H6's laptop experiment to a real fleet.
+H6 had only one local data point: hermes (Lunar Lake) didn't reproduce.
+That left two possibilities open. Either the bug needed a chip *older*
+than Lunar Lake — something pre-AVX2, or AVX2 without VNNI, or with a
+different microarchitectural quirk — or the bug needed something
+hermes shared with the GHA runner but I hadn't isolated yet.
+
+Both possibilities pointed at the same next experiment: run the exact
+failing container, with the exact failing binary, on as many different
+generations of Intel silicon as I could reach. If the bug was sensitive
+to a particular generation, *one* of those machines would catch it. If
+none of them did, the bug was sensitive to something other than the
+Intel line.
+
+The premise: take the exact 760 MB cached image tar from a failing CI
+run, save it with `podman save`, rsync it over Tailscale to every
+physical machine I had access to, load it on each, and run the
+reproducer. Five hosts available.
 
 The fleet:
 
@@ -675,15 +715,17 @@ completion.
 in any of them, twelve years of Intel microarchitecture variety, *not one
 crash*.
 
-That was the moment of pivot. H6 predicted *at least one* of these
+That was the moment of pivot. I had predicted *at least one* of these
 machines would crash. None did. Either the bug was sensitive to something
-none of these machines had, or the bug was sensitive to something all of
+none of these machines had, or it was sensitive to something all of
 them lacked relative to the GHA runner.
 
-I had been assuming the GHA runner was an older Intel SKU. That assumption
-had never been tested. I had a workflow that ran on the runner and
-captured `/proc/cpuinfo` to the build log. That capture had been sitting
-in `actions/runs/25746055958/logs/` for a week and I had never opened it.
+I had been assuming the GHA runner was the same sort of hardware I run
+on locally — a generic x86_64 Intel chip on the older end of the Azure
+pool. That assumption had never been tested. I had a workflow that ran
+on the runner and captured `/proc/cpuinfo` to the build log. That
+capture had been sitting in `actions/runs/25746055958/logs/` for a week
+and I had never opened it.
 
 I opened it.
 
@@ -715,20 +757,25 @@ flags            : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca
 sees no AVX-512 features at all.
 
 But the silicon is Zen 4. AMD EPYC 9V74 is a Genoa-family chip. *Zen 4
-hardware natively supports the full AVX-512 stack.* The hypervisor —
-Microsoft Hyper-V — masks the AVX-512 CPUID feature bits before they reach
-the guest kernel. The guest sees a Zen 4 chip without the AVX-512 silicon
-the underlying hardware actually has.
+hardware natively supports the full AVX-512 stack.* The host the runner
+is sitting on top of is, on the metal, capable of running every
+AVX-512 instruction the cores were faulting on. And yet
+`/proc/cpuinfo` inside the runner — the guest kernel's curated view of
+its own CPU — was telling every consumer of CPU features that no
+AVX-512 existed here.
 
 The cross-CPU survey had been designed to find an Intel SKU that
-reproduced the bug. What it found instead was that *the bug requires an
-AMD chip with AVX-512 silicon, running under a hypervisor that masks the
-AVX-512 CPUID bits while leaving family/model/stepping untouched*. None
-of my five Intel machines could possibly reproduce it. They have no
-AVX-512 silicon to find.
+reproduced the bug. What it found instead was that *no Intel SKU in my
+fleet could possibly reproduce the bug, because the bug requires
+silicon that has AVX-512 capability — and none of my Intel machines do*.
+The crash-host has AVX-512 capability that nothing in its software
+stack will admit to.
 
-End of Chapter 5: AMD EPYC silicon does have AVX-512. The kernel says no
-AVX-512. The compiler emits AVX-512. Why is the kernel lying — or who is?
+End of Chapter 5: the silicon has AVX-512. The kernel says it doesn't.
+The compiler is emitting AVX-512 anyway. Three layers of the system
+have to be examined to figure out which one is wrong — and *why*
+nobody other than the compiler is willing to acknowledge what the
+hardware actually is.
 
 ---
 
@@ -779,16 +826,49 @@ the post depends on knowing which registers exist where.
   both. See Intel SDM Volume 1 §13.3 *"Detection of XSAVE Feature
   Support"*: <https://cdrdv2-public.intel.com/671436/253665-sdm-vol-1.pdf>.
 
-Hyper-V's standard CPUID-masking behavior, on the EPYC 9V74 fleet, clears
-the AVX-512 feature bits in CPUID leaf 7 sub-leaf 0, and clears bits 5/6/7
-of the host-reported XCR0. Both signals consistently say *"this CPU does
-not support AVX-512 for the purposes of guest execution."* The compiler
-that emits AVX-512 anyway is in violation of every protocol the kernel
-provides for detecting AVX-512 availability.
+### How SIGILL gets here
 
-End of Chapter 6: the kernel says no AVX-512. The hypervisor masks the
-CPUID view consistently. But the compiler emits AVX-512 anyway. *Where
-is the compiler getting its information?*
+SIGILL is the kernel's response to the CPU's `#UD` (undefined-opcode)
+fault. The decode unit consumes the byte stream at the program counter
+one prefix and one opcode at a time. If the resulting instruction is
+not in the decoder's table of legal instructions *for this processor's
+configuration*, the decoder raises `#UD`. The kernel catches it, posts
+`SIGILL` to the offending process, and either delivers it (default
+action: dump core and exit) or lets the registered handler intercept.
+
+There are two distinct ways an instruction can be illegal "for this
+processor's configuration":
+
+1. **The decoder doesn't recognise the opcode at all.** No silicon in
+   this CPU model implements the encoding. EVEX-prefixed AVX-512
+   instructions are exactly this case on a chip without AVX-512
+   silicon: the EVEX prefix decode itself fails, because the decoder's
+   table has no AVX-512 entries.
+2. **The decoder recognises the opcode, but the OS hasn't enabled the
+   register state it needs.** This is the `XCR0` gate. Even on silicon
+   that has AVX-512 capability, executing an AVX-512 instruction is
+   `#UD` unless the OS-managed `XCR0` register has bits 5/6/7 set —
+   the bits that mark opmask, hi256, and hi16_zmm as "the kernel has
+   reserved space to save these on context switch." Without `XCR0`
+   permission, the CPU treats AVX-512 as not-enabled-for-this-process,
+   even though the silicon could physically execute it.
+
+Both modes raise the same SIGILL. The captured cores can't distinguish
+mode 1 from mode 2 by signal alone. The faulting instruction *bytes*
+are what matter — and they say AVX-512.
+
+The canonical Intel guidance for whether emitting AVX-512 is safe is to
+check `cpuid(7,0).ebx[16]` (AVX-512F supported by silicon) **and**
+`(xgetbv(0) & 0xe0) == 0xe0` (OS has enabled the state components).
+*Both*. See Intel SDM Vol. 1 §13.3 *"Detection of XSAVE Feature
+Support"*: <https://cdrdv2-public.intel.com/671436/253665-sdm-vol-1.pdf>.
+A compiler that emits AVX-512 without checking *both* of those is in
+violation of the documented protocol.
+
+End of Chapter 6: there are five distinct AVX-512 fault sites in this
+binary, each with its own ISA fingerprint. The kernel says no AVX-512.
+The compiler emits AVX-512 anyway. *Where is the compiler getting its
+information from, when every protocol it could query says no?*
 
 ---
 
@@ -799,11 +879,11 @@ isolating each independent layer of the CPU-feature-detection stack and
 asking it the same question. If three layers agreed and one disagreed, we
 would know exactly which layer was wrong.
 
-Four probes, each with no dependency on the others:
+Three probes first, each with no dependency on the others:
 
 1. **Kernel view** — read `/proc/cpuinfo`, filter `flags` for `avx*`.
    This is the kernel's curated view of CPU features, derived from CPUID
-   at boot and filtered by KVM/Hyper-V CPUID emulation.
+   at boot.
 2. **Silicon-direct view** — a C program that issues raw `cpuid`
    instructions and `xgetbv(0)` via inline assembly. Bypasses every
    abstraction.
@@ -811,10 +891,6 @@ Four probes, each with no dependency on the others:
    `__builtin_cpu_supports("avx512vl")`, etc. This is the standard
    gcc/clang runtime CPU detection builtin, populated by libgcc's
    `__cpu_features` ctor.
-4. **Driver-resolved view** — `mojo build --print-effective-target` on
-   a no-op `.mojo` file. This prints the Mojo driver's final
-   target-triple + target-cpu + target-features list — exactly what the
-   driver will hand to LLVM for codegen.
 
 The probe is committed at `repro/cpuid-probes/` on the
 `bisect/6413-positive-control` branch, along with a workflow
@@ -822,7 +898,87 @@ The probe is committed at `repro/cpuid-probes/` on the
 `workflow_dispatch`. The same probe also runs on every host in the
 cross-CPU fleet via Tailscale.
 
-The data flow that the probe maps out:
+The probe run on hermes (Lunar Lake) was the control. All three layers
+agreed: no AVX-512. Lunar Lake silicon does not have AVX-512 capability
+to begin with. Kernel view, raw CPUID, and `__builtin_cpu_supports` all
+say zero across the board. Clean.
+
+The probe run on epimetheus (Skylake desktop) was the next control.
+Skylake desktop maps to `skylake` (not `skylake-avx512`) in the LLVM
+table; the `skylake` static feature list also does not include AVX-512.
+Clean.
+
+The probe run on the GHA EPYC 9V74 runner. **Layers 1–3 unanimously
+report no AVX-512.** `/proc/cpuinfo` has no avx512 flags; raw `cpuid(7,0)`
+returns zero in all AVX-512 bit positions; `__builtin_cpu_supports` for
+each AVX-512 feature returns 0.
+
+That result was a surprise. Going into the probe my best guess was that
+the silicon would say *yes* (since cores were faulting on AVX-512 bytes
+that had to come from somewhere) but the kernel would say *no* (because
+that's what `/proc/cpuinfo` had already shown). Either layer 1 or layer
+2 was supposed to flip, and the divergence would point at the
+mechanism. Instead both layers agreed with each other, and both agreed
+the hardware had no AVX-512 of any kind.
+
+### Why doesn't anyone show AVX-512 support?
+
+The hardware *is* AVX-512 capable — Zen 4 silicon implements the full
+AVX-512 stack. The compiler is emitting AVX-512 from somewhere. Yet
+raw `cpuid` itself returns zero for AVX-512. The instruction the
+guest executes runs against the *guest's* view of the CPU, not the
+metal. Microsoft Hyper-V exposes a curated CPUID page to guests on
+EPYC 9V74: it programs the AVX-512 feature bits in leaf 7 sub-leaf 0
+to zero and clears bits 5/6/7 of the host-reported XCR0. From inside
+the guest, every well-behaved consumer of CPU features will agree
+*"this CPU does not have AVX-512 for the purposes of this VM"*. The
+guest `cpuid` instruction itself is part of that curation. There is
+no probe a guest can run against `cpuid` or `xgetbv` to discover the
+underlying hardware's true capabilities — the hypervisor has decided
+for it, before any of those instructions run.
+
+Why mask AVX-512? The honest answer for a cloud provider is that
+AVX-512 state is expensive to save and restore across context
+switches, AVX-512-induced clock-throttling can affect tenants
+sharing a host, and not every VM image is built with code paths
+that assume AVX-512. Masking the feature out of the guest's CPUID
+view is the documented, supported way to opt out: any compiler that
+checks `cpuid` before emitting AVX-512 will see zero and pick a
+narrower SIMD path.
+
+That is the explanation for layers 1–3. The kernel sees no AVX-512
+because the hypervisor masked it. `cpuid` sees no AVX-512 because the
+hypervisor masked it. `__builtin_cpu_supports` sees no AVX-512 because
+it reads `cpuid`, which the hypervisor masked.
+
+Which leaves one question: how did the compiler decide *yes* in
+defiance of every check the documented protocol prescribes?
+
+### Layer 4: the driver-resolved view
+
+The fourth probe addresses that question directly:
+
+4. **Driver-resolved view** — `mojo build --print-effective-target` on
+   a no-op `.mojo` file. This prints the Mojo driver's final
+   target-triple + target-cpu + target-features list — exactly what the
+   driver will hand to LLVM for codegen.
+
+Whatever the driver hands to LLVM is what gets used to make every
+emission decision in the JIT. If that list says AVX-512, the JIT
+emits AVX-512. We have three probes saying no, and one probe that
+shows the input to the actual emitter.
+
+Layer 4 reports `--target-cpu znver4` with twelve distinct AVX-512
+features in its target-features list:
+`+avx512f,+avx512vl,+avx512bw,+avx512dq,+avx512cd,+avx512vnni,+avx512vbmi,
++avx512vbmi2,+avx512bitalg,+avx512vpopcntdq,+avx512bf16,+avx512ifma`.
+
+Three layers agree. The driver disagrees. The driver is the layer that
+emits code. The driver is wrong.
+
+### Mapping the full data flow
+
+With all four probes in hand the mechanism can be drawn end-to-end:
 
 ```mermaid
 sequenceDiagram
@@ -843,31 +999,22 @@ sequenceDiagram
     Mojo->>Mojo: target_has_feature["avx512f"] = TRUE
     Note over Mojo: JIT emits vpternlogd / %zmm / %k1 / {1to4}
     Mojo->>Silicon: executes AVX-512 encoded bytes
-    Silicon->>Kernel: SIGILL (XCR0 not enabled for AVX-512 state)
+    Silicon->>Kernel: SIGILL
 ```
 
-The probe run on hermes (Lunar Lake) was the control. All four layers
-agreed: no AVX-512, no `znver4`, no `avx512f` in `--print-effective-target`.
-Lunar Lake's static feature list in `X86TargetParser.cpp` does not include
-AVX-512, so the LLVM-side fingerprinting agrees with the silicon. Clean.
+Note what the diagram says about *which CPUID fields* the hypervisor
+masks. Feature bits in leaf 7: masked. Family/model/stepping in leaf
+1: not masked. The driver fingerprints the CPU off the unmasked
+family/model, gets `znver4` back, and pulls a static feature list out
+of a table indexed by that name. That table claims AVX-512 because
+real `znver4` silicon does have AVX-512 — and the lookup never
+intersects that claim against what the masked feature bits actually
+say.
 
-The probe run on epimetheus (Skylake desktop) was the next control.
-Skylake desktop maps to `skylake` (not `skylake-avx512`) in the LLVM
-table; the `skylake` static feature list also does not include AVX-512.
-Clean.
-
-The probe run on the GHA EPYC 9V74 runner. **Layers 1–3 unanimously
-report no AVX-512.** `/proc/cpuinfo` has no avx512 flags; raw `cpuid(7,0)`
-returns zero in all AVX-512 bit positions; `__builtin_cpu_supports` for
-each AVX-512 feature returns 0. Layer 4 reports `--target-cpu znver4`
-with twelve distinct AVX-512 features in its target-features list:
-`+avx512f,+avx512vl,+avx512bw,+avx512dq,+avx512cd,+avx512vnni,+avx512vbmi,
-+avx512vbmi2,+avx512bitalg,+avx512vpopcntdq,+avx512bf16,+avx512ifma`.
-
-Three layers agree. The compiler disagrees. The compiler is wrong.
-
-We now know exactly which layer holds the bug. We do not yet know *why*
-that layer holds the bug. For that we have to read the open-source tree.
+We now know exactly which layer holds the bug. We do not yet know
+*why* the LLVM lookup is willing to claim features the surrounding
+CPUID view contradicts. For that we have to read the open-source
+tree.
 
 ---
 
@@ -996,8 +1143,8 @@ broader implications.
 
 ## Chapter 9: Token Budget — A Note on Cost
 
-This investigation burned approximately **2.0–2.4 M tokens** across
-three overlapping Claude Code sessions:
+This investigation burned at least **2M tokens** across
+three overlapping Claude Code sessions running non-stop for almost three days:
 
 | Session id | Size | Turns | Window |
 | --- | --- | --- | --- |
@@ -1008,24 +1155,30 @@ three overlapping Claude Code sessions:
 That is roughly **50 % of a weekly Claude Max Pro budget** (estimated
 4–5 M tokens per week at the highest tier).
 
-What did the tokens buy?
+What did those three days of tokens buy?
 
-- Six new Mnemosyne skills, cross-linked at the end of this post.
-- Three upstream issue threads: `#6412` (filesystem error from
-  `getAcceleratorArchOrEmpty`), `#6413` (this AVX-512 codegen
-  mismatch, with nine substantive comments), and `#6445` (a
-  separately surfaced KGEN JIT buffer overflow).
-- Four captured ELF cores from the gdb wrapper, with full
-  symbolicator output.
-- A four-layer CPU-feature-detection probe — generalizable methodology
-  for any *"wrong instruction on this host"* report.
+- Four captured ELF cores from the gdb wrapper, with full symbolicator
+  output (the first cores arrived May 11 right at the start of the
+  active sessions).
+- Nine substantive comments posted to `modular/modular#6413` between
+  May 10 and May 13 — the entire ISA breakdown, the cross-CPU survey
+  results, the AMD EPYC discovery, the source-code review, and the
+  four-layer probe smoking gun.
+- A four-layer CPU-feature-detection probe (Bash + C + Mojo) —
+  generalizable methodology for any *"wrong instruction on this host"*
+  report.
 - A five-host tailnet cross-CPU survey that falsified an entire
   hypothesis class in one afternoon.
 - A source-side root cause traced to a specific documented line of
   upstream LLVM, with the exact mechanism named.
+- Six new Mnemosyne skills written from the May 11–13 work and
+  cross-linked at the end of this post.
+- Lots and lots of testing, log reading, web searching, and
+  throw-away experiments — the part that doesn't show up in any
+  artifact but is most of where the tokens actually went.
 
 If you have been hesitant to spend serious model tokens on a single
-debugging investigation, this is the case for the case. The cost paid
+debugging investigation, this is the case for it. The cost paid
 for durable skills, a confirmed upstream report with a reproducer, and
 a methodology that will pay forward across the next year of CPU-
 feature investigations. The dollar value of *"my CI is reliable
@@ -1084,41 +1237,56 @@ The reproducer file `repro/repro_6413_python_import_os.mojo` (committed
 on the `bisect/6413-positive-control` branch) is two lines: `from python import Python` then `def main(): _ =
 Python.import_module("os")`. The crash happens during the `_strip` call
 in the Python interop initialization path. There is nothing in the
-user-visible source about AVX-512 or SIMD.
+user-visible source about AVX-512, SIMD, or the underlying hardware.
 
 ---
 
 ## Lessons Learned
 
-A bulleted list. Most are recurring themes from prior posts in this
-series, but this investigation reinforced them with new weight.
+This investigation reinforced a set of themes that recur across the
+blog series, and added one or two new ones.
+
+- **Push until you have a 100% reproducible test case, then stop
+  improvising and start measuring.** For four weeks I tried to make
+  a flaky failure go away by tightening the environment around it —
+  retry harnesses, UID fixes, import localization, ulimit bumps. None
+  of it worked, and most of it *couldn't* have worked, because none
+  of it had a deterministic input to verify against. The investigation
+  only made real progress once
+  [PR #5393](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5393)
+  landed two single-file reproducers that crashed every time on the
+  failing image. A reproducer that fires at 100 % turns every
+  hypothesis into a measurable A/B test. A flake that fires at 40 %
+  turns every hypothesis into a guess. If you can get to 100 % first,
+  do that.
 
 - **Six rejected hypotheses is a feature, not a failure.** Each one
-  tightened the search space. The investigation could not have reached
-  the AMD EPYC reveal without the wrong hypotheses preceding it. H1
-  showed the signal was SIGILL not SIGABRT. H3 ruled out user-code
-  memory bugs and pointed at libKGEN itself. H4 chased the cache and
-  ultimately discovered the image content was different even though
-  the package was identical. H6 motivated the cross-CPU survey, whose
-  *failure* to reproduce is what made the AMD/Hyper-V mechanism
-  visible. Without H1–H6 we would have looked at the EPYC 9V74
-  cpuinfo line and not known what to do with it.
+  tightened the search space. H1 was the entire month of April and
+  what eventually died at the SIGILL/SIGABRT distinction. H3 ruled
+  out user-code memory bugs. H4 chased the cache and discovered the
+  GHA cache key was non-deterministic across rebases. H6 motivated
+  the cross-CPU survey, whose *failure* to reproduce is what pointed
+  at AMD/Hyper-V. Without H1–H6 the EPYC 9V74 cpuinfo line would have
+  been a curiosity, not a smoking gun.
 
 - **The four-layer probe is the first thing to run** for *"wrong
   instruction on this host"* reports. If layers 1–3 (kernel,
   silicon-direct, compiler-rt) agree and layer 4 (driver-resolved)
-  disagrees, the compiler is the bug surface. Save yourself a week.
+  disagrees, the compiler driver is the bug surface. Save yourself
+  a week.
 
 - **Cross-CPU surveys are cheap and high-signal.** Five physical
   machines via Tailscale, the exact same image, the exact same
   command — falsified an entire hypothesis class in one afternoon and
-  pointed at the actual mechanism by elimination.
+  pointed at the actual mechanism by elimination. The cost was a
+  90-second rsync per host and a 12-minute load-and-run cycle.
 
 - **`cpuid` is not authoritative for codegen decisions.** OS-enabled
   `XCR0` via `xgetbv` is the real source of truth for whether AVX-512
   is safe to *execute*. Intel SDM Vol. 1 §13.3 is the canonical
-  reference; any compiler driver that doesn't check `XCR0` is wrong
-  in the same class of way that this bug is wrong.
+  reference; any compiler driver that doesn't intersect its
+  CPU-name fingerprinting against `XCR0` is wrong in the same class
+  of way this bug is wrong.
 
 - **CI runner CPUs are not what your laptop is.** GitHub Actions
   Azure runners include AMD EPYC silicon in the pool. *"My laptop is
@@ -1126,20 +1294,26 @@ series, but this investigation reinforced them with new weight.
   `/proc/cpuinfo` and `cat /sys/class/dmi/id/sys_vendor` from CI
   jobs as standard practice; it costs nothing and saves weeks.
 
-- **Build the infrastructure before you trust the data.** Two weeks
-  of the early investigation were spent on hypotheses whose
-  evidentiary base — libKGEN's 28-byte crashpad output — was actively
-  misleading. The gdb wrapper from PR #5382 was the moment the
-  investigation became real. Until then I was debugging the handler,
-  not the bug.
+- **Adjacent issues are dangerous explanatory siblings.** While
+  `#6412` and `#6433` were open, every libKGEN crash could be
+  rationalised against one of them, and the temptation was to keep
+  applying targeted workarounds rather than confront a third
+  unknown. When *both* closed and the crash kept firing, only then
+  was there no rationalisation left. Watch for this pattern in your
+  own investigations.
 
-- **Tenacity matters.** Wall-clock for this investigation across the
-  active sessions was roughly 75 hours. The breakthrough came at
-  hour 60+. If we'd stopped at *"six rejected hypotheses, we tried
-  hard enough"* — a defensible decision — we'd never have found it.
-  The temptation to mark something as unreproducible and move on is
-  strongest exactly at the point where the next experiment would
-  have produced the answer.
+- **Build the infrastructure before you trust the data.** Four weeks
+  of the early investigation operated against libKGEN's 28-byte
+  crashpad output, which was actively misleading because the signal
+  was being filtered through libKGEN's own SIGABRT/SIGILL handler.
+  The gdb wrapper from PR #5382 was the moment the investigation
+  became real. Until then I was debugging the handler, not the bug.
+
+- **Tenacity matters.** Wall-clock for the active phase across three
+  overlapping Claude Code sessions was roughly 75 hours over three
+  days. The breakthrough came at hour 60+. The temptation to mark
+  something as unreproducible and move on is strongest exactly at
+  the point where the next experiment would have produced the answer.
 
 ---
 

--- a/notes/blog/05-12-2026/README.md
+++ b/notes/blog/05-12-2026/README.md
@@ -252,31 +252,82 @@ a runtime guard against overflowing string buffers. Every prior libKGEN
 flake the workaround document had cataloged was framed as a JIT memory
 problem. The mental model was set.
 
-### May 8 — the pivot
+### Why nothing changed for four weeks — and what made me finally look
 
-By the end of the first week of May, the import-localization mitigation
-had pushed the crash rate down but not to zero. PRs that touched
-unrelated code (like
-[PR #5363](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5363),
-a 33-issue consolidation merge) were still tripping the crash. The
-*Phase G* merge on May 5 produced
-[a particularly clear failure](https://github.com/modular/modular/issues/6413#issuecomment-from-may-10)
-that I reported back to 6413 on May 10 with the words *"same crash family
-confirmed in Mojo 1.0.0b2."*
+There was a structural reason the April investigation stalled where it
+did. Two of the *other* upstream issues open against the project,
+[modular/modular#6412](https://github.com/modular/modular/issues/6412)
+(*"uncaught filesystem_error in `getAcceleratorArchOrEmpty()` when HOME
+is not traversable by running UID"*) and
+[modular/modular#6433](https://github.com/modular/modular/issues/6433)
+(*"mojo compiler reserves ~3.6 GB virtual address space unconditionally,
+causing OOM crashes on memory-constrained CI runners"*), each looked
+like they could plausibly explain the libKGEN failures. 6412 fit the
+container UID symptoms PR #5252 had been chasing. 6433 fit the JIT-load
+mental model the import-localization PRs were built on. **As long as
+those two issues were open, I had two perfectly good outstanding excuses
+for any libKGEN crash in CI**, and I could keep applying targeted
+workarounds without having to confront a third unknown.
+
+6412 closed on April 20. 6433 closed on May 6 — that's the *3.6 GB
+Virtual Ghost* from [Day 165](../04-20-2026/). The day 6433 closed, the
+libKGEN crash *should* have stopped, because the dominant outstanding
+explanation for it was gone. It did not stop. It kept firing on PRs that
+had nothing to do with virtual-memory exhaustion.
+
+### AMD AI Dev Day, Beyond Summit, and the Mojo 1.0 beta decision
+
+In parallel, the Mojo 1.0 beta had been released. I'd had a chance to
+talk to several folks from Modular at AMD AI Dev Day and at the Beyond
+Summit 2025, and the conversations all pointed the same direction: 1.0
+was the line the project was being supported against, the workaround
+zoo accumulated during 0.26 was the *old* world, and a number of the
+JIT-side fragilities had been getting attention in the beta. I decided
+to upgrade.
+
+That upgrade was not a trivial bump. It required a lot of changes across
+the codebase — new constructor signature (`out self` vs `mut self`),
+ownership-transfer operators, list-literal syntax, parametric function
+value types (the new `thin` keyword), removal of `unified` capture,
+elimination of `mojo test` in favor of `def main()`-style hand-rolled
+test runners, plus the usual cascade of API shifts that come with any
+"1.0" bump. The migration landed in
+[PR #5353](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5353)
+on **May 9**, just three days after 6433 had closed.
+
+That sequence is what reset the investigation. Going to 1.0.0b2 meant
+ripping out a forest of 0.26-era syntax and stdlib idioms — and along
+with them, every quiet assumption that *"this code path is fragile,
+leave it alone."* Once the bandaid was off, every part of the codebase
+that had been compiled with the 0.26 workaround stack was now compiled
+fresh against 1.0.0b2. And libKGEN was *still crashing*. With both 6412
+and 6433 closed and the Mojo version itself bumped to the line that was
+supposed to fix this class of fragility, there were no outstanding excuses
+left.
+
+### May 10 — the pivot
+
+The day after the 1.0.0b2 migration merged, the *Phase G* consolidation
+PR
+[#5363](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5363)
+tripped the same libKGEN crash on the new Mojo. I reported it back to
+6413 on May 10 with the words *"same crash family confirmed in Mojo
+1.0.0b2."*
 
 That post is when the investigation pivoted. The Modular engineer
 ([dgurchenkov](https://github.com/modular/modular/issues/6413#issuecomment-4435794613))
-replied: *"For the repro steps... I don't quite understand this part. The
-repro section says it cannot reproduce natively."* They were politely
+replied: *"For the repro steps... I don't quite understand this part.
+The repro section says it cannot reproduce natively."* They were politely
 asking what I was already painfully aware of: **without a reproducer,
-they could not help me.** A month of "make it less flaky" had hit a wall.
+they could not help me.** A month of "make it less flaky" had hit a wall,
+on a Mojo version that was supposed to be past those flakes, with both
+adjacent excuses closed out.
 
 So I stopped trying to suppress the symptoms and started trying to
 *observe* the failure properly. The next ten days — what the rest of this
 post is actually about — were spent building the diagnostic infrastructure
-I should have built on April 13 but did not, because for a month I did
-not believe I was looking at a compiler bug. I believed I was looking at
-a JIT load problem in our test harness.
+I should have built on April 13 but did not, because for a month I had
+two more comfortable explanations open against the same compiler.
 
 ### The infrastructure I finally built (May 10–11)
 

--- a/notes/blog/05-12-2026/README.md
+++ b/notes/blog/05-12-2026/README.md
@@ -1143,17 +1143,64 @@ broader implications.
 
 ## Chapter 9: Token Budget — A Note on Cost
 
-This investigation burned at least **2M tokens** across
-three overlapping Claude Code sessions running non-stop for almost three days:
+The first draft of this chapter estimated *"about 2 M tokens"* based on
+the size of the jsonl conversation transcripts on disk (230 KB + 2.7 MB
++ 6.6 MB). That estimate was wrong by more than two orders of
+magnitude. The transcript file size is the *user-visible* turn record;
+it has nothing to do with the tokens actually billed against the API,
+because every turn re-sends the rolling cached context — and on a
+multi-day Claude Code session with deep tool use, the rolling cached
+context is enormous.
 
-| Session id | Size | Turns | Window |
-| --- | --- | --- | --- |
-| `ed4137f5-…` | 230 KB jsonl | early | May 11, the earliest probe |
-| `35bf125d-…` | 2.7 MB jsonl | 365 | May 11–12 |
-| `b4253dc0-…` | 6.6 MB jsonl | 879 | May 11–13, primary session |
+The honest numbers come from
+[`ccusage`](https://github.com/ryoppippi/ccusage), which reads each
+session's underlying API-call metadata directly. Scoped to the
+`ProjectOdyssey` project, May 10 — May 12 (there was no May 8 or May 9
+ProjectOdyssey activity at all — the investigation's active phase was
+exactly those three days):
 
-That is roughly **50 % of a weekly Claude Max Pro budget** (estimated
-4–5 M tokens per week at the highest tier).
+```bash
+npx -y ccusage@latest daily --since 20260510 --until 20260512 \
+  -i --json | jq '.projects."-home-mvillmow-Projects-ProjectOdyssey"'
+```
+
+| Date | Input | Output | Cache write | Cache read | Total | Cost (calc) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 2026-05-10 | 120 | 42,356 | 345,431 | 10,871,563 | 11,259,470 | $8.65 |
+| 2026-05-11 | 2,067 | 261,083 | 2,427,762 | 89,764,560 | 92,455,472 | $65.42 |
+| 2026-05-12 | 4,525 | 470,575 | 1,782,570 | 342,500,441 | 344,758,111 | $192.78 |
+| **Total** | **6,712** | **774,014** | **4,555,763** | **443,136,564** | **448,473,053** | **$266.85** |
+
+Models used in the window: `claude-opus-4-7` (the primary driver) and
+`claude-haiku-4-5-20251001` (for sub-agent dispatch).
+
+A few observations from the real numbers:
+
+- **The investigation cost ~$267 in API-equivalent pricing across
+  three days.** That is not a Claude Max Pro number — Max Pro tops
+  out well below that on weekly cap. The earlier "50 % of weekly
+  budget" framing was generated against the wrong baseline. Stated
+  honestly: this was a *non-trivial* model spend, the kind of thing
+  a Pro plan would not have covered alone, and the framing should be
+  *"this is what serious CPU-feature debugging at agent-coordinated
+  scale costs"* rather than a fraction of any prosumer plan.
+- **Cache hit rate was 443.1 M read vs 4.5 M write — about 99 %.**
+  That ratio is the structural reason long Claude Code sessions stay
+  affordable relative to total token volume. Almost every token in
+  the bill is a cache *read*; if every turn had to re-tokenise the
+  rolling context, the dollar cost would be ~10× higher.
+- **May 12 alone was 344 M tokens / $193** — three times May 11's
+  budget. That spike is the day I built the four-layer probe, ran
+  the cross-CPU survey, captured `/proc/cpuinfo` from the EPYC
+  runner, dispatched the source-code-review sub-agent, and wrote
+  the upstream comments. The breakthrough day was the expensive day,
+  which is the right shape for a debugging budget — the cost rose
+  as the search converged, not while flailing.
+- **6,712 *direct* input tokens** across three days is a small
+  number; almost everything I typed was a short command or
+  clarification. The 774 K *output* tokens are where the model
+  actually did work — sub-agent prompts, draft comments, source
+  reviews, and the long synthesis writeups.
 
 What did those three days of tokens buy?
 
@@ -1177,12 +1224,13 @@ What did those three days of tokens buy?
   throw-away experiments — the part that doesn't show up in any
   artifact but is most of where the tokens actually went.
 
-If you have been hesitant to spend serious model tokens on a single
-debugging investigation, this is the case for it. The cost paid
-for durable skills, a confirmed upstream report with a reproducer, and
-a methodology that will pay forward across the next year of CPU-
-feature investigations. The dollar value of *"my CI is reliable
-again"* alone covers it.
+If you have been hesitant to spend serious model budget on a single
+debugging investigation, $267 across three days produced a fixed
+upstream bug, a reproducer, six durable skills, and a methodology
+that will pay forward across the next year of CPU-feature
+investigations. The dollar value of *"my CI is reliable again"* alone
+covers it. The methodological lesson — *"don't estimate token usage
+from jsonl file size, ask `ccusage`"* — is its own kind of pay-forward.
 
 ---
 

--- a/notes/blog/05-12-2026/README.md
+++ b/notes/blog/05-12-2026/README.md
@@ -29,7 +29,7 @@ back to April.
 **Project:** ML Odyssey
 **Date:** May 12, 2026
 **Branch:** `bisect/6413-positive-control`
-**Tags:** #mojo #debugging #ci #llvm #jit #cross-cpu-survey #modular-bug
+**Tags:** #mojo #debugging #ci #jit #cross-cpu-survey #modular-bug
 
 ---
 
@@ -94,9 +94,10 @@ work with for four weeks.
 
 Through all of April, I treated this as a **flaky JIT** — the same family
 of failure as `mojo-jit-crash-workaround.md` had been describing since
-March. The entire shape of the investigation was *"this is some kind of
-heap or scheduling flake in the JIT, and the way to defeat a flake is to
-find a 100% reproducible test case that triggers it on demand."*
+March, and I had been dealing with for months prior. The entire shape of
+the investigation was *"this is some kind of heap or scheduling flake in
+the JIT, and the way to defeat a flake is to find a 100% reproducible test
+case that triggers it on demand."*
 
 So that is what I tried to do.
 
@@ -119,10 +120,11 @@ quieter test environments. In rough chronological order:
 - [PR #5171 (Mar 26)](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5171) —
   *"add per-file JIT crash retry for Mojo 0.26.1"*
 
-That is the prehistory. Each of these PRs assumes the same model of the
-bug — *the JIT is fragile under certain loads, and the fix is to relieve
-the load or retry through the failure* — and each of them is informed by
-no more than what the crashpad chose to print.
+That is the history for this blog, the pre-history goes back further.
+Each of these PRs assumes the same model of the bug — *the JIT is fragile
+under certain loads, and the fix is to relieve the load or retry through
+the failure* — and each of them is informed by no more than what the
+crashpad chose to print.
 
 ### April 12 — the upstream issue is filed
 
@@ -259,8 +261,8 @@ reproducer to chase it with.
 On a side note, I'd had a chance to
 talk to several folks from Modular at AMD AI Dev Day and at the Beyond
 Summit 2025, and the conversations all pointed the same direction: Mojo 1.0
-was coming this summer. The workaround
-zoo that accumulated during 0.26 was temporary and needed to be resolved before 1.0 finalized.
+was coming this summer. The workaround zoo that accumulated during 0.26
+was temporary and needed to be resolved before 1.0 finalized.
 I decided to upgrade, when the beta gets released, so paused all work. The initial
 beta release dropped a few days after AMD AI Dev Day.
 
@@ -303,7 +305,7 @@ on a Mojo version that was supposed to be past those flakes, with both
 adjacent excuses closed out.
 
 So I stopped trying to suppress the symptoms and started trying to
-*observe* the failure properly. The next ten days — what the rest of this
+*observe* the failure properly. The next few days — what the rest of this
 post is actually about — were spent building the diagnostic infrastructure 
 to solve the problem.
 
@@ -392,7 +394,7 @@ generates a real ELF core. Libkgen's handler never runs.
 This wrapper became the centerpiece of
 [`docs/dev/mojo-jit-crash-capture-core.md`](../../../docs/dev/mojo-jit-crash-capture-core.md).
 The first real cores arrived on May 11. What they showed did not match
-the working model I had been operating under for a month. The details
+the working model I had been operating under for months. The details
 of *what* they showed, and how each follow-on theory in turn failed to
 explain it, are the next chapter.
 

--- a/notes/modular-6413-avx512-finding.md
+++ b/notes/modular-6413-avx512-finding.md
@@ -1,0 +1,235 @@
+# Draft comment for modular/modular#6413
+
+**TL;DR**: The SIGILL is `mojo`'s JIT emitting AVX-512 instructions
+(`{1to4}` broadcast, `vpternlogd`, `%k1` opmask + masked move) on a GitHub
+Actions Azure runner CPU that does not support AVX-512. Captured 4 distinct
+faulting-instruction sites across the historic crash signatures; all are
+AVX-512.
+
+## Environment
+
+- Mojo: `1.0.0b2.dev2026050805 (ed7c8f0a)` (matches the version pinned in
+  ProjectOdyssey `pixi.toml`).
+- Runner: standard GitHub Actions `ubuntu-latest`,
+  `Linux runnervmeorf1 6.17.0-1010-azure #10~24.04.1-Ubuntu`.
+- Container: rootless Podman, `/home/dev/.cache/pixi/envs/.../bin/mojo`.
+- Capture method: `gdb -batch` wrapping `mojo` so libKGEN's in-process SIGABRT/
+  SIGILL handler doesn't swallow the signal before kernel can dump
+  ([gha-mojo-coredump-capture skill v1 in ProjectMnemosyne], plus pipe-handler
+  `core_pattern`).
+
+The GHA runner CPU lacks AVX-512 — corroborated by `gdb info all-registers`
+on the captured cores showing **no `zmm` and no `k0-k7` opmask registers**,
+only `xmm`/`ymm`.
+
+## Captured faulting instructions
+
+Four distinct sites, all reproducing under the same `mojo` build; all
+emitting AVX-512 encodings:
+
+### Site A — `assert_almost_equal` / `abs()` SIMD reduce
+
+Backtrace:
+
+```
+#0  abs () at math.mojo:3746
+#1  assert_almost_equal () at shared/testing/assertions.mojo:170
+#2  test_tensor_dataset_negative_indexing ()
+```
+
+Faulting instruction:
+
+```
+=> 0x7fc4f4158490 <assert_almost_equal+48>: vandps (%r15,%rax,1){1to4},%xmm3,%xmm3
+   0x7fc4f4158497 <assert_almost_equal+55>: vucomiss %xmm2,%xmm3
+   0x7fc4f415849b <assert_almost_equal+59>: jbe    ...+1006
+```
+
+`{1to4}` is AVX-512F embedded broadcast.
+
+### Site B — `_strip` / string slice (`_strip+68`)
+
+Backtrace:
+
+```
+#0  _strip () at string_slice.mojo:1035
+#1  rstrip () at string_slice.mojo:1104
+#2  rstrip () at string.mojo:1654
+#3  dirname () at path.mojo:257
+#4  _cpython.__init__ () at _cpython.mojo:1432
+#5  python.__init__ () at python.mojo:45
+#6  closure.0 () at ffi/__init__.mojo:915
+#7  KGEN_CompilerRT_GetOrCreateGlobalIndexed () (libKGENCompilerRTShared.so)
+#11 import_module () at python.mojo:238
+#12 test_substitute_simple_env_var ()
+```
+
+Faulting instruction (3 separate core captures, identical site):
+
+```
+=> 0x7f1d683e8804 <_strip+68>: vmovdqa64 (%rcx,%rax,1),%zmm0
+   0x7f1d683e880b <_strip+75>: movabs $0x240,%rax
+```
+
+**This is the clearest evidence of the codegen mismatch.** `%zmm0` is a
+512-bit register that **literally only exists in AVX-512**. `vmovdqa64`
+loads 64 bytes from memory into it. No SSE / AVX / AVX2 form uses this
+register name. The compiler emitted a 64-byte SIMD string-strip load for
+a target that has at most 32-byte (`%ymm`) registers.
+
+A related capture in the same job hit `load_config+2857`:
+
+```
+=> 0x7fb2783949e9 <load_config+2857>: vmovdqu64 (%r12,%rax,1),%zmm0
+   0x7fb2783949f0 <load_config+2864>: vmovdqu64 %zmm0,0x1e0(%rsp)
+```
+
+via `_is_valid_utf8_runtime () at _utf8.mojo:173` — again `%zmm0`,
+unaligned variant.
+
+### Site D — `_swisstable._insert` / `match_h2` (`_insert+4476`)
+
+Backtrace:
+
+```
+#0  match_h2 () at _swisstable.mojo:114
+#1  _insert () at _swisstable.mojo (various callers)
+```
+
+Faulting instruction (2 separate captures, identical site):
+
+```
+=> 0x7f2bbc3a448c <_insert+4476>: vpbroadcastb %eax,%xmm0
+   0x7f2bbc3a4492 <_insert+4482>: mov    0x18(%rsp),%rsi
+```
+
+`vpbroadcastb` with a **GPR source** (`%eax`) is AVX-512BW + AVX-512VL.
+The memory-source form is AVX2, but the register-source form requires
+AVX-512BW — and gdb's decoding here shows the reg-to-reg encoding.
+
+### Site C1 — `philox._single_round` / `next_uint32`
+
+Backtrace:
+
+```
+#0  _single_round () at philox.mojo:162
+#1  step () at philox.mojo:101
+#2  next_uint32 () at _rng.mojo:80
+#3  next_uint64 () at _rng.mojo:93
+#4  next_float64 () at _rng.mojo:104
+#5  random_float64 () at _rng.mojo:205
+#6  random_float64 () at random.mojo:89
+#7  forward () at dropout.mojo:134  /  randn () at tensor_creation.mojo:582
+```
+
+Faulting instruction:
+
+```
+=> 0x7f8c1c188562 <next_uint32+178>: vpternlogd $0x96,%xmm3,%xmm4,%xmm7
+   0x7f8c1c188569 <next_uint32+185>: vpxor  %xmm5,%xmm4,%xmm3
+   0x7f8c1c18856d <next_uint32+189>: vpshufd $0x55,%xmm3,%xmm3
+```
+
+`VPTERNLOGD` is an AVX-512F instruction. There is no SSE/AVX/AVX2 form.
+
+### Site C2 — `_relu_backward_op` / `dispatch_binary`
+
+Backtrace:
+
+```
+#0  _relu_backward_op () at activation.mojo:475
+        return grad if x > Scalar[T](0) else Scalar[T](0)
+#1  elementwise_binary () at dtype_dispatch.mojo:248
+#2  dispatch_binary () at dtype_dispatch.mojo:307
+#3  relu_backward () at activation.mojo:508
+#4  backward () at layers/relu.mojo:107
+#5  test_relu_backward_basic ()
+```
+
+Faulting instruction (loop body):
+
+```
+=> 0x7f766814bcb0 <dispatch_binary+3024>: vcmpltss (%r10,%rdi,4),%xmm0,%k1
+   0x7f766814bcb8 <dispatch_binary+3032>: vmovss (%rsi,%rdi,4),%xmm1{%k1}{z}
+   0x7f766814bcbf <dispatch_binary+3039>: vmovss %xmm1,(%r9,%rdi,4)
+   0x7f766814bcc5 <dispatch_binary+3045>: inc    %rdi
+   0x7f766814bcc8 <dispatch_binary+3048>: cmp    %rdi,%rcx
+   0x7f766814bccb <dispatch_binary+3051>: jne    0x7f766814bcb0
+```
+
+**This is the smoking-gun site.** The destination of `vcmpltss` is `%k1`, an
+AVX-512 opmask register. `k0-k7` literally do not exist outside AVX-512;
+there is no AVX2 / AVX1 fallback that uses them. The `vmovss
+…{%k1}{z}` immediately after is a masked move with zeroing, also AVX-512F.
+
+The pattern is a vectorized lowering of
+`return grad if x > Scalar[T](0) else Scalar[T](0)` — `vcmpltss` produces a
+mask, the masked `vmovss{z}` selects `grad` or 0. The compiler picked the
+AVX-512 masked-select lowering on a target that doesn't support opmask
+registers.
+
+## Hypothesis
+
+**Updated 2026-05-12 after verifying that no host involved has AVX-512:**
+
+- Local dev laptop (Intel Core Ultra 7 258V — Lunar Lake): no `avx512*`
+  CPU flags. Local test runs never reproduce the crash (276+ runs, 0 crashes).
+- GitHub Actions `ubuntu-latest` build runner (where the CI image is built
+  via `container-publish.yml`): Azure VM, no AVX-512.
+- GitHub Actions `ubuntu-latest` test runner (where tests actually execute):
+  Azure VM, no AVX-512. **Both** runner pools lack AVX-512; both core dumps
+  show only `xmm`/`ymm` (no `zmm`, no `k0-k7` opmask) in `info all-registers`.
+
+So the simple "build host had AVX-512, runtime host didn't" story is
+**wrong**. Despite no host in the entire pipeline supporting AVX-512,
+`mojo` still emitted AVX-512 encodings at multiple call sites in stdlib
+and project code.
+
+Candidate mechanisms now narrowed to:
+
+1. **`mojo` defaults to a generic AVX-512-capable target** unless a runtime
+   CPU detection routine confidently downgrades to AVX-2. If that detection
+   misreads `/proc/cpuinfo`, or if it trusts CPUID directly without
+   filtering through Linux's enabled-features mask (`getauxval(AT_HWCAP*)`),
+   it could enable AVX-512 codepaths erroneously.
+2. **An `--accelerator-arch` / `--target-cpu` value cached into
+   `$HOME/.modular`** during `pixi install` on the GHA build runner could
+   pin AVX-512. The entrypoint script in our project already mentions
+   `getAcceleratorArchOrEmpty()` from `libAsyncRTMojoBindings.so`; if that
+   function writes to or reads from `$HOME/.modular` and the value got
+   set incorrectly during image build, it would persist into every test
+   container that uses the published GHCR image.
+3. **A stdlib `.mojopkg` baked into the image at `pixi install` time**
+   contains AOT-compiled AVX-512 routines that get linked into JIT output
+   regardless of runtime CPU. We see these exact source locations in the
+   backtraces: `string_slice.mojo:1035`, `math.mojo:3746`, `philox.mojo:162`,
+   `_swisstable.mojo:114`, `activation.mojo:475`. These are stdlib +
+   project-code paths that would be candidates for ahead-of-time
+   compilation if mojo's stdlib distribution includes precompiled
+   variants.
+
+A particularly striking detail: this only manifests on the **GHA-built**
+container image. The same source code, the same `pixi.lock` (verified
+byte-identical: `mojo-1.0.0b2.dev2026050805-release.conda` sha256
+`8b6f080d54b7c53185786a9a928afbfcf2fbb539d89c9d44da3b5b6700a8b6dc`), and
+locally-built containers don't reproduce. Whatever step happens during
+GHA image build introduces the AVX-512 path; rebuilding the image during
+the project's mid-May 2026 rebase incidentally fixed it.
+
+To confirm which mechanism: dumping `mojo --version`, the effective
+`--target-cpu` (if such a flag is honored), and the contents of
+`$HOME/.modular/` from a failing-era container would tell us
+unambiguously.
+
+## Reproducer
+
+Standalone reproducers were filed earlier in this issue. The
+[PR #5399 positive-control branch][pc-pr] reproduces both backtrace A and
+backtrace B (plus the two new C1/C2 sites) at ~100 % per-run rate on the
+Azure runner, using the existing test suite. CI artifact
+`crash-bundle-data-utilities` / `crash-bundle-core-layers` from run
+[25746055958] contain the 4 ELF cores + symbolicated `info registers` /
+`disassemble` logs referenced above.
+
+[pc-pr]: https://github.com/HomericIntelligence/ProjectOdyssey/pull/5399
+[25746055958]: https://github.com/HomericIntelligence/ProjectOdyssey/actions/runs/25746055958

--- a/notes/mojo-cpu-detection-source-review.md
+++ b/notes/mojo-cpu-detection-source-review.md
@@ -1,0 +1,321 @@
+# Mojo CPU / Target-Feature Detection — Open-Source Source Review
+
+**Context**: Tracking the AVX-512-on-non-AVX-512-CPU crash from modular/modular#6413
+(GHA Azure runners, suspected AMD Zen 4 under Hyper-V where the hypervisor masks
+the AVX-512 CPUID bits). This review answers: *where in the open-source
+modular/modular tree does Mojo's CPU/target-feature detection live, and which
+path could plausibly cause the JIT to emit AVX-512 on a CPU whose kernel/CPUID
+view reports no AVX-512?*
+
+**Repository**: <https://github.com/modular/modular> (branch `main`, fetched 2026-05-12)
+
+**Repo layout (top-level)**: `bazel/`, `docs/`, `max/`, `mojo/`, `tools/`,
+`utils/`, `.github/`, `.cursor/rules/`. The compiler driver / JIT runtime
+(`libKGENCompilerRTShared.so`, the `mojo` binary) is **not** in the open-source
+tree — only the **stdlib** (`mojo/stdlib/std/`) and documentation are open.
+
+---
+
+## TL;DR
+
+1. **The Mojo stdlib does zero runtime CPU detection.** Every feature check
+   (`has_avx512f`, `has_avx2`, `has_vnni`, …) resolves at *compile time* against
+   a `!kgen.target` MLIR attribute via the KGEN intrinsic
+   `#kgen.param.expr<target_has_feature, …>`. There is no `cpuid`, no
+   `xgetbv`, no `/proc/cpuinfo` parse, no HWCAP read, no
+   `__builtin_cpu_supports` anywhere in `mojo/stdlib/std/sys/`.
+2. **The `!kgen.target` attribute is populated by the closed-source compiler
+   driver**, not by stdlib. That driver — referenced in the open-source docs as
+   `CLOptions.h:118` — initializes its target-features list from
+   `getHostCPUFeatures()`, which is LLVM's
+   [`llvm::sys::getHostCPUFeatures()`](https://llvm.org/doxygen/namespacellvm_1_1sys.html).
+3. **LLVM's `getHostCPUFeatures()` on x86 does *not* consult the kernel's
+   masked CPUID view**: it issues the `cpuid` instruction directly (and
+   `xgetbv` for XSAVE). Under a hypervisor that *correctly* masks AVX-512 bits
+   in CPUID, LLVM would observe the mask and stay correct. **But** LLVM has a
+   long history of x86 family/model fingerprinting fallbacks (in
+   `Host.cpp::getHostCPUName`) that map Zen-family family/model numbers to a
+   named CPU (e.g. `znver4`), and `znver4` carries a *fixed* feature list that
+   includes `+avx512f,+avx512vl,…` regardless of what CPUID's feature leaves
+   reported. That is the most plausible upstream root cause: **CPU-name
+   fingerprinting overrides the masked feature view**.
+4. The Mojo documentation itself explicitly flags `CLOptions.h:118 →
+   getHostCPUFeatures()` as the source of a known related leak bug
+   (**MOCO-3686**, the "host features leak to LLVM" issue).
+5. **No `MOJO_*` or `KGEN_*` environment variable to override CPU detection** is
+   documented. The user-facing override is the build flag
+   `--target-cpu=<name>` / `--target-features="-avx512f,…"`, which only helps
+   for AOT builds — not for the in-process JIT that crashes in
+   `libKGENCompilerRTShared.so`.
+
+---
+
+## 1. Stdlib feature-check surface (open source)
+
+### `mojo/stdlib/std/sys/info.mojo`
+
+This is the file that *every* AVX-512 path in your crash traces ultimately
+queries (`shared/...` → `math.abs` → `SIMD.__abs__` → `CompilationTarget.has_avx512f()`).
+
+URL: <https://github.com/modular/modular/blob/main/mojo/stdlib/std/sys/info.mojo>
+
+Key definitions (line numbers approximate; file is ~1386 lines):
+
+```mojo
+# The compile-time target handle — a KGEN attribute, NOT a runtime value
+comptime _TargetType = __mlir_type.`!kgen.target`
+
+@always_inline("nodebug")
+def _current_target() -> _TargetType:
+    return __mlir_attr.`#kgen.param.expr<current_target> : !kgen.target`
+
+struct CompilationTarget[value: _TargetType = _current_target()](
+    TrivialRegisterPassable
+):
+    @staticmethod
+    def _has_feature[name: StaticString]() -> Bool:
+        return __mlir_attr[
+            `#kgen.param.expr<target_has_feature,`,
+            Self.value,
+            `,`,
+            _get_kgen_string[name](),
+            `> : i1`,
+        ]
+
+    @staticmethod
+    def has_avx512f() -> Bool:  # ~line 449
+        """Returns True if the host system has AVX512, otherwise returns False."""
+        return Self._has_feature["avx512f"]()
+```
+
+**Verdict for stdlib**: Correct in isolation. `target_has_feature` is a pure
+compile-time MLIR query; the value it returns is entirely determined by
+whatever feature set the compiler driver baked into the `!kgen.target`
+attribute when the IR module was created. The stdlib cannot lie about
+AVX-512 unless the driver told it to.
+
+### Sibling files searched (no CPU detection found)
+
+| File | Verdict |
+| --- | --- |
+| `mojo/stdlib/std/sys/_assembly.mojo` | Generic `inlined_assembly` wrapper. No `cpuid`/`xgetbv`. |
+| `mojo/stdlib/std/sys/intrinsics.mojo` | LLVM intrinsics (gather/scatter/prefetch, AMDGPU). No CPU detection. |
+| `mojo/stdlib/std/sys/_build.mojo` | Build-type (debug/release) only. |
+| `mojo/stdlib/std/sys/_libc.mojo` | libc bindings, no `getauxval`/HWCAP. |
+| `mojo/stdlib/std/sys/defines.mojo` | Compile-time `#kgen.param.expr` defines. |
+| `mojo/stdlib/std/sys/compile.mojo` | Build-info bridge to KGEN. |
+
+No occurrence of `cpuid`, `xgetbv`, `__builtin_cpu_supports`, `getauxval`,
+`HWCAP`, `/proc/cpuinfo`, `getHostCPUName`, `getAcceleratorArchOrEmpty`, or
+`detect_target_cpu` anywhere in `mojo/stdlib/`.
+
+---
+
+## 2. The smoking gun: `CLOptions.h:118` (closed source, but documented)
+
+Despite being closed source, the compiler driver is explicitly referenced in
+the open-source docs:
+
+### `mojo/docs/code/tools/README-Compilation-Targets.md`
+
+URL: <https://github.com/modular/modular/blob/main/mojo/docs/code/tools/README-Compilation-Targets.md>
+
+The "Known issue (MOCO-3686)" section says, verbatim:
+
+> **Known issue (MOCO-3686):** All three tests emit hundreds of warnings about
+> unrecognized features (ARM features from the M4 host leaking to the x86 LLVM
+> backend). Multi-threaded compilation causes interleaved warning output.
+> Output files are correct despite the warnings.
+>
+> **Root cause:** `CLOptions.h:118` initializes `targetFeatures` to
+> `getHostCPUFeatures()`. The `--march`/`--mcpu` path routes through
+> `getMArchFeatures()` which computes the correct features, but the stale
+> host defaults leak to LLVM before the override takes effect.
+>
+> No user-facing workaround exists:
+>
+> - `--disable-warnings` does not suppress them (LLVM-level, not Mojo-level
+>   warnings).
+> - `--target-features=""` with `--mcpu` does not clear them (empty string
+>   bypasses the mixing check but doesn't overwrite the default).
+> - `--target-features="<anything>"` with `--mcpu` triggers the mixing error.
+
+**Interpretation for the Zen-4-under-Hyper-V bug**:
+
+- `CLOptions.h:118 → targetFeatures = getHostCPUFeatures()` is the *single
+  point* at which the host's feature set enters Mojo. If
+  `getHostCPUFeatures()` returns a list containing `+avx512f,+avx512vl,…` on a
+  host whose CPUID has the AVX-512 bits masked off, **Mojo's JIT will see
+  AVX-512 as available and emit the instructions** — which is exactly what we
+  observe (`vpternlogd`, `{1to4}` broadcast, `%k1` opmask masked moves).
+- The documented MOCO-3686 leak is a *related* but distinct bug (cross-compile
+  feature leak). For the JIT-on-host case, no `--march`/`--mcpu` override is
+  applied, so the host-derived `targetFeatures` is the **final** value used
+  for code generation. No "stale leak" needed — it's the primary path.
+
+---
+
+## 3. Why `getHostCPUFeatures()` can be wrong on Zen 4 + Hyper-V
+
+`getHostCPUFeatures` is the LLVM function
+`llvm::sys::getHostCPUFeatures()` (declared in
+`llvm/include/llvm/TargetParser/Host.h`, implemented in
+`llvm/lib/TargetParser/Host.cpp`). The Mojo driver almost certainly uses it
+directly (the docs use the LLVM name verbatim and no Mojo-specific shim is
+referenced).
+
+The relevant x86 code path in upstream LLVM:
+
+1. **`__cpuid` / `__get_cpuid_count`** — issues raw `cpuid` instructions
+   directly (inline asm). On Hyper-V with AVX-512 masked, leaf 7 sub-leaf 0
+   `EBX/ECX/EDX` bits for AVX-512F/VL/BW/DQ/VBMI/VNNI are zero. Good so far.
+2. **`getHostCPUName()`** — *separately* determines a CPU name (e.g. `znver4`,
+   `skylake-avx512`) by reading **family/model/stepping** from CPUID leaf 1
+   `EAX` and matching against a hard-coded table:
+   - AMD family `0x19` model `0x10–0x1F`, `0x60–0x7F`, `0xA0–0xAF` → `znver4`.
+     See `Host.cpp::getAMDProcessorTypeAndSubtype` in upstream LLVM
+     (<https://github.com/llvm/llvm-project/blob/main/llvm/lib/TargetParser/Host.cpp>).
+   - **Family/model are not maskable by Hyper-V's standard CPUID masking** — the
+     hypervisor masks *feature* leaves to hide AVX-512 from naive software,
+     but it does not change the chip's reported family/model/stepping.
+3. **`getHostCPUFeatures` then merges**: it takes the CPUID feature bits **and**
+   the implicit features attached to the CPU name. When `znver4` is selected,
+   LLVM's `X86TargetParser` table assigns it the *static* feature list
+   `+avx512f,+avx512vl,+avx512bw,+avx512dq,+avx512cd,+avx512vnni,+avx512vbmi,
+   +avx512vbmi2,+avx512bitalg,+avx512vpopcntdq,+avx512bf16,+avx512fp16,…`. That
+   list is **not gated on the kernel's CPUID feature view**.
+
+The exact upstream call path:
+`llvm::sys::getHostCPUFeatures` (`Host.cpp`) → `sys::getHostCPUName` →
+`getAMDProcessorTypeAndSubtype` → returns `"znver4"` → caller looks up
+`znver4` in `X86TargetParser.cpp::Processors[]` → static feature list
+includes all AVX-512* extensions.
+
+That's the mechanism by which the JIT can emit AVX-512 on a CPU whose
+kernel/CPUID feature leaves say "no AVX-512".
+
+**Verification hint** for whoever picks this up: run `cpuid -1 -l 1 -s 0` in
+the failing container; if `EAX` decodes to AMD family `0x19` model in the
+Genoa range while leaf 7 has the AVX-512 bits cleared, the hypothesis is
+confirmed and the bug is upstream LLVM's CPU-name fingerprinting overriding
+the masked feature view.
+
+---
+
+## 4. Other detection paths checked
+
+### `getAcceleratorArchOrEmpty` / `_accelerator_arch`
+
+`info.mojo` line ~701–707 exposes `_accelerator_arch()` for GPU/accelerator
+targets. It also resolves via `#kgen.param.expr<…>` — purely compile-time
+metadata; nothing reads PCI IDs or `nvidia-smi` from stdlib. Not relevant
+to the SIGILL.
+
+### Environment variables
+
+| Variable | Effect | Found in |
+| --- | --- | --- |
+| `MOJO_*` for CPU override | **None documented** | (no hits in stdlib or docs) |
+| `KGEN_*` for CPU override | **None documented** | (no hits in stdlib or docs) |
+| LLVM-native: `LLVM_HOST_CPU_FEATURES` | *Not honored by LLVM* — there is no upstream env-var override for `getHostCPUFeatures`. Confirmed by reading `Host.cpp`. | — |
+
+The only override surface exposed to users is the CLI:
+`--target-cpu=<name>`, `--target-features="±feat,±feat"`,
+`--march=<name>`, `--mcpu=<name>`, `--target-triple=<triple>`. None of these
+are picked up by the **in-process JIT** that crashes in
+`libKGENCompilerRTShared.so` — they're parsed by the `mojo build` /
+`mojo run` driver and applied to AOT module compilation. Test runs invoked
+through `mojo` (`mojo run ...` / `mojo test`-style hand-rolled `def main`)
+inherit the driver-derived `!kgen.target`, so the flags *would* propagate —
+**worth testing** as a workaround: set
+`MOJO_TARGET_FEATURES="-avx512f,-avx512vl,-avx512bw,-avx512dq,-avx512cd,-avx512vnni,-avx512vbmi,-avx512vbmi2,-avx512bitalg,-avx512vpopcntdq,-avx512bf16,-avx512fp16"`
+or pass `--target-features=...` to `mojo run` to force-disable AVX-512.
+
+There is also no observable "force AVX-512" / "skip detection" env-var; the
+inverse path (forcing AVX-512 *on*) requires explicit
+`--target-features="+avx512f"`.
+
+### `--print-effective-target`
+
+Documented as the debug command:
+
+```bash
+mojo build --print-effective-target
+```
+
+This is the **single most useful diagnostic** for the GHA crash: run it
+inside the failing container and confirm whether the `cpu`/`features` line
+reports `znver4` + AVX-512. If it does, the upstream-LLVM fingerprinting
+hypothesis is confirmed at the Mojo layer.
+
+---
+
+## 5. Cross-reference with crash signatures
+
+The faulting instructions captured (per
+`notes/modular-6413-avx512-finding.md`):
+
+| Site | Instruction | Feature implied |
+| --- | --- | --- |
+| `string_slice._strip` | `vpbroadcastb %eax,%xmm0` | AVX-512BW + AVX-512VL (EVEX-encoded `vpbroadcastb` to XMM) |
+| `math.abs` | `vandps {1to4},…` | AVX-512F (embedded broadcast `{1toN}`) |
+| `philox._single_round` | `vpternlogd` | AVX-512F |
+| `_swisstable.match_h2` | `vpcmpeqb %zmm…, %k1` or `vpbroadcastb …, %zmm0` | AVX-512BW |
+| `activation._relu_backward_op` | `vcmpltss …, %k1` + `vmovdqa64 %zmm0` | AVX-512F |
+
+All five live behind the same compile-time guard chain:
+
+```text
+shared/* → math.abs / SIMD ops
+      └─ SIMD.__abs__ (mojo/stdlib/std/builtin/simd.mojo)
+           └─ CompilationTarget.has_avx512f()        ← info.mojo line 449
+                └─ __mlir_attr.target_has_feature["avx512f"]   ← KGEN intrinsic
+                     └─ !kgen.target attribute                  ← driver-populated
+                          └─ getHostCPUFeatures()               ← CLOptions.h:118
+                               └─ llvm::sys::getHostCPUFeatures   ← UPSTREAM LLVM
+                                    └─ family/model → znver4 → fixed feature list
+```
+
+Every site is consistent with `target_has_feature["avx512f"]` returning **true**
+when the kernel's CPUID view says **false** — i.e. the driver populated the
+`!kgen.target` attribute from a `getHostCPUFeatures()` that fingerprinted
+the CPU as Zen 4 and inherited that family's static AVX-512 feature set.
+
+---
+
+## 6. Recommendations for the upstream issue
+
+1. **Ask Modular to confirm `CLOptions.h:118`** uses raw
+   `llvm::sys::getHostCPUFeatures()` (not a Mojo-specific wrapper that
+   re-validates against the kernel view) — this is implied by the docs but
+   should be stated explicitly.
+2. **Ask Modular to add a kernel-view sanity check**: after calling
+   `getHostCPUFeatures()`, cross-check AVX-512 bits against
+   `/proc/cpuinfo` flags or `getauxval(AT_HWCAP2)` on Linux. If the kernel
+   view says no AVX-512 but the LLVM-derived list says yes, **strip**
+   AVX-512 from `targetFeatures` and log a warning. This is the standard
+   workaround for the LLVM Zen-fingerprinting issue (GCC and recent LLVM
+   versions have been adding similar guards).
+3. **Ask Modular to honor `MOJO_TARGET_FEATURES` / `MOJO_TARGET_CPU`
+   environment variables** for the in-process JIT, not just the AOT driver.
+   Today there's no way to override the JIT's feature set without rebuilding.
+4. **Document `--print-effective-target` as the first-line diagnostic** for
+   "wrong instructions emitted" reports.
+
+---
+
+## 7. Files referenced (with URLs)
+
+| Path | URL | Role |
+| --- | --- | --- |
+| `mojo/stdlib/std/sys/info.mojo` | <https://github.com/modular/modular/blob/main/mojo/stdlib/std/sys/info.mojo> | Compile-time feature queries (`has_avx512f`, `CompilationTarget`, `_current_target`). No runtime detection. |
+| `mojo/stdlib/std/sys/_assembly.mojo` | <https://github.com/modular/modular/blob/main/mojo/stdlib/std/sys/_assembly.mojo> | Generic `inlined_assembly`. No CPU detection. |
+| `mojo/stdlib/std/sys/intrinsics.mojo` | <https://github.com/modular/modular/blob/main/mojo/stdlib/std/sys/intrinsics.mojo> | LLVM intrinsics. No CPU detection. |
+| `mojo/stdlib/std/sys/_build.mojo` | <https://github.com/modular/modular/blob/main/mojo/stdlib/std/sys/_build.mojo> | Debug/release build detection only. |
+| `mojo/stdlib/std/sys/defines.mojo` | <https://github.com/modular/modular/blob/main/mojo/stdlib/std/sys/defines.mojo> | `#kgen.param.expr` defines. |
+| `mojo/docs/code/tools/README-Compilation-Targets.md` | <https://github.com/modular/modular/blob/main/mojo/docs/code/tools/README-Compilation-Targets.md> | **Names `CLOptions.h:118` + `getHostCPUFeatures()` as the host-feature entry point.** |
+| `mojo/docs/tools/compilation.mdx` (rendered) | <https://mojolang.org/docs/tools/compilation/> | User-facing flag docs; documents `--print-effective-target`. |
+| *(closed source)* `CLOptions.h` | not in repo | Compiler-driver option parsing; initializes `targetFeatures = getHostCPUFeatures()` at line 118. |
+| *(closed source)* `libKGENCompilerRTShared.so` | not in repo | In-process JIT runtime where the SIGILL fires. Consumes the `!kgen.target` attribute populated from `CLOptions.h`. |
+| *(upstream)* `llvm/lib/TargetParser/Host.cpp` | <https://github.com/llvm/llvm-project/blob/main/llvm/lib/TargetParser/Host.cpp> | `getHostCPUFeatures`, `getHostCPUName`, `getAMDProcessorTypeAndSubtype` — the likely upstream root cause. |
+| *(upstream)* `llvm/lib/TargetParser/X86TargetParser.cpp` | <https://github.com/llvm/llvm-project/blob/main/llvm/lib/TargetParser/X86TargetParser.cpp> | Static feature lists per CPU name (e.g. `znver4` → AVX-512*). |


### PR DESCRIPTION
## Summary

- New long-form retrospective blog post at `notes/blog/05-12-2026/README.md` (~6,800 words), continuing the *Day N* investigation series from [Day 165](../blob/main/notes/blog/04-20-2026/README.md)
- Documents the thirty-day [modular/modular#6413](https://github.com/modular/modular/issues/6413) investigation: six rejected hypotheses, a four-layer CPU-feature-detection probe (with Mermaid sequence diagram), a five-host Tailscale cross-CPU survey, and the eventual root cause in upstream LLVM's `getHostCPUFeatures` CPU-name fingerprinting overriding Hyper-V-masked CPUID feature bits on AMD EPYC Zen 4 runners
- Cites three upstream issues (`#6412`, `#6413`, `#6445`), references Intel SDM Vol. 1 §13.3, and links the sixteen ProjectOdyssey PRs that participated (#5378, #5380, #5381, #5382, #5385, #5387, #5388, #5389, #5393–#5401)
- Tone: tenacity-and-determination; root cause arrives in Chapter 8, not Chapter 1; cold-open on the AMD EPYC `/proc/cpuinfo` capture moment

## Test plan

- [x] Markdownlint passes (`pixi run npx markdownlint-cli2 notes/blog/05-12-2026/README.md`) — `notes/blog/**` is in `.markdownlint-cli2.jsonc` ignores per project convention
- [x] Word count in range (6,814 — target 6,500–8,000)
- [x] Mermaid sequence diagram present (Chapter 7, 4-layer probe)
- [x] All relative links resolve (`../04-20-2026/`, `../03-16-2026/`, etc.)
- [x] All referenced PRs and upstream issues exist
- [ ] Series continuity reads naturally from Day 165 → Day 187