### PR TITLE
fix(ci): stream ASan test output live & report signal-kill exit codes

### DIFF
--- a/justfile
+++ b/justfile
@@ -928,15 +928,33 @@ _test-group-asan-inner path pattern:
             test_count=$((test_count + 1))
 
             BINARY=$(mktemp /tmp/mojo-asan-XXXXXX)
-            output=""
-            output2=""
-            if output=$(pixi run mojo build {{MOJO_ASAN}} {{MOJO_STRICT}} -I "$REPO_ROOT" -I . -Xlinker -lm "$test_file" -o "$BINARY" 2>&1) && output2=$("$BINARY" 2>&1); then
-                echo "$output2"
+            # Stream output live so CI logs show ASan diagnostics on signal-kill (e.g. OOM SIGKILL),
+            # not just "❌ FAILED" with empty captures. Capture exit status via PIPESTATUS.
+            echo "--- build ---"
+            set +e
+            pixi run mojo build {{MOJO_ASAN}} {{MOJO_STRICT}} -I "$REPO_ROOT" -I . -Xlinker -lm "$test_file" -o "$BINARY" 2>&1
+            build_status=$?
+            run_status=-1
+            if [ $build_status -eq 0 ]; then
+                echo "--- run ---"
+                "$BINARY" 2>&1
+                run_status=$?
+            fi
+            set -e
+            if [ $build_status -eq 0 ] && [ $run_status -eq 0 ]; then
                 echo "✅ PASSED: $test_file"
                 passed_count=$((passed_count + 1))
             else
-                echo "$output"
-                echo "$output2"
+                if [ $build_status -ne 0 ]; then
+                    echo "build exit status: $build_status"
+                else
+                    echo "run exit status: $run_status (binary: $BINARY)"
+                    # On signal death (>=128), report which signal — invaluable for diagnosing OOM kills.
+                    if [ $run_status -gt 128 ]; then
+                        sig=$((run_status - 128))
+                        echo "killed by signal $sig"
+                    fi
+                fi
                 echo "❌ FAILED: $test_file"
                 failed_count=$((failed_count + 1))
                 failed_tests="$failed_tests\n  - $test_file"


### PR DESCRIPTION
## Summary

The `AddressSanitizer Tests` job has been flaking on `main` (3 of last 5 push runs failed) with empty failure logs — only `❌ FAILED: tests/shared/core/test_hash.mojo` and nothing else. The same test passes reliably:
- locally on bare metal (Mojo 1.0.0b2.dev2026050805, glibc 2.39)
- locally in the podman dev container
- on most CI runs

The blank failure log is the smoking gun: `_test-group-asan-inner` captured build/binary output into shell variables (`output=\$(...)`), then printed them on failure. But when a process is killed by a signal (e.g. `SIGKILL/137` from the OOM killer — ASan binaries need 3-6× memory), there's nothing in `\$output`/`\$output2` to print.

## Changes

`justfile` `_test-group-asan-inner` (lines 924-944):

- Stream `mojo build` and the test binary's output directly to stdout (live), so CI logs show ASan diagnostics even on signal death.
- Capture exit status via `\$?` with `set +e`/`set -e` bookends.
- On failure, print the actual exit code and, for signal deaths (\$status >= 128), the signal number — e.g. `killed by signal 9` makes OOM-kill obvious vs a real ASan-detected bug.

No behavior change for passing tests. No change to which tests run, what flags are used, or how passes are reported.

## Test plan

- [x] Local container run: `just test-group-asan "tests/shared/core" "test_hash.mojo"` — passes, output streams live
- [ ] CI: the next ASan run will either pass (intermittent OOM) or fail with a real diagnostic (so we can fix the actual bug)

## Follow-up

If CI keeps showing `killed by signal 9`, the next step is bumping the runner memory or splitting `test_hash.mojo` into smaller files. If it shows a real ASan stack trace, that's the actual fix target.