### PR TITLE
fix(ci): add setup-just step to release.yml build job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,9 @@ jobs:
       - name: Set up container
         uses: ./.github/actions/setup-container
 
+      - name: Set up just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
+
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:


### PR DESCRIPTION
## Summary

PR #5417 wired `just package-release` / `just build-recipe` / `just wheel`
into release.yml's build job but never installed `just` on the runner.

Tagging `v0.1.0-pkgtest` to smoke-test the release pipeline for #5413
surfaced this immediately ([run 26079157835](https://github.com/HomericIntelligence/ProjectOdyssey/actions/runs/26079157835)):

```text
Build Mojo .mojopkg: just: command not found
```

## Fix

Add `extractions/setup-just@53165ef7…` after the container setup, matching
the canonical pinned reference used in 8+ other workflows:

- `comprehensive-tests.yml`
- `_required.yml`
- `validate-configs.yml`
- `training-tests-weekly.yml`
- `build-validation.yml`
- `asan-tests.yml`
- `repro-6413.yml`

## Verification

- [x] `git diff` shows 3-line addition only (no other workflow changes)
- [x] `just pre-commit` clean
- [ ] After merge, re-tag `v0.1.0-pkgtest` and confirm release run reaches `create-release`

Refs #5413

🤖 Generated with [Claude Code](https://claude.com/claude-code)