### PR TITLE
fix(packaging): make conda recipe + install-local actually work end-to-end

### DIFF
--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   version: "0.1.0"
-  mojo_version: "=1.0.0b2"
+  mojo_version: ">=1.0.0b1"
 
 package:
   name: "projectodyssey"
@@ -35,7 +35,7 @@ tests:
   - script:
       - if: unix
         then:
-          - pixi run mojo run conda.recipe/test_import.mojo
+          - mojo run -I ${PREFIX}/lib/mojo conda.recipe/test_import.mojo
     requirements:
       run:
         - mojo-compiler ${{ mojo_version }}

--- a/python/projectodyssey/__init__.py
+++ b/python/projectodyssey/__init__.py
@@ -20,13 +20,18 @@ here; see Mojo's Python-interop docs if you need them.
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version as _get_version
 from pathlib import Path
 
 __all__ = ["mojopkg_path", "import_dir", "__version__"]
 
-# Kept in sync manually with mojo.toml and python/pyproject.toml.
-# When this drifts, the wheel build is the source of truth (it embeds this).
-__version__ = "0.1.0"
+# Single source of truth: python/pyproject.toml [project].version, read at
+# import time via importlib.metadata. The fallback is hit only in source/editable
+# installs that lack dist-info (e.g. running from a fresh checkout).
+try:
+    __version__: str = _get_version("projectodyssey")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
 
 # The .mojopkg ships as package data under projectodyssey/_data/.
 # Resolve relative to this module's file — works identically whether the

--- a/scripts/install_local_recipe.sh
+++ b/scripts/install_local_recipe.sh
@@ -32,11 +32,16 @@ echo "📦 Scratch pixi env: $SCRATCH"
 
 cd "$SCRATCH"
 pixi init --quiet
-pixi workspace channel add --quiet "$RECIPE_OUT"
-pixi workspace channel add --quiet "https://conda.modular.com/max"
 
+# Use `pixi project` for back-compat with pixi <0.40; newer pixi accepts
+# `pixi workspace` as an alias.
+pixi project channel add --quiet "$RECIPE_OUT"
+pixi project channel add --quiet "https://conda.modular.com/max"
+
+# Let the recipe's `mojo-compiler` run requirement resolve the right version
+# from conda.modular.com/max — pinning to a dev build that isn't on the
+# public channel breaks reproducibility.
 pixi add --quiet projectodyssey
-pixi add --quiet "mojo==1.0.0b2.dev2026050805"
 
 cat > smoke_test.mojo <<'EOF'
 from projectodyssey.tensor.tensor import Tensor


### PR DESCRIPTION
## Summary

Three packaging defects discovered while running issue #5413's acceptance
criteria end-to-end for the first time. The four implementation PRs
(#5414/5415/5416/5417) landed without ever running `just install-local` to
the finish line; once exercised, three bugs surface in sequence.

## Fixes

### 1. `conda.recipe/recipe.yaml` — unresolvable mojo pin
`mojo_version: "=1.0.0b2"` → `>=1.0.0b1`. `conda.modular.com/max` only
publishes `1.0.0b1`; the dev build pinned in `pixi.toml`
(`1.0.0b2.dev2026050805`) was never published to the public channel.
`rattler-build` failed with `No candidates were found for mojo-compiler 1.0.0b2.*`.

### 2. `conda.recipe/recipe.yaml` — broken in-recipe test
`pixi run mojo run conda.recipe/test_import.mojo` →
`mojo run -I \${PREFIX}/lib/mojo conda.recipe/test_import.mojo`.
`pixi` isn't on PATH in rattler-build's isolated test env, and without `-I`
the test mojo can't locate the package it just installed under
`\${PREFIX}/lib/mojo/projectodyssey.mojopkg`.

### 3. `scripts/install_local_recipe.sh` — two breakages
- `pixi workspace channel add` doesn't exist in pixi 0.39.5 (installed
  version); switched to `pixi project channel add` (works on both old and new).
- Removed the hard-pin to `mojo==1.0.0b2.dev2026050805` — the dev build
  isn't on the public channel, so the scratch env never resolved. The
  recipe's own `mojo-compiler >=1.0.0b1` run-requirement now resolves it.

### Drive-by: wheel version drift
`python/projectodyssey/__init__.py` hardcoded `__version__ = "0.1.0"`,
guaranteed to drift from `mojo.toml` / `recipe.yaml` / `python/pyproject.toml`.
Now reads via `importlib.metadata.version("projectodyssey")` with a
`PackageNotFoundError` fallback for source/editable installs. Pattern
matches Mnemosyne skill `versioning-consistency-release-workflow`.

## Verification

All run locally on this branch:

```text
just package-release   → build/release/projectodyssey.mojopkg (6.6 MiB) ✓
just install-local     → rattler-build .conda (6.36 MiB) + scratch pixi env
                         imports `from projectodyssey.tensor.tensor import Tensor`
                         and runs `Tensor[DType.float32]([2, 3])` ✓
                         (in-recipe `tests:` block also passes now)
just wheel             → dist/projectodyssey-0.1.0-py3-none-any.whl ✓
pip install + import   → projectodyssey.__version__ == "0.1.0"
                         projectodyssey.mojopkg_path() resolves ✓
just build             → 46 executables built, 0 failed ✓
just pre-commit        → all hooks pass ✓
```

## Why this isn't `Closes #5413`

Closing #5413 still requires:
- Tagging `v0.1.0-pkg-test` and verifying release artifacts attach
- Opening the PR against `modular/modular-community`

Those happen after this lands, on top of the merged main.

Refs #5413

## Test plan

- [x] `just package-release` produces the `.mojopkg`
- [x] `just install-local` succeeds (rattler-build + scratch pixi env smoke test)
- [x] `just wheel` produces an installable wheel
- [x] `pip install` + `import projectodyssey` works; `__version__` resolves via importlib.metadata
- [x] `just build` succeeds (46/46 executables)
- [x] `just pre-commit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)