### PR TITLE
fix(justfile): export USER_ID/GROUP_ID to podman compose up/down

### DIFF
--- a/justfile
+++ b/justfile
@@ -100,9 +100,16 @@ _ensure_build_dir mode:
 # first so `compose up` creates a fresh container mounted on `$PWD`. This
 # lets the same dev work seamlessly across multiple clones without
 # manually running `podman compose down` from the old clone first.
+#
+# docker-compose substitutes ${USER_ID}/${GROUP_ID} in docker-compose.yml from
+# its OWN environment, not from just's template vars. Without explicit
+# `USER_ID=... GROUP_ID=...` exports on the same line, the variables expand to
+# empty strings and the container would get `user: ":"` (invalid), causing
+# the compose call to fail or create a stuck container in an invalid state.
 podman-up:
     #!/usr/bin/env bash
     set -euo pipefail
+    export USER_ID="{{USER_ID}}" GROUP_ID="{{GROUP_ID}}" USER_NAME="${USER_NAME:-dev}"
     EXPECTED="{{repo_root}}"
     EXISTING=$(podman inspect projectodyssey-{{podman_service}}-1 \
         --format '{{{{range .Mounts}}{{{{if eq .Destination "/workspace"}}{{{{.Source}}{{{{end}}{{{{end}}' 2>/dev/null || echo "")
@@ -124,7 +131,8 @@ podman-up:
 
 # Stop Podman development environment
 podman-down:
-    @podman compose down
+    @USER_ID={{USER_ID}} GROUP_ID={{GROUP_ID}} USER_NAME=${USER_NAME:-dev} \
+        podman compose down
 
 # Build Podman images
 podman-build:


### PR DESCRIPTION
## Summary

Port the only generally-useful, gdb-free commit from PR #5382's branch (`ci-pipe-handler-cores`): the `USER_ID`/`GROUP_ID` export fix for `podman compose up`/`down`.

Cherry-picked from `9d452948` verbatim.

## Why

`docker-compose` substitutes `${USER_ID}`/`${GROUP_ID}` in `docker-compose.yml` from its own environment, **not** from just's template vars. Without explicit `USER_ID=... GROUP_ID=...` exports on the same line, the variables expand to empty strings and the container ends up with `user: ":"` (invalid) — causing the compose call to fail or create a stuck container in an invalid state.

This is the root of the UID-mismatch class of crashes documented by the `docker-mojo-uid-mismatch-crash-fix` skill (mismatched UID makes `/home/dev` unwritable inside the container, which triggers `__fortify_fail_abort` in `libKGENCompilerRTShared.so` during JIT init — easily confused with modular/modular#6413 but is a separate, fixable issue).

## What this PR does NOT touch

- No `Dockerfile` / `Dockerfile.ci` changes.
- No `scripts/` additions (gdb wrappers, coredump handlers — those belong in ProjectHephaestus).
- No new workflows.
- The other commits from PR #5382 (`133e6b56` docker-compose compat for `-e KEY=VAL`, the gdb wrapper, the coredump pipe handler, the modular#6413 repros) are **out of scope** per the decision to drop gdb from Dockerfiles on `main`. `133e6b56` is meaningful only in the presence of the gdb env vars added by `95891f90`; without those, it's a no-op.

## Verification

- ✅ Diff is `justfile`-only (10 lines, +9/-1).
- ⏳ After merge: `just podman-down && just podman-up && just shell` works locally; container created with correct UID mapping.

Companion of #5406 (main CI/CD repair). PR #5382 will be closed unmerged after both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)