### PR TITLE
Batch: 6 easy issues — release regex, SGD disambiguation, tensor equality, test coverage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,12 @@ jobs:
           VERSION="${{ steps.get-version.outputs.version }}"
 
           # Check version format (vX.Y.Z or vX.Y.Z-alpha.N, etc.)
-          if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+          # The pre-release suffix character class includes a hyphen: semver
+          # 2.0 §9 permits hyphens in pre-release identifiers (e.g.
+          # v0.1.0-rc-1, v0.1.0-pkg-test). See issue #5420.
+          if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$'; then
             echo "❌ Invalid version format: $VERSION"
-            echo "Expected format: vX.Y.Z or vX.Y.Z-suffix (e.g., v0.1.0, v1.2.3-alpha.1)"
+            echo "Expected format: vX.Y.Z or vX.Y.Z-suffix (e.g., v0.1.0, v1.2.3-alpha.1, v1.2.3-rc-1)"
             exit 1
           fi
 

--- a/src/projectodyssey/tensor/any_tensor.mojo
+++ b/src/projectodyssey/tensor/any_tensor.mojo
@@ -1985,6 +1985,54 @@ struct AnyTensor(
 
         return _anytensor_compare_op[_ne](self, other)
 
+    def array_equal(
+        self, other: AnyTensor, equal_nan: Bool = True
+    ) raises -> Bool:
+        """Whole-tensor equality returning a single `Bool`.
+
+        Unlike `__eq__`, which is element-wise and returns a tensor of
+        1.0/0.0, this returns one `Bool`: True iff `self` and `other` have
+        the same shape and dtype and every element compares equal.
+
+        With `equal_nan=True` (the default), NaN matches NaN position-wise —
+        mirroring `__hash__`, which canonicalizes NaN so NaN-containing
+        tensors hash equally. This is what makes a NaN-containing tensor
+        usable as a dict/set key: `__hash__` and `array_equal` agree, so
+        lookup succeeds. With `equal_nan=False`, IEEE 754 semantics apply
+        and any NaN makes the tensors unequal (see issue #4061).
+
+        Args:
+            other: The tensor to compare against.
+            equal_nan: If True, NaN equals NaN at the same position.
+
+        Returns:
+            True iff the tensors are equal under the chosen NaN policy.
+        """
+        from std.math import isnan
+
+        if self._dtype != other._dtype:
+            return False
+        if len(self._shape) != len(other._shape):
+            return False
+        for i in range(len(self._shape)):
+            if self._shape[i] != other._shape[i]:
+                return False
+        if self._numel != other._numel:
+            return False
+
+        for i in range(self._numel):
+            var a = self._get_float64(i)
+            var b = other._get_float64(i)
+            var a_nan = isnan(a)
+            var b_nan = isnan(b)
+            if a_nan or b_nan:
+                # Equal only if both are NaN and equal_nan is set.
+                if not (equal_nan and a_nan and b_nan):
+                    return False
+            elif a != b:
+                return False
+        return True
+
     def __lt__(self, other: AnyTensor) raises -> AnyTensor:
         """Element-wise less than: a < b.
 

--- a/src/projectodyssey/training/__init__.mojo
+++ b/src/projectodyssey/training/__init__.mojo
@@ -118,12 +118,18 @@ from projectodyssey.training.callbacks import (
 # ============================================================================
 
 
-# SGD Optimizer
-struct SGD(Movable, Optimizer):
-    """Stochastic Gradient Descent optimizer.
+# TrainingLoop SGD adapter
+struct TrainingLoopSGD(Movable, Optimizer):
+    """SGD adapter for the generic `TrainingLoop`.
 
-    Implements the Optimizer trait for use with generic TrainingLoop.
-    Delegates to the autograd SGD optimizer for actual gradient-based updates.
+    A thin `Optimizer`-trait adapter — `step()`/`zero_grad()` are no-ops
+    because `TrainingLoop` performs the actual gradient updates through the
+    autograd tape. Distinct from `projectodyssey.autograd.optimizers.SGD`,
+    the real gradient-based optimizer.
+
+    Renamed from `SGD` (issue #5392): two structs both named `SGD` were
+    re-exported into the top-level `projectodyssey` namespace, making
+    `from projectodyssey import SGD` an ambiguous import under `--Werror`.
     """
 
     var learning_rate: Float32
@@ -280,9 +286,11 @@ struct TrainingLoop[
     Example:
         ```mojo
         var model = SimpleMLP(...)
-        var optimizer = SGD(learning_rate=0.01)
+        var optimizer = TrainingLoopSGD(learning_rate=0.01)
         var loss_fn = MSELoss()
-        var loop = TrainingLoop[SimpleMLP, MSELoss, SGD](model, optimizer, loss_fn)
+        var loop = TrainingLoop[SimpleMLP, MSELoss, TrainingLoopSGD](
+            model, optimizer, loss_fn
+        )
         ```
     """
 

--- a/tests/projectodyssey/core/test_utility.mojo
+++ b/tests/projectodyssey/core/test_utility.mojo
@@ -17,6 +17,7 @@ from projectodyssey.tensor.any_tensor import (
     clone,
     item,
     diff,
+    nan_tensor,
 )
 from projectodyssey.core.shape import as_contiguous
 from projectodyssey.core.matrix import transpose_view
@@ -1053,6 +1054,67 @@ def test_diff_higher_order() raises:
         assert_value_at(d, i, 0.0, 1e-6, "Second-order differences should be 0")
 
 
+# ============================================================================
+# array_equal — whole-tensor NaN-aware equality (issues #4061, #5081)
+# ============================================================================
+
+
+def test_array_equal_identical() raises:
+    """Identical tensors compare equal."""
+    var a = full([3, 2], 4.0, DType.float32)
+    var b = full([3, 2], 4.0, DType.float32)
+    assert_true(a.array_equal(b), "identical tensors should be equal")
+
+
+def test_array_equal_different_values() raises:
+    """Tensors differing in one value are unequal."""
+    var a = full([4], 1.0, DType.float32)
+    var b = full([4], 1.0, DType.float32)
+    b.set(2, Float64(9.0))
+    assert_false(a.array_equal(b), "differing values should be unequal")
+
+
+def test_array_equal_different_shape() raises:
+    """Tensors of different shape are unequal."""
+    var a = ones([6], DType.float32)
+    var b = ones([2, 3], DType.float32)
+    assert_false(a.array_equal(b), "different shapes should be unequal")
+
+
+def test_array_equal_different_dtype() raises:
+    """Tensors of different dtype are unequal."""
+    var a = ones([4], DType.float32)
+    var b = ones([4], DType.float64)
+    assert_false(a.array_equal(b), "different dtypes should be unequal")
+
+
+def test_array_equal_nan_equal_when_equal_nan_true() raises:
+    """With equal_nan=True, NaN matches NaN position-wise (the default)."""
+    var a = nan_tensor([3], DType.float32)
+    var b = nan_tensor([3], DType.float32)
+    assert_true(
+        a.array_equal(b),
+        "NaN tensors should be equal under default equal_nan=True",
+    )
+
+
+def test_array_equal_nan_unequal_when_equal_nan_false() raises:
+    """With equal_nan=False, any NaN makes tensors unequal (IEEE 754)."""
+    var a = nan_tensor([3], DType.float32)
+    var b = nan_tensor([3], DType.float32)
+    assert_false(
+        a.array_equal(b, equal_nan=False),
+        "NaN tensors should be unequal under equal_nan=False",
+    )
+
+
+def test_array_equal_nan_vs_number() raises:
+    """A NaN element never equals a finite element, regardless of equal_nan."""
+    var a = nan_tensor([2], DType.float32)
+    var b = full([2], 1.0, DType.float32)
+    assert_false(a.array_equal(b), "NaN vs number should be unequal")
+
+
 def main() raises:
     """Run all test_utility tests."""
     print("Running test_utility tests...")
@@ -1209,5 +1271,26 @@ def main() raises:
 
     test_diff_higher_order()
     print("✓ test_diff_higher_order")
+
+    test_array_equal_identical()
+    print("✓ test_array_equal_identical")
+
+    test_array_equal_different_values()
+    print("✓ test_array_equal_different_values")
+
+    test_array_equal_different_shape()
+    print("✓ test_array_equal_different_shape")
+
+    test_array_equal_different_dtype()
+    print("✓ test_array_equal_different_dtype")
+
+    test_array_equal_nan_equal_when_equal_nan_true()
+    print("✓ test_array_equal_nan_equal_when_equal_nan_true")
+
+    test_array_equal_nan_unequal_when_equal_nan_false()
+    print("✓ test_array_equal_nan_unequal_when_equal_nan_false")
+
+    test_array_equal_nan_vs_number()
+    print("✓ test_array_equal_nan_vs_number")
 
     print("\nAll test_utility tests passed!")

--- a/tests/projectodyssey/tensor/test_tensor_creation.mojo
+++ b/tests/projectodyssey/tensor/test_tensor_creation.mojo
@@ -1,0 +1,179 @@
+"""Direct unit tests for the tensor_creation module (issue #5158).
+
+Other tests reach these creation functions through the
+`projectodyssey.tensor.any_tensor` re-export layer. This file imports
+straight from `projectodyssey.tensor.tensor_creation` so the module is
+verified independently of that re-export.
+"""
+
+from std.testing import assert_true, assert_equal, assert_almost_equal
+from std.math import isnan, isinf
+from projectodyssey.tensor.tensor_creation import (
+    zeros,
+    ones,
+    full,
+    empty,
+    arange,
+    eye,
+    linspace,
+    ones_like,
+    zeros_like,
+    full_like,
+    nan_tensor,
+    inf_tensor,
+    neg_inf_tensor,
+)
+
+
+def test_zeros_shape_and_values() raises:
+    """Zeros creates a correctly shaped all-zero tensor."""
+    var t = zeros([2, 3], DType.float32)
+    assert_equal(t.numel(), 6, "zeros numel")
+    assert_equal(t.shape()[0], 2, "zeros dim0")
+    assert_equal(t.shape()[1], 3, "zeros dim1")
+    for i in range(t.numel()):
+        assert_equal(t._get_float64(i), 0.0, "zeros element")
+
+
+def test_ones_values() raises:
+    """Ones creates an all-one tensor."""
+    var t = ones([4], DType.float32)
+    assert_equal(t.numel(), 4, "ones numel")
+    for i in range(t.numel()):
+        assert_equal(t._get_float64(i), 1.0, "ones element")
+
+
+def test_full_fill_value() raises:
+    """Full fills every element with the given value."""
+    var t = full([5], 3.5, DType.float32)
+    for i in range(t.numel()):
+        assert_almost_equal(t._get_float64(i), 3.5, atol=1e-6)
+
+
+def test_empty_shape() raises:
+    """Empty allocates a tensor of the requested shape."""
+    var t = empty([3, 2], DType.float32)
+    assert_equal(t.numel(), 6, "empty numel")
+    assert_equal(t.shape()[0], 3, "empty dim0")
+
+
+def test_arange_sequence() raises:
+    """Arange produces a 0,1,2,... sequence."""
+    var t = arange(0.0, 5.0, 1.0, DType.float32)
+    assert_equal(t.numel(), 5, "arange length")
+    for i in range(5):
+        assert_almost_equal(t._get_float64(i), Float64(i), atol=1e-6)
+
+
+def test_eye_identity() raises:
+    """Eye places ones on the main diagonal and zeros elsewhere."""
+    var t = eye(3, 3, 0, DType.float32)
+    assert_equal(t.numel(), 9, "eye numel")
+    for r in range(3):
+        for c in range(3):
+            var expected = 1.0 if r == c else 0.0
+            assert_almost_equal(t._get_float64(r * 3 + c), expected, atol=1e-6)
+
+
+def test_linspace_endpoints() raises:
+    """Linspace spans start..stop inclusive with even spacing."""
+    var t = linspace(0.0, 1.0, 5, DType.float32)
+    assert_equal(t.numel(), 5, "linspace length")
+    assert_almost_equal(t._get_float64(0), 0.0, atol=1e-6)
+    assert_almost_equal(t._get_float64(4), 1.0, atol=1e-6)
+    assert_almost_equal(t._get_float64(2), 0.5, atol=1e-6)
+
+
+def test_ones_like_matches_shape() raises:
+    """Ones_like copies the source shape and fills with ones."""
+    var src = zeros([2, 4], DType.float32)
+    var t = ones_like(src)
+    assert_equal(t.numel(), 8, "ones_like numel")
+    for i in range(t.numel()):
+        assert_equal(t._get_float64(i), 1.0, "ones_like element")
+
+
+def test_zeros_like_matches_shape() raises:
+    """Zeros_like copies the source shape and fills with zeros."""
+    var src = ones([6], DType.float32)
+    var t = zeros_like(src)
+    assert_equal(t.numel(), 6, "zeros_like numel")
+    for i in range(t.numel()):
+        assert_equal(t._get_float64(i), 0.0, "zeros_like element")
+
+
+def test_full_like_fill() raises:
+    """Full_like copies the source shape and fills with a constant."""
+    var src = zeros([3], DType.float32)
+    var t = full_like(src, 7.0)
+    for i in range(t.numel()):
+        assert_almost_equal(t._get_float64(i), 7.0, atol=1e-6)
+
+
+def test_nan_tensor_is_nan() raises:
+    """Nan_tensor fills every element with NaN."""
+    var t = nan_tensor([4], DType.float32)
+    for i in range(t.numel()):
+        assert_true(isnan(t._get_float64(i)), "nan_tensor element is NaN")
+
+
+def test_inf_tensor_is_positive_inf() raises:
+    """Inf_tensor fills with +infinity."""
+    var t = inf_tensor([4], DType.float32)
+    for i in range(t.numel()):
+        var v = t._get_float64(i)
+        assert_true(isinf(v) and v > 0.0, "inf_tensor element is +inf")
+
+
+def test_neg_inf_tensor_is_negative_inf() raises:
+    """Neg_inf_tensor fills with -infinity."""
+    var t = neg_inf_tensor([4], DType.float32)
+    for i in range(t.numel()):
+        var v = t._get_float64(i)
+        assert_true(isinf(v) and v < 0.0, "neg_inf_tensor element is -inf")
+
+
+def main() raises:
+    """Run all tensor_creation tests."""
+    print("Running test_tensor_creation tests...")
+
+    test_zeros_shape_and_values()
+    print("✓ test_zeros_shape_and_values")
+
+    test_ones_values()
+    print("✓ test_ones_values")
+
+    test_full_fill_value()
+    print("✓ test_full_fill_value")
+
+    test_empty_shape()
+    print("✓ test_empty_shape")
+
+    test_arange_sequence()
+    print("✓ test_arange_sequence")
+
+    test_eye_identity()
+    print("✓ test_eye_identity")
+
+    test_linspace_endpoints()
+    print("✓ test_linspace_endpoints")
+
+    test_ones_like_matches_shape()
+    print("✓ test_ones_like_matches_shape")
+
+    test_zeros_like_matches_shape()
+    print("✓ test_zeros_like_matches_shape")
+
+    test_full_like_fill()
+    print("✓ test_full_like_fill")
+
+    test_nan_tensor_is_nan()
+    print("✓ test_nan_tensor_is_nan")
+
+    test_inf_tensor_is_positive_inf()
+    print("✓ test_inf_tensor_is_positive_inf")
+
+    test_neg_inf_tensor_is_negative_inf()
+    print("✓ test_neg_inf_tensor_is_negative_inf")
+
+    print("\nAll test_tensor_creation tests passed!")

--- a/tests/projectodyssey/tensor/test_tensor_utils.mojo
+++ b/tests/projectodyssey/tensor/test_tensor_utils.mojo
@@ -1,0 +1,120 @@
+"""Direct unit tests for the tensor_utils module (issue #5158).
+
+Other tests reach these utilities through the
+`projectodyssey.tensor.any_tensor` re-export layer. This file imports
+straight from `projectodyssey.tensor.tensor_utils` so the module is
+verified independently of that re-export.
+"""
+
+from std.testing import assert_true, assert_equal, assert_almost_equal
+from projectodyssey.tensor.tensor_creation import zeros, ones, full, arange
+from projectodyssey.tensor.tensor_utils import (
+    calculate_max_batch_size,
+    copy,
+    clone,
+    item,
+    diff,
+    tolist,
+    contiguous,
+)
+
+
+def test_calculate_max_batch_size_positive() raises:
+    """Return a positive batch size for a small sample."""
+    var sample_shape: List[Int] = [3, 32, 32]
+    var n = calculate_max_batch_size(sample_shape, DType.float32)
+    assert_true(n > 0, "max batch size should be positive")
+
+
+def test_calculate_max_batch_size_smaller_for_tight_memory() raises:
+    """A tighter memory budget yields a smaller-or-equal batch size."""
+    var sample_shape: List[Int] = [3, 32, 32]
+    var big = calculate_max_batch_size(
+        sample_shape, DType.float32, max_memory_bytes=500_000_000
+    )
+    var small = calculate_max_batch_size(
+        sample_shape, DType.float32, max_memory_bytes=1_000_000
+    )
+    assert_true(small <= big, "tighter budget -> smaller batch")
+
+
+def test_copy_is_independent() raises:
+    """Copy returns a deep copy whose data does not alias the source."""
+    var src = full([4], 2.0, DType.float32)
+    var dst = copy(src)
+    assert_equal(dst.numel(), 4, "copy numel")
+    for i in range(4):
+        assert_almost_equal(dst._get_float64(i), 2.0, atol=1e-6)
+
+
+def test_clone_matches_source() raises:
+    """Clone reproduces the source shape and values."""
+    var src = arange(0.0, 6.0, 1.0, DType.float32)
+    var c = clone(src)
+    assert_equal(c.numel(), 6, "clone numel")
+    for i in range(6):
+        assert_almost_equal(c._get_float64(i), Float64(i), atol=1e-6)
+
+
+def test_item_single_element() raises:
+    """Item extracts the scalar value of a one-element tensor."""
+    var t = full([1], 9.0, DType.float32)
+    assert_almost_equal(item(t), 9.0, atol=1e-6)
+
+
+def test_diff_consecutive() raises:
+    """Diff returns consecutive differences (one shorter than input)."""
+    var t = arange(0.0, 5.0, 1.0, DType.float32)  # [0,1,2,3,4]
+    var d = diff(t)
+    assert_equal(d.numel(), 4, "diff length is N-1")
+    for i in range(4):
+        assert_almost_equal(d._get_float64(i), 1.0, atol=1e-6)
+
+
+def test_tolist_values() raises:
+    """Tolist flattens a tensor into a List[Float64]."""
+    var t = full([3], 4.0, DType.float32)
+    var lst = tolist(t)
+    assert_equal(len(lst), 3, "tolist length")
+    for i in range(3):
+        assert_almost_equal(lst[i], 4.0, atol=1e-6)
+
+
+def test_contiguous_preserves_values() raises:
+    """Contiguous returns a tensor with the same shape and values."""
+    var t = arange(0.0, 4.0, 1.0, DType.float32)
+    var c = contiguous(t)
+    assert_equal(c.numel(), 4, "contiguous numel")
+    for i in range(4):
+        assert_almost_equal(c._get_float64(i), Float64(i), atol=1e-6)
+
+
+def main() raises:
+    """Run all tensor_utils tests."""
+    print("Running test_tensor_utils tests...")
+
+    test_calculate_max_batch_size_positive()
+    print("✓ test_calculate_max_batch_size_positive")
+
+    test_calculate_max_batch_size_smaller_for_tight_memory()
+    print("✓ test_calculate_max_batch_size_smaller_for_tight_memory")
+
+    test_copy_is_independent()
+    print("✓ test_copy_is_independent")
+
+    test_clone_matches_source()
+    print("✓ test_clone_matches_source")
+
+    test_item_single_element()
+    print("✓ test_item_single_element")
+
+    test_diff_consecutive()
+    print("✓ test_diff_consecutive")
+
+    test_tolist_values()
+    print("✓ test_tolist_values")
+
+    test_contiguous_preserves_values()
+    print("✓ test_contiguous_preserves_values")
+
+    print("\nAll test_tensor_utils tests passed!")

--- a/tests/projectodyssey/test_imports.mojo
+++ b/tests/projectodyssey/test_imports.mojo
@@ -34,12 +34,11 @@ from projectodyssey.core import (
     tanh,
 )
 
-# projectodyssey.training.SGD is a struct-based wrapper around the autograd SGD
-# optimizer (src/projectodyssey/training/__init__.mojo) while projectodyssey.SGD re-exports
-# the lower-level projectodyssey.autograd.optimizers.SGD directly
-# (src/projectodyssey/__init__.mojo). They are intentionally two distinct types with
-# the same name, so we alias the training wrapper here to keep both
-# importable in one module without a name collision.
+# projectodyssey.training.TrainingLoopSGD is a thin Optimizer-trait adapter
+# for the generic TrainingLoop, distinct from projectodyssey.autograd's real
+# SGD optimizer (which projectodyssey.SGD re-exports). They were renamed apart
+# in issue #5392 — both used to be named `SGD`, which made the top-level
+# `from projectodyssey import SGD` an ambiguous import.
 from projectodyssey.training import (
     Callback,
     CosineAnnealingLR,
@@ -50,8 +49,8 @@ from projectodyssey.training import (
     ModelCheckpoint,
     MultiStepLR,
     ReduceLROnPlateau,
-    SGD as TrainingSGD,
     StepLR,
+    TrainingLoopSGD,
     TrainingState,
     WarmupLR,
     base,

--- a/tests/projectodyssey/training/test_gradient_clipping.mojo
+++ b/tests/projectodyssey/training/test_gradient_clipping.mojo
@@ -584,6 +584,72 @@ def test_clip_per_param_f64() raises:
         )
 
 
+# ============================================================================
+# Scalar fallback path tests (non-float dtypes — issue #5145)
+#
+# compute_gradient_norm_list / clip_gradients_by_global_norm /
+# clip_gradients_per_param / clip_gradients_by_value_list take a SIMD path for
+# float32/float64 and a scalar `_get_float64`/`_set_float64` fallback for every
+# other dtype. These tests exercise that fallback with int32 gradients.
+# ============================================================================
+
+
+def test_norm_scalar_fallback_int32() raises:
+    """Use the scalar path of compute_gradient_norm_list for int32 tensors."""
+    var grads = List[AnyTensor]()
+    # 9 elements of value 2 → norm = sqrt(9 * 4) = 6.0
+    grads.append(full([9], 2.0, DType.int32))
+    var norm = compute_gradient_norm_list(grads)
+    assert_close_float(
+        Float64(norm),
+        6.0,
+        atol=1e-4,
+        message="int32 scalar-fallback norm should be 6.0",
+    )
+
+
+def test_clip_by_global_norm_scalar_fallback_int32() raises:
+    """Report the int32 scalar-path norm from clip_gradients_by_global_norm."""
+    var grads = List[AnyTensor]()
+    grads.append(full([16], 3.0, DType.int32))  # norm = sqrt(16*9) = 12.0
+    var pre_norm = clip_gradients_by_global_norm(grads, max_norm=100.0)
+    assert_close_float(
+        Float64(pre_norm),
+        12.0,
+        atol=1e-4,
+        message="int32 scalar-fallback pre-clip norm should be 12.0",
+    )
+
+
+def test_clip_per_param_scalar_fallback_int32() raises:
+    """Run clip_gradients_per_param on int32 via its scalar fallback path."""
+    var grads = List[AnyTensor]()
+    grads.append(full([25], 2.0, DType.int32))  # local norm = sqrt(25*4) = 10
+    # max_norm above the local norm: a no-op clip, but exercises the path.
+    clip_gradients_per_param(grads, max_norm=100.0)
+    var v = grads[0]._get_float64(0)
+    assert_close_float(
+        v,
+        2.0,
+        atol=1e-4,
+        message="int32 scalar-fallback per-param value unchanged",
+    )
+
+
+def test_clip_by_value_scalar_fallback_int32() raises:
+    """Clamp int32 gradients via the value-clip scalar fallback path."""
+    var grads = List[AnyTensor]()
+    grads.append(full([8], 9.0, DType.int32))  # all 9 — above max
+    clip_gradients_by_value_list(grads, min_value=-5.0, max_value=5.0)
+    for j in range(8):
+        assert_close_float(
+            grads[0]._get_float64(j),
+            5.0,
+            atol=1e-4,
+            message="int32 value above max should clamp to 5.0",
+        )
+
+
 def main() raises:
     """Run all gradient clipping tests."""
     print("Testing Gradient Clipping...")
@@ -641,22 +707,38 @@ def main() raises:
     test_clip_per_param_non_aligned()
     print("✓ PASSED")
 
-    print("[14/17] Testing float64 gradient norm computation...")
+    print("[14/21] Testing float64 gradient norm computation...")
     test_compute_gradient_norm_f64()
     print("✓ PASSED")
 
-    print("[15/17] Testing float64 global norm clipping (with clipping)...")
+    print("[15/21] Testing float64 global norm clipping (with clipping)...")
     test_clip_by_global_norm_f64_with_clipping()
     print("✓ PASSED")
 
-    print("[16/17] Testing float64 value clipping...")
+    print("[16/21] Testing float64 value clipping...")
     test_clip_by_value_f64()
     print("✓ PASSED")
 
-    print("[17/17] Testing float64 per-param clipping...")
+    print("[17/21] Testing float64 per-param clipping...")
     test_clip_per_param_f64()
     print("✓ PASSED")
 
+    print("[18/21] Testing int32 scalar-fallback norm...")
+    test_norm_scalar_fallback_int32()
+    print("✓ PASSED")
+
+    print("[19/21] Testing int32 scalar-fallback global-norm clip...")
+    test_clip_by_global_norm_scalar_fallback_int32()
+    print("✓ PASSED")
+
+    print("[20/21] Testing int32 scalar-fallback per-param clip...")
+    test_clip_per_param_scalar_fallback_int32()
+    print("✓ PASSED")
+
+    print("[21/21] Testing int32 scalar-fallback value clip...")
+    test_clip_by_value_scalar_fallback_int32()
+    print("✓ PASSED")
+
     print("\n" + "=" * 70)
-    print("All 17 gradient clipping tests PASSED! ✓")
+    print("All 21 gradient clipping tests PASSED! ✓")
     print("Gradient clipping utilities are working correctly.")

--- a/tests/projectodyssey/training/test_training_loop.mojo
+++ b/tests/projectodyssey/training/test_training_loop.mojo
@@ -8,7 +8,7 @@ Tests cover:
 Issue #2728: Enable Training Loop Tests with SimpleMLP and AnyTensor.randn.
 Tests enabled after core infrastructure was completed:
 - MSELoss.compute() implementation
-- SGD/TrainingLoop integration via autograd
+- TrainingLoopSGD/TrainingLoop integration via autograd
 - AnyTensor.randn export from projectodyssey.core
 """
 
@@ -29,7 +29,11 @@ from tests.projectodyssey.conftest import (
     create_simple_model,
     create_test_vector,
 )
-from projectodyssey.training import SGD, MSELoss, TrainingLoop
+from projectodyssey.training import (
+    TrainingLoopSGD,
+    MSELoss,
+    TrainingLoop,
+)
 from projectodyssey.training.trainer_interface import DataLoader
 from projectodyssey.tensor.any_tensor import (
     AnyTensor,
@@ -78,9 +82,9 @@ def test_training_loop_single_batch() raises:
     """
     # Create model, optimizer, and loss function
     var model = create_simple_model()
-    var optimizer = SGD(learning_rate=0.01)
+    var optimizer = TrainingLoopSGD(learning_rate=0.01)
     var loss_fn = MSELoss()
-    var training_loop = TrainingLoop[SimpleMLP, MSELoss, SGD](
+    var training_loop = TrainingLoop[SimpleMLP, MSELoss, TrainingLoopSGD](
         model^, optimizer^, loss_fn^
     )
 
@@ -110,9 +114,9 @@ def test_training_loop_full_epoch() raises:
     """
     # Create model, optimizer, and loss function
     var model = create_simple_model()
-    var optimizer = SGD(learning_rate=0.01)
+    var optimizer = TrainingLoopSGD(learning_rate=0.01)
     var loss_fn = MSELoss()
-    var training_loop = TrainingLoop[SimpleMLP, MSELoss, SGD](
+    var training_loop = TrainingLoop[SimpleMLP, MSELoss, TrainingLoopSGD](
         model^, optimizer^, loss_fn^
     )
 
@@ -157,9 +161,9 @@ def test_training_loop_multiple_epochs() raises:
     """
     # Create model, optimizer, and loss function
     var model = create_simple_model()
-    var optimizer = SGD(learning_rate=0.1)
+    var optimizer = TrainingLoopSGD(learning_rate=0.1)
     var loss_fn = MSELoss()
-    var training_loop = TrainingLoop[SimpleMLP, MSELoss, SGD](
+    var training_loop = TrainingLoop[SimpleMLP, MSELoss, TrainingLoopSGD](
         model^, optimizer^, loss_fn^
     )
 
@@ -196,9 +200,9 @@ def test_training_loop_forward_pass() raises:
     """
     # Create model, optimizer, and loss function
     var model = create_simple_model()
-    var optimizer = SGD(learning_rate=0.01)
+    var optimizer = TrainingLoopSGD(learning_rate=0.01)
     var loss_fn = MSELoss()
-    var training_loop = TrainingLoop[SimpleMLP, MSELoss, SGD](
+    var training_loop = TrainingLoop[SimpleMLP, MSELoss, TrainingLoopSGD](
         model^, optimizer^, loss_fn^
     )
 
@@ -226,9 +230,9 @@ def test_training_loop_forward_batches_independently() raises:
     """
     # Create model, optimizer, and loss function
     var model = create_simple_model()
-    var optimizer = SGD(learning_rate=0.01)
+    var optimizer = TrainingLoopSGD(learning_rate=0.01)
     var loss_fn = MSELoss()
-    var training_loop = TrainingLoop[SimpleMLP, MSELoss, SGD](
+    var training_loop = TrainingLoop[SimpleMLP, MSELoss, TrainingLoopSGD](
         model^, optimizer^, loss_fn^
     )
 
@@ -258,9 +262,9 @@ def test_training_loop_computes_loss() raises:
     """
     # Create model, optimizer, and loss function
     var model = create_simple_model()
-    var optimizer = SGD(learning_rate=0.01)
+    var optimizer = TrainingLoopSGD(learning_rate=0.01)
     var loss_fn = MSELoss()
-    var training_loop = TrainingLoop[SimpleMLP, MSELoss, SGD](
+    var training_loop = TrainingLoop[SimpleMLP, MSELoss, TrainingLoopSGD](
         model^, optimizer^, loss_fn^
     )
 
@@ -294,9 +298,9 @@ def test_training_loop_loss_scalar() raises:
     """
     # Create model, optimizer, and loss function
     var model = create_simple_model()
-    var optimizer = SGD(learning_rate=0.01)
+    var optimizer = TrainingLoopSGD(learning_rate=0.01)
     var loss_fn = MSELoss()
-    var training_loop = TrainingLoop[SimpleMLP, MSELoss, SGD](
+    var training_loop = TrainingLoop[SimpleMLP, MSELoss, TrainingLoopSGD](
         model^, optimizer^, loss_fn^
     )
 
@@ -331,9 +335,9 @@ def test_training_loop_backward_pass() raises:
     """
     # Create model, optimizer, and loss function
     var model = create_simple_model()
-    var optimizer = SGD(learning_rate=0.01)
+    var optimizer = TrainingLoopSGD(learning_rate=0.01)
     var loss_fn = MSELoss()
-    var training_loop = TrainingLoop[SimpleMLP, MSELoss, SGD](
+    var training_loop = TrainingLoop[SimpleMLP, MSELoss, TrainingLoopSGD](
         model^, optimizer^, loss_fn^
     )
 
@@ -365,9 +369,9 @@ def test_training_loop_gradient_accumulation() raises:
     """
     # Create model, optimizer, and loss function
     var model = create_simple_model()
-    var optimizer = SGD(learning_rate=0.01)
+    var optimizer = TrainingLoopSGD(learning_rate=0.01)
     var loss_fn = MSELoss()
-    var training_loop = TrainingLoop[SimpleMLP, MSELoss, SGD](
+    var training_loop = TrainingLoop[SimpleMLP, MSELoss, TrainingLoopSGD](
         model^, optimizer^, loss_fn^
     )
 
@@ -405,9 +409,9 @@ def test_training_loop_updates_weights() raises:
     """
     # Create model, optimizer, and loss function
     var model = create_simple_model()
-    var optimizer = SGD(learning_rate=0.1)
+    var optimizer = TrainingLoopSGD(learning_rate=0.1)
     var loss_fn = MSELoss()
-    var training_loop = TrainingLoop[SimpleMLP, MSELoss, SGD](
+    var training_loop = TrainingLoop[SimpleMLP, MSELoss, TrainingLoopSGD](
         model^, optimizer^, loss_fn^
     )
 
@@ -441,16 +445,16 @@ def test_training_loop_respects_learning_rate() raises:
     var model2 = create_simple_model()
 
     # Different learning rates
-    var optimizer1 = SGD(learning_rate=0.001)
-    var optimizer2 = SGD(learning_rate=0.1)  # 100x larger
+    var optimizer1 = TrainingLoopSGD(learning_rate=0.001)
+    var optimizer2 = TrainingLoopSGD(learning_rate=0.1)  # 100x larger
 
     var loss_fn1 = MSELoss()
     var loss_fn2 = MSELoss()
 
-    var loop1 = TrainingLoop[SimpleMLP, MSELoss, SGD](
+    var loop1 = TrainingLoop[SimpleMLP, MSELoss, TrainingLoopSGD](
         model1^, optimizer1^, loss_fn1^
     )
-    var loop2 = TrainingLoop[SimpleMLP, MSELoss, SGD](
+    var loop2 = TrainingLoop[SimpleMLP, MSELoss, TrainingLoopSGD](
         model2^, optimizer2^, loss_fn2^
     )
 
@@ -484,9 +488,9 @@ def test_training_loop_processes_variable_batch_sizes() raises:
     """
     # Create model, optimizer, and loss function
     var model = create_simple_model()
-    var optimizer = SGD(learning_rate=0.01)
+    var optimizer = TrainingLoopSGD(learning_rate=0.01)
     var loss_fn = MSELoss()
-    var training_loop = TrainingLoop[SimpleMLP, MSELoss, SGD](
+    var training_loop = TrainingLoop[SimpleMLP, MSELoss, TrainingLoopSGD](
         model^, optimizer^, loss_fn^
     )
 
@@ -515,9 +519,9 @@ def test_training_loop_averages_loss_over_batch() raises:
     """
     # Create model, optimizer, and loss function
     var model = create_simple_model()
-    var optimizer = SGD(learning_rate=0.01)
+    var optimizer = TrainingLoopSGD(learning_rate=0.01)
     var loss_fn = MSELoss(reduction="mean")
-    var training_loop = TrainingLoop[SimpleMLP, MSELoss, SGD](
+    var training_loop = TrainingLoop[SimpleMLP, MSELoss, TrainingLoopSGD](
         model^, optimizer^, loss_fn^
     )
 
@@ -549,9 +553,9 @@ def test_training_loop_property_loss_decreases_on_simple_problem() raises:
     """
     # Create model, optimizer, and loss function
     var model = create_simple_model()
-    var optimizer = SGD(learning_rate=0.01)
+    var optimizer = TrainingLoopSGD(learning_rate=0.01)
     var loss_fn = MSELoss()
-    var training_loop = TrainingLoop[SimpleMLP, MSELoss, SGD](
+    var training_loop = TrainingLoop[SimpleMLP, MSELoss, TrainingLoopSGD](
         model^, optimizer^, loss_fn^
     )
 


### PR DESCRIPTION
## Summary

Batches six small, low-risk issues into one PR (per request). Each is an isolated commit.

| Commit | Issue(s) | Change |
|--------|----------|--------|
| `fix(ci)` | #5420 | `release.yml` version regex now accepts hyphens in semver pre-release suffixes (`v0.1.0-rc-1`). |
| `fix(training)` | #5392 | Rename the `TrainingLoop` `SGD` adapter → `TrainingLoopSGD` so `from projectodyssey import SGD` is no longer ambiguous under `--Werror`. |
| `feat(tensor)` | #4061, #5081 | Add `AnyTensor.array_equal(other, equal_nan=True)` — whole-tensor `Bool` equality, NaN-aware to mirror `__hash__` (makes NaN-containing tensors usable as dict keys). |
| `test(tensor,training)` | #5145, #5158 | int32 scalar-fallback tests for the 4 gradient-clipping functions; direct unit tests for `tensor_creation.mojo` / `tensor_utils.mojo`. |

## Notes

- **#5081** (element-wise `__eq__`/`__ne__`) was already satisfied — `AnyTensor` has those as element-wise ops. The genuinely missing piece was #4061's whole-tensor NaN-aware equality, added as `array_equal`.
- **#5153** (audit core/ for manual dtype dispatch) — audit completed and posted as a comment on the issue; remaining modules (`arithmetic_contiguous.mojo` 40 ladders, `elementwise.mojo` 74, etc.) are substantial follow-up work, so #5153 stays open as the tracking issue rather than being bundled here.

## Verification

- `mojo package --Werror` builds clean.
- `from projectodyssey import SGD` resolves unambiguously (verified with a `--Werror` run).
- All affected test groups pass: `test_training_loop`, `test_imports`, `test_gradient_clipping` (21 tests, +4 new), `test_tensor_creation` (13 new), `test_tensor_utils` (8 new), `test_utility` (+7 `array_equal` tests).

Closes #5420
Closes #5392
Closes #4061
Closes #5081
Closes #5145
Closes #5158

🤖 Generated with [Claude Code](https://claude.com/claude-code)