### PR TITLE
fix(ci): bump release.yml test job timeout 20→60 min

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,7 +232,12 @@ jobs:
   test:
     needs: [validate-version, build]
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # `just test-mojo` runs the full Mojo suite (each test is a `def main()`
+    # program compiled + run individually). The release gate runs the same
+    # suite PR CI does; 20 min was not enough headroom and the job was
+    # cancelled mid-run. 60 min matches the budget comprehensive-tests.yml
+    # gives the equivalent work.
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

release.yml's `test` job runs `just test-mojo` — the full Mojo suite,
each test compiled and run as an individual `def main()` program. On
release run [26109950724](https://github.com/HomericIntelligence/ProjectOdyssey/actions/runs/26109950724)
the job was **cancelled at exactly 20 minutes** (16:17→16:38) with `just`
still mid-run:

```text
Terminate orphan process: pid (3109) (just)
```

## Fix

Bump `timeout-minutes` 20 → 60 for the test job. The release pipeline
intentionally gates on the same full suite PR CI runs; 60 min matches
the budget `comprehensive-tests.yml` gives the equivalent work.

## Test plan

- [x] `git diff` shows a single-value change (20 → 60)
- [ ] After merge: re-tag, release.yml `test` job completes; `create-release` runs

Refs #5413

🤖 Generated with [Claude Code](https://claude.com/claude-code)