### PR TITLE
fix(ci): repair main container-publish (nightly SBOM tag + summary aggregator)

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -102,8 +102,16 @@ jobs:
           TAGS=""
           SHORT_SHA="${SHA:0:7}"
 
-          # Branch tag
-          if [[ "$EVENT_NAME" == "push" && "$REF" == refs/heads/* ]]; then
+          # Branch tag — also emit on schedule (nightly) and workflow_dispatch
+          # so the downstream "Export image for SBOM" step can
+          # `podman save ...:${github.ref_name}` from the locally-built image
+          # without round-tripping through the registry. Previously only
+          # emitted on push, which left scheduled nightly runs without a
+          # local `:main` tag and failed SBOM export with "image not known".
+          if [[ ( "$EVENT_NAME" == "push" \
+                  || "$EVENT_NAME" == "schedule" \
+                  || "$EVENT_NAME" == "workflow_dispatch" ) \
+                && "$REF" == refs/heads/* ]]; then
             TAGS="${TAGS}${REGISTRY}/${IMAGE_NAME}:${REF_NAME}${SUFFIX} "
           fi
 
@@ -286,3 +294,35 @@ jobs:
           echo "# Interactive shell" >> $GITHUB_STEP_SUMMARY
           echo "podman run -it $REGISTRY/$IMAGE_NAME:$IMAGE_TAG bash" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: Assert needs results (aggregator gate)
+        # Make `summary` the single required status-check context for this
+        # workflow. Branch protection should require `summary` instead of the
+        # individual `build-and-push (...)`, `test-images`, and `security-scan`
+        # contexts — those two are designed to skip on pull_request events
+        # (see their job-level `if:`), and a whole-job skip does NOT satisfy a
+        # required context. `success` || `skipped` is acceptable for them;
+        # `build-and-push` must always be `success` because it runs on every
+        # event.
+        env:
+          BUILD_RESULT: ${{ needs.build-and-push.result }}
+          TEST_IMAGES_RESULT: ${{ needs.test-images.result }}
+          SECURITY_SCAN_RESULT: ${{ needs.security-scan.result }}
+        run: |
+          fail=0
+          echo "build-and-push   = $BUILD_RESULT"
+          echo "test-images      = $TEST_IMAGES_RESULT"
+          echo "security-scan    = $SECURITY_SCAN_RESULT"
+          if [[ "$BUILD_RESULT" != "success" ]]; then
+            echo "::error::build-and-push must be 'success' (got: $BUILD_RESULT)"
+            fail=1
+          fi
+          case "$TEST_IMAGES_RESULT" in
+            success|skipped) ;;
+            *) echo "::error::test-images must be 'success' or 'skipped' (got: $TEST_IMAGES_RESULT)"; fail=1 ;;
+          esac
+          case "$SECURITY_SCAN_RESULT" in
+            success|skipped) ;;
+            *) echo "::error::security-scan must be 'success' or 'skipped' (got: $SECURITY_SCAN_RESULT)"; fail=1 ;;
+          esac
+          exit "$fail"


### PR DESCRIPTION
## Summary

Two related fixes for `.github/workflows/container-publish.yml` to repair `main`'s CI/CD:

### 1. Nightly SBOM `image not known` failure

The tag generation block only emitted the `:${ref_name}` branch tag when `github.event_name == "push"`. On a scheduled (nightly) run no `:main` tag is built locally, so the downstream **Export image for SBOM** step's

```bash
podman save -o /tmp/runtime-image.tar "$REGISTRY/$IMAGE_NAME:${{ github.ref_name }}"
```

fails with `image not known`. Three consecutive nightly failures (2026-05-12 / 13 / 14).

**Fix:** also emit the branch tag on `schedule` and `workflow_dispatch` events. The existing `refs/heads/*` guard still gates correctly; tag events (`refs/tags/v*`) are handled by the separate semver block and are untouched.

### 2. `test-images` / `security-scan` required-context misconfig

Both jobs are gated `if: github.event_name != 'pull_request'` (lines ~191, ~233), so on every PR they skip whole-job. Branch protection on `main` requires both as status-check contexts, but a whole-job skip does **not** satisfy a required context — any PR that triggers `container-publish.yml` is permanently `BLOCKED` (as PR #5382 demonstrated this week).

**Fix:** turn `summary` (which already has `if: always()` and `needs: [build-and-push, test-images, security-scan]`) into an explicit aggregator gate. New step fails the job unless:

- `build-and-push.result == 'success'` (must run on every event)
- `test-images.result ∈ {success, skipped}` (skip is by-design on PRs)
- `security-scan.result ∈ {success, skipped}` (skip is by-design on PRs)

## Follow-up (branch protection — admin)

After this merges, branch protection on `main` will be updated to require only `summary` from this workflow, and drop `build-and-push (ci|production|runtime)`, `test-images`, and `security-scan` as required contexts. That admin edit is the second half of the fix; the workflow change here is a no-op until it lands.

## What this PR does NOT touch

- `Dockerfile` / `Dockerfile.ci` — no changes.
- libKGEN / modular/modular#6413 JIT crashes in `Comprehensive Tests` — tracked upstream, intentionally out of scope.
- The `paths:` filter on `container-publish.yml` — left as-is.

## Verification

- ✅ `python -c "import yaml; yaml.safe_load(open('.github/workflows/container-publish.yml'))"` → OK.
- ⏳ After merge: `gh workflow run container-publish.yml` → expect success on `workflow_dispatch`.
- ⏳ Next 06:00 UTC nightly schedule → expect success (no more `image not known`).
- ⏳ Throwaway PR touching `Dockerfile.ci` (comment-only) → `mergeStateStatus` reaches `CLEAN` after the branch-protection update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)