### PR TITLE
fix(tests): update test_io_helpers fixtures-path assertion after shared→projectodyssey rename

### DIFF
--- a/tests/projectodyssey/fixtures/io_helpers.mojo
+++ b/tests/projectodyssey/fixtures/io_helpers.mojo
@@ -275,7 +275,7 @@ def get_test_data_path(filename: String) -> String:
     Example:
         ```mojo
         var image_path = get_test_data_path("sample_image.png")
-        # image_path = "/path/to/tests/shared/fixtures/images/sample_image.png"
+        # image_path = "/path/to/tests/projectodyssey/fixtures/images/sample_image.png"
         ```
 
     Note:

--- a/tests/projectodyssey/fixtures/test_io_helpers.mojo
+++ b/tests/projectodyssey/fixtures/test_io_helpers.mojo
@@ -326,7 +326,7 @@ def test_get_test_data_path() raises:
     var path = get_test_data_path("sample.txt")
 
     # Test: path should start with fixtures directory
-    var expected_prefix = "tests/shared/fixtures/"
+    var expected_prefix = "tests/projectodyssey/fixtures/"
     var starts_correctly = path.startswith(expected_prefix)
     assert_true(starts_correctly, "Path should start with fixtures directory")
 


### PR DESCRIPTION
## Summary

PR #5414's `shared/` → `src/projectodyssey/` rename updated the
`get_test_data_path` implementation but missed the test asserting its
prefix:

```text
Unhandled exception caught during execution: Path should start with fixtures directory
```

`io_helpers.mojo:287` correctly returns `tests/projectodyssey/fixtures/`,
but `test_io_helpers.mojo:329` still expected `tests/shared/fixtures/`.

This failed 1 of 298 tests on release.yml run [26134164326](https://github.com/HomericIntelligence/ProjectOdyssey/actions/runs/26134164326)
— it surfaced now because the release pipeline runs the **full** Mojo
suite via `just test-mojo`, while the per-PR `comprehensive-tests.yml`
splits tests into named groups and `tests/projectodyssey/fixtures/`
isn't in a required group, so the stale assertion slipped past #5414.

## Fix

- `test_io_helpers.mojo:329`: `tests/shared/fixtures/` → `tests/projectodyssey/fixtures/`
- `io_helpers.mojo:278`: same fix to a stale docstring example

## Verification

```text
mojo --Werror -I src -I . tests/projectodyssey/fixtures/test_io_helpers.mojo
→ All test_io_helpers tests passed!
```

Refs #5413

🤖 Generated with [Claude Code](https://claude.com/claude-code)