### PR TITLE
feat(training): add per-layer LayerHook trait and registry (#5418)

### DIFF
--- a/src/projectodyssey/training/layer_hooks.mojo
+++ b/src/projectodyssey/training/layer_hooks.mojo
@@ -1,0 +1,231 @@
+"""Per-layer pre/post-forward hooks with read-write tensor access.
+
+`LayerHook` is a per-layer instrumentation point, distinct from the
+whole-model `Callback` trait in `base.mojo`. Where `Callback` is read-only
+and fired by the trainer around epochs/batches, a `LayerHook` runs
+immediately before and after an individual layer's `forward()` and may
+mutate the layer's input and output tensors.
+
+The two traits are kept separate so the read-only invariant on `Callback`
+is preserved.
+
+Composition: a `HookRegistry[H]` holds hook instances keyed by layer name.
+On invocation it runs every hook registered for a layer in registration
+order; the first hook returning a non-CONTINUE signal short-circuits the
+rest and propagates that signal.
+
+Example:
+    ```mojo
+    from projectodyssey.training.layer_hooks import (
+        HookRegistry, ActivationStatsHook
+    )
+
+    var reg = HookRegistry[ActivationStatsHook]()
+    reg.register("conv1", ActivationStatsHook())
+
+    # Inside a model's forward(), around each layer:
+    _ = reg.run_pre_forward("conv1", input)
+    var out = conv1.forward(input)
+    _ = reg.run_post_forward("conv1", input, out)
+    ```
+"""
+
+from projectodyssey.tensor.any_tensor import AnyTensor
+from projectodyssey.training.base import CallbackSignal, CONTINUE
+
+
+trait LayerHook(Copyable, Movable):
+    """Per-layer pre/post-forward hook with read-write tensor access.
+
+    Implementations run around an individual layer's `forward()` call.
+    Unlike `Callback`, a `LayerHook` receives the layer's input and output
+    tensors by mutable reference and may modify them (e.g. forward-time
+    output clipping, activation rescaling).
+
+    Both methods return a `CallbackSignal`; returning `STOP` halts the
+    remaining hooks for that layer and propagates out of the registry.
+    """
+
+    def on_pre_forward(
+        mut self, layer_name: String, mut input: AnyTensor
+    ) raises -> CallbackSignal:
+        """Run before a layer's `forward()`.
+
+        Args:
+            layer_name: Name of the layer about to run.
+            input: The layer's input tensor (mutable — may be rewritten).
+
+        Returns:
+            CONTINUE to proceed, STOP to halt remaining hooks.
+        """
+        ...
+
+    def on_post_forward(
+        mut self, layer_name: String, input: AnyTensor, mut output: AnyTensor
+    ) raises -> CallbackSignal:
+        """Run after a layer's `forward()`.
+
+        Args:
+            layer_name: Name of the layer that just ran.
+            input: The layer's input tensor (read-only here).
+            output: The layer's output tensor (mutable — may be rewritten).
+
+        Returns:
+            CONTINUE to proceed, STOP to halt remaining hooks.
+        """
+        ...
+
+
+struct HookRegistry[H: LayerHook](Copyable, Movable):
+    """Holds `LayerHook` instances keyed by layer name.
+
+    A model opts into per-layer hooks by owning a `HookRegistry` and calling
+    `run_pre_forward` / `run_post_forward` around each layer in its
+    `forward()` sequence.
+
+    The registry is parametric on a single hook type `H`. Mojo does not
+    support heterogeneous trait-object lists, so all hooks in one registry
+    share a type; register multiple instances to compose behavior.
+
+    Parameters:
+        H: The concrete `LayerHook` implementation stored by this registry.
+    """
+
+    var _hooks: List[Self.H]
+    """Registered hook instances, parallel to `_names`."""
+    var _names: List[String]
+    """Layer-name match for each hook. The empty string matches every layer."""
+
+    def __init__(out self):
+        """Create an empty registry."""
+        self._hooks = List[Self.H]()
+        self._names = List[String]()
+
+    def register(mut self, layer_name: String, var hook: Self.H):
+        """Register a hook for a specific layer.
+
+        Args:
+            layer_name: The layer name this hook fires on.
+            hook: The hook instance (ownership transferred).
+        """
+        self._names.append(layer_name)
+        self._hooks.append(hook^)
+
+    def register_all_layers(mut self, var hook: Self.H):
+        """Register a hook that fires on every layer.
+
+        Args:
+            hook: The hook instance (ownership transferred).
+        """
+        self._names.append(String(""))
+        self._hooks.append(hook^)
+
+    def _matches(self, registered_name: String, layer_name: String) -> Bool:
+        """Whether a registered entry applies to `layer_name`.
+
+        An empty registered name is the all-layers wildcard.
+        """
+        return registered_name == "" or registered_name == layer_name
+
+    def run_pre_forward(
+        mut self, layer_name: String, mut input: AnyTensor
+    ) raises -> CallbackSignal:
+        """Invoke every matching hook's `on_pre_forward` in registration order.
+
+        Args:
+            layer_name: The layer about to run.
+            input: The layer's input tensor (mutable).
+
+        Returns:
+            The first non-CONTINUE signal, or CONTINUE if all hooks continue.
+        """
+        for i in range(len(self._hooks)):
+            if self._matches(self._names[i], layer_name):
+                var signal = self._hooks[i].on_pre_forward(layer_name, input)
+                if signal.value != CONTINUE.value:
+                    return signal
+        return CONTINUE
+
+    def run_post_forward(
+        mut self, layer_name: String, input: AnyTensor, mut output: AnyTensor
+    ) raises -> CallbackSignal:
+        """Invoke every matching hook's `on_post_forward` in registration order.
+
+        Args:
+            layer_name: The layer that just ran.
+            input: The layer's input tensor (read-only).
+            output: The layer's output tensor (mutable).
+
+        Returns:
+            The first non-CONTINUE signal, or CONTINUE if all hooks continue.
+        """
+        for i in range(len(self._hooks)):
+            if self._matches(self._names[i], layer_name):
+                var signal = self._hooks[i].on_post_forward(
+                    layer_name, input, output
+                )
+                if signal.value != CONTINUE.value:
+                    return signal
+        return CONTINUE
+
+
+struct ActivationStatsHook(Copyable, LayerHook, Movable):
+    """Example `LayerHook` that records output activation statistics.
+
+    After each layer's `forward()`, records the mean and maximum absolute
+    value of the output tensor. Demonstrates the per-layer instrumentation
+    use case from issue #5418 — activation statistics that need the layer's
+    output tensor, which `LoggingCallback` cannot reach.
+
+    This hook does not mutate tensors; it only observes.
+    """
+
+    var last_mean: Float64
+    """Mean of the most recent layer output (0.0 before the first call)."""
+    var last_max_abs: Float64
+    """Maximum absolute value of the most recent layer output."""
+    var call_count: Int
+    """Number of `on_post_forward` invocations so far."""
+
+    def __init__(out self):
+        """Create a hook with zeroed statistics."""
+        self.last_mean = 0.0
+        self.last_max_abs = 0.0
+        self.call_count = 0
+
+    def on_pre_forward(
+        mut self, layer_name: String, mut input: AnyTensor
+    ) raises -> CallbackSignal:
+        """No-op: this hook only observes outputs."""
+        return CONTINUE
+
+    def on_post_forward(
+        mut self, layer_name: String, input: AnyTensor, mut output: AnyTensor
+    ) raises -> CallbackSignal:
+        """Record mean and max-abs of the layer output.
+
+        Args:
+            layer_name: The layer that just ran.
+            input: The layer's input tensor (unused).
+            output: The layer's output tensor (observed, not modified).
+
+        Returns:
+            CONTINUE — observation never halts the forward pass.
+        """
+        var n = output.numel()
+        if n == 0:
+            self.last_mean = 0.0
+            self.last_max_abs = 0.0
+        else:
+            var total = 0.0
+            var max_abs = 0.0
+            for i in range(n):
+                var v = output._get_float64(i)
+                total += v
+                var abs_v = v if v >= 0.0 else -v
+                if abs_v > max_abs:
+                    max_abs = abs_v
+            self.last_mean = total / Float64(n)
+            self.last_max_abs = max_abs
+        self.call_count += 1
+        return CONTINUE

--- a/tests/projectodyssey/training/test_layer_hooks.mojo
+++ b/tests/projectodyssey/training/test_layer_hooks.mojo
@@ -1,0 +1,199 @@
+"""Tests for the per-layer LayerHook mechanism (issue #5418).
+
+Covers:
+- HookRegistry registration (by layer name and all-layers wildcard)
+- run_pre_forward / run_post_forward dispatch and name matching
+- Multi-hook composition in registration order
+- STOP short-circuit semantics
+- ActivationStatsHook output statistics
+"""
+
+from std.testing import assert_true, assert_equal, assert_false
+from projectodyssey.tensor.any_tensor import AnyTensor
+from projectodyssey.tensor.tensor_creation import zeros, ones
+from projectodyssey.training.base import CallbackSignal, CONTINUE, STOP
+from projectodyssey.training.layer_hooks import (
+    LayerHook,
+    HookRegistry,
+    ActivationStatsHook,
+)
+
+
+struct CountingHook(Copyable, LayerHook, Movable):
+    """Test hook: counts pre/post invocations and can be set to STOP."""
+
+    var pre_count: Int
+    var post_count: Int
+    var stop_on_pre: Bool
+
+    def __init__(out self, stop_on_pre: Bool = False):
+        self.pre_count = 0
+        self.post_count = 0
+        self.stop_on_pre = stop_on_pre
+
+    def on_pre_forward(
+        mut self, layer_name: String, mut input: AnyTensor
+    ) raises -> CallbackSignal:
+        self.pre_count += 1
+        if self.stop_on_pre:
+            return STOP
+        return CONTINUE
+
+    def on_post_forward(
+        mut self, layer_name: String, input: AnyTensor, mut output: AnyTensor
+    ) raises -> CallbackSignal:
+        self.post_count += 1
+        return CONTINUE
+
+
+def test_register_and_run_pre_forward() raises:
+    """A hook registered for a layer fires on that layer's pre-forward."""
+    var reg = HookRegistry[CountingHook]()
+    reg.register("conv1", CountingHook())
+
+    var x = zeros([2, 3], DType.float32)
+    var signal = reg.run_pre_forward("conv1", x)
+
+    assert_equal(signal.value, CONTINUE.value, "should return CONTINUE")
+    assert_equal(reg._hooks[0].pre_count, 1, "pre_count incremented")
+
+
+def test_name_mismatch_does_not_fire() raises:
+    """A hook registered for one layer does not fire for a different layer."""
+    var reg = HookRegistry[CountingHook]()
+    reg.register("conv1", CountingHook())
+
+    var x = zeros([2, 3], DType.float32)
+    _ = reg.run_pre_forward("conv2", x)
+
+    assert_equal(reg._hooks[0].pre_count, 0, "must not fire on conv2")
+
+
+def test_all_layers_wildcard_fires_everywhere() raises:
+    """Wildcard registration makes a hook fire on every layer name."""
+    var reg = HookRegistry[CountingHook]()
+    reg.register_all_layers(CountingHook())
+
+    var x = zeros([2, 3], DType.float32)
+    _ = reg.run_pre_forward("conv1", x)
+    _ = reg.run_pre_forward("fc1", x)
+
+    assert_equal(reg._hooks[0].pre_count, 2, "wildcard fires on both layers")
+
+
+def test_post_forward_runs() raises:
+    """Post-forward dispatch invokes the matching hook's on_post_forward."""
+    var reg = HookRegistry[CountingHook]()
+    reg.register("conv1", CountingHook())
+
+    var x = zeros([2, 3], DType.float32)
+    var y = zeros([2, 3], DType.float32)
+    var signal = reg.run_post_forward("conv1", x, y)
+
+    assert_equal(signal.value, CONTINUE.value, "post returns CONTINUE")
+    assert_equal(reg._hooks[0].post_count, 1, "post_count incremented")
+
+
+def test_multiple_hooks_compose_in_order() raises:
+    """Multiple hooks on the same layer all run in registration order."""
+    var reg = HookRegistry[CountingHook]()
+    reg.register("conv1", CountingHook())
+    reg.register("conv1", CountingHook())
+
+    var x = zeros([2, 3], DType.float32)
+    _ = reg.run_pre_forward("conv1", x)
+
+    assert_equal(reg._hooks[0].pre_count, 1, "first hook ran")
+    assert_equal(reg._hooks[1].pre_count, 1, "second hook ran")
+
+
+def test_stop_short_circuits_remaining_hooks() raises:
+    """A hook returning STOP halts the remaining hooks for that layer."""
+    var reg = HookRegistry[CountingHook]()
+    reg.register("conv1", CountingHook(stop_on_pre=True))
+    reg.register("conv1", CountingHook())
+
+    var x = zeros([2, 3], DType.float32)
+    var signal = reg.run_pre_forward("conv1", x)
+
+    assert_equal(signal.value, STOP.value, "registry propagates STOP")
+    assert_equal(reg._hooks[0].pre_count, 1, "first (STOP) hook ran")
+    assert_equal(reg._hooks[1].pre_count, 0, "second hook short-circuited")
+
+
+def test_empty_registry_returns_continue() raises:
+    """A registry with no hooks returns CONTINUE."""
+    var reg = HookRegistry[CountingHook]()
+    var x = zeros([2, 3], DType.float32)
+    assert_equal(
+        reg.run_pre_forward("conv1", x).value,
+        CONTINUE.value,
+        "empty registry continues",
+    )
+
+
+def test_activation_stats_hook_records_mean() raises:
+    """ActivationStatsHook records the mean of a layer's output."""
+    var reg = HookRegistry[ActivationStatsHook]()
+    reg.register("conv1", ActivationStatsHook())
+
+    var x = zeros([1, 4], DType.float32)
+    var out = ones([1, 4], DType.float32)
+    _ = reg.run_post_forward("conv1", x, out)
+
+    assert_equal(reg._hooks[0].call_count, 1, "stats hook ran once")
+    assert_true(
+        reg._hooks[0].last_mean > 0.99 and reg._hooks[0].last_mean < 1.01,
+        "mean of all-ones output is 1.0",
+    )
+    assert_true(
+        reg._hooks[0].last_max_abs > 0.99 and reg._hooks[0].last_max_abs < 1.01,
+        "max-abs of all-ones output is 1.0",
+    )
+
+
+def test_activation_stats_hook_zero_output() raises:
+    """ActivationStatsHook reports zero stats for an all-zero output."""
+    var reg = HookRegistry[ActivationStatsHook]()
+    reg.register_all_layers(ActivationStatsHook())
+
+    var x = zeros([1, 4], DType.float32)
+    var out = zeros([2, 8], DType.float32)
+    _ = reg.run_post_forward("any_layer", x, out)
+
+    assert_equal(reg._hooks[0].last_mean, 0.0, "zero output -> zero mean")
+    assert_equal(reg._hooks[0].last_max_abs, 0.0, "zero output -> zero max-abs")
+
+
+def main() raises:
+    """Run all test_layer_hooks tests."""
+    print("Running test_layer_hooks tests...")
+
+    test_register_and_run_pre_forward()
+    print("✓ test_register_and_run_pre_forward")
+
+    test_name_mismatch_does_not_fire()
+    print("✓ test_name_mismatch_does_not_fire")
+
+    test_all_layers_wildcard_fires_everywhere()
+    print("✓ test_all_layers_wildcard_fires_everywhere")
+
+    test_post_forward_runs()
+    print("✓ test_post_forward_runs")
+
+    test_multiple_hooks_compose_in_order()
+    print("✓ test_multiple_hooks_compose_in_order")
+
+    test_stop_short_circuits_remaining_hooks()
+    print("✓ test_stop_short_circuits_remaining_hooks")
+
+    test_empty_registry_returns_continue()
+    print("✓ test_empty_registry_returns_continue")
+
+    test_activation_stats_hook_records_mean()
+    print("✓ test_activation_stats_hook_records_mean")
+
+    test_activation_stats_hook_zero_output()
+    print("✓ test_activation_stats_hook_zero_output")
+
+    print("\nAll test_layer_hooks tests passed!")


### PR DESCRIPTION
## Summary

Adds a per-layer pre/post-forward hook mechanism, distinct from the whole-model `Callback` trait. `Callback` is read-only and fired by the trainer around epochs/batches; `LayerHook` runs around an individual layer's `forward()` and receives the input/output tensors by mutable reference. The two traits are kept separate so `Callback`'s read-only invariant is preserved.

## Changes Made

New `src/projectodyssey/training/layer_hooks.mojo`:
- **`LayerHook` trait** — `on_pre_forward(mut input)` / `on_post_forward(input, mut output)`, both returning `CallbackSignal`.
- **`HookRegistry[H: LayerHook]`** — holds hooks keyed by layer name (with an all-layers wildcard); a model opts in by owning a registry and calling `run_pre_forward`/`run_post_forward` around each layer.
- **`ActivationStatsHook`** — example hook recording output mean / max-abs (the activation-statistics use case from the issue).

## Design decisions

Posted on #5418 before implementation; the three open questions are resolved there:
1. **Registration** — separate registry, not the `Module` trait. Keeps hook-free models zero-cost; avoids breaking the 6 existing `Module` implementors.
2. **Signal** — reuse `CallbackSignal` (CONTINUE/STOP). No skip-layer/replace-output vocabulary in v1 (YAGNI).
3. **Composition** — multiple hooks per layer run in registration order; first non-CONTINUE signal short-circuits.

`HookRegistry` is parametric on one hook type because Mojo has no heterogeneous trait-object lists — register multiple instances to compose. v1 exposes read-write input/output tensors; generic mutable per-layer *parameter* access is deferred (not expressible through Mojo's trait system without a concrete layer type) — noted as follow-up in the issue comment.

## Files Modified

- `src/projectodyssey/training/layer_hooks.mojo` (new)
- `tests/projectodyssey/training/test_layer_hooks.mojo` (new, 9 tests)

## Verification

- `mojo package` builds clean.
- All 9 tests pass: registration, name matching, wildcard, composition order, STOP short-circuit, and the example hook's statistics.

Closes #5418

🤖 Generated with [Claude Code](https://claude.com/claude-code)