### PR TITLE
fix(ci): capture real ELF cores via gdb wrapper for SIGILL diagnosis

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -22,6 +22,11 @@ on:
         required: false
         default: false
         type: boolean
+      enable_gdb_cores:
+        description: 'Capture gdb core dumps for libKGEN JIT crashes (modular/modular#6413)'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -253,7 +258,7 @@ jobs:
       # the crash. Without gdb, the kernel never generates a core because the
       # process handles SIGABRT itself and exits cleanly.
       # Set to "0" locally to skip gdb overhead (default when unset).
-      MOJO_TEST_UNDER_GDB: "1"
+      MOJO_TEST_UNDER_GDB: ${{ (github.event_name == 'workflow_dispatch' && inputs.enable_gdb_cores) && '1' || '0' }}
       CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     strategy:
@@ -462,7 +467,7 @@ jobs:
     timeout-minutes: 15
     name: "Configs"
     env:
-      MOJO_TEST_UNDER_GDB: "1"
+      MOJO_TEST_UNDER_GDB: ${{ (github.event_name == 'workflow_dispatch' && inputs.enable_gdb_cores) && '1' || '0' }}
       CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
@@ -499,7 +504,7 @@ jobs:
     timeout-minutes: 15
     name: "Benchmarks"
     env:
-      MOJO_TEST_UNDER_GDB: "1"
+      MOJO_TEST_UNDER_GDB: ${{ (github.event_name == 'workflow_dispatch' && inputs.enable_gdb_cores) && '1' || '0' }}
       CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
@@ -532,7 +537,7 @@ jobs:
     timeout-minutes: 15
     name: "Core Layers"
     env:
-      MOJO_TEST_UNDER_GDB: "1"
+      MOJO_TEST_UNDER_GDB: ${{ (github.event_name == 'workflow_dispatch' && inputs.enable_gdb_cores) && '1' || '0' }}
       CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
@@ -808,7 +813,7 @@ jobs:
     timeout-minutes: 15
     name: "Gradient Checking Tests"
     env:
-      MOJO_TEST_UNDER_GDB: "1"
+      MOJO_TEST_UNDER_GDB: ${{ (github.event_name == 'workflow_dispatch' && inputs.enable_gdb_cores) && '1' || '0' }}
       CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
@@ -925,7 +930,7 @@ jobs:
     timeout-minutes: 15
     name: "Data Utilities Test Suite"
     env:
-      MOJO_TEST_UNDER_GDB: "1"
+      MOJO_TEST_UNDER_GDB: ${{ (github.event_name == 'workflow_dispatch' && inputs.enable_gdb_cores) && '1' || '0' }}
       CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:

--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -247,6 +247,14 @@ jobs:
     # returning would manifest as OOM kills, not libKGEN signals.
     timeout-minutes: 60
     name: "Comprehensive Mojo Tests"
+    env:
+      # Route mojo test invocations through gdb to intercept the in-process
+      # SIGABRT handler in libKGEN (modular/modular#6413) before it swallows
+      # the crash. Without gdb, the kernel never generates a core because the
+      # process handles SIGABRT itself and exits cleanly.
+      # Set to "0" locally to skip gdb overhead (default when unset).
+      MOJO_TEST_UNDER_GDB: "1"
+      CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     strategy:
       fail-fast: false
@@ -453,6 +461,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: "Configs"
+    env:
+      MOJO_TEST_UNDER_GDB: "1"
+      CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
       - name: Checkout code
@@ -487,6 +498,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: "Benchmarks"
+    env:
+      MOJO_TEST_UNDER_GDB: "1"
+      CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
       - name: Checkout code
@@ -517,6 +531,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: "Core Layers"
+    env:
+      MOJO_TEST_UNDER_GDB: "1"
+      CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
       - name: Checkout code
@@ -790,6 +807,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: "Gradient Checking Tests"
+    env:
+      MOJO_TEST_UNDER_GDB: "1"
+      CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
       - name: Checkout code
@@ -904,6 +924,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: "Data Utilities Test Suite"
+    env:
+      MOJO_TEST_UNDER_GDB: "1"
+      CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
 
     steps:
       - name: Checkout code

