### PR TITLE
fix(packaging): run `just build-recipe` inside container

### DIFF
--- a/justfile
+++ b/justfile
@@ -504,16 +504,28 @@ package-release: (package "release")
 # in https://repo.prefix.dev/modular-community; "publish" means a PR to
 # https://github.com/modular/modular-community adding `recipes/projectodyssey/`.
 
-# Build the conda package locally via rattler-build
+# Build the conda package locally via rattler-build (runs inside container
+# so it can write into build/, which is owned by the container user when
+# earlier `just package-release` steps populated build/release/).
 build-recipe:
-    @echo "Building conda package via rattler-build…"
-    @mkdir -p build/recipe
+    @just _run "just _build-recipe-inner"
+
+[private]
+_build-recipe-inner:
+    #!/usr/bin/env bash
+    set -e
+    echo "Building conda package via rattler-build…"
+    mkdir -p build/recipe
     pixi exec --spec rattler-build -- rattler-build build \
         --recipe conda.recipe/recipe.yaml \
         -c conda-forge -c https://conda.modular.com/max \
         -c https://repo.prefix.dev/modular-community \
         --output-dir build/recipe
-    @echo "✅ Conda package built under build/recipe/"
+    # Make outputs readable by the host user too — `just install-local` and
+    # release.yml's downstream steps (find … -exec cp, checksums) run on the
+    # host where the container's uid maps to a different subuid.
+    chmod -R o+rX build/recipe
+    echo "✅ Conda package built under build/recipe/"
 
 # Install the locally-built conda package into a scratch pixi env (smoke test)
 install-local: build-recipe


### PR DESCRIPTION
## Summary

Third packaging defect surfaced while smoke-testing #5413's release
pipeline ([run 26080164811](https://github.com/HomericIntelligence/ProjectOdyssey/actions/runs/26080164811)):

```text
Build conda package via rattler-build:
  mkdir: cannot create directory 'build/recipe': Permission denied
```

## Root cause

`just package-release` (runs inside the container) populates
`build/release/`, leaving `build/` owned by the container's mapped uid.
`just build-recipe` (ran on the host) then tries to create `build/recipe/`
as the host user — different uid — and `mkdir` fails. I hit the same issue
locally while running PR #5419's smoke tests and worked around it manually
with `podman exec chmod o+w /workspace/build`. CI has no such escape hatch.

## Fix

Run `build-recipe` inside the container too (via `_run`), so both Mojo and
conda artifacts land under the same container-mapped uid. Then `chmod -R o+rX`
the output tree so host-side consumers (`install_local_recipe.sh`'s scratch
pixi env, `release.yml`'s `find -exec cp`, checksum generation) can still
read it.

## Verification

Locally on this branch:

```text
just package-release     → build/release/projectodyssey.mojopkg (container) ✓
just install-local       → build-recipe (container) →
                           build/recipe/linux-64/projectodyssey-0.1.0-*.conda ✓
                           scratch pixi env → import projectodyssey ✓
```

Refs #5413

🤖 Generated with [Claude Code](https://claude.com/claude-code)