### PR TITLE
fix(ci): pin sanitizer builds to x86-64-v3 (no AVX-512) to fix SIGILL flake

### DIFF
--- a/justfile
+++ b/justfile
@@ -38,8 +38,19 @@ MOJO_RELEASE := "-g0 -O3"
 MOJO_TEST := "-g1"
 
 # Sanitizer flags
-MOJO_ASAN := "--sanitize address"
-MOJO_TSAN := "--sanitize thread"
+#
+# Pin sanitizer builds to a pre-AVX-512 CPU baseline. The Mojo compiler
+# defaults `--target-cpu` to the host CPU; CI runners report AVX-512-capable
+# CPUs (e.g. Cascadelake) but the actual executing cores intermittently
+# don't have AVX-512 enabled, producing SIGILL (signal 4, "Illegal
+# instruction") during sanitizer-instrumented runs. `x86-64-v3` is the
+# Haswell-era microarchitecture level: AVX/AVX2/BMI2/FMA, no AVX-512.
+# Every x86_64 GitHub-hosted runner supports v3, so this is safe everywhere.
+# See ProjectMnemosyne skill `mojo-jit-crash-and-retry-strategies` (AVX-512
+# ISA mismatch pattern) for prior diagnosis on this class of crash.
+MOJO_SAN_TARGET_CPU := "--mcpu=x86-64-v3"
+MOJO_ASAN := "--sanitize address " + MOJO_SAN_TARGET_CPU
+MOJO_TSAN := "--sanitize thread " + MOJO_SAN_TARGET_CPU
 
 # ==============================================================================
 # Internal Helpers


### PR DESCRIPTION
## Summary

ASan jobs have been intermittently failing on CI with SIGILL — most
recently on PR #5422 ([run 26100599650](https://github.com/HomericIntelligence/ProjectOdyssey/actions/runs/26100599650))
and across multiple main runs (2026-05-10..18). Pattern:

```text
--- run ---
/tmp/justXXX/_test-group-asan-inner: line 986: 109 Illegal instruction (core dumped) "$BINARY" 2>&1
run exit status: 132 (binary: /tmp/mojo-asan-XXXXXX)
killed by signal 4
```

The test (`test_hash.mojo`) passes locally and on most main runs. No code
in the test was changed.

## Root cause

AVX-512 ISA mismatch (cataloged in ProjectMnemosyne skill
`mojo-jit-crash-and-retry-strategies`): Mojo defaults `--target-cpu` to
the host CPU. GitHub-hosted runners report AVX-512-capable CPUs (e.g.
Cascadelake) so the compiler emits AVX-512 ops, but the cores that
actually execute the sanitizer-instrumented binary intermittently lack
AVX-512 → SIGILL.

`mojo build --print-effective-target` on my Lunar Lake dev host already
excludes AVX-512 (because the E-cores don't have it), so this never
reproduces locally — only on CI.

## Fix

Pin sanitizer builds to `--mcpu=x86-64-v3` (Haswell, 2013):
AVX/AVX2/BMI2/FMA but no AVX-512. Every x86_64 GitHub-hosted runner
supports v3, so this is safe everywhere. Only sanitizer modes are
pinned — regular release/test builds keep host-CPU defaults where
performance matters.

```text
MOJO_SAN_TARGET_CPU := "--mcpu=x86-64-v3"
MOJO_ASAN := "--sanitize address " + MOJO_SAN_TARGET_CPU
MOJO_TSAN := "--sanitize thread " + MOJO_SAN_TARGET_CPU
```

## Verification

```text
just --evaluate MOJO_ASAN
→ --sanitize address --mcpu=x86-64-v3                                ✓

just test-group-asan "tests/projectodyssey/core" "test_hash.mojo"
→ 1 passed, 0 failed                                                 ✓
```

Refs #5413

## Test plan

- [x] `just --evaluate` confirms variable expansion
- [x] ASan test passes locally with the new flag
- [ ] CI: ASan workflow finishes successfully on this branch
- [ ] No regression in regular `test-mojo` / build-validation jobs (host CPU still used there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)