### PR TITLE
fix(ci): release workflow attaches .mojopkg/.conda/.whl artifacts (PR 3 of 4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,49 +129,48 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build twine
+          # twine validates wheels post-build; the wheel itself is produced
+          # by `just wheel` via the pixi-managed env inside the container.
+          pip install twine
 
-      - name: Build Mojo packages
+      - name: Build Mojo .mojopkg
+        # Builds build/release/projectodyssey.mojopkg via `just package-release`
+        # and copies it into dist/. Previously this step looked for sources at
+        # src/*.mojo (wrong path post-rename in #5413) and used `mojo build`
+        # (wrong subcommand — that produces executables, not a library
+        # package), so the release workflow never actually shipped a .mojopkg.
         run: |
-          echo "Building Mojo packages for release..."
-          mkdir -p dist/mojo
+          echo "Building projectodyssey.mojopkg…"
+          mkdir -p dist
+          just package-release
+          cp build/release/projectodyssey.mojopkg dist/
+          ls -la dist/projectodyssey.mojopkg
 
-          # Check if Mojo source files exist
-          if [ -d "src" ] && [ -n "$(find src -name '*.mojo' -o -name '*.🔥' 2>/dev/null)" ]; then
-            echo "Building Mojo packages..."
-
-            # Build all Mojo packages inside container
-            podman compose exec -T projectodyssey-dev bash -c '
-              find src -name "*.mojo" -o -name "*.🔥" | while read -r file; do
-                echo "Building: $file"
-                pixi run mojo build -I . "$file" -o "dist/mojo/$(basename "$file" .mojo)"
-              done
-            '
-
-            echo "✅ Mojo packages built successfully"
-          else
-            echo "⚠️  No Mojo source files found - skipping Mojo build"
-            echo "This is expected during initial development phases."
-          fi
-
-      - name: Build Python packages
+      - name: Build conda package via rattler-build
+        # Produces the .conda artifact consumers ultimately install via
+        # `pixi add projectodyssey` once the recipe is merged into
+        # modular/modular-community (see scripts/publish_modular_community.py).
         run: |
-          echo "Building Python packages for release..."
+          echo "Building conda package…"
+          just build-recipe
+          # rattler-build writes to build/recipe/<platform>/; copy any .conda
+          # produced into dist/.
+          find build/recipe -name '*.conda' -exec cp {} dist/ \;
+          ls -la dist/*.conda 2>&1 || echo "⚠️  no .conda produced — check build/recipe/"
 
-          # Check if Python package configuration exists
-          if [ -f "pyproject.toml" ] || [ -f "setup.py" ]; then
-            echo "Building Python distribution packages..."
-            python -m build
+      - name: Build Python wheel
+        # Produces dist/projectodyssey-<version>-py3-none-any.whl — pure-Python
+        # wheel that bundles projectodyssey.mojopkg as package data so consumers
+        # can `pip install projectodyssey` and feed `projectodyssey.import_dir()`
+        # to `mojo run -I`. (Requires PR #5416 merged for the `just wheel`
+        # recipe to exist.)
+        run: |
+          echo "Building Python wheel…"
+          just wheel
+          ls -la dist/projectodyssey-*.whl
 
-            # Validate packages
-            echo "Validating packages with twine..."
-            twine check dist/*.tar.gz dist/*.whl
-
-            echo "✅ Python packages built and validated"
-          else
-            echo "⚠️  No Python package configuration found - skipping Python build"
-            echo "This is expected during initial development phases."
-          fi
+      - name: Validate wheel with twine
+        run: twine check dist/projectodyssey-*.whl
 
       - name: Generate checksums
         run: |
@@ -179,7 +178,7 @@ jobs:
           cd dist
 
           # Generate checksums for all artifacts
-          find . -type f \( -name "*.tar.gz" -o -name "*.whl" -o -name "*.mojopkg" \) \
+          find . -type f \( -name "*.tar.gz" -o -name "*.whl" -o -name "*.mojopkg"  -o -name "*.conda" \) \
             -exec sha256sum {} \; > checksums.txt
 
           echo "Checksums generated:"
@@ -400,9 +399,10 @@ jobs:
           draft: false
           prerelease: ${{ needs.validate-version.outputs.is_prerelease }}
           files: |
-            dist/*.tar.gz
+            dist/*.mojopkg
+            dist/*.conda
             dist/*.whl
-            dist/mojo/*
+            dist/*.tar.gz
             dist/checksums.txt
             dist/BUILD_MANIFEST.txt
           fail_on_unmatched_files: false

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ examples/*/train
 examples/*/inference
 test_*
 !tests/**
+!conda.recipe/test_*
 .worktrees/
 .claude/worktrees/
 .issue_implementer/

--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -1,0 +1,56 @@
+context:
+  version: "0.1.0"
+  mojo_version: "=1.0.0b2"
+
+package:
+  name: "projectodyssey"
+  version: ${{ version }}
+
+source:
+  # Local development: build straight from the working tree.
+  # For modular-community submission, replace with:
+  #
+  #   - git: https://github.com/HomericIntelligence/ProjectOdyssey.git
+  #     rev: <commit-sha-or-tag>
+  #
+  # See scripts/publish_modular_community.py — it rewrites this block
+  # automatically when copying the recipe into modular/modular-community.
+  - path: ..
+
+build:
+  number: 0
+  script:
+    - mkdir -p ${PREFIX}/lib/mojo
+    - mojo package -I src src/projectodyssey -o ${PREFIX}/lib/mojo/projectodyssey.mojopkg
+
+requirements:
+  build:
+    - mojo-compiler ${{ mojo_version }}
+  host:
+    - mojo-compiler ${{ mojo_version }}
+  run:
+    - mojo-compiler ${{ mojo_version }}
+
+tests:
+  - script:
+      - if: unix
+        then:
+          - pixi run mojo run conda.recipe/test_import.mojo
+    requirements:
+      run:
+        - mojo-compiler ${{ mojo_version }}
+    files:
+      source:
+        - conda.recipe/test_import.mojo
+
+about:
+  homepage: https://github.com/HomericIntelligence/ProjectOdyssey
+  license: BSD-3-Clause
+  license_file: LICENSE
+  summary: Mojo-based AI research platform for reproducing classic research papers. Provides reusable tensor ops, autograd, layers, optimizers, and training infrastructure.
+  repository: https://github.com/HomericIntelligence/ProjectOdyssey.git
+
+extra:
+  project_name: projectodyssey
+  maintainers:
+    - mvillmow

--- a/conda.recipe/test_import.mojo
+++ b/conda.recipe/test_import.mojo
@@ -1,0 +1,22 @@
+# Smoke test executed by the `tests:` block in recipe.yaml.
+#
+# Imports canonical public symbols from the installed projectodyssey.mojopkg
+# and instantiates one to prove the package is not just parseable but
+# actually usable. If any import or instantiation fails, rattler-build
+# fails the package test and the recipe is rejected.
+#
+# Positive imports only: Mojo import failures are compile-time errors,
+# so there is no equivalent of pytest.raises(ImportError) here.
+
+from projectodyssey.tensor.tensor import Tensor
+from projectodyssey.tensor.any_tensor import AnyTensor, zeros
+
+
+def main() raises:
+    # Compile-time-typed tensor.
+    var _t = Tensor[DType.float32]([2, 3])
+
+    # Runtime-typed tensor via the zeros() factory (canonical creation path).
+    var _a = zeros([2, 3], DType.float32)
+
+    print("projectodyssey package import test: OK")

--- a/justfile
+++ b/justfile
@@ -497,6 +497,38 @@ package-debug: (package "debug")
 package-release: (package "release")
 
 # ==============================================================================
+# Conda Recipe (rattler-build) — install/publish to modular-community
+# ==============================================================================
+# Wraps the real tools — there is no `mojo install` or `mojo publish` CLI in
+# Mojo 1.0. "Install" means `pixi add projectodyssey` once the recipe lands
+# in https://repo.prefix.dev/modular-community; "publish" means a PR to
+# https://github.com/modular/modular-community adding `recipes/projectodyssey/`.
+
+# Build the conda package locally via rattler-build
+build-recipe:
+    @echo "Building conda package via rattler-build…"
+    @mkdir -p build/recipe
+    pixi exec --spec rattler-build -- rattler-build build \
+        --recipe conda.recipe/recipe.yaml \
+        -c conda-forge -c https://conda.modular.com/max \
+        -c https://repo.prefix.dev/modular-community \
+        --output-dir build/recipe
+    @echo "✅ Conda package built under build/recipe/"
+
+# Install the locally-built conda package into a scratch pixi env (smoke test)
+install-local: build-recipe
+    @echo "Smoke-testing locally-built package in a scratch pixi env…"
+    @bash scripts/install_local_recipe.sh
+
+# Open a PR to modular/modular-community publishing the current recipe
+publish:
+    @python3 scripts/publish_modular_community.py
+
+# Dry-run of publish: prints the PR body and recipe diff without pushing
+publish-dry-run:
+    @python3 scripts/publish_modular_community.py --dry-run
+
+# ==============================================================================
 # Model Training and Inference
 # ==============================================================================
 

--- a/scripts/install_local_recipe.sh
+++ b/scripts/install_local_recipe.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Smoke-test the locally-built conda package by installing it into a scratch
+# pixi env and running a one-line import. Called by `just install-local`.
+#
+# Why a shell script? `pixi add --channel <local-path>` requires shelling out
+# and the surrounding logic is `mkdir`/`pixi init`/`pixi run` — no Mojo or
+# Python value-add. If this grows past ~50 lines, promote to Python per
+# ADR-001.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RECIPE_OUT="$REPO_ROOT/build/recipe"
+
+if [ ! -d "$RECIPE_OUT" ]; then
+    echo "❌ $RECIPE_OUT does not exist — run 'just build-recipe' first" >&2
+    exit 1
+fi
+
+# Find the .conda package rattler-build produced. There should be exactly one
+# under build/recipe/<platform>/.
+CONDA_PKG=$(find "$RECIPE_OUT" -name 'projectodyssey-*.conda' -type f | head -1)
+if [ -z "$CONDA_PKG" ]; then
+    echo "❌ no projectodyssey-*.conda found under $RECIPE_OUT" >&2
+    echo "   (did 'just build-recipe' succeed?)" >&2
+    exit 1
+fi
+
+SCRATCH="$(mktemp -d -t projectodyssey-install-XXXXXX)"
+echo "📦 Scratch pixi env: $SCRATCH"
+
+cd "$SCRATCH"
+pixi init --quiet
+pixi workspace channel add --quiet "$RECIPE_OUT"
+pixi workspace channel add --quiet "https://conda.modular.com/max"
+
+pixi add --quiet projectodyssey
+pixi add --quiet "mojo==1.0.0b2.dev2026050805"
+
+cat > smoke_test.mojo <<'EOF'
+from projectodyssey.tensor.tensor import Tensor
+from projectodyssey.tensor.any_tensor import zeros
+
+
+def main() raises:
+    var _t = Tensor[DType.float32]([2, 3])
+    var _a = zeros([2, 3], DType.float32)
+    print("install-local smoke test: OK")
+EOF
+
+echo "▶️  pixi run mojo run smoke_test.mojo"
+pixi run mojo run smoke_test.mojo
+
+echo
+echo "✅ Local recipe install validated."
+echo "   Scratch env left at $SCRATCH for inspection — safe to remove."

--- a/scripts/publish_modular_community.py
+++ b/scripts/publish_modular_community.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Publish projectodyssey's conda recipe to modular/modular-community.
+
+There is no `mojo publish` CLI in Mojo 1.0. Publishing a Mojo library to the
+`https://repo.prefix.dev/modular-community` channel works by opening a PR
+against `modular/modular-community` that adds a `recipes/<package_name>/`
+folder containing the rattler-build recipe.
+
+This script automates that PR:
+
+1. Clones (or refreshes) modular/modular-community at
+   `$HOME/.cache/projectodyssey/modular-community`.
+2. Copies `conda.recipe/recipe.yaml` and `conda.recipe/test_import.mojo`
+   into `recipes/projectodyssey/`.
+3. Rewrites the `source:` block from `path: ..` (local) to a `git:` source
+   pinned at the current `HEAD` commit SHA so the recipe is reproducible
+   in modular-community's CI.
+4. Creates a branch, commits, and opens a PR via `gh`.
+
+Python (not Mojo) per ADR-001: this is GitHub automation involving
+subprocess output capture and string templating, both of which Mojo's
+runtime is not designed for.
+
+Usage::
+
+    python3 scripts/publish_modular_community.py            # opens PR
+    python3 scripts/publish_modular_community.py --dry-run  # prints plan, no push
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+PACKAGE_NAME = "projectodyssey"
+UPSTREAM_REPO_URL = "https://github.com/HomericIntelligence/ProjectOdyssey.git"
+MODULAR_COMMUNITY_REPO = "modular/modular-community"
+MODULAR_COMMUNITY_URL = f"https://github.com/{MODULAR_COMMUNITY_REPO}.git"
+CACHE_DIR = Path.home() / ".cache" / "projectodyssey" / "modular-community"
+
+
+def run(cmd: list[str], *, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess and return its CompletedProcess (text mode)."""
+    return subprocess.run(cmd, cwd=cwd, check=check, capture_output=True, text=True)
+
+
+def repo_root() -> Path:
+    """Resolve the ProjectOdyssey repo root from the script's location."""
+    return Path(__file__).resolve().parent.parent
+
+
+def current_commit_sha(root: Path) -> str:
+    """Return the current HEAD commit SHA on the source repo."""
+    return run(["git", "rev-parse", "HEAD"], cwd=root).stdout.strip()
+
+
+def rewrite_source_block(recipe_text: str, commit_sha: str) -> str:
+    """Replace the `source:` block in recipe.yaml with a git source.
+
+    The local recipe uses ``source: - path: ..`` for fast iteration during
+    development. modular-community needs a reproducible source — a git URL
+    pinned to a commit SHA. This rewrite is purely textual; we keep the
+    surrounding fields (build, requirements, tests, about) untouched.
+    """
+    # Match the entire `source:` block up to the next top-level key (`build:`).
+    pattern = re.compile(r"^source:\n(?:[ \t]+.*\n|\n)*?(?=^[A-Za-z])", re.MULTILINE)
+    replacement = (
+        f"source:\n"
+        f"  - git: {UPSTREAM_REPO_URL[:-4]}\n"  # strip ".git" — the modular-community recipes don't suffix it
+        f"    rev: {commit_sha}\n\n"
+    )
+    rewritten, n = pattern.subn(replacement, recipe_text, count=1)
+    if n != 1:
+        raise RuntimeError(
+            "could not locate `source:` block in conda.recipe/recipe.yaml — "
+            "did the recipe layout change? See scripts/publish_modular_community.py "
+            "for the regex this script expects."
+        )
+    return rewritten
+
+
+def ensure_clone(dry_run: bool) -> Path:
+    """Clone or refresh modular/modular-community at the cache path."""
+    if not CACHE_DIR.exists():
+        if dry_run:
+            print(f"[dry-run] would clone {MODULAR_COMMUNITY_URL} → {CACHE_DIR}")
+            return CACHE_DIR
+        CACHE_DIR.parent.mkdir(parents=True, exist_ok=True)
+        run(["gh", "repo", "clone", MODULAR_COMMUNITY_REPO, str(CACHE_DIR)])
+    else:
+        if dry_run:
+            print(f"[dry-run] would refresh {CACHE_DIR} against origin/main")
+        else:
+            run(["git", "fetch", "origin", "--quiet"], cwd=CACHE_DIR)
+            run(["git", "checkout", "main"], cwd=CACHE_DIR)
+            run(["git", "pull", "--ff-only", "origin", "main", "--quiet"], cwd=CACHE_DIR)
+    return CACHE_DIR
+
+
+def copy_recipe(source_root: Path, target_repo: Path, commit_sha: str, dry_run: bool) -> Path:
+    """Copy recipe.yaml + test_import.mojo into recipes/projectodyssey/.
+
+    Returns the path to the destination directory.
+    """
+    src_recipe = source_root / "conda.recipe" / "recipe.yaml"
+    src_test = source_root / "conda.recipe" / "test_import.mojo"
+    if not src_recipe.exists():
+        raise SystemExit(f"missing {src_recipe}; run from ProjectOdyssey repo root")
+    if not src_test.exists():
+        raise SystemExit(f"missing {src_test}")
+
+    dest_dir = target_repo / "recipes" / PACKAGE_NAME
+    if dry_run:
+        print(f"[dry-run] would write {dest_dir}/recipe.yaml (with git source pinned to {commit_sha})")
+        print(f"[dry-run] would write {dest_dir}/test_import.mojo")
+        return dest_dir
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    rewritten = rewrite_source_block(src_recipe.read_text(), commit_sha)
+    (dest_dir / "recipe.yaml").write_text(rewritten)
+    shutil.copy(src_test, dest_dir / "test_import.mojo")
+    return dest_dir
+
+
+def pr_body(commit_sha: str) -> str:
+    """Return the body for the modular-community PR."""
+    return f"""## Summary
+
+Adds the `projectodyssey` recipe so consumers can install ProjectOdyssey's
+Mojo library via `pixi add projectodyssey` from the modular-community
+channel.
+
+- **Source**: https://github.com/HomericIntelligence/ProjectOdyssey (BSD-3-Clause)
+- **Pinned to commit**: `{commit_sha}`
+
+The recipe builds with `mojo package -I src src/projectodyssey -o ${{PREFIX}}/lib/mojo/projectodyssey.mojopkg`
+and includes a `tests:` block that imports and instantiates a Tensor and an
+AnyTensor from the built `.mojopkg` to prove the package is importable.
+
+## Test Plan
+
+- [ ] `rattler-build build --recipe recipes/projectodyssey/recipe.yaml` succeeds
+- [ ] The recipe's `tests:` block passes (smoke import)
+
+Generated by `scripts/publish_modular_community.py` in ProjectOdyssey.
+"""
+
+
+def maybe_open_pr(target_repo: Path, branch: str, commit_sha: str, dry_run: bool) -> None:
+    """Create a branch, commit, push, and open a PR."""
+    title = f"feat: add {PACKAGE_NAME} recipe (pinned at {commit_sha[:7]})"
+
+    if dry_run:
+        print()
+        print("====== PR title ======")
+        print(title)
+        print()
+        print("====== PR body ======")
+        print(pr_body(commit_sha))
+        print()
+        print(f"[dry-run] would: git checkout -b {branch}; git add recipes/{PACKAGE_NAME}; commit; push; gh pr create")
+        return
+
+    # Branch + commit + push + PR.
+    run(["git", "checkout", "-B", branch], cwd=target_repo)
+    run(["git", "add", f"recipes/{PACKAGE_NAME}"], cwd=target_repo)
+
+    status = run(["git", "status", "--porcelain"], cwd=target_repo).stdout
+    if not status.strip():
+        print("nothing to commit — recipe already up to date in modular-community")
+        return
+
+    run(["git", "commit", "-m", title], cwd=target_repo)
+    run(["git", "push", "-u", "origin", branch], cwd=target_repo)
+
+    result = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            MODULAR_COMMUNITY_REPO,
+            "--base",
+            "main",
+            "--head",
+            branch,
+            "--title",
+            title,
+            "--body",
+            pr_body(commit_sha),
+        ],
+        cwd=target_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        # Idempotent: PR may already exist.
+        if "already exists" in result.stderr:
+            print(f"PR already exists for branch {branch}; nothing to do")
+            return
+        print(result.stderr, file=sys.stderr)
+        raise SystemExit(result.returncode)
+    print(result.stdout.strip())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the plan (recipe rewrite, PR title/body) without pushing or opening a PR.",
+    )
+    args = parser.parse_args()
+
+    root = repo_root()
+    if not (root / "conda.recipe" / "recipe.yaml").exists():
+        raise SystemExit(
+            f"could not find conda.recipe/recipe.yaml under {root}; run this script from a checkout of ProjectOdyssey"
+        )
+
+    sha = current_commit_sha(root)
+    print(f"ProjectOdyssey HEAD: {sha}")
+
+    target = ensure_clone(args.dry_run)
+    dest = copy_recipe(root, target, sha, args.dry_run)
+    print(f"recipe target: {dest}")
+
+    branch = f"projectodyssey-recipe-{sha[:7]}"
+    maybe_open_pr(target, branch, sha, args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_test_coverage.py
+++ b/scripts/validate_test_coverage.py
@@ -56,6 +56,10 @@ def find_test_files(root_dir: Path) -> List[Path]:
         "examples/googlenet_cifar10/test_model.mojo",
         "examples/mobilenetv1_cifar10/test_model.mojo",
         "examples/resnet18_cifar10/test_model.mojo",
+        # Conda recipe smoke test — executed by rattler-build's `tests:`
+        # block when the package is built (see conda.recipe/recipe.yaml),
+        # not by the per-PR CI test matrix.
+        "conda.recipe/test_import.mojo",
     ]
 
     # Exclude E2E model tests (run weekly, not per-PR)


### PR DESCRIPTION
Third of four PRs implementing #5413 (ship ProjectOdyssey as an installable Mojo package).

## What was broken

The previous `release.yml` build steps **never actually shipped any packaging artifacts**:

1. **Build Mojo packages**: looked for sources at `src/*.mojo` (the rename in #5413 put
   them at `src/projectodyssey/*.mojo`) AND used `mojo build` instead of `mojo package`.
   Result: always printed "⚠️  No Mojo source files found - skipping" and shipped nothing.
2. **Build Python packages**: ran `python -m build` against the root `pyproject.toml`,
   which only packages `scripts/` (Python tooling), not the Mojo library. The produced
   wheel was meaningless to consumers.
3. **Release-asset files** list pointed at `dist/mojo/*` (never written) and missed
   `*.mojopkg` / `*.conda` entirely.

## Changes

- Replace the two broken build steps with three steps calling the just recipes from the
  other packaging PRs:
  - `just package-release` → `dist/projectodyssey.mojopkg`
  - `just build-recipe` (from PR #5415) → `dist/projectodyssey-*.conda`
  - `just wheel` (from PR #5416) → `dist/projectodyssey-*.whl`
- Add `twine check` on the wheel to catch metadata issues before PyPI.
- Update checksums glob to include `*.conda`.
- Rewrite the release-asset upload `files:` list: `.mojopkg`, `.conda`, `.whl`, `.tar.gz`,
  checksums, and the build manifest. Removed the dead `dist/mojo/*` entry.

## Verification

This PR only edits `release.yml`. The recipes it calls were already verified end-to-end in
PRs 1/2/4:

- `just package-release` produces a valid 6.6 MB `.mojopkg` (PR 1 / #5414, already merged).
- The conda recipe is structurally valid + `just publish-dry-run` works (PR 2 / #5415).
- The wheel `pip install` + Python API + `mojo run -I` round trip works (PR 4 / #5416).
- `pre-commit run --all-files` clean.

The workflow's first real exercise will be the next tagged release after this lands.

## Dependencies

- Stacked on **#5415** (PR 2) — needed for `just build-recipe`.
- Also needs **#5416** (PR 4) to be merged before tagging a release for `just wheel` to exist.

## Test Plan

- [ ] CI checks pass on this PR (the workflow is `on: push tags`, not on PR, so this PR's
      CI only validates the YAML & pre-commit hooks)
- [ ] After merge: tag `v0.0.0-pkg-test` and confirm `.mojopkg`, `.conda`, `.whl`,
      `checksums.txt` all appear as release assets.

Refs #5413

🤖 Generated with [Claude Code](https://claude.com/claude-code)