### PR TITLE
refactor(core): route matrix.mojo dtype dispatch through dtype_dispatch (#5293)

### DIFF
--- a/src/projectodyssey/core/dtype_dispatch.mojo
+++ b/src/projectodyssey/core/dtype_dispatch.mojo
@@ -1520,3 +1520,186 @@ def dispatch_hard_tanh_backward(
         )
 
     return result^
+
+
+# ============================================================================
+# Typed-Kernel Dispatch (in-place result, integer shape args)
+# ============================================================================
+#
+# Matrix/linear-algebra kernels do not fit the unary/binary `op` shape: they
+# write into a pre-allocated `result` tensor and take integer shape arguments
+# instead of returning a new tensor. These helpers provide the same 12-branch
+# ordinal dispatch for that family of kernels, keyed on an explicit `dtype`
+# so the caller chooses which operand drives specialization.
+
+
+def dispatch_kernel_3t1i[
+    kernel: def[T: DType](AnyTensor, AnyTensor, AnyTensor, Int) thin -> None
+](dtype: DType, t0: AnyTensor, t1: AnyTensor, t2: AnyTensor, i0: Int) raises:
+    """Dispatch a (3-tensor, 1-int) typed kernel by runtime dtype.
+
+    Parameters:
+        kernel: Compile-time specialized kernel taking three tensors and one
+            integer argument.
+
+    Args:
+        dtype: Runtime dtype that selects the compile-time specialization.
+        t0: First tensor argument (typically the output).
+        t1: Second tensor argument.
+        t2: Third tensor argument.
+        i0: Integer shape argument.
+
+    Raises:
+        Error: If `dtype` is not one of the 11 supported dtypes.
+    """
+    var ordinal = dtype_to_ordinal(dtype)
+    if ordinal == DTYPE_FLOAT16:
+        kernel[DType.float16](t0, t1, t2, i0)
+    elif ordinal == DTYPE_FLOAT32:
+        kernel[DType.float32](t0, t1, t2, i0)
+    elif ordinal == DTYPE_FLOAT64:
+        kernel[DType.float64](t0, t1, t2, i0)
+    elif ordinal == DTYPE_INT8:
+        kernel[DType.int8](t0, t1, t2, i0)
+    elif ordinal == DTYPE_INT16:
+        kernel[DType.int16](t0, t1, t2, i0)
+    elif ordinal == DTYPE_INT32:
+        kernel[DType.int32](t0, t1, t2, i0)
+    elif ordinal == DTYPE_INT64:
+        kernel[DType.int64](t0, t1, t2, i0)
+    elif ordinal == DTYPE_UINT8:
+        kernel[DType.uint8](t0, t1, t2, i0)
+    elif ordinal == DTYPE_UINT16:
+        kernel[DType.uint16](t0, t1, t2, i0)
+    elif ordinal == DTYPE_UINT32:
+        kernel[DType.uint32](t0, t1, t2, i0)
+    elif ordinal == DTYPE_UINT64:
+        kernel[DType.uint64](t0, t1, t2, i0)
+    else:
+        raise Error(
+            "dispatch_kernel_3t1i: unsupported dtype '"
+            + _format_dtype_name(dtype)
+            + "'"
+        )
+
+
+def dispatch_kernel_3t2i[
+    kernel: def[T: DType](
+        AnyTensor, AnyTensor, AnyTensor, Int, Int
+    ) thin -> None
+](
+    dtype: DType,
+    t0: AnyTensor,
+    t1: AnyTensor,
+    t2: AnyTensor,
+    i0: Int,
+    i1: Int,
+) raises:
+    """Dispatch a (3-tensor, 2-int) typed kernel by runtime dtype.
+
+    Parameters:
+        kernel: Compile-time specialized kernel taking three tensors and two
+            integer arguments.
+
+    Args:
+        dtype: Runtime dtype that selects the compile-time specialization.
+        t0: First tensor argument (typically the output).
+        t1: Second tensor argument.
+        t2: Third tensor argument.
+        i0: First integer shape argument.
+        i1: Second integer shape argument.
+
+    Raises:
+        Error: If `dtype` is not one of the 11 supported dtypes.
+    """
+    var ordinal = dtype_to_ordinal(dtype)
+    if ordinal == DTYPE_FLOAT16:
+        kernel[DType.float16](t0, t1, t2, i0, i1)
+    elif ordinal == DTYPE_FLOAT32:
+        kernel[DType.float32](t0, t1, t2, i0, i1)
+    elif ordinal == DTYPE_FLOAT64:
+        kernel[DType.float64](t0, t1, t2, i0, i1)
+    elif ordinal == DTYPE_INT8:
+        kernel[DType.int8](t0, t1, t2, i0, i1)
+    elif ordinal == DTYPE_INT16:
+        kernel[DType.int16](t0, t1, t2, i0, i1)
+    elif ordinal == DTYPE_INT32:
+        kernel[DType.int32](t0, t1, t2, i0, i1)
+    elif ordinal == DTYPE_INT64:
+        kernel[DType.int64](t0, t1, t2, i0, i1)
+    elif ordinal == DTYPE_UINT8:
+        kernel[DType.uint8](t0, t1, t2, i0, i1)
+    elif ordinal == DTYPE_UINT16:
+        kernel[DType.uint16](t0, t1, t2, i0, i1)
+    elif ordinal == DTYPE_UINT32:
+        kernel[DType.uint32](t0, t1, t2, i0, i1)
+    elif ordinal == DTYPE_UINT64:
+        kernel[DType.uint64](t0, t1, t2, i0, i1)
+    else:
+        raise Error(
+            "dispatch_kernel_3t2i: unsupported dtype '"
+            + _format_dtype_name(dtype)
+            + "'"
+        )
+
+
+def dispatch_kernel_3t3i[
+    kernel: def[T: DType](
+        AnyTensor, AnyTensor, AnyTensor, Int, Int, Int
+    ) thin -> None
+](
+    dtype: DType,
+    t0: AnyTensor,
+    t1: AnyTensor,
+    t2: AnyTensor,
+    i0: Int,
+    i1: Int,
+    i2: Int,
+) raises:
+    """Dispatch a (3-tensor, 3-int) typed kernel by runtime dtype.
+
+    Parameters:
+        kernel: Compile-time specialized kernel taking three tensors and three
+            integer arguments.
+
+    Args:
+        dtype: Runtime dtype that selects the compile-time specialization.
+        t0: First tensor argument (typically the output).
+        t1: Second tensor argument.
+        t2: Third tensor argument.
+        i0: First integer shape argument.
+        i1: Second integer shape argument.
+        i2: Third integer shape argument.
+
+    Raises:
+        Error: If `dtype` is not one of the 11 supported dtypes.
+    """
+    var ordinal = dtype_to_ordinal(dtype)
+    if ordinal == DTYPE_FLOAT16:
+        kernel[DType.float16](t0, t1, t2, i0, i1, i2)
+    elif ordinal == DTYPE_FLOAT32:
+        kernel[DType.float32](t0, t1, t2, i0, i1, i2)
+    elif ordinal == DTYPE_FLOAT64:
+        kernel[DType.float64](t0, t1, t2, i0, i1, i2)
+    elif ordinal == DTYPE_INT8:
+        kernel[DType.int8](t0, t1, t2, i0, i1, i2)
+    elif ordinal == DTYPE_INT16:
+        kernel[DType.int16](t0, t1, t2, i0, i1, i2)
+    elif ordinal == DTYPE_INT32:
+        kernel[DType.int32](t0, t1, t2, i0, i1, i2)
+    elif ordinal == DTYPE_INT64:
+        kernel[DType.int64](t0, t1, t2, i0, i1, i2)
+    elif ordinal == DTYPE_UINT8:
+        kernel[DType.uint8](t0, t1, t2, i0, i1, i2)
+    elif ordinal == DTYPE_UINT16:
+        kernel[DType.uint16](t0, t1, t2, i0, i1, i2)
+    elif ordinal == DTYPE_UINT32:
+        kernel[DType.uint32](t0, t1, t2, i0, i1, i2)
+    elif ordinal == DTYPE_UINT64:
+        kernel[DType.uint64](t0, t1, t2, i0, i1, i2)
+    else:
+        raise Error(
+            "dispatch_kernel_3t3i: unsupported dtype '"
+            + _format_dtype_name(dtype)
+            + "'"
+        )

--- a/src/projectodyssey/core/matrix.mojo
+++ b/src/projectodyssey/core/matrix.mojo
@@ -20,6 +20,11 @@ from std.collections import List
 from std.memory import memcpy
 from projectodyssey.tensor.any_tensor import AnyTensor
 from projectodyssey.core.gradient_types import GradientPair
+from projectodyssey.core.dtype_dispatch import (
+    dispatch_kernel_3t1i,
+    dispatch_kernel_3t2i,
+    dispatch_kernel_3t3i,
+)
 from projectodyssey.base.dtype_ordinal import (
     dtype_to_ordinal,
     format_dtype_name,
@@ -79,35 +84,7 @@ def _dispatch_matmul_2d_1d(
     result: AnyTensor, a: AnyTensor, b: AnyTensor, m: Int, k: Int
 ) raises:
     """Runtime dispatch for 2D @ 1D matmul using ordinal-based dispatch."""
-    var ordinal = dtype_to_ordinal(a._dtype)
-    if ordinal == DTYPE_FLOAT16:
-        _matmul_2d_1d_impl[DType.float16](result, a, b, m, k)
-    elif ordinal == DTYPE_FLOAT32:
-        _matmul_2d_1d_impl[DType.float32](result, a, b, m, k)
-    elif ordinal == DTYPE_FLOAT64:
-        _matmul_2d_1d_impl[DType.float64](result, a, b, m, k)
-    elif ordinal == DTYPE_INT8:
-        _matmul_2d_1d_impl[DType.int8](result, a, b, m, k)
-    elif ordinal == DTYPE_INT16:
-        _matmul_2d_1d_impl[DType.int16](result, a, b, m, k)
-    elif ordinal == DTYPE_INT32:
-        _matmul_2d_1d_impl[DType.int32](result, a, b, m, k)
-    elif ordinal == DTYPE_INT64:
-        _matmul_2d_1d_impl[DType.int64](result, a, b, m, k)
-    elif ordinal == DTYPE_UINT8:
-        _matmul_2d_1d_impl[DType.uint8](result, a, b, m, k)
-    elif ordinal == DTYPE_UINT16:
-        _matmul_2d_1d_impl[DType.uint16](result, a, b, m, k)
-    elif ordinal == DTYPE_UINT32:
-        _matmul_2d_1d_impl[DType.uint32](result, a, b, m, k)
-    elif ordinal == DTYPE_UINT64:
-        _matmul_2d_1d_impl[DType.uint64](result, a, b, m, k)
-    else:
-        raise Error(
-            "matmul_2d_1d: unsupported dtype '"
-            + format_dtype_name(a._dtype)
-            + "'"
-        )
+    dispatch_kernel_3t2i[_matmul_2d_1d_impl](a._dtype, result, a, b, m, k)
 
 
 @always_inline
@@ -146,35 +123,7 @@ def _dispatch_matmul_1d_2d(
     result: AnyTensor, a: AnyTensor, b: AnyTensor, m: Int, n: Int
 ) raises:
     """Runtime dispatch for 1D @ 2D matmul using ordinal-based dispatch."""
-    var ordinal = dtype_to_ordinal(a._dtype)
-    if ordinal == DTYPE_FLOAT16:
-        _matmul_1d_2d_impl[DType.float16](result, a, b, m, n)
-    elif ordinal == DTYPE_FLOAT32:
-        _matmul_1d_2d_impl[DType.float32](result, a, b, m, n)
-    elif ordinal == DTYPE_FLOAT64:
-        _matmul_1d_2d_impl[DType.float64](result, a, b, m, n)
-    elif ordinal == DTYPE_INT8:
-        _matmul_1d_2d_impl[DType.int8](result, a, b, m, n)
-    elif ordinal == DTYPE_INT16:
-        _matmul_1d_2d_impl[DType.int16](result, a, b, m, n)
-    elif ordinal == DTYPE_INT32:
-        _matmul_1d_2d_impl[DType.int32](result, a, b, m, n)
-    elif ordinal == DTYPE_INT64:
-        _matmul_1d_2d_impl[DType.int64](result, a, b, m, n)
-    elif ordinal == DTYPE_UINT8:
-        _matmul_1d_2d_impl[DType.uint8](result, a, b, m, n)
-    elif ordinal == DTYPE_UINT16:
-        _matmul_1d_2d_impl[DType.uint16](result, a, b, m, n)
-    elif ordinal == DTYPE_UINT32:
-        _matmul_1d_2d_impl[DType.uint32](result, a, b, m, n)
-    elif ordinal == DTYPE_UINT64:
-        _matmul_1d_2d_impl[DType.uint64](result, a, b, m, n)
-    else:
-        raise Error(
-            "matmul_1d_2d: unsupported dtype '"
-            + format_dtype_name(a._dtype)
-            + "'"
-        )
+    dispatch_kernel_3t2i[_matmul_1d_2d_impl](a._dtype, result, a, b, m, n)
 
 
 @always_inline
@@ -229,35 +178,9 @@ def _dispatch_matmul_2d_2d(
     b_cols: Int,
 ) raises:
     """Runtime dispatch for 2D @ 2D matmul using ordinal-based dispatch."""
-    var ordinal = dtype_to_ordinal(a._dtype)
-    if ordinal == DTYPE_FLOAT16:
-        _matmul_2d_2d_impl[DType.float16](result, a, b, a_rows, a_cols, b_cols)
-    elif ordinal == DTYPE_FLOAT32:
-        _matmul_2d_2d_impl[DType.float32](result, a, b, a_rows, a_cols, b_cols)
-    elif ordinal == DTYPE_FLOAT64:
-        _matmul_2d_2d_impl[DType.float64](result, a, b, a_rows, a_cols, b_cols)
-    elif ordinal == DTYPE_INT8:
-        _matmul_2d_2d_impl[DType.int8](result, a, b, a_rows, a_cols, b_cols)
-    elif ordinal == DTYPE_INT16:
-        _matmul_2d_2d_impl[DType.int16](result, a, b, a_rows, a_cols, b_cols)
-    elif ordinal == DTYPE_INT32:
-        _matmul_2d_2d_impl[DType.int32](result, a, b, a_rows, a_cols, b_cols)
-    elif ordinal == DTYPE_INT64:
-        _matmul_2d_2d_impl[DType.int64](result, a, b, a_rows, a_cols, b_cols)
-    elif ordinal == DTYPE_UINT8:
-        _matmul_2d_2d_impl[DType.uint8](result, a, b, a_rows, a_cols, b_cols)
-    elif ordinal == DTYPE_UINT16:
-        _matmul_2d_2d_impl[DType.uint16](result, a, b, a_rows, a_cols, b_cols)
-    elif ordinal == DTYPE_UINT32:
-        _matmul_2d_2d_impl[DType.uint32](result, a, b, a_rows, a_cols, b_cols)
-    elif ordinal == DTYPE_UINT64:
-        _matmul_2d_2d_impl[DType.uint64](result, a, b, a_rows, a_cols, b_cols)
-    else:
-        raise Error(
-            "matmul_2d_2d: unsupported dtype '"
-            + format_dtype_name(a._dtype)
-            + "'"
-        )
+    dispatch_kernel_3t3i[_matmul_2d_2d_impl](
+        a._dtype, result, a, b, a_rows, a_cols, b_cols
+    )
 
 
 @always_inline
@@ -603,33 +526,7 @@ def _dispatch_dot(
     result: AnyTensor, a: AnyTensor, b: AnyTensor, length: Int
 ) raises:
     """Runtime dispatch for dot product using ordinal-based dispatch."""
-    var ordinal = dtype_to_ordinal(a._dtype)
-    if ordinal == DTYPE_FLOAT16:
-        _dot_impl[DType.float16](result, a, b, length)
-    elif ordinal == DTYPE_FLOAT32:
-        _dot_impl[DType.float32](result, a, b, length)
-    elif ordinal == DTYPE_FLOAT64:
-        _dot_impl[DType.float64](result, a, b, length)
-    elif ordinal == DTYPE_INT8:
-        _dot_impl[DType.int8](result, a, b, length)
-    elif ordinal == DTYPE_INT16:
-        _dot_impl[DType.int16](result, a, b, length)
-    elif ordinal == DTYPE_INT32:
-        _dot_impl[DType.int32](result, a, b, length)
-    elif ordinal == DTYPE_INT64:
-        _dot_impl[DType.int64](result, a, b, length)
-    elif ordinal == DTYPE_UINT8:
-        _dot_impl[DType.uint8](result, a, b, length)
-    elif ordinal == DTYPE_UINT16:
-        _dot_impl[DType.uint16](result, a, b, length)
-    elif ordinal == DTYPE_UINT32:
-        _dot_impl[DType.uint32](result, a, b, length)
-    elif ordinal == DTYPE_UINT64:
-        _dot_impl[DType.uint64](result, a, b, length)
-    else:
-        raise Error(
-            "dot: unsupported dtype '" + format_dtype_name(a._dtype) + "'"
-        )
+    dispatch_kernel_3t1i[_dot_impl](a._dtype, result, a, b, length)
 
 
 @always_inline
@@ -651,33 +548,7 @@ def _dispatch_outer(
     result: AnyTensor, a: AnyTensor, b: AnyTensor, len_a: Int, len_b: Int
 ) raises:
     """Runtime dispatch for outer product using ordinal-based dispatch."""
-    var ordinal = dtype_to_ordinal(a._dtype)
-    if ordinal == DTYPE_FLOAT16:
-        _outer_impl[DType.float16](result, a, b, len_a, len_b)
-    elif ordinal == DTYPE_FLOAT32:
-        _outer_impl[DType.float32](result, a, b, len_a, len_b)
-    elif ordinal == DTYPE_FLOAT64:
-        _outer_impl[DType.float64](result, a, b, len_a, len_b)
-    elif ordinal == DTYPE_INT8:
-        _outer_impl[DType.int8](result, a, b, len_a, len_b)
-    elif ordinal == DTYPE_INT16:
-        _outer_impl[DType.int16](result, a, b, len_a, len_b)
-    elif ordinal == DTYPE_INT32:
-        _outer_impl[DType.int32](result, a, b, len_a, len_b)
-    elif ordinal == DTYPE_INT64:
-        _outer_impl[DType.int64](result, a, b, len_a, len_b)
-    elif ordinal == DTYPE_UINT8:
-        _outer_impl[DType.uint8](result, a, b, len_a, len_b)
-    elif ordinal == DTYPE_UINT16:
-        _outer_impl[DType.uint16](result, a, b, len_a, len_b)
-    elif ordinal == DTYPE_UINT32:
-        _outer_impl[DType.uint32](result, a, b, len_a, len_b)
-    elif ordinal == DTYPE_UINT64:
-        _outer_impl[DType.uint64](result, a, b, len_a, len_b)
-    else:
-        raise Error(
-            "outer: unsupported dtype '" + format_dtype_name(a._dtype) + "'"
-        )
+    dispatch_kernel_3t2i[_outer_impl](a._dtype, result, a, b, len_a, len_b)
 
 
 @always_inline
@@ -699,35 +570,9 @@ def _dispatch_matmul_backward_2d_1d(
     grad_a: AnyTensor, grad_output: AnyTensor, b: AnyTensor, m: Int, k: Int
 ) raises:
     """Runtime dispatch for 2D @ 1D backward using ordinal-based dispatch."""
-    var ordinal = dtype_to_ordinal(grad_output._dtype)
-    if ordinal == DTYPE_FLOAT16:
-        _matmul_backward_2d_1d_impl[DType.float16](grad_a, grad_output, b, m, k)
-    elif ordinal == DTYPE_FLOAT32:
-        _matmul_backward_2d_1d_impl[DType.float32](grad_a, grad_output, b, m, k)
-    elif ordinal == DTYPE_FLOAT64:
-        _matmul_backward_2d_1d_impl[DType.float64](grad_a, grad_output, b, m, k)
-    elif ordinal == DTYPE_INT8:
-        _matmul_backward_2d_1d_impl[DType.int8](grad_a, grad_output, b, m, k)
-    elif ordinal == DTYPE_INT16:
-        _matmul_backward_2d_1d_impl[DType.int16](grad_a, grad_output, b, m, k)
-    elif ordinal == DTYPE_INT32:
-        _matmul_backward_2d_1d_impl[DType.int32](grad_a, grad_output, b, m, k)
-    elif ordinal == DTYPE_INT64:
-        _matmul_backward_2d_1d_impl[DType.int64](grad_a, grad_output, b, m, k)
-    elif ordinal == DTYPE_UINT8:
-        _matmul_backward_2d_1d_impl[DType.uint8](grad_a, grad_output, b, m, k)
-    elif ordinal == DTYPE_UINT16:
-        _matmul_backward_2d_1d_impl[DType.uint16](grad_a, grad_output, b, m, k)
-    elif ordinal == DTYPE_UINT32:
-        _matmul_backward_2d_1d_impl[DType.uint32](grad_a, grad_output, b, m, k)
-    elif ordinal == DTYPE_UINT64:
-        _matmul_backward_2d_1d_impl[DType.uint64](grad_a, grad_output, b, m, k)
-    else:
-        raise Error(
-            "matmul_backward_2d_1d: unsupported dtype '"
-            + format_dtype_name(grad_output._dtype)
-            + "'"
-        )
+    dispatch_kernel_3t2i[_matmul_backward_2d_1d_impl](
+        grad_output._dtype, grad_a, grad_output, b, m, k
+    )
 
 
 @always_inline
@@ -749,35 +594,9 @@ def _dispatch_matmul_backward_1d_2d(
     grad_b: AnyTensor, a: AnyTensor, grad_output: AnyTensor, k: Int, n: Int
 ) raises:
     """Runtime dispatch for 1D @ 2D backward using ordinal-based dispatch."""
-    var ordinal = dtype_to_ordinal(a._dtype)
-    if ordinal == DTYPE_FLOAT16:
-        _matmul_backward_1d_2d_impl[DType.float16](grad_b, a, grad_output, k, n)
-    elif ordinal == DTYPE_FLOAT32:
-        _matmul_backward_1d_2d_impl[DType.float32](grad_b, a, grad_output, k, n)
-    elif ordinal == DTYPE_FLOAT64:
-        _matmul_backward_1d_2d_impl[DType.float64](grad_b, a, grad_output, k, n)
-    elif ordinal == DTYPE_INT8:
-        _matmul_backward_1d_2d_impl[DType.int8](grad_b, a, grad_output, k, n)
-    elif ordinal == DTYPE_INT16:
-        _matmul_backward_1d_2d_impl[DType.int16](grad_b, a, grad_output, k, n)
-    elif ordinal == DTYPE_INT32:
-        _matmul_backward_1d_2d_impl[DType.int32](grad_b, a, grad_output, k, n)
-    elif ordinal == DTYPE_INT64:
-        _matmul_backward_1d_2d_impl[DType.int64](grad_b, a, grad_output, k, n)
-    elif ordinal == DTYPE_UINT8:
-        _matmul_backward_1d_2d_impl[DType.uint8](grad_b, a, grad_output, k, n)
-    elif ordinal == DTYPE_UINT16:
-        _matmul_backward_1d_2d_impl[DType.uint16](grad_b, a, grad_output, k, n)
-    elif ordinal == DTYPE_UINT32:
-        _matmul_backward_1d_2d_impl[DType.uint32](grad_b, a, grad_output, k, n)
-    elif ordinal == DTYPE_UINT64:
-        _matmul_backward_1d_2d_impl[DType.uint64](grad_b, a, grad_output, k, n)
-    else:
-        raise Error(
-            "matmul_backward_1d_2d: unsupported dtype '"
-            + format_dtype_name(a._dtype)
-            + "'"
-        )
+    dispatch_kernel_3t2i[_matmul_backward_1d_2d_impl](
+        a._dtype, grad_b, a, grad_output, k, n
+    )
 
 
 def matmul(a: AnyTensor, b: AnyTensor) raises -> AnyTensor:
@@ -1610,57 +1429,15 @@ def _dispatch_matmul_2d_2d_grad_a(
 ) raises:
     """Runtime dispatch for grad_a computation in 2D @ 2D matmul backward
     using ordinal-based dispatch."""
-    var ordinal = dtype_to_ordinal(grad_output._dtype)
-    if ordinal == DTYPE_FLOAT16:
-        _matmul_2d_2d_grad_a_impl[DType.float16](
-            grad_a, grad_output, b, grad_out_rows, grad_out_cols, b_rows
-        )
-    elif ordinal == DTYPE_FLOAT32:
-        _matmul_2d_2d_grad_a_impl[DType.float32](
-            grad_a, grad_output, b, grad_out_rows, grad_out_cols, b_rows
-        )
-    elif ordinal == DTYPE_FLOAT64:
-        _matmul_2d_2d_grad_a_impl[DType.float64](
-            grad_a, grad_output, b, grad_out_rows, grad_out_cols, b_rows
-        )
-    elif ordinal == DTYPE_INT8:
-        _matmul_2d_2d_grad_a_impl[DType.int8](
-            grad_a, grad_output, b, grad_out_rows, grad_out_cols, b_rows
-        )
-    elif ordinal == DTYPE_INT16:
-        _matmul_2d_2d_grad_a_impl[DType.int16](
-            grad_a, grad_output, b, grad_out_rows, grad_out_cols, b_rows
-        )
-    elif ordinal == DTYPE_INT32:
-        _matmul_2d_2d_grad_a_impl[DType.int32](
-            grad_a, grad_output, b, grad_out_rows, grad_out_cols, b_rows
-        )
-    elif ordinal == DTYPE_INT64:
-        _matmul_2d_2d_grad_a_impl[DType.int64](
-            grad_a, grad_output, b, grad_out_rows, grad_out_cols, b_rows
-        )
-    elif ordinal == DTYPE_UINT8:
-        _matmul_2d_2d_grad_a_impl[DType.uint8](
-            grad_a, grad_output, b, grad_out_rows, grad_out_cols, b_rows
-        )
-    elif ordinal == DTYPE_UINT16:
-        _matmul_2d_2d_grad_a_impl[DType.uint16](
-            grad_a, grad_output, b, grad_out_rows, grad_out_cols, b_rows
-        )
-    elif ordinal == DTYPE_UINT32:
-        _matmul_2d_2d_grad_a_impl[DType.uint32](
-            grad_a, grad_output, b, grad_out_rows, grad_out_cols, b_rows
-        )
-    elif ordinal == DTYPE_UINT64:
-        _matmul_2d_2d_grad_a_impl[DType.uint64](
-            grad_a, grad_output, b, grad_out_rows, grad_out_cols, b_rows
-        )
-    else:
-        raise Error(
-            "matmul_2d_2d_grad_a: unsupported dtype '"
-            + format_dtype_name(grad_output._dtype)
-            + "'"
-        )
+    dispatch_kernel_3t3i[_matmul_2d_2d_grad_a_impl](
+        grad_output._dtype,
+        grad_a,
+        grad_output,
+        b,
+        grad_out_rows,
+        grad_out_cols,
+        b_rows,
+    )
 
 
 def _dispatch_matmul_2d_2d_grad_b(
@@ -1673,57 +1450,15 @@ def _dispatch_matmul_2d_2d_grad_b(
 ) raises:
     """Runtime dispatch for grad_b computation in 2D @ 2D matmul backward
     using ordinal-based dispatch."""
-    var ordinal = dtype_to_ordinal(a._dtype)
-    if ordinal == DTYPE_FLOAT16:
-        _matmul_2d_2d_grad_b_impl[DType.float16](
-            grad_b, a, grad_output, a_rows, a_cols, grad_out_cols
-        )
-    elif ordinal == DTYPE_FLOAT32:
-        _matmul_2d_2d_grad_b_impl[DType.float32](
-            grad_b, a, grad_output, a_rows, a_cols, grad_out_cols
-        )
-    elif ordinal == DTYPE_FLOAT64:
-        _matmul_2d_2d_grad_b_impl[DType.float64](
-            grad_b, a, grad_output, a_rows, a_cols, grad_out_cols
-        )
-    elif ordinal == DTYPE_INT8:
-        _matmul_2d_2d_grad_b_impl[DType.int8](
-            grad_b, a, grad_output, a_rows, a_cols, grad_out_cols
-        )
-    elif ordinal == DTYPE_INT16:
-        _matmul_2d_2d_grad_b_impl[DType.int16](
-            grad_b, a, grad_output, a_rows, a_cols, grad_out_cols
-        )
-    elif ordinal == DTYPE_INT32:
-        _matmul_2d_2d_grad_b_impl[DType.int32](
-            grad_b, a, grad_output, a_rows, a_cols, grad_out_cols
-        )
-    elif ordinal == DTYPE_INT64:
-        _matmul_2d_2d_grad_b_impl[DType.int64](
-            grad_b, a, grad_output, a_rows, a_cols, grad_out_cols
-        )
-    elif ordinal == DTYPE_UINT8:
-        _matmul_2d_2d_grad_b_impl[DType.uint8](
-            grad_b, a, grad_output, a_rows, a_cols, grad_out_cols
-        )
-    elif ordinal == DTYPE_UINT16:
-        _matmul_2d_2d_grad_b_impl[DType.uint16](
-            grad_b, a, grad_output, a_rows, a_cols, grad_out_cols
-        )
-    elif ordinal == DTYPE_UINT32:
-        _matmul_2d_2d_grad_b_impl[DType.uint32](
-            grad_b, a, grad_output, a_rows, a_cols, grad_out_cols
-        )
-    elif ordinal == DTYPE_UINT64:
-        _matmul_2d_2d_grad_b_impl[DType.uint64](
-            grad_b, a, grad_output, a_rows, a_cols, grad_out_cols
-        )
-    else:
-        raise Error(
-            "matmul_2d_2d_grad_b: unsupported dtype '"
-            + format_dtype_name(a._dtype)
-            + "'"
-        )
+    dispatch_kernel_3t3i[_matmul_2d_2d_grad_b_impl](
+        a._dtype,
+        grad_b,
+        a,
+        grad_output,
+        a_rows,
+        a_cols,
+        grad_out_cols,
+    )
 
 
 def matmul_backward(


### PR DESCRIPTION
## Summary

`matrix.mojo` carried 9 hand-written `_dispatch_*` functions, each an identical 12-branch ordinal switch (~270 lines of duplicated branching) that bypassed `dtype_dispatch.mojo` — the module built to eliminate exactly this DRY violation (audit finding #5293).

## Changes Made

- **`dtype_dispatch.mojo`** — added 3 generic typed-kernel dispatchers (`dispatch_kernel_3t1i`, `_3t2i`, `_3t3i`) covering the in-place-result, integer-shape-arg kernel family. Each takes a parametric kernel function-value parameter and an explicit `dtype` so the caller picks which operand drives specialization.
- **`matrix.mojo`** — converted 9 dispatchers (`matmul_2d_1d`, `matmul_1d_2d`, `matmul_2d_2d`, `dot`, `outer`, `matmul_backward_2d_1d`, `matmul_backward_1d_2d`, `matmul_2d_2d_grad_a`, `matmul_2d_2d_grad_b`) to one-line calls.

## Files Modified

- `src/projectodyssey/core/dtype_dispatch.mojo` (+185)
- `src/projectodyssey/core/matrix.mojo` (−301 net)

## Scope note

The 2 remaining `_dispatch_*` functions (`matmul_batched` — 7 int args; `transpose_copy` — `List[Int]` args) are one-off signatures. A single-use generic helper would be relocation, not deduplication, so they're left as-is per KISS.

## Verification

- `mojo package` builds clean.
- `test_matrix`, `test_matrix_edge_cases`, `test_matmul`, `test_dtype_dispatch` all pass — behavior unchanged (pure refactor).

Closes #5293

🤖 Generated with [Claude Code](https://claude.com/claude-code)