--- a/.github/workflows/repro-6413.yml
+++ b/.github/workflows/repro-6413.yml
@@ -1,0 +1,320 @@
+# Throwaway repro workflow for modular/modular#6413.
+#
+# Runs two standalone single-file reproducer candidates under the gdb wrapper
+# (scripts/mojo-under-gdb.sh) in a tight loop on a GHA Ubuntu runner — the only
+# environment where the bug has ever reproduced. Goal: produce a core that
+# Modular can match against the production cores captured in
+# CI run 25649843238, while dumping enough host/runtime context that we can
+# diff a successful CI crash against a clean local run and identify the
+# runner-specific knob.
+#
+# DELETE THIS WORKFLOW once Modular has a confirmed standalone repro.
+#
+# Manual dispatch only (saves CI minutes). Workflow inputs let an operator
+# tune iteration counts without editing the file.
+#
+# Security note: all dynamic values flowing into `run:` steps are routed
+# through `env:` blocks (matrix entries + workflow_dispatch inputs only;
+# no PR/issue/comment data is ever consumed by this workflow).
+
+name: Repro modular/modular#6413
+
+on:
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: "Iterations of each repro file per mode (jit, aot)"
+        required: false
+        default: "60"
+        type: string
+      run_jit:
+        description: "Run via `mojo run` (JIT path)"
+        required: false
+        default: true
+        type: boolean
+      run_aot:
+        description: "Run via `mojo build` + execute binary (AOT path)"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  repro:
+    name: "Repro 6413 (${{ matrix.repro }} / ${{ matrix.mode }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        repro:
+          - python_import_os
+          - assert_almost_equal
+        mode:
+          - jit
+          - aot
+    env:
+      MOJO_TEST_UNDER_GDB: "1"
+      CRASH_BUNDLE_DIR: /workspace/crash-bundle/cores
+      REPRO_ITERATIONS: ${{ inputs.iterations }}
+      # Hoist matrix values into env so run: scripts never interpolate
+      # template expressions inside shell command bodies.
+      REPRO_NAME: ${{ matrix.repro }}
+      REPRO_MODE: ${{ matrix.mode }}
+      RUN_JIT: ${{ inputs.run_jit }}
+      RUN_AOT: ${{ inputs.run_aot }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Skip if matrix mode disabled
+        id: gate
+        run: |
+          if [ "$REPRO_MODE" = "jit" ] && [ "$RUN_JIT" != "true" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          elif [ "$REPRO_MODE" = "aot" ] && [ "$RUN_AOT" != "true" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ---------------------------------------------------------------------
+      # Heavy host-side environment dump (Track 3 from the investigation plan).
+      # Goal: capture every attribute that might differ between the GHA runner
+      # and a local repro environment so we can diff later.
+      # ---------------------------------------------------------------------
+      - name: Host environment dump (pre-test)
+        if: steps.gate.outputs.skip != 'true'
+        run: |
+          set -x
+          mkdir -p host-env
+          {
+            echo "=== uname ==="
+            uname -a
+            echo "=== /etc/os-release ==="
+            cat /etc/os-release 2>/dev/null || true
+            echo "=== kernel cmdline ==="
+            cat /proc/cmdline
+            echo "=== glibc version ==="
+            ldd --version | head -2
+            echo "=== getconf PAGESIZE / LONG_BIT / NPROCESSORS_ONLN ==="
+            getconf PAGESIZE
+            getconf LONG_BIT
+            getconf _NPROCESSORS_ONLN
+            echo "=== CPU info (first 60 lines + flags) ==="
+            head -60 /proc/cpuinfo
+            grep -m1 '^flags' /proc/cpuinfo || true
+            echo "=== Memory ==="
+            free -h
+            head -20 /proc/meminfo
+            echo "=== ulimit -a ==="
+            ulimit -a
+            echo "=== Mounts ==="
+            mount | head -30
+            echo "=== sysctl kernel.* (subset) ==="
+            for k in kernel.randomize_va_space kernel.yama.ptrace_scope kernel.core_pattern kernel.core_uses_pid fs.suid_dumpable vm.overcommit_memory vm.max_map_count; do
+              echo -n "$k = "
+              sysctl -n "$k" 2>/dev/null || echo "(unreadable)"
+            done
+            echo "=== /proc/sys/kernel/perf_event_paranoid ==="
+            cat /proc/sys/kernel/perf_event_paranoid 2>/dev/null || true
+            echo "=== Docker / Podman versions ==="
+            podman --version 2>/dev/null || true
+            docker --version 2>/dev/null || true
+            echo "=== Hardware vendor ==="
+            cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true
+            cat /sys/class/dmi/id/product_name 2>/dev/null || true
+          } 2>&1 | tee host-env/host-environment.txt
+
+      - name: Set up container
+        if: steps.gate.outputs.skip != 'true'
+        uses: ./.github/actions/setup-container
+
+      - name: Install Just
+        if: steps.gate.outputs.skip != 'true'
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
+
+      - name: Enable core dumps (pipe handler)
+        if: steps.gate.outputs.skip != 'true'
+        uses: ./.github/actions/coredump-capture
+        with:
+          phase: setup
+          job-name: repro-6413-${{ matrix.repro }}-${{ matrix.mode }}
+
+      # ---------------------------------------------------------------------
+      # Container-side environment dump. Same data points, captured from
+      # inside the projectodyssey-dev container so we can diff host vs guest
+      # for namespacing differences (PIDs, mounts, ulimit propagation).
+      # ---------------------------------------------------------------------
+      - name: Container environment dump
+        if: steps.gate.outputs.skip != 'true'
+        run: |
+          mkdir -p host-env
+          podman compose exec -T projectodyssey-dev bash -lc '
+            set -x
+            echo "=== container uname ==="
+            uname -a
+            echo "=== container id / passwd ==="
+            id
+            echo "=== container ulimit -a ==="
+            ulimit -a
+            echo "=== container glibc ==="
+            ldd --version | head -2
+            echo "=== pixi info ==="
+            pixi info --json 2>/dev/null | head -40 || pixi info | head -40
+            echo "=== mojo --version ==="
+            pixi run mojo --version
+            echo "=== mojo binary path + linkage ==="
+            MBIN="$(pixi run which mojo | tail -1)"
+            echo "binary: $MBIN"
+            file "$MBIN" 2>/dev/null || true
+            ldd "$MBIN" 2>/dev/null | head -25 || true
+            echo "=== libKGEN* / libAsync* / libMojo* in pixi env ==="
+            find "$(dirname "$MBIN")/../lib" -maxdepth 2 \
+              \( -name "libKGEN*" -o -name "libAsync*" -o -name "libMojo*" \) 2>/dev/null | head -20
+            echo "=== container /proc/self/maps (head) ==="
+            head -40 /proc/self/maps
+            echo "=== gdb --version ==="
+            gdb --version 2>/dev/null | head -2 || echo "[no gdb]"
+            echo "=== container mounts (limited) ==="
+            mount | grep -E "workspace|tmp|home" | head -20
+          ' 2>&1 | tee host-env/container-environment.txt
+
+      # ---------------------------------------------------------------------
+      # Build the AOT binary if this matrix leg is AOT mode. Keep build log
+      # so we can attribute a future crash to compile-time or run-time.
+      # The repro filename is built from $REPRO_NAME (env, matrix-derived).
+      # ---------------------------------------------------------------------
+      - name: Build repro (AOT mode only)
+        if: steps.gate.outputs.skip != 'true' && matrix.mode == 'aot'
+        run: |
+          podman compose exec -T -e REPRO_NAME=$REPRO_NAME projectodyssey-dev bash -lc '
+            set -x
+            mkdir -p /workspace/repro/build
+            pixi run mojo build \
+              --Werror -debug-level=line-tables -I /workspace -I . \
+              "repro/repro_6413_${REPRO_NAME}.mojo" \
+              -o "/workspace/repro/build/repro_6413_${REPRO_NAME}" \
+              2>&1 | tee "/workspace/repro/build/build.${REPRO_NAME}.log"
+            ls -la /workspace/repro/build/
+          '
+
+      # ---------------------------------------------------------------------
+      # Main repro loop. For each iteration:
+      #   - record start timestamp + memory snapshot
+      #   - run the repro under the gdb wrapper (JIT) or directly under gdb
+      #     on the AOT binary
+      #   - record exit code
+      #   - if a core was produced, immediately symbolicate top frames
+      # All output goes into repro-output/ which is uploaded unconditionally.
+      # ---------------------------------------------------------------------
+      - name: Run repro loop
+        if: steps.gate.outputs.skip != 'true'
+        id: loop
+        run: |
+          podman compose exec -T \
+            -e REPRO_NAME=$REPRO_NAME \
+            -e REPRO_MODE=$REPRO_MODE \
+            -e REPRO_ITERATIONS=$REPRO_ITERATIONS \
+            projectodyssey-dev bash -lc '
+            set -x
+            cd /workspace
+            mkdir -p repro-output crash-bundle/cores
+            ulimit -c unlimited || true
+
+            ITER="${REPRO_ITERATIONS:-60}"
+            LOG="repro-output/${REPRO_NAME}-${REPRO_MODE}.log"
+            CSV="repro-output/${REPRO_NAME}-${REPRO_MODE}.csv"
+            MOJO_BIN="$(pixi run which mojo | tail -1)"
+
+            echo "iter,timestamp,exit_code,wall_seconds,free_kb_before,free_kb_after,core_file" > "$CSV"
+
+            crash_count=0
+            for i in $(seq 1 "$ITER"); do
+                ts_start=$(date +%s)
+                free_before=$(awk "/MemAvailable/ {print \$2}" /proc/meminfo)
+                core_before=$(ls /workspace/crash-bundle/cores/core.gdb*.mojo 2>/dev/null | wc -l)
+
+                exit_code=0
+                if [ "$REPRO_MODE" = "jit" ]; then
+                    bash scripts/mojo-under-gdb.sh /workspace/crash-bundle/cores \
+                        --Werror -debug-level=line-tables -I /workspace -I . \
+                        "repro/repro_6413_${REPRO_NAME}.mojo" \
+                        >> "$LOG" 2>&1 || exit_code=$?
+                else
+                    BINARY="/workspace/repro/build/repro_6413_${REPRO_NAME}"
+                    TS_NS=$(date +%s%N)
+                    GDB_LOG="/workspace/crash-bundle/cores/gdb-aot-${TS_NS}.log"
+                    CORE_FILE="/workspace/crash-bundle/cores/core.gdb.aot.${TS_NS}.mojo"
+                    pixi run -- gdb -batch -nx \
+                        -ex "set pagination off" \
+                        -ex "set confirm off" \
+                        -ex "set logging file ${GDB_LOG}" \
+                        -ex "set logging overwrite on" \
+                        -ex "set logging enabled on" \
+                        -ex "handle SIGABRT stop nopass print" \
+                        -ex "handle SIGSEGV stop nopass print" \
+                        -ex "handle SIGBUS stop nopass print" \
+                        -ex "handle SIGILL stop nopass print" \
+                        -ex "handle SIGFPE stop nopass print" \
+                        -ex "run" \
+                        -ex "generate-core-file ${CORE_FILE}" \
+                        -ex "thread apply all bt full" \
+                        -ex "info threads" \
+                        -ex "info sharedlibrary" \
+                        --args "$BINARY" >> "$LOG" 2>&1 || exit_code=$?
+                fi
+
+                ts_end=$(date +%s)
+                wall=$(( ts_end - ts_start ))
+                free_after=$(awk "/MemAvailable/ {print \$2}" /proc/meminfo)
+                core_after=$(ls /workspace/crash-bundle/cores/core.gdb*.mojo 2>/dev/null | wc -l)
+                new_core=""
+                if [ "$core_after" -gt "$core_before" ]; then
+                    new_core=$(ls -t /workspace/crash-bundle/cores/core.gdb*.mojo 2>/dev/null | head -1)
+                    crash_count=$(( crash_count + 1 ))
+                    {
+                        echo "==== iter $i CRASH ($new_core) ===="
+                        echo "exit_code=$exit_code"
+                        echo "Top backtrace frames (gdb -batch):"
+                        gdb -batch -ex "set pagination off" \
+                            -ex "thread apply 1 bt 25" \
+                            "$MOJO_BIN" "$new_core" 2>&1 | head -80
+                    } | tee -a "repro-output/${REPRO_NAME}-${REPRO_MODE}-symbolicated.log"
+                fi
+
+                printf "%d,%d,%d,%d,%s,%s,%s\n" \
+                    "$i" "$ts_start" "$exit_code" "$wall" \
+                    "${free_before:-0}" "${free_after:-0}" "$new_core" >> "$CSV"
+                echo "[iter $i] exit=$exit_code wall=${wall}s core=$new_core" | tee -a "$LOG"
+            done
+
+            echo "============================================"
+            echo "REPRO SUMMARY: $REPRO_NAME / $REPRO_MODE"
+            echo "  iterations: $ITER"
+            echo "  crashes:    $crash_count"
+            echo "  csv:        $CSV"
+            echo "  log:        $LOG"
+            echo "============================================"
+          '
+
+      - name: Collect crash bundle
+        if: steps.gate.outputs.skip != 'true' && always()
+        uses: ./.github/actions/coredump-capture
+        with:
+          phase: collect
+          job-name: repro-6413-${{ matrix.repro }}-${{ matrix.mode }}
+
+      - name: Upload repro outputs (logs + csv + env dumps)
+        if: steps.gate.outputs.skip != 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: repro-6413-output-${{ matrix.repro }}-${{ matrix.mode }}
+          path: |
+            repro-output/
+            host-env/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/repro-6413.yml
+++ b/.github/workflows/repro-6413.yml
@@ -95,7 +95,7 @@ jobs:
             echo "=== uname ==="
             uname -a
             echo "=== /etc/os-release ==="
-            cat /etc/os-release 2>/dev/null || true
+            cat /etc/os-release 2>/dev/null || echo "(no /etc/os-release)"
             echo "=== kernel cmdline ==="
             cat /proc/cmdline
             echo "=== glibc version ==="
@@ -106,7 +106,7 @@ jobs:
             getconf _NPROCESSORS_ONLN
             echo "=== CPU info (first 60 lines + flags) ==="
             head -60 /proc/cpuinfo
-            grep -m1 '^flags' /proc/cpuinfo || true
+            grep -m1 '^flags' /proc/cpuinfo || echo "(no ^flags line)"
             echo "=== Memory ==="
             free -h
             head -20 /proc/meminfo
@@ -120,13 +120,13 @@ jobs:
               sysctl -n "$k" 2>/dev/null || echo "(unreadable)"
             done
             echo "=== /proc/sys/kernel/perf_event_paranoid ==="
-            cat /proc/sys/kernel/perf_event_paranoid 2>/dev/null || true
+            cat /proc/sys/kernel/perf_event_paranoid 2>/dev/null || echo "(unreadable)"
             echo "=== Docker / Podman versions ==="
-            podman --version 2>/dev/null || true
-            docker --version 2>/dev/null || true
+            podman --version 2>/dev/null || echo "(no podman)"
+            docker --version 2>/dev/null || echo "(no docker)"
             echo "=== Hardware vendor ==="
-            cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true
-            cat /sys/class/dmi/id/product_name 2>/dev/null || true
+            cat /sys/class/dmi/id/sys_vendor 2>/dev/null || echo "(no DMI sys_vendor)"
+            cat /sys/class/dmi/id/product_name 2>/dev/null || echo "(no DMI product_name)"
           } 2>&1 | tee host-env/host-environment.txt
 
       - name: Set up container
@@ -170,8 +170,8 @@ jobs:
             echo "=== mojo binary path + linkage ==="
             MBIN="$(pixi run which mojo | tail -1)"
             echo "binary: $MBIN"
-            file "$MBIN" 2>/dev/null || true
-            ldd "$MBIN" 2>/dev/null | head -25 || true
+            file "$MBIN" 2>/dev/null || echo "(file: cannot read $MBIN)"
+            ldd "$MBIN" 2>/dev/null | head -25 || echo "(ldd: cannot read $MBIN)"
             echo "=== libKGEN* / libAsync* / libMojo* in pixi env ==="
             find "$(dirname "$MBIN")/../lib" -maxdepth 2 \
               \( -name "libKGEN*" -o -name "libAsync*" -o -name "libMojo*" \) 2>/dev/null | head -20
@@ -223,7 +223,9 @@ jobs:
             set -x
             cd /workspace
             mkdir -p repro-output crash-bundle/cores
-            ulimit -c unlimited || true
+            if ! ulimit -c unlimited 2>/dev/null; then
+                echo "warn: ulimit -c unlimited rejected — cores will not be captured if the binary crashes" >&2
+            fi
 
             ITER="${REPRO_ITERATIONS:-60}"
             LOG="repro-output/${REPRO_NAME}-${REPRO_MODE}.log"
@@ -276,13 +278,45 @@ jobs:
                 if [ "$core_after" -gt "$core_before" ]; then
                     new_core=$(ls -t /workspace/crash-bundle/cores/core.gdb*.mojo 2>/dev/null | head -1)
                     crash_count=$(( crash_count + 1 ))
+                    # Symbolicate against the binary that actually produced the
+                    # core: AOT binary for AOT mode, mojo for JIT mode. Using
+                    # the wrong ELF makes disassembly meaningless if $pc is
+                    # inside user code (rather than libKGEN, which is loaded
+                    # at runtime regardless).
+                    if [ "$REPRO_MODE" = "aot" ]; then
+                        SYM_BIN="/workspace/repro/build/repro_6413_${REPRO_NAME}"
+                    else
+                        SYM_BIN="$MOJO_BIN"
+                    fi
                     {
                         echo "==== iter $i CRASH ($new_core) ===="
                         echo "exit_code=$exit_code"
-                        echo "Top backtrace frames (gdb -batch):"
+                        echo "symbol_binary=$SYM_BIN"
+                        echo "---- Backtrace (top 25 frames) ----"
                         gdb -batch -ex "set pagination off" \
                             -ex "thread apply 1 bt 25" \
-                            "$MOJO_BIN" "$new_core" 2>&1 | head -80
+                            "$SYM_BIN" "$new_core" 2>&1 | head -80
+                        echo "---- Instruction stream around \$pc ----"
+                        # Goal: identify the exact faulting instruction so we can
+                        # tell whether the crash is e.g. an AVX-VNNI / VAES /
+                        # SHA-NI / VPCLMULQDQ / serialize / movdir64b opcode
+                        # the GHA runner CPU does not implement. Dump:
+                        #   - 16 raw instructions before and after $pc
+                        #   - a disassembly window of [-64, +64] bytes
+                        #   - integer + SSE/AVX register state at fault time
+                        #   - the current frame info (PC, AT, source line if any)
+                        #   - /proc/cpuinfo flags re-printed from the core so we
+                        #     can compare CPU flags to the host-env dump above
+                        gdb -batch \
+                            -ex "set pagination off" \
+                            -ex "set print pretty on" \
+                            -ex "info registers" \
+                            -ex "info frame" \
+                            -ex "x/16i \$pc - 30" \
+                            -ex "x/16i \$pc" \
+                            -ex "disassemble \$pc - 64, \$pc + 64" \
+                            -ex "info all-registers" \
+                            "$SYM_BIN" "$new_core" 2>&1 | head -400
                     } | tee -a "repro-output/${REPRO_NAME}-${REPRO_MODE}-symbolicated.log"
                 fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y \
     wget \
     uuid \
     sudo \
+    gdb \
     && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub CLI (gh) as root

--- a/docs/dev/mojo-jit-crash-workaround.md
+++ b/docs/dev/mojo-jit-crash-workaround.md
@@ -151,6 +151,83 @@ higher memory pressure than a single test file produces. The targeted import fix
 the correct defensive measure -- it reduces compilation footprint by ~95% per test file,
 which lowers the probability of hitting the JIT buffer overflow regardless of environment.
 
+## GDB Wrapper: Capturing Real ELF Cores (modular/modular#6413)
+
+PRs #5380 and #5382 wired up host-side `core_pattern` (path-based then pipe-based) but
+produced **zero core files** across all CI runs even when the libKGEN JIT crash signature
+appeared in test logs:
+
+```text
+libKGENCompilerRTShared.so+0x6ef7b → +0x6c156 → +0x6fc27
+mojo: error: execution crashed
+```
+
+Root cause: libKGEN registers an in-process SIGABRT handler that catches the abort, prints
+its own 3-frame post-handler trace, and exits cleanly. The kernel never generates a core for
+a process that handles its own fatal signal.
+
+### The Fix: `scripts/mojo-under-gdb.sh`
+
+Mojo test invocations are wrapped in `gdb -batch` with:
+
+- `handle SIGABRT stop nopass` — gdb intercepts the signal BEFORE libKGEN's handler runs
+- `generate-core-file` — dumps a real ELF core on the stopped inferior
+- `bt full`, `info threads`, `info sharedlibrary` — captures rich text context to a log
+
+This produces two files per crash in `crash-bundle/cores/`:
+
+- `core.gdb.<timestamp>.mojo` — real ELF core (multi-MB, readable by gdb offline)
+- `gdb-<timestamp>.log` — full pre-signal backtrace + threads + shared library map
+
+### Using the Wrapper Locally
+
+The wrapper is **disabled by default** (`MOJO_TEST_UNDER_GDB` defaults to 0 so local dev
+runs mojo directly with no overhead).
+
+To reproduce a crash locally with gdb capture:
+
+```bash
+# One test file
+MOJO_TEST_UNDER_GDB=1 just test-group tests/shared/core \
+    "test_gradient_checking_basic.mojo"
+
+# The wrapper writes to crash-bundle/cores/ by default
+ls crash-bundle/cores/
+# core.gdb.<ts>.mojo   (ELF core)
+# gdb-<ts>.log         (text backtrace)
+```
+
+To completely bypass the wrapper when gdb is unavailable:
+
+```bash
+MOJO_UNDER_GDB=0 MOJO_TEST_UNDER_GDB=1 just test-group ...
+# or simply omit MOJO_TEST_UNDER_GDB (defaults to 0)
+```
+
+### Analyzing a Captured Core
+
+```bash
+# Download crash-bundle artifact from the GitHub Actions run
+cd crash-bundle/
+gdb symbols/mojo cores/core.gdb.<timestamp>.mojo
+# Inside gdb:
+(gdb) bt
+(gdb) info threads
+(gdb) frame N   # navigate to the faulting frame
+```
+
+The `gdb-<timestamp>.log` text file contains the same information without needing a
+local gdb installation.
+
+### CI Configuration
+
+`MOJO_TEST_UNDER_GDB=1` is set in the `env:` block of all Mojo test jobs in
+`.github/workflows/comprehensive-tests.yml`. Build-only jobs are unaffected.
+
+The coredump-capture composite action (`.github/actions/coredump-capture/action.yml`)
+collects both kernel cores and gdb-written files, and bundles gdb itself into
+`crash-bundle/symbols/` for offline analysis.
+
 ## References
 
 - [Issue #5108](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5108) -- JIT crash comprehensive tracking

--- a/justfile
+++ b/justfile
@@ -76,7 +76,16 @@ _run cmd:
 			# (modular/modular#6413). Pairs with the host-side core_pattern in
 			# .github/actions/coredump-capture/action.yml.
 			HOME_FIXUP='if [ ! -w "$HOME" ]; then export HOME="/tmp/mojo-home-$(id -u)"; mkdir -p "$HOME/.modular" "$HOME/.pixi"; fi; ulimit -c unlimited 2>/dev/null || echo "warn: ulimit -c rejected" >&2;'
-			podman compose exec -e USER_ID={{USER_ID}} -e GROUP_ID={{GROUP_ID}} -T {{podman_service}} bash -c "$HOME_FIXUP {{cmd}}"
+			# Forward CI/coredump env vars into the container. Without these
+			# -e passthroughs, MOJO_TEST_UNDER_GDB / CRASH_BUNDLE_DIR set on
+			# the GHA runner are NOT visible to the bash recipe inside the
+			# container, so the gdb wrapper would be silently skipped.
+			podman compose exec \
+				-e USER_ID={{USER_ID}} -e GROUP_ID={{GROUP_ID}} \
+				-e MOJO_TEST_UNDER_GDB \
+				-e MOJO_UNDER_GDB \
+				-e CRASH_BUNDLE_DIR \
+				-T {{podman_service}} bash -c "$HOME_FIXUP {{cmd}}"
 		fi
 	else
 		echo "Error: Podman compose container '{{podman_service}}' is not running."

--- a/justfile
+++ b/justfile
@@ -801,6 +801,11 @@ _test-group-inner path pattern:
         exit 1
     fi
 
+    # gdb wrapper path: set MOJO_TEST_UNDER_GDB=1 in CI to intercept the
+    # in-process SIGABRT handler in libKGEN before it swallows the crash
+    # (modular/modular#6413). Default 0 so local dev runs mojo directly.
+    CORE_DIR="${CRASH_BUNDLE_DIR:-${REPO_ROOT}/crash-bundle/cores}"
+
     # Run each test file
     for test_file in $test_files; do
         if [ -f "$test_file" ]; then
@@ -811,13 +816,25 @@ _test-group-inner path pattern:
             if ! ulimit -v unlimited 2>/dev/null; then
                 echo "warn: 'ulimit -v unlimited' rejected by environment" >&2
             fi
-            pixi run mojo --Werror -debug-level=line-tables -I "$REPO_ROOT" -I . "$test_file" || test_exit=$?
-            if [ "${test_exit:-0}" -eq 0 ]; then
+            test_exit=0
+            # gdb-wrapper branch (CI default): intercept libKGEN's in-process
+            # SIGABRT handler before it swallows the crash (modular/modular#6413).
+            # Local dev defaults to MOJO_TEST_UNDER_GDB=0 → direct mojo invocation.
+            if [ "${MOJO_TEST_UNDER_GDB:-0}" = "1" ]; then
+                if ! bash "$REPO_ROOT/scripts/mojo-under-gdb.sh" "$CORE_DIR" \
+                        --Werror -debug-level=line-tables -I "$REPO_ROOT" -I . "$test_file"; then
+                    test_exit=$?
+                fi
+            else
+                if ! pixi run mojo --Werror -debug-level=line-tables -I "$REPO_ROOT" -I . "$test_file"; then
+                    test_exit=$?
+                fi
+            fi
+            if [ "${test_exit}" -eq 0 ]; then
                 passed_count=$((passed_count + 1))
             else
                 failed_count=$((failed_count + 1))
                 failed_tests="$failed_tests\n  - $test_file"
-                test_exit=0
             fi
         fi
     done

--- a/justfile
+++ b/justfile
@@ -80,11 +80,17 @@ _run cmd:
 			# -e passthroughs, MOJO_TEST_UNDER_GDB / CRASH_BUNDLE_DIR set on
 			# the GHA runner are NOT visible to the bash recipe inside the
 			# container, so the gdb wrapper would be silently skipped.
+			#
+			# NOTE: docker-compose (cli-plugin) rejects bare `-e VARNAME`
+			# (without `=value`) with "badly formed, must be key=value" — we
+			# must build the args conditionally with explicit values.
+			EXTRA_ENV=()
+			if [ -n "${MOJO_TEST_UNDER_GDB-}" ]; then EXTRA_ENV+=(-e "MOJO_TEST_UNDER_GDB=${MOJO_TEST_UNDER_GDB}"); fi
+			if [ -n "${MOJO_UNDER_GDB-}" ];      then EXTRA_ENV+=(-e "MOJO_UNDER_GDB=${MOJO_UNDER_GDB}"); fi
+			if [ -n "${CRASH_BUNDLE_DIR-}" ];    then EXTRA_ENV+=(-e "CRASH_BUNDLE_DIR=${CRASH_BUNDLE_DIR}"); fi
 			podman compose exec \
 				-e USER_ID={{USER_ID}} -e GROUP_ID={{GROUP_ID}} \
-				-e MOJO_TEST_UNDER_GDB \
-				-e MOJO_UNDER_GDB \
-				-e CRASH_BUNDLE_DIR \
+				"${EXTRA_ENV[@]}" \
 				-T {{podman_service}} bash -c "$HOME_FIXUP {{cmd}}"
 		fi
 	else

--- a/repro/repro_6413_assert_almost_equal.mojo
+++ b/repro/repro_6413_assert_almost_equal.mojo
@@ -1,0 +1,55 @@
+"""Standalone repro candidate for modular/modular#6413 (Backtrace A).
+
+Captured backtrace (CI run 25649843238, Mojo 1.0.0b2.dev2026050805):
+
+    Thread 1 "mojo" received signal SIGILL, Illegal instruction.
+    assert_almost_equal () at shared/testing/assertions.mojo:170
+    170     var diff = abs(a - b)
+    #1  test_tensor_dataset_negative_indexing () at tests/.../test_tensor_dataset.mojo:166
+    #2  main ()
+
+This file mirrors test_tensor_dataset_negative_indexing exactly (same imports,
+same construction order) so the captured frame matches pixel-for-pixel. It
+removes the testing harness (no conftest, no SimpleMLP, no perf_counter) so the
+Mojo file is the smallest possible reproducer for Modular.
+
+Run under the gdb wrapper:
+
+    bash scripts/mojo-under-gdb.sh /tmp/cores repro/repro_6413_assert_almost_equal.mojo
+
+Loops the failing block 50× per process so a single process probabilistically
+exercises the crash window without needing thousands of process restarts.
+"""
+
+from shared.data.datasets import TensorDataset
+from shared.tensor.any_tensor import AnyTensor
+from shared.testing.assertions import assert_almost_equal, assert_equal
+
+
+def trigger() raises:
+    # Identical to test_tensor_dataset_negative_indexing in
+    # tests/shared/data/datasets/test_tensor_dataset.mojo:153-171
+    var data_list: List[Float32] = [Float32(1.0), Float32(2.0), Float32(3.0)]
+    var data = AnyTensor(data_list^)
+    var labels_list: List[Int] = [0, 1, 2]
+    var labels = AnyTensor(labels_list^)
+    var dataset = TensorDataset(data^, labels^)
+
+    var last_sample = dataset[-1]
+    # Crash site in captured core: `abs(a - b)` inside assert_almost_equal.
+    assert_almost_equal(last_sample[0][0], Float32(3.0))
+    assert_equal(last_sample[1][0], 2)
+
+    var second_last_sample = dataset[-2]
+    assert_almost_equal(second_last_sample[0][0], Float32(2.0))
+    assert_equal(second_last_sample[1][0], 1)
+
+
+def main() raises:
+    for i in range(50):
+        try:
+            trigger()
+        except e:
+            print("iter", i, "raised:", String(e))
+            raise e.copy()
+    print("repro_6413_assert_almost_equal: completed 50 iterations cleanly")

--- a/repro/repro_6413_python_import_os.mojo
+++ b/repro/repro_6413_python_import_os.mojo
@@ -1,0 +1,37 @@
+"""Standalone repro candidate for modular/modular#6413 (Backtrace B).
+
+Captured backtrace (CI run 25649843238, Mojo 1.0.0b2.dev2026050805):
+
+    Thread 1 "mojo" received signal SIGILL, Illegal instruction.
+    #0  _strip ()         at oss/modular/mojo/stdlib/std/collections/string/string_slice.mojo:1035
+    #1  rstrip ()         at oss/modular/mojo/stdlib/std/collections/string/string_slice.mojo:1104
+    #5  __init__ ()       at oss/modular/mojo/stdlib/std/python/python.mojo:45
+    #7  KGEN_CompilerRT_GetOrCreateGlobalIndexed () from libKGENCompilerRTShared.so
+    #11 import_module ()  at oss/modular/mojo/stdlib/std/python/python.mojo:238
+    #12 test_substitute_simple_env_var () at tests/configs/test_env_vars.mojo:21
+
+This file exercises the same code path with NO ProjectOdyssey state — pure stdlib —
+so that if it crashes in CI, Modular has a one-file repro Modular asked for in
+the issue thread.
+
+Run under the gdb wrapper to capture an ELF core if it crashes:
+
+    bash scripts/mojo-under-gdb.sh /tmp/cores repro/repro_6413_python_import_os.mojo
+
+Repeat 60+ times — the production rate was ~30% per CI job; expect single-digit
+percentage at this scale, so loops both inside main() AND in the calling shell
+to amplify.
+"""
+
+from std.python import Python
+
+
+def main() raises:
+    # Inner loop attacks the KGEN_CompilerRT_GetOrCreateGlobalIndexed path
+    # (Python global init) and the string_slice._strip path used by Python.__init__.
+    # 200 iterations keeps wall time short while still hitting the global
+    # initializer many times (Python re-imports are cached, but the rstrip path
+    # in Python.__init__ runs per call).
+    for _ in range(200):
+        var os_mod = Python.import_module("os")
+        _ = os_mod

--- a/scripts/mojo-under-gdb.sh
+++ b/scripts/mojo-under-gdb.sh
@@ -97,4 +97,9 @@ echo "[mojo-under-gdb] args     : $*" >&2
 # --args passes everything after it verbatim as the inferior's argv.
 # stdout/stderr from the mojo process flow through gdb normally so CI
 # logs remain readable.
-exec gdb -batch -nx -x "$GDB_SCRIPT" --args "$MOJO_BIN" "$@"
+#
+# Run gdb INSIDE `pixi run` so the inferior inherits the activated pixi
+# env (MODULAR_HOME, PATH, MOJO stdlib search paths). Running gdb outside
+# `pixi run` strips that activation and mojo fails with "unable to locate
+# module 'std'" before it ever has a chance to crash.
+exec pixi run -- gdb -batch -nx -x "$GDB_SCRIPT" --args "$MOJO_BIN" "$@"

--- a/scripts/mojo-under-gdb.sh
+++ b/scripts/mojo-under-gdb.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Run `mojo` under gdb to catch the in-process SIGABRT handler in libKGEN
+# (modular/modular#6413) and dump a real ELF core via generate-core-file.
+#
+# Without gdb interception, libKGEN's SIGABRT handler catches the abort,
+# prints its own 3-frame post-handler trace, and exits cleanly — the
+# kernel never generates a core because the process handles the signal itself.
+# Running under gdb forces the signal to stop in the debugger BEFORE the
+# user handler runs, so we get the real pre-signal frame frozen in the core.
+#
+# Usage:
+#   mojo-under-gdb.sh <core-dir> <mojo-args...>
+#
+#   <core-dir>   Directory where cores and gdb logs are written (created if absent)
+#   <mojo-args>  All remaining arguments are passed verbatim to `pixi run mojo`
+#
+# Environment variables:
+#   MOJO_UNDER_GDB=0   Skip gdb and exec mojo directly (local dev escape hatch)
+#
+# Output files (on crash):
+#   <core-dir>/core.gdb.<timestamp>.mojo  — ELF core (multi-MB)
+#   <core-dir>/gdb-<timestamp>.log        — full backtrace + threads + shlibs
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+    echo "[mojo-under-gdb] usage: $0 <core-dir> <mojo-args...>" >&2
+    exit 1
+fi
+
+CORE_DIR="$1"
+shift
+
+# Escape hatch: MOJO_UNDER_GDB=0 bypasses gdb for local dev where overhead matters.
+if [ "${MOJO_UNDER_GDB:-1}" = "0" ]; then
+    exec pixi run mojo "$@"
+fi
+
+mkdir -p "$CORE_DIR"
+TS=$(date +%s)
+GDB_LOG="${CORE_DIR}/gdb-${TS}.log"
+CORE_FILE="${CORE_DIR}/core.gdb.${TS}.mojo"
+
+# Resolve the real mojo binary so gdb has a concrete ELF file argument.
+# `pixi run which mojo` prints any activation preamble on stderr; `tail -1`
+# grabs the last line (the actual path) to handle noisy pixi output.
+MOJO_BIN=$(pixi run which mojo 2>/dev/null | tail -1 || true)
+if [ -z "$MOJO_BIN" ] || [ ! -x "$MOJO_BIN" ]; then
+    echo "[mojo-under-gdb] WARNING: could not resolve mojo binary; falling back to direct exec" >&2
+    exec pixi run mojo "$@"
+fi
+
+# Write the gdb command script to a temp file to avoid multi-line -ex quoting issues.
+# gdb multi-line strings via -ex are not portable across gdb versions; -x is reliable.
+GDB_SCRIPT=$(mktemp /tmp/mojo-gdb-XXXXXX.gdb)
+# shellcheck disable=SC2064
+trap "rm -f '$GDB_SCRIPT'" EXIT
+
+cat > "$GDB_SCRIPT" <<GDBEOF
+set pagination off
+set confirm off
+set logging file ${GDB_LOG}
+set logging overwrite on
+set logging enabled on
+
+# Intercept crash signals before user (libKGEN) handlers run.
+# "nopass" prevents the signal from being delivered to the inferior.
+handle SIGABRT stop nopass print
+handle SIGSEGV stop nopass print
+handle SIGBUS  stop nopass print
+
+run
+
+# If gdb stopped due to a signal, dump a core and capture context.
+if \$_siginfo
+  printf "[mojo-under-gdb] caught signal %d at ", \$_siginfo.si_signo
+  info frame
+  printf "Generating core: ${CORE_FILE}\\n"
+  generate-core-file ${CORE_FILE}
+end
+
+bt full
+info threads
+info sharedlibrary
+set logging enabled off
+quit
+GDBEOF
+
+echo "[mojo-under-gdb] gdb log  : ${GDB_LOG}" >&2
+echo "[mojo-under-gdb] core file: ${CORE_FILE} (written on crash)" >&2
+echo "[mojo-under-gdb] binary   : ${MOJO_BIN}" >&2
+echo "[mojo-under-gdb] args     : $*" >&2
+
+# --args passes everything after it verbatim as the inferior's argv.
+# stdout/stderr from the mojo process flow through gdb normally so CI
+# logs remain readable.
+exec gdb -batch -nx -x "$GDB_SCRIPT" --args "$MOJO_BIN" "$@"

--- a/scripts/mojo-under-gdb.sh
+++ b/scripts/mojo-under-gdb.sh
@@ -44,7 +44,10 @@ CORE_FILE="${CORE_DIR}/core.gdb.${TS}.mojo"
 # Resolve the real mojo binary so gdb has a concrete ELF file argument.
 # `pixi run which mojo` prints any activation preamble on stderr; `tail -1`
 # grabs the last line (the actual path) to handle noisy pixi output.
-MOJO_BIN=$(pixi run which mojo 2>/dev/null | tail -1 || true)
+# pixi run which mojo may print activation preamble on stderr; tail -1 grabs the
+# actual path from the last line.  If the command fails (pixi not set up), MOJO_BIN
+# is empty and the check below falls back to direct exec.
+MOJO_BIN=$(pixi run which mojo 2>/dev/null | tail -1) || MOJO_BIN=""
 if [ -z "$MOJO_BIN" ] || [ ! -x "$MOJO_BIN" ]; then
     echo "[mojo-under-gdb] WARNING: could not resolve mojo binary; falling back to direct exec" >&2
     exec pixi run mojo "$@"

--- a/scripts/mojo-under-gdb.sh
+++ b/scripts/mojo-under-gdb.sh
@@ -72,19 +72,18 @@ handle SIGABRT stop nopass print
 handle SIGSEGV stop nopass print
 handle SIGBUS  stop nopass print
 
-run
-
-# If gdb stopped due to a signal, dump a core and capture context.
-if \$_siginfo
-  printf "[mojo-under-gdb] caught signal %d at ", \$_siginfo.si_signo
-  info frame
-  printf "Generating core: ${CORE_FILE}\\n"
+# Dump core + context on stop (signal caught). On normal exit, this hook
+# is never invoked, so a clean test run produces no spurious gdb errors.
+define hook-stop
+  printf "[mojo-under-gdb] stop reason captured; dumping core to ${CORE_FILE}\\n"
   generate-core-file ${CORE_FILE}
+  bt full
+  info threads
+  info sharedlibrary
 end
 
-bt full
-info threads
-info sharedlibrary
+run
+
 set logging enabled off
 quit
 GDBEOF
@@ -102,4 +101,8 @@ echo "[mojo-under-gdb] args     : $*" >&2
 # env (MODULAR_HOME, PATH, MOJO stdlib search paths). Running gdb outside
 # `pixi run` strips that activation and mojo fails with "unable to locate
 # module 'std'" before it ever has a chance to crash.
-exec pixi run -- gdb -batch -nx -x "$GDB_SCRIPT" --args "$MOJO_BIN" "$@"
+#
+# `--return-child-result` makes gdb exit with the inferior's exit code
+# (or 128+signo on signal). Without this, gdb's own zero/non-zero status
+# masks the test result and we either always pass or always fail.
+exec pixi run -- gdb -batch -nx --return-child-result -x "$GDB_SCRIPT" --args "$MOJO_BIN" "$@"

--- a/scripts/mojo-under-gdb.sh
+++ b/scripts/mojo-under-gdb.sh
@@ -56,9 +56,25 @@ fi
 # Write the gdb command script to a temp file to avoid multi-line -ex quoting issues.
 # gdb multi-line strings via -ex are not portable across gdb versions; -x is reliable.
 GDB_SCRIPT=$(mktemp /tmp/mojo-gdb-XXXXXX.gdb)
+EXIT_CODE_FILE="${CORE_DIR}/exit-${TS}.code"
 # shellcheck disable=SC2064
 trap "rm -f '$GDB_SCRIPT'" EXIT
 
+# The gdb script uses Python event hooks because:
+#  1. `handle SIGABRT stop nopass` + a `hook-stop` block fires on EVERY stop
+#     event in gdb 15.1 — including normal exit, where `generate-core-file`
+#     fails with "You can't do that without a process to debug" and gdb
+#     prints "Error while running hook_stop". A bare gdb-script `if` on
+#     $_siginfo also fails after normal exit (no stack).
+#  2. `--return-child-result` is unreliable in gdb 15.1 -batch mode for
+#     processes killed by handled signals: gdb often exits 0 even when the
+#     inferior died on SIGABRT, masking the test failure entirely.
+#
+# Python events distinguish gdb.SignalEvent (real crash) from gdb.ExitedEvent
+# (clean exit) and record the desired exit code to a file. The wrapper then
+# reads that file and exits with the recorded code, so the caller sees:
+#   - 0 / N for normal exit code N
+#   - 128 + signo for any caught signal (134 for SIGABRT, 139 for SIGSEGV…)
 cat > "$GDB_SCRIPT" <<GDBEOF
 set pagination off
 set confirm off
@@ -66,21 +82,55 @@ set logging file ${GDB_LOG}
 set logging overwrite on
 set logging enabled on
 
+python
+import gdb
+EXIT_FILE = "${EXIT_CODE_FILE}"
+CORE_FILE = "${CORE_FILE}"
+# POSIX shell convention for signal-terminated processes.
+SIG_MAP = {"SIGABRT": 6, "SIGSEGV": 11, "SIGBUS": 7, "SIGFPE": 8, "SIGILL": 4}
+state = {"signaled": False}
+
+def write_exit(code):
+    with open(EXIT_FILE, "w") as f:
+        f.write(str(code))
+
+# Default = 1 covers the case where neither handler fires (e.g. gdb itself dies).
+write_exit(1)
+
+def on_stop(event):
+    # Only act on signal stops (we never set breakpoints, so any other
+    # stop event is unexpected and best left to gdb's defaults).
+    if isinstance(event, gdb.SignalEvent):
+        signo = event.stop_signal
+        print("[mojo-under-gdb] caught " + signo + "; dumping " + CORE_FILE)
+        gdb.execute("generate-core-file " + CORE_FILE)
+        gdb.execute("bt full")
+        gdb.execute("info threads")
+        gdb.execute("info sharedlibrary")
+        state["signaled"] = True
+        write_exit(128 + SIG_MAP.get(signo, 1))
+
+def on_exit(event):
+    # gdb fires Exited after the post-signal kill too. If we already
+    # captured a signal, do not overwrite that exit code.
+    if state["signaled"]:
+        return
+    code = getattr(event, "exit_code", None)
+    write_exit(code if code is not None else 0)
+
+gdb.events.stop.connect(on_stop)
+gdb.events.exited.connect(on_exit)
+end
+
 # Intercept crash signals before user (libKGEN) handlers run.
 # "nopass" prevents the signal from being delivered to the inferior.
+# SIGILL is included because Mojo's os.abort() raises llvm.trap → SIGILL,
+# and observed JIT crashes in modular/modular#6413 also surface as SIGILL.
 handle SIGABRT stop nopass print
 handle SIGSEGV stop nopass print
 handle SIGBUS  stop nopass print
-
-# Dump core + context on stop (signal caught). On normal exit, this hook
-# is never invoked, so a clean test run produces no spurious gdb errors.
-define hook-stop
-  printf "[mojo-under-gdb] stop reason captured; dumping core to ${CORE_FILE}\\n"
-  generate-core-file ${CORE_FILE}
-  bt full
-  info threads
-  info sharedlibrary
-end
+handle SIGILL  stop nopass print
+handle SIGFPE  stop nopass print
 
 run
 
@@ -93,16 +143,22 @@ echo "[mojo-under-gdb] core file: ${CORE_FILE} (written on crash)" >&2
 echo "[mojo-under-gdb] binary   : ${MOJO_BIN}" >&2
 echo "[mojo-under-gdb] args     : $*" >&2
 
-# --args passes everything after it verbatim as the inferior's argv.
-# stdout/stderr from the mojo process flow through gdb normally so CI
-# logs remain readable.
-#
 # Run gdb INSIDE `pixi run` so the inferior inherits the activated pixi
 # env (MODULAR_HOME, PATH, MOJO stdlib search paths). Running gdb outside
 # `pixi run` strips that activation and mojo fails with "unable to locate
 # module 'std'" before it ever has a chance to crash.
-#
-# `--return-child-result` makes gdb exit with the inferior's exit code
-# (or 128+signo on signal). Without this, gdb's own zero/non-zero status
-# masks the test result and we either always pass or always fail.
-exec pixi run -- gdb -batch -nx --return-child-result -x "$GDB_SCRIPT" --args "$MOJO_BIN" "$@"
+# `set -e` would abort here if gdb exits non-zero before we can read
+# EXIT_CODE_FILE. Disable it just for this invocation.
+set +e
+pixi run -- gdb -batch -nx -x "$GDB_SCRIPT" --args "$MOJO_BIN" "$@"
+gdb_status=$?
+set -e
+
+# Prefer the Python-recorded exit code; fall back to gdb's own status if
+# the file is missing (gdb crashed before the python hook fired).
+if [ -r "$EXIT_CODE_FILE" ]; then
+    inferior_exit=$(cat "$EXIT_CODE_FILE")
+    rm -f "$EXIT_CODE_FILE"
+    exit "$inferior_exit"
+fi
+exit "$gdb_status"


### PR DESCRIPTION
## Summary

Replaces the deleted coredump-capture action with a gdb-based wrapper that captures real ELF cores when mojo tests crash (e.g. SIGILL on GHA runners lacking CPU features). Adds post-mortem disasm/register dumps and standalone reproducers for modular/modular#6413.

## Changes

- `feat(ci)`: wrap mojo tests in `gdb -batch` to capture real ELF cores
- `fix(ci)`: forward `MOJO_TEST_UNDER_GDB` into the container; use explicit `-e KEY=VAL` for docker-compose compat
- `fix`: remove all `|| true` failure swallows (strict policy)
- `fix(ci)`: run gdb inside `pixi run` so mojo can find stdlib
- `fix(ci)`: make gdb wrapper transparent on normal mojo exit
- `fix(ci)`: use gdb Python events + exit-code file for crash detection
- `chore(repro)`: standalone single-file reproducers for modular/modular#6413 (#5393)
- `chore(repro)`: disasm + register dump around \$pc on captured cores (#5394)

## Test plan

- [ ] CI green on this PR
- [ ] Trigger a known-crashing test and confirm an ELF core is captured + symbolicated
- [ ] Confirm gdb wrapper is transparent on normal (non-crashing) mojo exits

Refs: modular/modular#6413