### PR TITLE
fix(ci): chmod dist/ in release.yml so in-container `just wheel` can write

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,9 +142,16 @@ jobs:
         # src/*.mojo (wrong path post-rename in #5413) and used `mojo build`
         # (wrong subcommand — that produces executables, not a library
         # package), so the release workflow never actually shipped a .mojopkg.
+        #
+        # `dist/` must be world-writable: `just wheel` runs INSIDE the dev
+        # container (per #5424) and writes its .tmp-XXX staging directly into
+        # dist/, but the container user maps to a different host uid via the
+        # rootless Podman subuid mapping. Without `chmod 777`, the container
+        # would hit `PermissionError: [Errno 13]` on `dist/.tmp-XXX`.
         run: |
           echo "Building projectodyssey.mojopkg…"
           mkdir -p dist
+          chmod 777 dist
           just package-release
           cp build/release/projectodyssey.mojopkg dist/
           ls -la dist/projectodyssey.mojopkg


### PR DESCRIPTION
## Summary

After #5424 moved `just wheel` inside the dev container, release run
[26104580442](https://github.com/HomericIntelligence/ProjectOdyssey/actions/runs/26104580442) hit:

```text
Building wheel via python -m build…
PermissionError: [Errno 13] Permission denied: '/workspace/dist/.tmp-x81vhkrl'
error: Recipe `_wheel-inner` failed with exit code 1
```

Root cause: release.yml's "Build Mojo .mojopkg" step creates `dist/` on
the host (uid 1001) and copies the mojopkg into it. The next step runs
`just wheel` INSIDE the container, where the container user maps to a
different host uid via rootless Podman subuid mapping. The container
can't write `dist/.tmp-XXX` into a directory owned by a foreign uid.

## Fix

`chmod 777 dist` right after `mkdir -p dist`. The container can then
write its staging directory, and the host can still write into dist/
on the prior and subsequent steps. Mirrors the pattern already used in
the `podman-up` recipe for the workspace itself.

## Test plan

- [x] `git diff` shows a single 1-line addition (plus a comment)
- [x] `just pre-commit` passes
- [ ] After merge: retag `v0.1.0-pkgtest`, release run reaches `create-release`

Refs #5413

🤖 Generated with [Claude Code](https://claude.com/claude-code)