### PR TITLE
feat(packaging): Python wheel bundling .mojopkg (PR 4 of 4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 __pycache__
 *.pyc
 
+# Python wheel build artifacts (produced by `just wheel`)
+*.egg-info/
+python/build/
+
 # agentic build artifacts
 logs/
 build/

--- a/justfile
+++ b/justfile
@@ -529,6 +529,24 @@ publish-dry-run:
     @python3 scripts/publish_modular_community.py --dry-run
 
 # ==============================================================================
+# Python Wheel — pure-Python wrapper that bundles the .mojopkg
+# ==============================================================================
+# `pip install projectodyssey` ships projectodyssey.mojopkg as Python package
+# data. Consumers call `projectodyssey.import_dir()` to get the path to feed
+# `mojo run -I`. No native Python bindings (those are out-of-scope; see the
+# tracking issue's "Out of scope" section).
+
+# Build the wheel: produces dist/projectodyssey-<version>-py3-none-any.whl
+wheel: package-release
+    @echo "Staging projectodyssey.mojopkg into python/projectodyssey/_data/"
+    @mkdir -p python/projectodyssey/_data
+    @cp build/release/projectodyssey.mojopkg python/projectodyssey/_data/
+    @echo "Building wheel via python -m build…"
+    cd python && pixi run python -m build --wheel --outdir ../dist
+    @ls -la dist/projectodyssey-*.whl
+    @echo "✅ Wheel built. Verify with:  pip install dist/projectodyssey-*.whl"
+
+# ==============================================================================
 # Model Training and Inference
 # ==============================================================================
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -7,8 +7,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -154,6 +152,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pymdown-extensions-10.21.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pynacl-1.6.2-py314h1594a91_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-benchmark-5.2.3-pyhd8ed1ab_0.conda
@@ -161,6 +160,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-timeout-2.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.4-habeac84_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-build-1.5.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.2.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
@@ -226,8 +226,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -481,6 +479,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pymdown-extensions-10.21.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pynacl-1.6.2-py314h1594a91_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.0-py314h3987850_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
@@ -489,6 +488,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-timeout-2.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.4-habeac84_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-build-1.5.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.2.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
@@ -598,8 +598,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -4171,6 +4169,18 @@ packages:
   - pkg:pypi/pyparsing?source=hash-mapping
   size: 110893
   timestamp: 1769003998136
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
+  sha256: 065ac44591da9abf1ff740feb25929554b920b00d09287a551fcced2c9791092
+  md5: d4582021af437c931d7d77ec39007845
+  depends:
+  - python >=3.9
+  - tomli >=1.1.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyproject-hooks?source=hash-mapping
+  size: 15528
+  timestamp: 1733710122949
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.0-py314h3987850_1.conda
   sha256: 70e2bedac4505bacf317371406c3246023536ec2337a8eb2310dab5afa90dbad
   md5: 5abdb958cf8cc0b43cf078d0559f7969
@@ -4312,6 +4322,25 @@ packages:
   size: 36705460
   timestamp: 1775614357822
   python_site_packages_path: lib/python3.14/site-packages
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-build-1.5.0-pyhc364b38_0.conda
+  sha256: eb8d5e44fddee9033eb7cfdd5ea584b7594b50e31c7602bef553af0fd4ee9266
+  md5: fa587158c0d768127faa1a3b4df01e5d
+  depends:
+  - python >=3.10
+  - colorama
+  - importlib-metadata >=4.6
+  - packaging >=24.0
+  - pyproject_hooks
+  - tomli >=1.1.0
+  - python
+  constrains:
+  - build <0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/build?source=hash-mapping
+  size: 28946
+  timestamp: 1778048948266
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
   sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
   md5: 5b8d21249ff20967101ffa321cab24e8

--- a/pixi.toml
+++ b/pixi.toml
@@ -28,6 +28,9 @@ pydantic = ">=2.12.5,<3"
 # Dev-only tools (not needed at runtime)
 flask = ">=3.0.0,<4"
 pip = ">=25.3,<26"
+# Python build frontend — used by `just wheel` to produce the
+# projectodyssey wheel from python/pyproject.toml.
+python-build = ">=1.2,<2"
 
 # Testing
 pytest = ">=8.1.0,<9"

--- a/python/projectodyssey/__init__.py
+++ b/python/projectodyssey/__init__.py
@@ -21,6 +21,9 @@ here; see Mojo's Python-interop docs if you need them.
 from __future__ import annotations
 
 import os
+
+# nosemgrep: python.lang.compatibility.python37.python37-compatibility-importlib
+# Safe to use here: this wheel pins requires-python = ">=3.10" (see pyproject.toml).
 from importlib.resources import files
 
 __all__ = ["mojopkg_path", "import_dir", "__version__"]

--- a/python/projectodyssey/__init__.py
+++ b/python/projectodyssey/__init__.py
@@ -22,9 +22,9 @@ from __future__ import annotations
 
 import os
 
-# nosemgrep: python.lang.compatibility.python37.python37-compatibility-importlib
-# Safe to use here: this wheel pins requires-python = ">=3.10" (see pyproject.toml).
-from importlib.resources import files
+# Safe: this wheel pins requires-python = ">=3.10" (see pyproject.toml),
+# and importlib.resources has been a stable module since 3.9.
+from importlib.resources import files  # nosemgrep: python.lang.compatibility.python37.python37-compatibility-importlib
 
 __all__ = ["mojopkg_path", "import_dir", "__version__"]
 

--- a/python/projectodyssey/__init__.py
+++ b/python/projectodyssey/__init__.py
@@ -20,11 +20,7 @@ here; see Mojo's Python-interop docs if you need them.
 
 from __future__ import annotations
 
-import os
-
-# Safe: this wheel pins requires-python = ">=3.10" (see pyproject.toml),
-# and importlib.resources has been a stable module since 3.9.
-from importlib.resources import files  # nosemgrep: python.lang.compatibility.python37.python37-compatibility-importlib
+from pathlib import Path
 
 __all__ = ["mojopkg_path", "import_dir", "__version__"]
 
@@ -32,10 +28,17 @@ __all__ = ["mojopkg_path", "import_dir", "__version__"]
 # When this drifts, the wheel build is the source of truth (it embeds this).
 __version__ = "0.1.0"
 
+# The .mojopkg ships as package data under projectodyssey/_data/.
+# Resolve relative to this module's file — works identically whether the
+# package was installed by pip, dropped on PYTHONPATH, or imported from
+# a source checkout. No reliance on importlib.resources (which Semgrep
+# flags) and no backport dependency.
+_DATA_DIR = Path(__file__).resolve().parent / "_data"
+
 
 def mojopkg_path() -> str:
     """Absolute filesystem path to the bundled `projectodyssey.mojopkg`."""
-    return os.fspath(files(__package__) / "_data" / "projectodyssey.mojopkg")
+    return str(_DATA_DIR / "projectodyssey.mojopkg")
 
 
 def import_dir() -> str:
@@ -43,4 +46,4 @@ def import_dir() -> str:
 
     Returns the parent directory of `projectodyssey.mojopkg`.
     """
-    return os.fspath(files(__package__) / "_data")
+    return str(_DATA_DIR)

--- a/python/projectodyssey/__init__.py
+++ b/python/projectodyssey/__init__.py
@@ -1,0 +1,43 @@
+"""ProjectOdyssey — pip-installable wrapper around the Mojo library.
+
+This wheel bundles the compiled `projectodyssey.mojopkg` so consumers can
+``pip install projectodyssey`` and then use the package from Mojo code:
+
+    >>> import projectodyssey
+    >>> projectodyssey.mojopkg_path()
+    '/path/to/site-packages/projectodyssey/_data/projectodyssey.mojopkg'
+    >>> projectodyssey.import_dir()
+    '/path/to/site-packages/projectodyssey/_data'
+
+Then in your Mojo project:
+
+    pixi run mojo run -I "$(python -c 'import projectodyssey; print(projectodyssey.import_dir())')" main.mojo
+
+The wheel is pure-Python — no compiled bindings. Mojo→Python bindings via
+`@export def PyInit_*` + `mojo build --emit shared-lib` are out of scope
+here; see Mojo's Python-interop docs if you need them.
+"""
+
+from __future__ import annotations
+
+import os
+from importlib.resources import files
+
+__all__ = ["mojopkg_path", "import_dir", "__version__"]
+
+# Kept in sync manually with mojo.toml and python/pyproject.toml.
+# When this drifts, the wheel build is the source of truth (it embeds this).
+__version__ = "0.1.0"
+
+
+def mojopkg_path() -> str:
+    """Absolute filesystem path to the bundled `projectodyssey.mojopkg`."""
+    return os.fspath(files(__package__) / "_data" / "projectodyssey.mojopkg")
+
+
+def import_dir() -> str:
+    """Directory to pass to ``mojo run -I`` so the package can be imported.
+
+    Returns the parent directory of `projectodyssey.mojopkg`.
+    """
+    return os.fspath(files(__package__) / "_data")

--- a/python/projectodyssey/_data/.gitkeep
+++ b/python/projectodyssey/_data/.gitkeep
@@ -1,0 +1,7 @@
+# Placeholder so the _data/ directory exists in source control.
+#
+# `just wheel` copies build/release/projectodyssey.mojopkg into this
+# directory just before invoking `python -m build --wheel`, so the
+# wheel ships with the .mojopkg as package data.
+#
+# The .mojopkg itself is gitignored (it's a build artifact).

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,43 @@
+# Wheel-only project config — pure-Python wheel that bundles
+# `projectodyssey.mojopkg` as package data so consumers can
+# `pip install projectodyssey` and feed the path to `mojo run -I`.
+#
+# Dependency-management note: this file is intentionally minimal and is
+# NOT a source of truth for the project's dependencies. The repo-level
+# `pixi.toml` remains the single source of truth per CLAUDE.md. This
+# pyproject.toml is consulted only when building the wheel.
+
+[build-system]
+requires = ["setuptools>=82", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "projectodyssey"
+version = "0.1.0"
+description = "ProjectOdyssey: ML Odyssey shared library bundled as a Mojo .mojopkg. Use projectodyssey.import_dir() to get the path to feed `mojo run -I`."
+license = { text = "BSD-3-Clause" }
+authors = [
+    { name = "Micah Villmow", email = "4211002+mvillmow@users.noreply.github.com" },
+]
+requires-python = ">=3.10"
+keywords = ["mojo", "ml", "tensor", "autograd"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+
+[project.urls]
+Homepage = "https://github.com/HomericIntelligence/ProjectOdyssey"
+Repository = "https://github.com/HomericIntelligence/ProjectOdyssey"
+Issues = "https://github.com/HomericIntelligence/ProjectOdyssey/issues"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["projectodyssey*"]
+
+[tool.setuptools.package-data]
+projectodyssey = ["_data/*.mojopkg"]


### PR DESCRIPTION
Fourth of four PRs implementing #5413 (ship ProjectOdyssey as an installable Mojo package).

## Summary

Adds a pip-installable wheel that ships `projectodyssey.mojopkg` as Python package data.

After this lands and is published to GitHub releases (or PyPI), consumers can:

```bash
pip install projectodyssey
mojo run -I "$(python -c 'import projectodyssey; print(projectodyssey.import_dir())')" main.mojo
```

The wheel is **pure-Python** — no compiled bindings. Mojo→Python bindings via `@export` +
`mojo build --emit shared-lib` are documented as out-of-scope on #5413; this loader-only
wheel is a clean staging point for that follow-up if there's user demand.

## Changes

- `python/projectodyssey/__init__.py` — exposes `mojopkg_path()`, `import_dir()`, `__version__`.
- `python/projectodyssey/_data/.gitkeep` — keeps the data dir in source control. The actual
  `.mojopkg` is staged in at build time by `just wheel` and is gitignored.
- `python/pyproject.toml` — wheel-only build config (setuptools backend).
- `justfile`: `wheel` recipe = `package-release` → stage → `python -m build --wheel`.
- `pixi.toml`: add `python-build` to `feature.dev` so wheels can be built without an external
  pip install.
- `.gitignore`: exclude `*.egg-info/` and `python/build/`.

## Verification (local end-to-end)

- `pixi run mojo package -I src src/projectodyssey -o /tmp/projectodyssey.mojopkg` ✓
- `python -m build --wheel` produces `dist/projectodyssey-0.1.0-py3-none-any.whl` ✓
- `pip install --target <scratch> dist/projectodyssey-*.whl` ✓
- Python API call: `projectodyssey.__version__` / `mojopkg_path()` / `import_dir()` ✓
  (existing file, ~6.6 MB)
- `mojo run -I <scratch>/projectodyssey/_data smoke.mojo` ✓ — smoke test imports `Tensor` +
  `zeros` and prints `"wheel-installed mojopkg works"`.
- `pixi run pre-commit run --all-files` ✓ (full suite — ruff, mypy, bandit, markdownlint,
  validate-test-coverage).

## Caveat (documented in the commit)

The internal module name inside a `.mojopkg` is taken from the `-o` filename. The build
command must produce `projectodyssey.mojopkg` exactly. The `just wheel` recipe gets this
right because it pulls from `build/release/projectodyssey.mojopkg` (the canonical
`just package-release` output).

## Test Plan

- [ ] CI build + tests pass
- [ ] After merge: `just wheel` in the podman container produces a valid wheel
- [ ] (Eventual) PyPI release via PR 3's release workflow

Refs #5413
Independent of PR #5415 (PR 2). PR 3 (release workflow) will attach this wheel as a
release asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)