### PR TITLE
test(ci): add non-root user smoke test to container-publish (#5147)

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -223,6 +223,27 @@ jobs:
             pixi run mojo --version
           echo "Production image working"
 
+      - name: Smoke test — non-root user (#5147)
+        env:
+          IMAGE_TAG: ${{ github.ref_name }}
+        run: |
+          # Verify the image runs as the non-root `dev` user and that
+          # pixi / mojo / pre-commit all work under that user. The Dockerfile
+          # sets `USER ${USER_NAME}` (default dev) in every stage; this asserts
+          # the published image actually behaves that way end-to-end.
+          echo "Verifying non-root user on runtime + ci images..."
+          for suffix in "" "-ci"; do
+            img="$REGISTRY/$IMAGE_NAME:${IMAGE_TAG}${suffix}"
+            echo "--- $img ---"
+            podman run --rm "$img" bash -c '
+              set -euo pipefail
+              whoami
+              test "$(id -un)" != "root"
+              pixi run mojo --version
+              pixi run pre-commit --version'
+          done
+          echo "Non-root user smoke test passed"
+
       - name: Run smoke tests
         env:
           IMAGE_TAG: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

Adds a non-root-user smoke test to `container-publish.yml` (#5147).

## Background

`Dockerfile.ci` sets `USER ${USER_NAME}` (default `dev`) in every stage, but the publish workflow's smoke tests (`podman run … pixi run mojo --version`) never verified the published images actually run as a **non-root** user, or that pixi/mojo/pre-commit all work under that user.

## Changes Made

New `Smoke test — non-root user` step in `container-publish.yml`: for the `runtime` and `-ci` images, it asserts `id -un` is not `root` and runs `pixi run mojo --version` + `pixi run pre-commit --version`.

## Note on the issue's other concern

The issue also flagged a hardcoded `--from=builder /home/dev/build/` COPY path. That is **already resolved** — `Dockerfile.ci` uses `ARG BUILD_DIR=/build` and the COPY lines reference `/build`. No change needed there.

## Verification

- `container-publish.yml` parses as valid YAML.
- The `-ci` image tag is confirmed built by the workflow matrix (`target: ci` → `suffix: -ci`).
- The `ci` stage already runs `pre-commit install-hooks` as `dev`, so the assertion is sound.

Closes #5147

🤖 Generated with [Claude Code](https://claude.com/claude-code)