### PR TITLE
fix(config): add type-checked ConfigValue accessors (#5295)

### DIFF
--- a/src/projectodyssey/utils/config.mojo
+++ b/src/projectodyssey/utils/config.mojo
@@ -27,24 +27,21 @@ struct ConfigValue(Copyable, Movable):
     Supports common types needed for ML configurations: integers, floats,
     strings, booleans, and lists.
 
-    ## Fragile-Access Warning (POLA)
+    ## Type-Safe Access (POLA)
 
-    ConfigValue is a tagged union with no runtime type enforcement. Accessing
-    the wrong field (e.g. reading `int_val` when `value_type == "float"`)
-    silently returns a zero-initialised default — no error is raised.
-
-    Always guard access with a `value_type` check before reading a field:
+    Use the `as_*` accessor methods (`as_int`, `as_float`, `as_string`,
+    `as_bool`, `as_list`) to read a value. They check `value_type` and raise
+    `Error` on a mismatch, so a wrong-type read fails loudly instead of
+    silently returning a zero-initialised default.
 
     ```mojo
-    if cv.value_type == "int":
-        use(cv.int_val)
-    elif cv.value_type == "float":
-        use(cv.float_val)
-    # ... etc.
+    var lr = cv.as_float()   # raises if cv is not a float
     ```
 
-    Prefer the typed helpers on `Config` (`get_int`, `get_float`, `get_string`,
-    `get_bool`) which perform this guard and raise on mismatch.
+    The raw `int_val` / `float_val` / `str_val` / `bool_val` / `list_val`
+    fields remain public for serialization code that has already branched on
+    `value_type`, but new call sites should prefer the `as_*` methods.
+    `Config`'s typed helpers (`get_int`, `get_float`, ...) delegate to them.
     """
 
     var value_type: String
@@ -170,6 +167,86 @@ struct ConfigValue(Copyable, Movable):
         cv.bool_val = self.bool_val
         cv.list_val = self.list_val.copy()
         return cv^
+
+    def as_int(self) raises -> Int:
+        """Return the integer value, or raise if this is not an int.
+
+        Returns:
+            The stored integer value.
+
+        Raises:
+            Error: If `value_type` is not 'int'.
+        """
+        if self.value_type != "int":
+            raise Error(
+                "ConfigValue type mismatch: expected int but got "
+                + self.value_type
+            )
+        return self.int_val
+
+    def as_float(self) raises -> Float64:
+        """Return the float value, or raise if this is not a float.
+
+        Returns:
+            The stored Float64 value.
+
+        Raises:
+            Error: If `value_type` is not 'float'.
+        """
+        if self.value_type != "float":
+            raise Error(
+                "ConfigValue type mismatch: expected float but got "
+                + self.value_type
+            )
+        return self.float_val
+
+    def as_string(self) raises -> String:
+        """Return the string value, or raise if this is not a string.
+
+        Returns:
+            The stored String value.
+
+        Raises:
+            Error: If `value_type` is not 'string'.
+        """
+        if self.value_type != "string":
+            raise Error(
+                "ConfigValue type mismatch: expected string but got "
+                + self.value_type
+            )
+        return self.str_val
+
+    def as_bool(self) raises -> Bool:
+        """Return the boolean value, or raise if this is not a bool.
+
+        Returns:
+            The stored Bool value.
+
+        Raises:
+            Error: If `value_type` is not 'bool'.
+        """
+        if self.value_type != "bool":
+            raise Error(
+                "ConfigValue type mismatch: expected bool but got "
+                + self.value_type
+            )
+        return self.bool_val
+
+    def as_list(self) raises -> List[String]:
+        """Return a copy of the list value, or raise if this is not a list.
+
+        Returns:
+            A copy of the stored List[String] value.
+
+        Raises:
+            Error: If `value_type` is not 'list'.
+        """
+        if self.value_type != "list":
+            raise Error(
+                "ConfigValue type mismatch: expected list but got "
+                + self.value_type
+            )
+        return self.list_val.copy()
 
 
 # ============================================================================
@@ -310,14 +387,10 @@ struct Config(Copyable, ImplicitlyCopyable, Movable):
             return default
 
         ref val = self.data[key]
-        if val.value_type != "string":
-            raise Error(
-                "Type mismatch for key '"
-                + key
-                + "': expected string but got "
-                + val.value_type
-            )
-        return val.str_val
+        try:
+            return val.as_string()
+        except e:
+            raise Error("Type mismatch for key '" + key + "': " + String(e))
 
     def get_int(self, key: String, default: Int = 0) raises -> Int:
         """Get integer value with optional default.
@@ -336,14 +409,10 @@ struct Config(Copyable, ImplicitlyCopyable, Movable):
             return default
 
         ref val = self.data[key]
-        if val.value_type != "int":
-            raise Error(
-                "Type mismatch for key '"
-                + key
-                + "': expected int but got "
-                + val.value_type
-            )
-        return val.int_val
+        try:
+            return val.as_int()
+        except e:
+            raise Error("Type mismatch for key '" + key + "': " + String(e))
 
     def get_float(self, key: String, default: Float64 = 0.0) raises -> Float64:
         """Get float value with optional default.
@@ -362,14 +431,10 @@ struct Config(Copyable, ImplicitlyCopyable, Movable):
             return default
 
         ref val = self.data[key]
-        if val.value_type != "float":
-            raise Error(
-                "Type mismatch for key '"
-                + key
-                + "': expected float but got "
-                + val.value_type
-            )
-        return val.float_val
+        try:
+            return val.as_float()
+        except e:
+            raise Error("Type mismatch for key '" + key + "': " + String(e))
 
     def get_bool(self, key: String, default: Bool = False) raises -> Bool:
         """Get boolean value with optional default.
@@ -388,14 +453,10 @@ struct Config(Copyable, ImplicitlyCopyable, Movable):
             return default
 
         ref val = self.data[key]
-        if val.value_type != "bool":
-            raise Error(
-                "Type mismatch for key '"
-                + key
-                + "': expected bool but got "
-                + val.value_type
-            )
-        return val.bool_val
+        try:
+            return val.as_bool()
+        except e:
+            raise Error("Type mismatch for key '" + key + "': " + String(e))
 
     def get_list(self, key: String) raises -> List[String]:
         """Get list value.
@@ -413,18 +474,10 @@ struct Config(Copyable, ImplicitlyCopyable, Movable):
             return []
 
         ref val = self.data[key]
-        if val.value_type != "list":
-            raise Error(
-                "Type mismatch for key '"
-                + key
-                + "': expected list but got "
-                + val.value_type
-            )
-        # Copy list_val before returning to avoid partial destruction of val
-        var list_copy = List[String]()
-        for i in range(len(val.list_val)):
-            list_copy.append(val.list_val[i])
-        return list_copy^
+        try:
+            return val.as_list()
+        except e:
+            raise Error("Type mismatch for key '" + key + "': " + String(e))
 
     def get(self, key: String) raises -> ConfigValue:
         """Get raw configuration value by key.

--- a/tests/projectodyssey/utils/test_config.mojo
+++ b/tests/projectodyssey/utils/test_config.mojo
@@ -17,6 +17,98 @@ from tests.projectodyssey.conftest import (
     assert_not_equal,
     TestFixtures,
 )
+from projectodyssey.utils.config import ConfigValue
+
+
+def test_configvalue_as_int_correct_type() raises:
+    """`as_int` returns the value when value_type is 'int'."""
+    var cv = ConfigValue(42)
+    assert_equal(cv.as_int(), 42, "as_int should return stored int")
+
+
+def test_configvalue_as_float_correct_type() raises:
+    """`as_float` returns the value when value_type is 'float'."""
+    var cv = ConfigValue(Float64(3.5))
+    assert_equal(cv.as_float(), 3.5, "as_float should return stored float")
+
+
+def test_configvalue_as_string_correct_type() raises:
+    """`as_string` returns the value when value_type is 'string'."""
+    var cv = ConfigValue(String("relu"))
+    assert_equal(cv.as_string(), "relu", "as_string should return stored str")
+
+
+def test_configvalue_as_bool_correct_type() raises:
+    """`as_bool` returns the value when value_type is 'bool'."""
+    var cv = ConfigValue(True)
+    assert_true(cv.as_bool(), "as_bool should return stored bool")
+
+
+def test_configvalue_as_list_correct_type() raises:
+    """`as_list` returns a copy of the value when value_type is 'list'."""
+    var items = List[String]()
+    items.append("a")
+    items.append("b")
+    var cv = ConfigValue(items^)
+    var got = cv.as_list()
+    assert_equal(len(got), 2, "as_list should return 2-element list")
+    assert_equal(got[0], "a", "as_list element 0")
+    assert_equal(got[1], "b", "as_list element 1")
+
+
+def test_configvalue_as_int_wrong_type_raises() raises:
+    """`as_int` raises when value_type is not 'int' (no silent zero)."""
+    var cv = ConfigValue(Float64(1.0))
+    var raised = False
+    try:
+        _ = cv.as_int()
+    except:
+        raised = True
+    assert_true(raised, "as_int on a float ConfigValue must raise")
+
+
+def test_configvalue_as_float_wrong_type_raises() raises:
+    """`as_float` raises when value_type is not 'float'."""
+    var cv = ConfigValue(7)
+    var raised = False
+    try:
+        _ = cv.as_float()
+    except:
+        raised = True
+    assert_true(raised, "as_float on an int ConfigValue must raise")
+
+
+def test_configvalue_as_string_wrong_type_raises() raises:
+    """`as_string` raises when value_type is not 'string'."""
+    var cv = ConfigValue(True)
+    var raised = False
+    try:
+        _ = cv.as_string()
+    except:
+        raised = True
+    assert_true(raised, "as_string on a bool ConfigValue must raise")
+
+
+def test_configvalue_as_bool_wrong_type_raises() raises:
+    """`as_bool` raises when value_type is not 'bool'."""
+    var cv = ConfigValue(String("yes"))
+    var raised = False
+    try:
+        _ = cv.as_bool()
+    except:
+        raised = True
+    assert_true(raised, "as_bool on a string ConfigValue must raise")
+
+
+def test_configvalue_as_list_wrong_type_raises() raises:
+    """`as_list` raises when value_type is not 'list'."""
+    var cv = ConfigValue(5)
+    var raised = False
+    try:
+        _ = cv.as_list()
+    except:
+        raised = True
+    assert_true(raised, "as_list on an int ConfigValue must raise")
 
 
 def test_load_yaml_config():
@@ -365,6 +457,36 @@ def test_config_from_cli_args():
 def main() raises:
     """Run all test_config tests."""
     print("Running test_config tests...")
+
+    test_configvalue_as_int_correct_type()
+    print("✓ test_configvalue_as_int_correct_type")
+
+    test_configvalue_as_float_correct_type()
+    print("✓ test_configvalue_as_float_correct_type")
+
+    test_configvalue_as_string_correct_type()
+    print("✓ test_configvalue_as_string_correct_type")
+
+    test_configvalue_as_bool_correct_type()
+    print("✓ test_configvalue_as_bool_correct_type")
+
+    test_configvalue_as_list_correct_type()
+    print("✓ test_configvalue_as_list_correct_type")
+
+    test_configvalue_as_int_wrong_type_raises()
+    print("✓ test_configvalue_as_int_wrong_type_raises")
+
+    test_configvalue_as_float_wrong_type_raises()
+    print("✓ test_configvalue_as_float_wrong_type_raises")
+
+    test_configvalue_as_string_wrong_type_raises()
+    print("✓ test_configvalue_as_string_wrong_type_raises")
+
+    test_configvalue_as_bool_wrong_type_raises()
+    print("✓ test_configvalue_as_bool_wrong_type_raises")
+
+    test_configvalue_as_list_wrong_type_raises()
+    print("✓ test_configvalue_as_list_wrong_type_raises")
 
     test_load_yaml_config()
     print("✓ test_load_yaml_config")


### PR DESCRIPTION
## Summary

`ConfigValue` is a tagged union with five parallel fields (`int_val`, `float_val`, `str_val`, `bool_val`, `list_val`) discriminated by a `value_type` string. Reading the wrong field silently returned a zero-initialised default — a POLA violation (audit finding #5295).

## Changes Made

- **`config.mojo`** — added five `as_*` accessor methods (`as_int`, `as_float`, `as_string`, `as_bool`, `as_list`) that check `value_type` and raise `Error` on mismatch. The struct now enforces its own invariant. `Config.get_int/float/string/bool/list` delegate to these methods (single source of truth for the guard).
- **`test_config.mojo`** — added 10 real tests (correct-type access + wrong-type-raises for all five accessors); the file previously held only TODO stubs.

## Files Modified

- `src/projectodyssey/utils/config.mojo`
- `tests/projectodyssey/utils/test_config.mojo`

## Scope note

The raw fields stay public — serialization code in `config.mojo` (`to_yaml`/`to_json`) already branches on `value_type` correctly. A full variant-type rewrite would be scope creep for a MINOR finding; type-checked accessors remove the silent-failure footgun with a minimal change.

## Verification

- `mojo package` builds clean.
- `test_config` passes — all 10 new `test_configvalue_*` tests run and pass.

Closes #5295

🤖 Generated with [Claude Code](https://claude.com/claude-code)