### PR TITLE
fix(packaging): narrow `just wheel` chmod to just the wheel file

### DIFF
--- a/justfile
+++ b/justfile
@@ -580,8 +580,10 @@ _wheel-inner:
     cd ..
     # Make wheel outputs readable by the host (release.yml's `find -exec cp`,
     # checksum generation, twine validation all run host-side). Chmod only the
-    # files we just created — not the pre-existing host-owned tree.
-    chmod -R o+rX dist
+    # wheels themselves — `dist/` may already contain host-owned siblings
+    # (`projectodyssey.mojopkg`, `*.conda`) that the container user can't chmod
+    # even though it owns `dist/.tmp-XXX` (release.yml `chmod 777`'d dist/ in #5425).
+    chmod o+r dist/projectodyssey-*.whl
     chmod o+r python/projectodyssey/_data/projectodyssey.mojopkg
     ls -la dist/projectodyssey-*.whl
     echo "✅ Wheel built. Verify with:  pip install dist/projectodyssey-*.whl"


### PR DESCRIPTION
## Summary

PR #5424's `chmod -R o+rX dist` walks the whole tree, but `dist/` now
contains host-owned siblings (`projectodyssey.mojopkg`, `*.conda`) that
the container user doesn't own. chmod on files you don't own → EPERM:

```text
chmod: changing permissions of 'dist': Operation not permitted
chmod: changing permissions of 'dist/projectodyssey-...-.conda': Operation not permitted
chmod: changing permissions of 'dist/projectodyssey.mojopkg': Operation not permitted
```

Surfaced by release.yml run [26106431657](https://github.com/HomericIntelligence/ProjectOdyssey/actions/runs/26106431657)
— wheel built successfully; only the post-chmod failed.

## Fix

Chmod only the wheel files this recipe just produced:

```text
chmod o+r dist/projectodyssey-*.whl
chmod o+r python/projectodyssey/_data/projectodyssey.mojopkg
```

The other files in `dist/` are already host-owned and host-readable; they
don't need a chmod.

## Test plan

- [x] `just wheel` works locally; produced wheel readable by host
- [ ] After merge: re-tag and confirm release.yml reaches `create-release`

Refs #5413

🤖 Generated with [Claude Code](https://claude.com/claude-code)