### PR TITLE
test(ci): add gradient-checker soak workflow (#5170)

### DIFF
--- a/.github/workflows/gradient-soak.yml
+++ b/.github/workflows/gradient-soak.yml
@@ -1,0 +1,81 @@
+name: Gradient Checker Soak Test
+
+# Soak test for issue #5170: runs the gradient-checking test group many times
+# in succession to build statistical confidence that the intermittent JIT
+# crash addressed by #5104 (per-element bitcast elimination) is eliminated.
+#
+# This is a SOAK test — deliberate repetition to *detect* a flake — not a
+# retry that masks one. It is scheduled (weekly) and manually dispatchable,
+# never run per-PR (it is long-running).
+#
+# REMOVE THIS WORKFLOW once enough consecutive clean runs have established
+# confidence that the gradient-checker JIT crash is gone (see #5170).
+
+on:
+  # Weekly, Sunday 05:00 UTC (after the Saturday model-e2e run).
+  schedule:
+    - cron: '0 5 * * 0'
+
+  # On-demand: lets a maintainer run the soak immediately and pick the
+  # iteration count.
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: 'Number of soak iterations'
+        required: false
+        type: string
+        default: '15'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  gradient-soak:
+    name: Gradient Checker Soak
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    # Scheduled runs only on main; workflow_dispatch from any branch.
+    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up container
+        uses: ./.github/actions/setup-container
+
+      - name: Run gradient-checker soak
+        env:
+          ITERATIONS: ${{ github.event.inputs.iterations || '15' }}
+        run: |
+          echo "Gradient-checker soak — $ITERATIONS iterations"
+          echo "Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+          echo ""
+
+          failures=0
+          for i in $(seq 1 "$ITERATIONS"); do
+            echo "=================================================="
+            echo "Soak iteration $i / $ITERATIONS"
+            echo "=================================================="
+            if ! just test-group "tests/projectodyssey/core" \
+                "test_gradient_checking_basic.mojo test_gradient_checking_dtype.mojo"; then
+              echo "Iteration $i FAILED"
+              failures=$((failures + 1))
+            fi
+          done
+
+          echo ""
+          echo "=================================================="
+          echo "Soak complete: $failures / $ITERATIONS iterations failed"
+          echo "=================================================="
+          if [ "$failures" -ne 0 ]; then
+            echo "Gradient-checker soak detected failures — the JIT crash"
+            echo "is NOT yet eliminated. Investigate before removing this job."
+            exit 1
+          fi
+          echo "All $ITERATIONS iterations passed."


### PR DESCRIPTION
## Summary

Adds `gradient-soak.yml` — a soak-test workflow for the gradient checker (#5170).

## Background

#5104 eliminated the per-element bitcast in the gradient checker's tight loops, which should fix the intermittent JIT crash. But the crash was intermittent by nature — a single green CI run isn't proof it's gone.

## Changes Made

New `.github/workflows/gradient-soak.yml`:
- Runs the gradient-checking test group **15× in succession** (`test_gradient_checking_basic.mojo`, `test_gradient_checking_dtype.mojo` via `just test-group`).
- Fails if any iteration crashes.
- Triggers: weekly `schedule` + `workflow_dispatch` (with a configurable iteration count). **Not** run per-PR — it's long-running.
- Documented as removable once confidence is established (per the issue).

## Note on the no-retries policy

This is a **soak test** — deliberate repetition to *detect* a flake — which is the opposite of a `gh run rerun` that *masks* one. It does not conflict with the no-CI-retries policy.

## Verification

- `gradient-soak.yml` parses as valid YAML; pre-commit passes.
- `.github/actions/setup-container` exists; both named gradient test files exist.

Closes #5170

🤖 Generated with [Claude Code](https://claude.com/claude-code)