### PR TITLE
feat(packaging): conda recipe + just install/publish (PR 2 of 4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ examples/*/train
 examples/*/inference
 test_*
 !tests/**
+!conda.recipe/test_*
 .worktrees/
 .claude/worktrees/
 .issue_implementer/

--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -1,0 +1,56 @@
+context:
+  version: "0.1.0"
+  mojo_version: "=1.0.0b2"
+
+package:
+  name: "projectodyssey"
+  version: ${{ version }}
+
+source:
+  # Local development: build straight from the working tree.
+  # For modular-community submission, replace with:
+  #
+  #   - git: https://github.com/HomericIntelligence/ProjectOdyssey.git
+  #     rev: <commit-sha-or-tag>
+  #
+  # See scripts/publish_modular_community.py — it rewrites this block
+  # automatically when copying the recipe into modular/modular-community.
+  - path: ..
+
+build:
+  number: 0
+  script:
+    - mkdir -p ${PREFIX}/lib/mojo
+    - mojo package -I src src/projectodyssey -o ${PREFIX}/lib/mojo/projectodyssey.mojopkg
+
+requirements:
+  build:
+    - mojo-compiler ${{ mojo_version }}
+  host:
+    - mojo-compiler ${{ mojo_version }}
+  run:
+    - mojo-compiler ${{ mojo_version }}
+
+tests:
+  - script:
+      - if: unix
+        then:
+          - pixi run mojo run conda.recipe/test_import.mojo
+    requirements:
+      run:
+        - mojo-compiler ${{ mojo_version }}
+    files:
+      source:
+        - conda.recipe/test_import.mojo
+
+about:
+  homepage: https://github.com/HomericIntelligence/ProjectOdyssey
+  license: BSD-3-Clause
+  license_file: LICENSE
+  summary: Mojo-based AI research platform for reproducing classic research papers. Provides reusable tensor ops, autograd, layers, optimizers, and training infrastructure.
+  repository: https://github.com/HomericIntelligence/ProjectOdyssey.git
+
+extra:
+  project_name: projectodyssey
+  maintainers:
+    - mvillmow

--- a/conda.recipe/test_import.mojo
+++ b/conda.recipe/test_import.mojo
@@ -1,0 +1,22 @@
+# Smoke test executed by the `tests:` block in recipe.yaml.
+#
+# Imports canonical public symbols from the installed projectodyssey.mojopkg
+# and instantiates one to prove the package is not just parseable but
+# actually usable. If any import or instantiation fails, rattler-build
+# fails the package test and the recipe is rejected.
+#
+# Positive imports only: Mojo import failures are compile-time errors,
+# so there is no equivalent of pytest.raises(ImportError) here.
+
+from projectodyssey.tensor.tensor import Tensor
+from projectodyssey.tensor.any_tensor import AnyTensor, zeros
+
+
+def main() raises:
+    # Compile-time-typed tensor.
+    var _t = Tensor[DType.float32]([2, 3])
+
+    # Runtime-typed tensor via the zeros() factory (canonical creation path).
+    var _a = zeros([2, 3], DType.float32)
+
+    print("projectodyssey package import test: OK")

--- a/justfile
+++ b/justfile
@@ -497,6 +497,38 @@ package-debug: (package "debug")
 package-release: (package "release")
 
 # ==============================================================================
+# Conda Recipe (rattler-build) — install/publish to modular-community
+# ==============================================================================
+# Wraps the real tools — there is no `mojo install` or `mojo publish` CLI in
+# Mojo 1.0. "Install" means `pixi add projectodyssey` once the recipe lands
+# in https://repo.prefix.dev/modular-community; "publish" means a PR to
+# https://github.com/modular/modular-community adding `recipes/projectodyssey/`.
+
+# Build the conda package locally via rattler-build
+build-recipe:
+    @echo "Building conda package via rattler-build…"
+    @mkdir -p build/recipe
+    pixi exec --spec rattler-build -- rattler-build build \
+        --recipe conda.recipe/recipe.yaml \
+        -c conda-forge -c https://conda.modular.com/max \
+        -c https://repo.prefix.dev/modular-community \
+        --output-dir build/recipe
+    @echo "✅ Conda package built under build/recipe/"
+
+# Install the locally-built conda package into a scratch pixi env (smoke test)
+install-local: build-recipe
+    @echo "Smoke-testing locally-built package in a scratch pixi env…"
+    @bash scripts/install_local_recipe.sh
+
+# Open a PR to modular/modular-community publishing the current recipe
+publish:
+    @python3 scripts/publish_modular_community.py
+
+# Dry-run of publish: prints the PR body and recipe diff without pushing
+publish-dry-run:
+    @python3 scripts/publish_modular_community.py --dry-run
+
+# ==============================================================================
 # Model Training and Inference
 # ==============================================================================
 

--- a/scripts/install_local_recipe.sh
+++ b/scripts/install_local_recipe.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Smoke-test the locally-built conda package by installing it into a scratch
+# pixi env and running a one-line import. Called by `just install-local`.
+#
+# Why a shell script? `pixi add --channel <local-path>` requires shelling out
+# and the surrounding logic is `mkdir`/`pixi init`/`pixi run` — no Mojo or
+# Python value-add. If this grows past ~50 lines, promote to Python per
+# ADR-001.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RECIPE_OUT="$REPO_ROOT/build/recipe"
+
+if [ ! -d "$RECIPE_OUT" ]; then
+    echo "❌ $RECIPE_OUT does not exist — run 'just build-recipe' first" >&2
+    exit 1
+fi
+
+# Find the .conda package rattler-build produced. There should be exactly one
+# under build/recipe/<platform>/.
+CONDA_PKG=$(find "$RECIPE_OUT" -name 'projectodyssey-*.conda' -type f | head -1)
+if [ -z "$CONDA_PKG" ]; then
+    echo "❌ no projectodyssey-*.conda found under $RECIPE_OUT" >&2
+    echo "   (did 'just build-recipe' succeed?)" >&2
+    exit 1
+fi
+
+SCRATCH="$(mktemp -d -t projectodyssey-install-XXXXXX)"
+echo "📦 Scratch pixi env: $SCRATCH"
+
+cd "$SCRATCH"
+pixi init --quiet
+pixi workspace channel add --quiet "$RECIPE_OUT"
+pixi workspace channel add --quiet "https://conda.modular.com/max"
+
+pixi add --quiet projectodyssey
+pixi add --quiet "mojo==1.0.0b2.dev2026050805"
+
+cat > smoke_test.mojo <<'EOF'
+from projectodyssey.tensor.tensor import Tensor
+from projectodyssey.tensor.any_tensor import zeros
+
+
+def main() raises:
+    var _t = Tensor[DType.float32]([2, 3])
+    var _a = zeros([2, 3], DType.float32)
+    print("install-local smoke test: OK")
+EOF
+
+echo "▶️  pixi run mojo run smoke_test.mojo"
+pixi run mojo run smoke_test.mojo
+
+echo
+echo "✅ Local recipe install validated."
+echo "   Scratch env left at $SCRATCH for inspection — safe to remove."

--- a/scripts/publish_modular_community.py
+++ b/scripts/publish_modular_community.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Publish projectodyssey's conda recipe to modular/modular-community.
+
+There is no `mojo publish` CLI in Mojo 1.0. Publishing a Mojo library to the
+`https://repo.prefix.dev/modular-community` channel works by opening a PR
+against `modular/modular-community` that adds a `recipes/<package_name>/`
+folder containing the rattler-build recipe.
+
+This script automates that PR:
+
+1. Clones (or refreshes) modular/modular-community at
+   `$HOME/.cache/projectodyssey/modular-community`.
+2. Copies `conda.recipe/recipe.yaml` and `conda.recipe/test_import.mojo`
+   into `recipes/projectodyssey/`.
+3. Rewrites the `source:` block from `path: ..` (local) to a `git:` source
+   pinned at the current `HEAD` commit SHA so the recipe is reproducible
+   in modular-community's CI.
+4. Creates a branch, commits, and opens a PR via `gh`.
+
+Python (not Mojo) per ADR-001: this is GitHub automation involving
+subprocess output capture and string templating, both of which Mojo's
+runtime is not designed for.
+
+Usage::
+
+    python3 scripts/publish_modular_community.py            # opens PR
+    python3 scripts/publish_modular_community.py --dry-run  # prints plan, no push
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+PACKAGE_NAME = "projectodyssey"
+UPSTREAM_REPO_URL = "https://github.com/HomericIntelligence/ProjectOdyssey.git"
+MODULAR_COMMUNITY_REPO = "modular/modular-community"
+MODULAR_COMMUNITY_URL = f"https://github.com/{MODULAR_COMMUNITY_REPO}.git"
+CACHE_DIR = Path.home() / ".cache" / "projectodyssey" / "modular-community"
+
+
+def run(cmd: list[str], *, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess and return its CompletedProcess (text mode)."""
+    return subprocess.run(cmd, cwd=cwd, check=check, capture_output=True, text=True)
+
+
+def repo_root() -> Path:
+    """Resolve the ProjectOdyssey repo root from the script's location."""
+    return Path(__file__).resolve().parent.parent
+
+
+def current_commit_sha(root: Path) -> str:
+    """Return the current HEAD commit SHA on the source repo."""
+    return run(["git", "rev-parse", "HEAD"], cwd=root).stdout.strip()
+
+
+def rewrite_source_block(recipe_text: str, commit_sha: str) -> str:
+    """Replace the `source:` block in recipe.yaml with a git source.
+
+    The local recipe uses ``source: - path: ..`` for fast iteration during
+    development. modular-community needs a reproducible source — a git URL
+    pinned to a commit SHA. This rewrite is purely textual; we keep the
+    surrounding fields (build, requirements, tests, about) untouched.
+    """
+    # Match the entire `source:` block up to the next top-level key (`build:`).
+    pattern = re.compile(r"^source:\n(?:[ \t]+.*\n|\n)*?(?=^[A-Za-z])", re.MULTILINE)
+    replacement = (
+        f"source:\n"
+        f"  - git: {UPSTREAM_REPO_URL[:-4]}\n"  # strip ".git" — the modular-community recipes don't suffix it
+        f"    rev: {commit_sha}\n\n"
+    )
+    rewritten, n = pattern.subn(replacement, recipe_text, count=1)
+    if n != 1:
+        raise RuntimeError(
+            "could not locate `source:` block in conda.recipe/recipe.yaml — "
+            "did the recipe layout change? See scripts/publish_modular_community.py "
+            "for the regex this script expects."
+        )
+    return rewritten
+
+
+def ensure_clone(dry_run: bool) -> Path:
+    """Clone or refresh modular/modular-community at the cache path."""
+    if not CACHE_DIR.exists():
+        if dry_run:
+            print(f"[dry-run] would clone {MODULAR_COMMUNITY_URL} → {CACHE_DIR}")
+            return CACHE_DIR
+        CACHE_DIR.parent.mkdir(parents=True, exist_ok=True)
+        run(["gh", "repo", "clone", MODULAR_COMMUNITY_REPO, str(CACHE_DIR)])
+    else:
+        if dry_run:
+            print(f"[dry-run] would refresh {CACHE_DIR} against origin/main")
+        else:
+            run(["git", "fetch", "origin", "--quiet"], cwd=CACHE_DIR)
+            run(["git", "checkout", "main"], cwd=CACHE_DIR)
+            run(["git", "pull", "--ff-only", "origin", "main", "--quiet"], cwd=CACHE_DIR)
+    return CACHE_DIR
+
+
+def copy_recipe(source_root: Path, target_repo: Path, commit_sha: str, dry_run: bool) -> Path:
+    """Copy recipe.yaml + test_import.mojo into recipes/projectodyssey/.
+
+    Returns the path to the destination directory.
+    """
+    src_recipe = source_root / "conda.recipe" / "recipe.yaml"
+    src_test = source_root / "conda.recipe" / "test_import.mojo"
+    if not src_recipe.exists():
+        raise SystemExit(f"missing {src_recipe}; run from ProjectOdyssey repo root")
+    if not src_test.exists():
+        raise SystemExit(f"missing {src_test}")
+
+    dest_dir = target_repo / "recipes" / PACKAGE_NAME
+    if dry_run:
+        print(f"[dry-run] would write {dest_dir}/recipe.yaml (with git source pinned to {commit_sha})")
+        print(f"[dry-run] would write {dest_dir}/test_import.mojo")
+        return dest_dir
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    rewritten = rewrite_source_block(src_recipe.read_text(), commit_sha)
+    (dest_dir / "recipe.yaml").write_text(rewritten)
+    shutil.copy(src_test, dest_dir / "test_import.mojo")
+    return dest_dir
+
+
+def pr_body(commit_sha: str) -> str:
+    """Return the body for the modular-community PR."""
+    return f"""## Summary
+
+Adds the `projectodyssey` recipe so consumers can install ProjectOdyssey's
+Mojo library via `pixi add projectodyssey` from the modular-community
+channel.
+
+- **Source**: https://github.com/HomericIntelligence/ProjectOdyssey (BSD-3-Clause)
+- **Pinned to commit**: `{commit_sha}`
+
+The recipe builds with `mojo package -I src src/projectodyssey -o ${{PREFIX}}/lib/mojo/projectodyssey.mojopkg`
+and includes a `tests:` block that imports and instantiates a Tensor and an
+AnyTensor from the built `.mojopkg` to prove the package is importable.
+
+## Test Plan
+
+- [ ] `rattler-build build --recipe recipes/projectodyssey/recipe.yaml` succeeds
+- [ ] The recipe's `tests:` block passes (smoke import)
+
+Generated by `scripts/publish_modular_community.py` in ProjectOdyssey.
+"""
+
+
+def maybe_open_pr(target_repo: Path, branch: str, commit_sha: str, dry_run: bool) -> None:
+    """Create a branch, commit, push, and open a PR."""
+    title = f"feat: add {PACKAGE_NAME} recipe (pinned at {commit_sha[:7]})"
+
+    if dry_run:
+        print()
+        print("====== PR title ======")
+        print(title)
+        print()
+        print("====== PR body ======")
+        print(pr_body(commit_sha))
+        print()
+        print(f"[dry-run] would: git checkout -b {branch}; git add recipes/{PACKAGE_NAME}; commit; push; gh pr create")
+        return
+
+    # Branch + commit + push + PR.
+    run(["git", "checkout", "-B", branch], cwd=target_repo)
+    run(["git", "add", f"recipes/{PACKAGE_NAME}"], cwd=target_repo)
+
+    status = run(["git", "status", "--porcelain"], cwd=target_repo).stdout
+    if not status.strip():
+        print("nothing to commit — recipe already up to date in modular-community")
+        return
+
+    run(["git", "commit", "-m", title], cwd=target_repo)
+    run(["git", "push", "-u", "origin", branch], cwd=target_repo)
+
+    result = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            MODULAR_COMMUNITY_REPO,
+            "--base",
+            "main",
+            "--head",
+            branch,
+            "--title",
+            title,
+            "--body",
+            pr_body(commit_sha),
+        ],
+        cwd=target_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        # Idempotent: PR may already exist.
+        if "already exists" in result.stderr:
+            print(f"PR already exists for branch {branch}; nothing to do")
+            return
+        print(result.stderr, file=sys.stderr)
+        raise SystemExit(result.returncode)
+    print(result.stdout.strip())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the plan (recipe rewrite, PR title/body) without pushing or opening a PR.",
+    )
+    args = parser.parse_args()
+
+    root = repo_root()
+    if not (root / "conda.recipe" / "recipe.yaml").exists():
+        raise SystemExit(
+            f"could not find conda.recipe/recipe.yaml under {root}; run this script from a checkout of ProjectOdyssey"
+        )
+
+    sha = current_commit_sha(root)
+    print(f"ProjectOdyssey HEAD: {sha}")
+
+    target = ensure_clone(args.dry_run)
+    dest = copy_recipe(root, target, sha, args.dry_run)
+    print(f"recipe target: {dest}")
+
+    branch = f"projectodyssey-recipe-{sha[:7]}"
+    maybe_open_pr(target, branch, sha, args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_test_coverage.py
+++ b/scripts/validate_test_coverage.py
@@ -56,6 +56,10 @@ def find_test_files(root_dir: Path) -> List[Path]:
         "examples/googlenet_cifar10/test_model.mojo",
         "examples/mobilenetv1_cifar10/test_model.mojo",
         "examples/resnet18_cifar10/test_model.mojo",
+        # Conda recipe smoke test — executed by rattler-build's `tests:`
+        # block when the package is built (see conda.recipe/recipe.yaml),
+        # not by the per-PR CI test matrix.
+        "conda.recipe/test_import.mojo",
     ]
 
     # Exclude E2E model tests (run weekly, not per-PR)


### PR DESCRIPTION
Second of four PRs implementing #5413 (ship ProjectOdyssey as an installable Mojo package).

Adds the conda packaging story so consumers can eventually `pixi add projectodyssey` from the
modular-community channel. There is no `mojo install` / `mojo publish` CLI in Mojo 1.0; this
PR wraps the real tools (rattler-build for building, `gh` CLI for the publish PR).

## Summary

- `conda.recipe/recipe.yaml` — rattler-build recipe. Uses `source: path: ..` for fast local
  iteration; the publish script rewrites it to a pinned `git:` source when submitting upstream.
  Mirrors the pattern of [decimo](https://github.com/modular/modular-community/blob/main/recipes/decimo/recipe.yaml)
  / [mist](https://github.com/modular/modular-community/blob/main/recipes/mist/recipe.yaml).
- `conda.recipe/test_import.mojo` — the recipe's `tests:` block runs this; imports Tensor +
  AnyTensor and instantiates each (positive imports only — Mojo import failures are
  compile-time, no `pytest.raises(ImportError)` equivalent).
- `scripts/publish_modular_community.py` (Python per ADR-001) — clones modular/modular-community,
  rewrites source to a pinned git ref, branches, commits, opens a PR. Idempotent. Supports
  `--dry-run`.
- `scripts/install_local_recipe.sh` — installs the locally-built `.conda` into a scratch pixi
  env and runs an import smoke test.
- `justfile` recipes: `build-recipe`, `install-local`, `publish`, `publish-dry-run`.
- `.gitignore` exception so `conda.recipe/test_import.mojo` isn't swallowed by the global
  `test_*` rule.

## Verification (local)

- `pixi run mojo package -I src src/projectodyssey -o <tmp>/projectodyssey.mojopkg` ✓
- `pixi run mojo run -I <tmp> conda.recipe/test_import.mojo` ✓ (prints `package import test: OK`)
- `pixi run mojo run --Werror -I src conda.recipe/test_import.mojo` ✓
- `just publish-dry-run` ✓ (prints PR title/body, branch name, recipe target)
- Recipe-rewrite script verified to preserve all non-`source:` YAML keys (structural diff).
- `pixi run pre-commit run --all-files` ✓ (ruff format/check, bandit, mypy, markdownlint, YAML).

## Not yet run

- `just build-recipe` end-to-end (requires rattler-build network fetch, ~5-10 min). The underlying
  `mojo package` call is the same one tested above.
- `just publish` against the real modular/modular-community (deferred to PR 3 — wait until the
  release workflow attaches `.mojopkg` to GitHub releases so the channel PR can reference a tag).

## Test Plan

- [ ] CI build + tests pass
- [ ] `just publish-dry-run` in CI prints the expected PR plan (no network mutations)
- [ ] After merge: run `just build-recipe` locally to confirm rattler-build accepts the recipe

Refs #5413
Stacked on #5414 (PR 1, already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)