### PR TITLE
fix(packaging): don't double-add upstream remote in publish script

### DIFF
--- a/scripts/publish_modular_community.py
+++ b/scripts/publish_modular_community.py
@@ -102,20 +102,18 @@ def ensure_clone(dry_run: bool) -> Path:
     if not CACHE_DIR.exists():
         if dry_run:
             print(f"[dry-run] would clone {FORK_REPO} → {CACHE_DIR}")
-            print(f"[dry-run] would add upstream remote {MODULAR_COMMUNITY_REPO}")
             return CACHE_DIR
         CACHE_DIR.parent.mkdir(parents=True, exist_ok=True)
+        # `gh repo clone` of a fork auto-adds an `upstream` remote pointing at
+        # the parent (modular/modular-community) — no explicit `remote add`.
         run(["gh", "repo", "clone", FORK_REPO, str(CACHE_DIR)])
-        run(
-            ["git", "remote", "add", "upstream", f"https://github.com/{MODULAR_COMMUNITY_REPO}.git"],
-            cwd=CACHE_DIR,
-        )
 
     if dry_run:
         print(f"[dry-run] would sync {CACHE_DIR} main from upstream/{MODULAR_COMMUNITY_REPO}")
         return CACHE_DIR
 
-    # `upstream` may be missing if the cache predates the fork workflow — add it.
+    # `upstream` is normally added by `gh repo clone` of a fork; add it only
+    # if a pre-fork-workflow cache is missing it.
     remotes = run(["git", "remote"], cwd=CACHE_DIR).stdout.split()
     if "upstream" not in remotes:
         run(


### PR DESCRIPTION
## Summary

PR #5432's fork workflow added an explicit `git remote add upstream` in
`ensure_clone`'s first-clone path. But `gh repo clone` of a fork already
auto-adds an `upstream` remote pointing at the parent, so the first real
`just publish` run failed:

```text
CalledProcessError: Command '['git', 'remote', 'add', 'upstream',
'https://github.com/modular/modular-community.git']' returned non-zero exit status 3.
```

## Fix

Drop the redundant `remote add` from the clone path. The existing
idempotent block (add only if `upstream` is absent) already covers the
pre-fork-workflow-cache edge case.

## Verification

After this fix, `just publish` succeeded and opened the modular-community
PR: https://github.com/modular/modular-community/pull/274

Ruff + mypy + bandit pass.

Refs #5413

🤖 Generated with [Claude Code](https://claude.com/claude-code)