### PR TITLE
fix(packaging): run `just wheel` inside container (mirror #5422 fix)

### DIFF
--- a/justfile
+++ b/justfile
@@ -549,14 +549,31 @@ publish-dry-run:
 # tracking issue's "Out of scope" section).
 
 # Build the wheel: produces dist/projectodyssey-<version>-py3-none-any.whl
+#
+# Runs inside the dev container so `pixi` is available (GitHub-hosted runners
+# don't ship pixi at the host level, and `package-release` already populates
+# build/release/ as the container uid — keeping wheel in-container avoids
+# the same uid-mismatch perms issue that `build-recipe` hit in #5422).
 wheel: package-release
-    @echo "Staging projectodyssey.mojopkg into python/projectodyssey/_data/"
-    @mkdir -p python/projectodyssey/_data
-    @cp build/release/projectodyssey.mojopkg python/projectodyssey/_data/
-    @echo "Building wheel via python -m build…"
+    @just _run "just _wheel-inner"
+
+[private]
+_wheel-inner:
+    #!/usr/bin/env bash
+    set -e
+    echo "Staging projectodyssey.mojopkg into python/projectodyssey/_data/"
+    mkdir -p python/projectodyssey/_data
+    cp build/release/projectodyssey.mojopkg python/projectodyssey/_data/
+    echo "Building wheel via python -m build…"
     cd python && pixi run python -m build --wheel --outdir ../dist
-    @ls -la dist/projectodyssey-*.whl
-    @echo "✅ Wheel built. Verify with:  pip install dist/projectodyssey-*.whl"
+    cd ..
+    # Make wheel outputs readable by the host (release.yml's `find -exec cp`,
+    # checksum generation, twine validation all run host-side). Chmod only the
+    # files we just created — not the pre-existing host-owned tree.
+    chmod -R o+rX dist
+    chmod o+r python/projectodyssey/_data/projectodyssey.mojopkg
+    ls -la dist/projectodyssey-*.whl
+    echo "✅ Wheel built. Verify with:  pip install dist/projectodyssey-*.whl"
 
 # ==============================================================================
 # Model Training and Inference


### PR DESCRIPTION
## Summary

Same defect as #5422 (build-recipe), just one recipe further along the
release pipeline:

```text
Building wheel via python -m build…
cd python && pixi run python -m build --wheel --outdir ../dist
sh: 1: pixi: not found
error: recipe `wheel` failed on line 557 with exit code 127
```

Surfaced by release.yml run [26102738696](https://github.com/HomericIntelligence/ProjectOdyssey/actions/runs/26102738696)
after #5422 unblocked `build-recipe`.

## Fix

Wrap `wheel` in `_run` so it executes inside the dev container where pixi
is available. Then chmod the produced wheel `o+r` so host-side consumers
(twine validation, checksum generation, `find -exec cp`) can read it.

```text
wheel: package-release
    @just _run "just _wheel-inner"

[private]
_wheel-inner:
    ...
    cd python && pixi run python -m build --wheel --outdir ../dist
    chmod -R o+rX dist
    chmod o+r python/projectodyssey/_data/projectodyssey.mojopkg
```

Surgical chmod targets only `dist/` and the staged `.mojopkg` — a blanket
`chmod` on `python/projectodyssey/_data/` would fail on the host-owned
`.gitkeep` because the container user doesn't own it.

## Verification

```text
just wheel
→ dist/projectodyssey-0.1.0-py3-none-any.whl (6.6 MB)                   ✓
host: cat dist/projectodyssey-*.whl > /dev/null                          ✓
```

Refs #5413

🤖 Generated with [Claude Code](https://claude.com/claude-code)