### PR TITLE
feat(examples): add grok/lenet_emnist with AdamW, subset training, and multi-metric checkpointing

### DIFF
--- a/examples/grok/lenet_emnist/README.md
+++ b/examples/grok/lenet_emnist/README.md
@@ -154,7 +154,7 @@ Differences from `examples/lenet_emnist/`:
 
 ## Multi-metric best-checkpoint tracker
 
-Per-metric tracking modes via `--track-metric NAME:MODE` (repeatable):
+Per-metric tracking modes via `--track-metric NAME:MODE,NAME:MODE,...` (comma-separated, single flag):
 
 | Mode | Files saved | When |
 | --- | --- | --- |
@@ -167,10 +167,12 @@ Each `.bin` file is accompanied by a `.json` sidecar with `{"metric", "mode_kind
 Defaults from `train.sh`:
 
 ```text
---track-metric test_acc:max         # the headline "best model" checkpoint
---track-metric test_loss:both       # detect post-peak loss recovery (grok signal)
---track-metric train_loss:min       # sanity: training did converge
---track-metric weight_l2_norm:max   # detect weight-norm growth phase
+--track-metric "test_acc:max,test_loss:both,train_loss:min,weight_l2_norm:max"
+#                ^             ^             ^              ^
+#                |             |             |              detect weight-norm growth phase
+#                |             |             sanity: training did converge
+#                |             detect post-peak loss recovery (grok signal)
+#                the headline "best model" checkpoint
 ```
 
 The `min_after_max` and `max_after_min` distinction matters: a naive
@@ -195,7 +197,7 @@ during Phase 3).
 | `--max-batches` | 0 | If > 0, stop training after N batches per epoch (dry-run aid) |
 | `--log-every` | 1 | Emit EPOCH structured line every K epochs |
 | `--checkpoint-every` | 1 | Run checkpoint update every K epochs |
-| `--track-metric` | (repeatable) | `metric_name:mode` — see table above |
+| `--track-metric` | `test_acc:max` | Comma-separated list of `metric_name:mode` — see table above |
 
 `train.sh` presets a sensible subset of these per profile.
 

--- a/examples/grok/lenet_emnist/README.md
+++ b/examples/grok/lenet_emnist/README.md
@@ -1,0 +1,266 @@
+# Grokking experiment: LeNet-5 on EMNIST subset
+
+A grokking-aimed training regime for LeNet-5 on a small EMNIST subset. Forks
+`examples/lenet_emnist/` and adds AdamW with strong weight decay, a subset
+sampler, full per-epoch instrumentation (train/test loss + accuracy + weight
+L2 norm), and a multi-metric best-checkpoint tracker.
+
+**Architecture**: LeNet-5 (LeCun et al., 1998) — unchanged from
+`examples/lenet_emnist/`.
+
+**Dataset**: EMNIST Balanced (47 classes), subsampled at training time.
+
+**Status**: 🧪 **Experimental scaffold** — the training regime is wired and
+verified end-to-end. Whether grokking actually occurs on LeNet+EMNIST is a
+research question this scaffold is built to investigate; expectations are
+calibrated below.
+
+> **Looking for the standard supervised LeNet baseline?** Use
+> [`examples/lenet_emnist/`](../../lenet_emnist/). That example uses SGD and the
+> full training set and is the right starting point for "I just want LeNet on
+> EMNIST to work."
+
+## Why this example exists
+
+A user trained the standard LeNet-5 / EMNIST example for 500 epochs hoping
+to observe *grokking* (Power et al. 2022 — delayed generalization where
+test accuracy jumps long after training loss plateaus). They observed the
+opposite: late-stage overfitting (peak test acc 86.72 % at epoch 246,
+slowly regressed to 85.91 % by epoch 500 while training loss kept dropping).
+Two skills were captured in ProjectMnemosyne:
+
+- [`training-diagnosis-loss-accuracy-decoupling-overfitting`](https://github.com/HomericIntelligence/ProjectMnemosyne/blob/main/skills/training-diagnosis-loss-accuracy-decoupling-overfitting.md)
+  — diagnosing why loss can keep falling while test accuracy plateaus.
+- [`training-grokking-preconditions-and-vision-recipe`](https://github.com/HomericIntelligence/ProjectMnemosyne/blob/main/skills/training-grokking-preconditions-and-vision-recipe.md)
+  — what grokking actually requires (small subset, AdamW, weight_decay ≈ 1.0,
+  10–100× memorization-time of epochs, simple/algorithmic task structure).
+
+This example implements the *recipe* from that second skill.
+
+## Realistic expectations
+
+Even with this scaffold, grokking on LeNet + EMNIST is not guaranteed and
+arguably unlikely. Published vision-task grokking (Liu et al. 2023,
+*Omnigrok*) used small MLPs on MNIST, not convnets on EMNIST. The convolutional
+inductive bias encodes a generalizing prior, which tends to make the model
+generalize from epoch 1 rather than going through the memorize-then-grok
+sequence. The honest outcome distribution:
+
+| Outcome | Approximate probability |
+| --- | --- |
+| LeNet (2 conv + FC) on EMNIST shows clear grokking | Very unlikely |
+| MLP-only variant on MNIST (closest to Omnigrok) shows grokking | Plausible |
+| Any configuration shows interesting *partial* phase transitions | Likely |
+| You learn something about the train-loss-vs-test-acc dynamics | Certain |
+
+If you want a known-working grokking recipe, the cleanest single experiment is
+the *original* Power et al. setup: modular addition mod 113 with a 2-layer
+transformer, 30 % train fraction, `weight_decay=1.0`, AdamW, ~50k epochs. That
+is a different example and would live elsewhere in the repo.
+
+## Architecture
+
+LeNet-5 with 47-class output (matches EMNIST Balanced):
+
+```text
+Input (1, 1, 28, 28)
+  -> Conv2D(6, 5×5)  -> ReLU -> MaxPool(2×2)   (1, 6, 12, 12)
+  -> Conv2D(16, 5×5) -> ReLU -> MaxPool(2×2)   (1, 16, 4, 4)
+  -> Flatten                                    (1, 256)
+  -> Linear(120) -> ReLU
+  -> Linear(84)  -> ReLU
+  -> Linear(47)                                 logits
+
+~61 k trainable parameters across 10 tensors (conv1/2 kernel+bias,
+fc1/2/3 weights+bias).
+```
+
+## Quick start
+
+### 1. One-time setup
+
+EMNIST balanced split (~130 MB extracted). If `datasets/emnist/*.idx*` files
+already exist you can skip this.
+
+```bash
+just download-emnist
+```
+
+(If the `just download-emnist` recipe errors after the download — known shell-quoting bug
+in the flatten step — manually extract:
+
+```bash
+cd datasets/emnist && for f in gzip/emnist-balanced-*.gz; do gunzip -c "$f" > "$(basename "$f" .gz)"; done
+```
+
+then verify the four `emnist-balanced-{train,test}-{images,labels}-idx*-ubyte`
+files exist.)
+
+### 2. Choose an execution profile and run
+
+```bash
+# ~30 s — verify the pipeline runs end-to-end after any change.
+./examples/grok/lenet_emnist/train.sh dry-run
+
+# ~5–15 min — verify Phase 1 (train_acc -> 100 %) is reachable on the
+# 1k-sample subset. Does NOT wait for grokking.
+./examples/grok/lenet_emnist/train.sh smoke
+
+# Hours to a day — real grokking attempt: 30k epochs on 1k samples,
+# checkpoints every 500 epochs.
+./examples/grok/lenet_emnist/train.sh full
+```
+
+Each profile is a single invocation of `pixi run mojo run -I src
+examples/grok/lenet_emnist/run_train.mojo` with profile-specific flags
+preset. Extra arguments are appended, so e.g. `./train.sh smoke
+--weight-decay 0.5` overrides the default for that run.
+
+### 3. Analyze the log
+
+```bash
+./examples/grok/lenet_emnist/train.sh full > /tmp/grok_full.log 2>&1
+python examples/grok/lenet_emnist/analyze_phases.py --mode full /tmp/grok_full.log
+```
+
+The analyzer parses the `EPOCH <n> train_loss=… train_acc=… …` lines and
+reports:
+
+- Whether **Phase 1** (memorization complete: train_acc ≥ 99 % for ≥ 3
+  consecutive logged epochs) was reached, and at what epoch.
+- Whether **Phase 3** (grokking onset: test_acc jumps ≥ 20 pp within a
+  200-epoch window while train_acc stays ≥ 99 %) was detected.
+- Whether the *loss-vs-accuracy decoupling* fingerprint of late-stage
+  overfitting is present (mirroring the diagnostic skill linked above).
+
+There is no separate "Phase 2" detector — Phase 2 (plateau) is simply the
+span of logged epochs between Phase 1 reaching and either Phase 3 firing
+or the run ending.
+
+## What the training script does differently
+
+Differences from `examples/lenet_emnist/`:
+
+| Aspect | `lenet_emnist/` (baseline) | `grok/lenet_emnist/` (this example) |
+| --- | --- | --- |
+| Optimizer | SGD | AdamW (decoupled weight decay) |
+| Default weight decay | n/a | **1.0** (grokking-aimed; standard regularization values are ~1e-4) |
+| Default learning rate | 0.001 | 0.001 |
+| Default batch size | 32 | 64 |
+| Default epochs | 10 | 1 / 300 / 30000 per profile |
+| Training set | Full 112,800 samples | Subsampled to 1,000 (configurable via `--subset-size`) |
+| Per-epoch logging | Test accuracy only | train_loss, train_acc, test_loss, test_acc, weight_l2_norm |
+| Checkpointing | One save at end of training | Multi-metric best-checkpoint tracker (see below) |
+
+## Multi-metric best-checkpoint tracker
+
+Per-metric tracking modes via `--track-metric NAME:MODE` (repeatable):
+
+| Mode | Files saved | When |
+| --- | --- | --- |
+| `max` | `{name}_best.bin` | New highest value seen |
+| `min` | `{name}_best.bin` | New lowest value seen |
+| `both` | `{name}_best.bin`, `{name}_min.bin`, `{name}_min_after_max.bin`, `{name}_max_after_min.bin` | All four; `min_after_max` only after a maximum has been seen, `max_after_min` only after a minimum has been seen |
+
+Each `.bin` file is accompanied by a `.json` sidecar with `{"metric", "mode_kind", "value", "epoch"}`.
+
+Defaults from `train.sh`:
+
+```text
+--track-metric test_acc:max         # the headline "best model" checkpoint
+--track-metric test_loss:both       # detect post-peak loss recovery (grok signal)
+--track-metric train_loss:min       # sanity: training did converge
+--track-metric weight_l2_norm:max   # detect weight-norm growth phase
+```
+
+The `min_after_max` and `max_after_min` distinction matters: a naive
+"best loss" tracker is trivially won by epoch 1 (loss starts highest, then
+falls monotonically). `min_after_max` only counts once the loss has already
+established a maximum and *then* dropped to a new minimum — this is the
+grokking-relevant signal (test loss spikes during Phase 2, then collapses
+during Phase 3).
+
+## CLI flags (`run_train.mojo`)
+
+| Flag | Default | Purpose |
+| --- | --- | --- |
+| `--epochs` | 10 | Total training epochs |
+| `--batch-size` | 32 | Mini-batch size |
+| `--lr` | 0.001 | AdamW learning rate |
+| `--weight-decay` | 0.01 | Decoupled weight decay (grokking wants ~1.0) |
+| `--precision` | fp32 | Mixed-precision mode (currently always fp32) |
+| `--data-dir` | `datasets/emnist` | EMNIST IDX-file directory |
+| `--weights-dir` | `lenet5_weights` | Checkpoint output directory |
+| `--subset-size` | 0 | If > 0, slice train set to first N samples |
+| `--max-batches` | 0 | If > 0, stop training after N batches per epoch (dry-run aid) |
+| `--log-every` | 1 | Emit EPOCH structured line every K epochs |
+| `--checkpoint-every` | 1 | Run checkpoint update every K epochs |
+| `--track-metric` | (repeatable) | `metric_name:mode` — see table above |
+
+`train.sh` presets a sensible subset of these per profile.
+
+## File structure
+
+```text
+examples/grok/lenet_emnist/
+├── README.md           # this file
+├── model.mojo          # LeNet5 + AdamWState struct + update_parameters_adamw
+├── train.mojo          # training loop, instrumentation, MultiMetricCheckpointer
+├── run_train.mojo      # CLI wrapper
+├── run_infer.mojo      # inference entry point (loads "best" checkpoint)
+├── train.sh            # dry-run / smoke / full dispatcher (user-facing)
+├── analyze_phases.py   # post-hoc log analyzer
+└── checkpoints/        # .gitignore'd; per-metric best checkpoints land here
+```
+
+## Implementation notes
+
+- **Manual AdamW, not autograd.** The autograd substrate in
+  `src/projectodyssey/autograd/` is incomplete for convnet training (see
+  tracker issue [#5452](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5452)):
+  `variable_conv2d`, `variable_maxpool2d`, `variable_linear`,
+  `variable_cross_entropy`, and `tape.backward()` dispatch are all
+  TODO/in-progress per `src/projectodyssey/autograd/README.md`. So this
+  example uses the same manual forward + manual `*_backward` pattern as
+  `examples/lenet_emnist/`, but calls
+  [`adamw_step`](../../src/projectodyssey/training/optimizers/adamw.mojo) ten
+  times per optimizer step (once per parameter) with its own first/second
+  moment state. Once #5452 lands this example will be ported to the autograd
+  path along with the others.
+- **Weight decay = 1.0 is intentional** and ~100× higher than the standard
+  regularization value (1e-4). Grokking depends on weight decay *slowly
+  outcompeting* the memorization circuit; smaller decay just produces an
+  overfit model.
+- **MLP-only mode is on the wishlist but not implemented yet.** The
+  published Omnigrok recipe uses a small MLP (no convs) on MNIST. Adding
+  a `--mlp-only` flag that bypasses the conv layers would give a stronger
+  grokking-attempt baseline. Filed as a follow-up.
+
+## References
+
+- Power, Burns, Smith, Edwards, Misra, Toner — *Grokking: Generalization
+  Beyond Overfitting on Small Algorithmic Datasets* (2022).
+  <https://arxiv.org/abs/2201.02177>
+- Nanda, Chan, Lieberum, Smith, Steinhardt — *Progress Measures for Grokking
+  via Mechanistic Interpretability* (ICLR 2023).
+  <https://arxiv.org/abs/2301.05217>
+- Liu, Michaud, Tegmark — *Omnigrok: Grokking Beyond Algorithmic Data*
+  (2023). <https://arxiv.org/abs/2210.01117>
+- Thilak, Littwin, Zhai, Saremi, Paiss, Susskind — *The Slingshot
+  Mechanism: An Empirical Study of Adaptive Optimizers and the Grokking
+  Phenomenon* (2022). <https://arxiv.org/abs/2206.04817>
+- Loshchilov, Hutter — *Decoupled Weight Decay Regularization* (ICLR 2019).
+  <https://arxiv.org/abs/1711.05101>
+- LeCun, Bottou, Bengio, Haffner — *Gradient-based learning applied to
+  document recognition* (1998). The LeNet-5 paper. DOI:
+  [10.1109/5.726791](https://doi.org/10.1109/5.726791)
+
+## Related issues
+
+- [#5452 — `feat(autograd): complete autograd substrate for convnet training`](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5452)
+- [#5449 — `feat(optim): add Muon optimizer`](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5449)
+- [#5450 — `feat(optim): add NorMuon optimizer`](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5450)
+- [#5451 — `feat(optim): add Lion and Shampoo`](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5451)
+
+Once these land, this example can be the natural benchmark for optimizer
+comparisons on a controlled small-data regime.

--- a/examples/grok/lenet_emnist/analyze_phases.py
+++ b/examples/grok/lenet_emnist/analyze_phases.py
@@ -12,7 +12,7 @@ emitted by ``examples/grok/lenet_emnist/train.mojo`` and reports:
   skill. Triggers when test accuracy peaks early then regresses while
   training loss keeps falling.
 
-- Phase 1 (memorization complete): train_acc >= 99 % for >= 5 consecutive
+- Phase 1 (memorization complete): train_acc >= 99 % for >= 3 consecutive
   logged epochs.
 
 - Phase 3 (grokking onset): test_acc jumps by >= 20 percentage points within
@@ -43,11 +43,11 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-EPOCH_RE = re.compile(
-    r"EPOCH\s+(?P<epoch>\d+)"
-    r"(?:\s+(?P<kvs>(?:\S+=\S+\s*)+))?"
-)
-KV_RE = re.compile(r"(?P<key>\w+)=(?P<val>[-+]?(?:nan|inf|\d*\.?\d+(?:[eE][-+]?\d+)?))")
+# Match: "EPOCH 1 train_loss= 4.82926 train_acc= 0.0 test_loss= 3.85 test_acc= 2.13 weight_l2= 0.0"
+# Mojo's print() inserts a space after each value, so we accept "key= value" (with optional space
+# around the =) rather than the stricter "key=value".
+EPOCH_RE = re.compile(r"EPOCH\s+(?P<epoch>\d+)(?P<rest>.*)")
+KV_RE = re.compile(r"(?P<key>\w+)\s*=\s*(?P<val>[-+]?(?:nan|inf|\d*\.?\d+(?:[eE][-+]?\d+)?))")
 
 
 @dataclass
@@ -60,11 +60,14 @@ def parse_log(path: Path) -> list[EpochRow]:
     """Extract EPOCH rows from the log file. Tolerates non-EPOCH chatter around them."""
     rows: list[EpochRow] = []
     text = path.read_text(encoding="utf-8", errors="replace")
-    for m in EPOCH_RE.finditer(text):
+    for line in text.splitlines():
+        m = EPOCH_RE.search(line)
+        if not m:
+            continue
         epoch = int(m.group("epoch"))
-        kvs_blob = m.group("kvs") or ""
+        rest = m.group("rest") or ""
         metrics: dict[str, float] = {}
-        for kv in KV_RE.finditer(kvs_blob):
+        for kv in KV_RE.finditer(rest):
             try:
                 metrics[kv.group("key")] = float(kv.group("val"))
             except ValueError:
@@ -101,17 +104,10 @@ def diagnose_overfitting(rows: list[EpochRow]) -> dict:
         drop_ratio = (loss_at_peak - loss_at_end) / loss_at_peak
 
     post_peak = [v for e, v in accs if e > peak_epoch and v is not None]
-    below_peak_fraction = (
-        sum(1 for v in post_peak if v < peak_acc - 0.05) / len(post_peak)
-        if post_peak
-        else 0.0
-    )
+    below_peak_fraction = sum(1 for v in post_peak if v < peak_acc - 0.05) / len(post_peak) if post_peak else 0.0
 
     decoupling = (
-        drop_ratio is not None
-        and drop_ratio > 0.10
-        and (peak_acc - final_acc) > 0.3
-        and below_peak_fraction > 0.5
+        drop_ratio is not None and drop_ratio > 0.10 and (peak_acc - final_acc) > 0.3 and below_peak_fraction > 0.5
     )
 
     return {
@@ -146,14 +142,10 @@ def detect_phase1(rows: list[EpochRow], threshold: float = 99.0, consecutive: in
         else:
             run = 0
             first_epoch = None
-    last_train_acc = next(
-        (r.metrics["train_acc"] for r in reversed(rows) if "train_acc" in r.metrics), None
-    )
+    last_train_acc = next((r.metrics["train_acc"] for r in reversed(rows) if "train_acc" in r.metrics), None)
     return {
         "reached": False,
-        "max_train_acc_seen": max(
-            (r.metrics["train_acc"] for r in rows if "train_acc" in r.metrics), default=None
-        ),
+        "max_train_acc_seen": max((r.metrics["train_acc"] for r in rows if "train_acc" in r.metrics), default=None),
         "last_train_acc": last_train_acc,
         "needed": threshold,
     }
@@ -241,10 +233,7 @@ def emit_full(rows: list[EpochRow]) -> int:
     if p1["reached"]:
         print(f"Phase 1 (memorization complete):   reached at epoch {p1['first_epoch']}")
     else:
-        print(
-            f"Phase 1 (memorization complete):   NOT reached "
-            f"(max train_acc = {p1['max_train_acc_seen']:.2f}%)"
-        )
+        print(f"Phase 1 (memorization complete):   NOT reached (max train_acc = {p1['max_train_acc_seen']:.2f}%)")
 
     p3 = detect_phase3(rows)
     if p3["reached"]:
@@ -265,14 +254,8 @@ def emit_full(rows: list[EpochRow]) -> int:
         print(f"  peak test_acc:           {diag['peak_acc']:.4f}% at epoch {diag['peak_epoch']}")
         print(f"  final test_acc:          {diag['final_acc']:.4f}% at epoch {diag['final_epoch']}")
         if diag["loss_drop_after_peak_ratio"] is not None:
-            print(
-                f"  train_loss drop ratio after peak: "
-                f"{diag['loss_drop_after_peak_ratio']*100:.1f}%"
-            )
-        print(
-            f"  fraction of post-peak epochs below peak: "
-            f"{diag['post_peak_below_peak_fraction']*100:.1f}%"
-        )
+            print(f"  train_loss drop ratio after peak: {diag['loss_drop_after_peak_ratio'] * 100:.1f}%")
+        print(f"  fraction of post-peak epochs below peak: {diag['post_peak_below_peak_fraction'] * 100:.1f}%")
         verdict = (
             "OVERFITTING DETECTED (train loss kept falling while test accuracy regressed)"
             if diag["decoupling_detected"]

--- a/examples/grok/lenet_emnist/analyze_phases.py
+++ b/examples/grok/lenet_emnist/analyze_phases.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Analyze a grok/lenet_emnist training log for phase transitions and overfitting.
+
+Parses structured per-epoch lines of the form
+
+    EPOCH 50 train_loss=2.3e-4 train_acc=100.000 test_loss=4.21 test_acc=14.7 weight_l2=18.4
+
+emitted by ``examples/grok/lenet_emnist/train.mojo`` and reports:
+
+- Late-stage overfitting (loss-vs-accuracy decoupling): the diagnosis from the
+  ProjectMnemosyne ``training-diagnosis-loss-accuracy-decoupling-overfitting``
+  skill. Triggers when test accuracy peaks early then regresses while
+  training loss keeps falling.
+
+- Phase 1 (memorization complete): train_acc >= 99 % for >= 5 consecutive
+  logged epochs.
+
+- Phase 3 (grokking onset): test_acc jumps by >= 20 percentage points within
+  any 200-epoch window while train_acc stays >= 99 %.
+
+Modes:
+    --mode dry-run   verify log shape only (>= 1 EPOCH line, NaN-free)
+    --mode smoke     report Phase 1 reached or explain why not
+    --mode full      full Phase 1/2/3 + overfitting report (default)
+
+Usage:
+    python analyze_phases.py --mode smoke /tmp/grok_smoke.log
+    ./train.sh smoke 2>&1 | tee /tmp/run.log
+    python analyze_phases.py --mode smoke /tmp/run.log
+
+Exit codes:
+    0 = analysis complete (regardless of whether grokking observed)
+    1 = log malformed / no EPOCH lines / NaN detected (test failure)
+    2 = argument error
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+EPOCH_RE = re.compile(
+    r"EPOCH\s+(?P<epoch>\d+)"
+    r"(?:\s+(?P<kvs>(?:\S+=\S+\s*)+))?"
+)
+KV_RE = re.compile(r"(?P<key>\w+)=(?P<val>[-+]?(?:nan|inf|\d*\.?\d+(?:[eE][-+]?\d+)?))")
+
+
+@dataclass
+class EpochRow:
+    epoch: int
+    metrics: dict[str, float]
+
+
+def parse_log(path: Path) -> list[EpochRow]:
+    """Extract EPOCH rows from the log file. Tolerates non-EPOCH chatter around them."""
+    rows: list[EpochRow] = []
+    text = path.read_text(encoding="utf-8", errors="replace")
+    for m in EPOCH_RE.finditer(text):
+        epoch = int(m.group("epoch"))
+        kvs_blob = m.group("kvs") or ""
+        metrics: dict[str, float] = {}
+        for kv in KV_RE.finditer(kvs_blob):
+            try:
+                metrics[kv.group("key")] = float(kv.group("val"))
+            except ValueError:
+                continue
+        rows.append(EpochRow(epoch=epoch, metrics=metrics))
+    return rows
+
+
+def detect_nans(rows: list[EpochRow]) -> list[tuple[int, str, float]]:
+    bad: list[tuple[int, str, float]] = []
+    for r in rows:
+        for k, v in r.metrics.items():
+            if math.isnan(v) or math.isinf(v):
+                bad.append((r.epoch, k, v))
+    return bad
+
+
+def diagnose_overfitting(rows: list[EpochRow]) -> dict:
+    """Loss-vs-accuracy decoupling diagnosis. Mirrors the criteria in the
+    ``training-diagnosis-loss-accuracy-decoupling-overfitting`` skill."""
+    accs = [(r.epoch, r.metrics.get("test_acc")) for r in rows if "test_acc" in r.metrics]
+    losses = {r.epoch: r.metrics.get("train_loss") for r in rows if "train_loss" in r.metrics}
+    if len(accs) < 5:
+        return {"applicable": False, "reason": "fewer than 5 test_acc points"}
+
+    peak_acc = max(v for _, v in accs if v is not None)
+    peak_epoch = next(e for e, v in accs if v is not None and v == peak_acc)
+    final_epoch, final_acc = accs[-1]
+    loss_at_peak = losses.get(peak_epoch)
+    loss_at_end = losses.get(final_epoch)
+
+    drop_ratio = None
+    if loss_at_peak and loss_at_end and loss_at_peak > 0:
+        drop_ratio = (loss_at_peak - loss_at_end) / loss_at_peak
+
+    post_peak = [v for e, v in accs if e > peak_epoch and v is not None]
+    below_peak_fraction = (
+        sum(1 for v in post_peak if v < peak_acc - 0.05) / len(post_peak)
+        if post_peak
+        else 0.0
+    )
+
+    decoupling = (
+        drop_ratio is not None
+        and drop_ratio > 0.10
+        and (peak_acc - final_acc) > 0.3
+        and below_peak_fraction > 0.5
+    )
+
+    return {
+        "applicable": True,
+        "decoupling_detected": decoupling,
+        "peak_acc": peak_acc,
+        "peak_epoch": peak_epoch,
+        "final_acc": final_acc,
+        "final_epoch": final_epoch,
+        "loss_drop_after_peak_ratio": drop_ratio,
+        "post_peak_below_peak_fraction": below_peak_fraction,
+    }
+
+
+def detect_phase1(rows: list[EpochRow], threshold: float = 99.0, consecutive: int = 3) -> dict:
+    """Phase 1 = memorization complete: train_acc >= threshold for `consecutive` logged epochs.
+
+    Default is 3 (not 5) because real runs use --log-every 50 to keep logs readable; requiring 5
+    logged points at 99% would mean 250 actual epochs of memorization, which is too strict."""
+    run = 0
+    first_epoch: int | None = None
+    for r in rows:
+        ta = r.metrics.get("train_acc")
+        if ta is None:
+            continue
+        if ta >= threshold:
+            if run == 0:
+                first_epoch = r.epoch
+            run += 1
+            if run >= consecutive:
+                return {"reached": True, "first_epoch": first_epoch}
+        else:
+            run = 0
+            first_epoch = None
+    last_train_acc = next(
+        (r.metrics["train_acc"] for r in reversed(rows) if "train_acc" in r.metrics), None
+    )
+    return {
+        "reached": False,
+        "max_train_acc_seen": max(
+            (r.metrics["train_acc"] for r in rows if "train_acc" in r.metrics), default=None
+        ),
+        "last_train_acc": last_train_acc,
+        "needed": threshold,
+    }
+
+
+def detect_phase3(rows: list[EpochRow], jump_pp: float = 20.0, window: int = 200) -> dict:
+    """Phase 3 = grokking onset: test_acc rises by >= jump_pp inside any `window`-epoch
+    span while train_acc remains >= 99 %."""
+    rows_with = [r for r in rows if "test_acc" in r.metrics and "train_acc" in r.metrics]
+    if len(rows_with) < 2:
+        return {"reached": False, "reason": "insufficient data"}
+
+    for i, r_start in enumerate(rows_with):
+        if r_start.metrics["train_acc"] < 99.0:
+            continue
+        for r_end in rows_with[i + 1 :]:
+            if r_end.epoch - r_start.epoch > window:
+                break
+            if r_end.metrics["train_acc"] < 99.0:
+                continue
+            jump = r_end.metrics["test_acc"] - r_start.metrics["test_acc"]
+            if jump >= jump_pp:
+                return {
+                    "reached": True,
+                    "from_epoch": r_start.epoch,
+                    "to_epoch": r_end.epoch,
+                    "test_acc_before": r_start.metrics["test_acc"],
+                    "test_acc_after": r_end.metrics["test_acc"],
+                    "jump_pp": jump,
+                }
+    return {"reached": False, "reason": "no qualifying window found"}
+
+
+def emit_dry_run(rows: list[EpochRow]) -> int:
+    if not rows:
+        print("DRY-RUN FAIL: no EPOCH lines found in log", file=sys.stderr)
+        return 1
+    nans = detect_nans(rows)
+    if nans:
+        print(f"DRY-RUN FAIL: {len(nans)} NaN/inf metric(s):", file=sys.stderr)
+        for e, k, v in nans[:5]:
+            print(f"  epoch={e} {k}={v}", file=sys.stderr)
+        return 1
+    r = rows[0]
+    print(f"DRY-RUN OK: {len(rows)} EPOCH line(s) parsed; first epoch = {r.epoch}")
+    print(f"  metrics: {sorted(r.metrics)}")
+    return 0
+
+
+def emit_smoke(rows: list[EpochRow]) -> int:
+    if not rows:
+        print("SMOKE FAIL: no EPOCH lines found", file=sys.stderr)
+        return 1
+    nans = detect_nans(rows)
+    if nans:
+        print(f"SMOKE FAIL: {len(nans)} NaN/inf metric(s) — training diverged", file=sys.stderr)
+        return 1
+    p1 = detect_phase1(rows)
+    if p1["reached"]:
+        print(f"SMOKE OK: Phase 1 (memorization) reached at epoch {p1['first_epoch']}")
+        print("  Model is fitting the training subset. Ready for `full` run to attempt grokking.")
+    else:
+        print("SMOKE INCOMPLETE: Phase 1 (memorization) NOT reached")
+        print(f"  max train_acc seen: {p1['max_train_acc_seen']:.2f}% (need >= {p1['needed']}%)")
+        print(f"  last train_acc:     {p1['last_train_acc']}")
+        print("  Either: (a) need more epochs in smoke, (b) subset too large to memorize,")
+        print("           or (c) optimizer/lr/wd not driving convergence.")
+    return 0
+
+
+def emit_full(rows: list[EpochRow]) -> int:
+    if not rows:
+        print("FULL FAIL: no EPOCH lines found", file=sys.stderr)
+        return 1
+    nans = detect_nans(rows)
+    if nans:
+        print(f"WARN: {len(nans)} NaN/inf metric(s) encountered during run", file=sys.stderr)
+        for e, k, v in nans[:5]:
+            print(f"  epoch={e} {k}={v}", file=sys.stderr)
+
+    print(f"Parsed {len(rows)} EPOCH lines (epochs {rows[0].epoch}..{rows[-1].epoch})")
+    print()
+
+    p1 = detect_phase1(rows)
+    if p1["reached"]:
+        print(f"Phase 1 (memorization complete):   reached at epoch {p1['first_epoch']}")
+    else:
+        print(
+            f"Phase 1 (memorization complete):   NOT reached "
+            f"(max train_acc = {p1['max_train_acc_seen']:.2f}%)"
+        )
+
+    p3 = detect_phase3(rows)
+    if p3["reached"]:
+        print(
+            f"Phase 3 (grokking onset):          DETECTED — epochs "
+            f"{p3['from_epoch']} -> {p3['to_epoch']}, "
+            f"test_acc {p3['test_acc_before']:.2f}% -> {p3['test_acc_after']:.2f}% "
+            f"(+{p3['jump_pp']:.2f} pp)"
+        )
+    else:
+        print(f"Phase 3 (grokking onset):          NOT detected ({p3.get('reason', '')})")
+
+    print()
+
+    diag = diagnose_overfitting(rows)
+    if diag["applicable"]:
+        print("Loss-vs-accuracy decoupling diagnosis:")
+        print(f"  peak test_acc:           {diag['peak_acc']:.4f}% at epoch {diag['peak_epoch']}")
+        print(f"  final test_acc:          {diag['final_acc']:.4f}% at epoch {diag['final_epoch']}")
+        if diag["loss_drop_after_peak_ratio"] is not None:
+            print(
+                f"  train_loss drop ratio after peak: "
+                f"{diag['loss_drop_after_peak_ratio']*100:.1f}%"
+            )
+        print(
+            f"  fraction of post-peak epochs below peak: "
+            f"{diag['post_peak_below_peak_fraction']*100:.1f}%"
+        )
+        verdict = (
+            "OVERFITTING DETECTED (train loss kept falling while test accuracy regressed)"
+            if diag["decoupling_detected"]
+            else "no overfitting decoupling signal"
+        )
+        print(f"  verdict: {verdict}")
+    else:
+        print(f"Loss-vs-accuracy diagnosis:        skipped ({diag.get('reason', '')})")
+
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--mode",
+        choices=("dry-run", "smoke", "full"),
+        default="full",
+        help="analysis depth (default: full)",
+    )
+    parser.add_argument(
+        "log",
+        type=Path,
+        help="path to the training log (the file ./train.sh writes to)",
+    )
+    args = parser.parse_args()
+
+    if not args.log.exists():
+        print(f"error: log not found: {args.log}", file=sys.stderr)
+        return 2
+
+    rows = parse_log(args.log)
+    if args.mode == "dry-run":
+        return emit_dry_run(rows)
+    if args.mode == "smoke":
+        return emit_smoke(rows)
+    return emit_full(rows)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/grok/lenet_emnist/model.mojo
+++ b/examples/grok/lenet_emnist/model.mojo
@@ -1,0 +1,630 @@
+"""LeNet-5 Model for EMNIST Classification.
+
+Classic LeNet-5 architecture adapted for EMNIST dataset (28x28 grayscale images).
+
+Architecture:
+    Input (28x28x1) ->
+    Conv2D(6 filters, 5x5) -> ReLU -> MaxPool(2x2, stride=2) ->
+    Conv2D(16 filters, 5x5) -> ReLU -> MaxPool(2x2, stride=2) ->
+    Flatten ->
+    Linear(120) -> ReLU ->
+    Linear(84) -> ReLU ->
+    Linear(num_classes)
+
+References:
+    - LeCun, Y., Bottou, L., Bengio, Y., & Haffner, P. (1998).
+      Gradient-based learning applied to document recognition.
+      Proceedings of the IEEE, 86(11), 2278-2324.
+    - EMNIST Dataset: https://www.nist.gov/itl/products-and-services/emnist-dataset
+    - Reference Implementation: https://github.com/mattwang44/LeNet-from-Scratch
+"""
+
+from projectodyssey.tensor.any_tensor import AnyTensor, zeros, zeros_like
+from projectodyssey.training.optimizers.adamw import adamw_step
+from projectodyssey.core.conv import conv2d, conv2d_backward
+from projectodyssey.core.pooling import maxpool2d, maxpool2d_backward
+from projectodyssey.core.linear import linear, linear_backward
+from projectodyssey.core.activation import relu, relu_backward
+from projectodyssey.core.initializers import kaiming_uniform, xavier_uniform
+from projectodyssey.core.shape import conv2d_output_shape, pool_output_shape
+from projectodyssey.core.traits import Model
+from projectodyssey.training.model_utils import (
+    save_model_weights,
+    load_model_weights,
+    get_model_parameter_names,
+)
+from std.collections import List
+
+
+# ============================================================================
+# Architecture Hyperparameters
+# ============================================================================
+# All architecture dimensions are defined here for easy modification.
+# Change these values to experiment with different model sizes.
+
+# Input dimensions
+comptime INPUT_HEIGHT = 28
+comptime INPUT_WIDTH = 28
+comptime INPUT_CHANNELS = 1
+
+# Conv layer 1 hyperparameters
+comptime CONV1_OUT_CHANNELS = 6
+comptime CONV1_KERNEL_SIZE = 5
+comptime CONV1_STRIDE = 1
+comptime CONV1_PADDING = 0
+
+# Pool layer 1 hyperparameters
+comptime POOL1_KERNEL_SIZE = 2
+comptime POOL1_STRIDE = 2
+comptime POOL1_PADDING = 0
+
+# Conv layer 2 hyperparameters
+comptime CONV2_OUT_CHANNELS = 16
+comptime CONV2_KERNEL_SIZE = 5
+comptime CONV2_STRIDE = 1
+comptime CONV2_PADDING = 0
+
+# Pool layer 2 hyperparameters
+comptime POOL2_KERNEL_SIZE = 2
+comptime POOL2_STRIDE = 2
+comptime POOL2_PADDING = 0
+
+# Fully connected layer sizes
+comptime FC1_OUT_FEATURES = 120
+comptime FC2_OUT_FEATURES = 84
+
+
+def compute_flattened_size() -> Int:
+    """Compute the flattened feature size after all conv/pool layers.
+
+    This derives the FC1 input dimension from the architecture hyperparameters.
+
+    Returns:
+        Number of features after flattening (channels * height * width).
+    """
+    # After conv1: Use shared conv2d_output_shape
+    var h1, w1 = conv2d_output_shape(
+        INPUT_HEIGHT,
+        INPUT_WIDTH,
+        CONV1_KERNEL_SIZE,
+        CONV1_KERNEL_SIZE,
+        CONV1_STRIDE,
+        CONV1_PADDING,
+    )
+
+    # After pool1: Use shared pool_output_shape
+    var h2, w2 = pool_output_shape(
+        h1, w1, POOL1_KERNEL_SIZE, POOL1_STRIDE, POOL1_PADDING
+    )
+
+    # After conv2
+    var h3, w3 = conv2d_output_shape(
+        h2,
+        w2,
+        CONV2_KERNEL_SIZE,
+        CONV2_KERNEL_SIZE,
+        CONV2_STRIDE,
+        CONV2_PADDING,
+    )
+
+    # After pool2
+    var h4, w4 = pool_output_shape(
+        h3, w3, POOL2_KERNEL_SIZE, POOL2_STRIDE, POOL2_PADDING
+    )
+
+    return CONV2_OUT_CHANNELS * h4 * w4
+
+
+struct LeNet5(Model, Movable):
+    """LeNet-5 model for EMNIST classification.
+
+    Architecture is defined by module-level constants (CONV1_*, POOL1_*, etc.)
+    for easy experimentation. FC layer input sizes are automatically derived
+    from the conv/pool layer dimensions.
+
+    Attributes:
+        num_classes: Number of output classes (47 for EMNIST Balanced)
+        conv1_kernel: First conv layer weights (CONV1_OUT_CHANNELS, INPUT_CHANNELS, k, k)
+        conv1_bias: First conv layer bias (CONV1_OUT_CHANNELS,)
+        conv2_kernel: Second conv layer weights (CONV2_OUT_CHANNELS, CONV1_OUT_CHANNELS, k, k)
+        conv2_bias: Second conv layer bias (CONV2_OUT_CHANNELS,)
+        fc1_weights: First FC layer weights (FC1_OUT_FEATURES, flattened_size)
+        fc1_bias: First FC layer bias (FC1_OUT_FEATURES,)
+        fc2_weights: Second FC layer weights (FC2_OUT_FEATURES, FC1_OUT_FEATURES)
+        fc2_bias: Second FC layer bias (FC2_OUT_FEATURES,)
+        fc3_weights: Third FC layer weights (num_classes, FC2_OUT_FEATURES)
+        fc3_bias: Third FC layer bias (num_classes,).
+    """
+
+    var num_classes: Int
+
+    # Layer parameters
+    var conv1_kernel: AnyTensor
+    var conv1_bias: AnyTensor
+    var conv2_kernel: AnyTensor
+    var conv2_bias: AnyTensor
+    var fc1_weights: AnyTensor
+    var fc1_bias: AnyTensor
+    var fc2_weights: AnyTensor
+    var fc2_bias: AnyTensor
+    var fc3_weights: AnyTensor
+    var fc3_bias: AnyTensor
+
+    def __init__(out self, num_classes: Int = 47) raises:
+        """Initialize LeNet-5 model with random weights.
+
+        Args:
+            num_classes: Number of output classes (default: 47 for EMNIST Balanced).
+        """
+        self.num_classes = num_classes
+
+        # Compute derived dimensions
+        var flattened_size = compute_flattened_size()
+
+        # Conv1: INPUT_CHANNELS -> CONV1_OUT_CHANNELS, kernel CONV1_KERNEL_SIZE x CONV1_KERNEL_SIZE
+        var conv1_shape: List[Int] = [
+            CONV1_OUT_CHANNELS,
+            INPUT_CHANNELS,
+            CONV1_KERNEL_SIZE,
+            CONV1_KERNEL_SIZE,
+        ]
+        var conv1_fan_in = (
+            INPUT_CHANNELS * CONV1_KERNEL_SIZE * CONV1_KERNEL_SIZE
+        )
+        var conv1_fan_out = (
+            CONV1_OUT_CHANNELS * CONV1_KERNEL_SIZE * CONV1_KERNEL_SIZE
+        )
+        self.conv1_kernel = kaiming_uniform(
+            conv1_fan_in, conv1_fan_out, conv1_shape, dtype=DType.float32
+        )
+        var conv1_bias_shape: List[Int] = [CONV1_OUT_CHANNELS]
+        self.conv1_bias = zeros(conv1_bias_shape, DType.float32)
+
+        # Conv2: CONV1_OUT_CHANNELS -> CONV2_OUT_CHANNELS, kernel CONV2_KERNEL_SIZE x CONV2_KERNEL_SIZE
+        var conv2_shape: List[Int] = [
+            CONV2_OUT_CHANNELS,
+            CONV1_OUT_CHANNELS,
+            CONV2_KERNEL_SIZE,
+            CONV2_KERNEL_SIZE,
+        ]
+        var conv2_fan_in = (
+            CONV1_OUT_CHANNELS * CONV2_KERNEL_SIZE * CONV2_KERNEL_SIZE
+        )
+        var conv2_fan_out = (
+            CONV2_OUT_CHANNELS * CONV2_KERNEL_SIZE * CONV2_KERNEL_SIZE
+        )
+        self.conv2_kernel = kaiming_uniform(
+            conv2_fan_in, conv2_fan_out, conv2_shape, dtype=DType.float32
+        )
+        var conv2_bias_shape: List[Int] = [CONV2_OUT_CHANNELS]
+        self.conv2_bias = zeros(conv2_bias_shape, DType.float32)
+
+        # FC1: flattened_size -> FC1_OUT_FEATURES (derived from conv/pool layers)
+        var fc1_shape: List[Int] = [FC1_OUT_FEATURES, flattened_size]
+        self.fc1_weights = kaiming_uniform(
+            flattened_size, FC1_OUT_FEATURES, fc1_shape, dtype=DType.float32
+        )
+        var fc1_bias_shape: List[Int] = [FC1_OUT_FEATURES]
+        self.fc1_bias = zeros(fc1_bias_shape, DType.float32)
+
+        # FC2: FC1_OUT_FEATURES -> FC2_OUT_FEATURES
+        var fc2_shape: List[Int] = [FC2_OUT_FEATURES, FC1_OUT_FEATURES]
+        self.fc2_weights = kaiming_uniform(
+            FC1_OUT_FEATURES, FC2_OUT_FEATURES, fc2_shape, dtype=DType.float32
+        )
+        var fc2_bias_shape: List[Int] = [FC2_OUT_FEATURES]
+        self.fc2_bias = zeros(fc2_bias_shape, DType.float32)
+
+        # FC3: FC2_OUT_FEATURES -> num_classes
+        var fc3_shape: List[Int] = [num_classes, FC2_OUT_FEATURES]
+        self.fc3_weights = kaiming_uniform(
+            FC2_OUT_FEATURES, num_classes, fc3_shape, dtype=DType.float32
+        )
+        var fc3_bias_shape: List[Int] = [num_classes]
+        self.fc3_bias = zeros(fc3_bias_shape, DType.float32)
+
+    def forward(mut self, input: AnyTensor) raises -> AnyTensor:
+        """Forward pass through LeNet-5.
+
+        Args:
+            input: Input tensor of shape (batch, INPUT_CHANNELS, INPUT_HEIGHT, INPUT_WIDTH).
+
+        Returns:
+            Output logits of shape (batch, num_classes).
+        """
+        # Conv1 + ReLU + MaxPool
+        var conv1_out = conv2d(
+            input,
+            self.conv1_kernel,
+            self.conv1_bias,
+            stride=CONV1_STRIDE,
+            padding=CONV1_PADDING,
+        )
+        var relu1_out = relu(conv1_out)
+        var pool1_out = maxpool2d(
+            relu1_out,
+            kernel_size=POOL1_KERNEL_SIZE,
+            stride=POOL1_STRIDE,
+            padding=POOL1_PADDING,
+        )
+
+        # Conv2 + ReLU + MaxPool
+        var conv2_out = conv2d(
+            pool1_out,
+            self.conv2_kernel,
+            self.conv2_bias,
+            stride=CONV2_STRIDE,
+            padding=CONV2_PADDING,
+        )
+        var relu2_out = relu(conv2_out)
+        var pool2_out = maxpool2d(
+            relu2_out,
+            kernel_size=POOL2_KERNEL_SIZE,
+            stride=POOL2_STRIDE,
+            padding=POOL2_PADDING,
+        )
+
+        # Flatten: (batch, CONV2_OUT_CHANNELS, h, w) -> (batch, flattened_size)
+        var pool2_shape = pool2_out.shape()
+        var batch_size = pool2_shape[0]
+        var flattened_size = pool2_shape[1] * pool2_shape[2] * pool2_shape[3]
+
+        var flatten_shape: List[Int] = [batch_size, flattened_size]
+        var flattened = pool2_out.reshape(flatten_shape)
+
+        # FC1 + ReLU
+        var fc1_out = linear(flattened, self.fc1_weights, self.fc1_bias)
+        var relu3_out = relu(fc1_out)
+
+        # FC2 + ReLU
+        var fc2_out = linear(relu3_out, self.fc2_weights, self.fc2_bias)
+        var relu4_out = relu(fc2_out)
+
+        # FC3 (output logits)
+        var output = linear(relu4_out, self.fc3_weights, self.fc3_bias)
+
+        return output^
+
+    def predict(mut self, input: AnyTensor) raises -> Int:
+        """Predict class for a single input.
+
+        Args:
+            input: Input tensor of shape (1, 1, 28, 28).
+
+        Returns:
+            Predicted class index (0 to num_classes-1).
+        """
+        var logits = self.forward(input)
+
+        # Find argmax
+        var logits_shape = logits.shape()
+        var max_idx = 0
+        var max_val = logits[0]
+
+        for i in range(1, logits_shape[1]):
+            if logits[i] > max_val:
+                max_val = logits[i]
+                max_idx = i
+
+        return max_idx
+
+    def save_weights(self, weights_dir: String) raises:
+        """Save model weights to directory.
+
+        Args:
+            weights_dir: Directory to save weight files (one file per parameter).
+
+        Note:
+            Creates directory if it doesn't exist. Each parameter saved as:
+            - conv1_kernel.weights
+            - conv1_bias.weights
+            - etc.
+        """
+        # Collect all parameters
+        var parameters: List[AnyTensor] = []
+        parameters.append(self.conv1_kernel)
+        parameters.append(self.conv1_bias)
+        parameters.append(self.conv2_kernel)
+        parameters.append(self.conv2_bias)
+        parameters.append(self.fc1_weights)
+        parameters.append(self.fc1_bias)
+        parameters.append(self.fc2_weights)
+        parameters.append(self.fc2_bias)
+        parameters.append(self.fc3_weights)
+        parameters.append(self.fc3_bias)
+
+        # Get standard parameter names
+        var param_names = get_model_parameter_names("lenet5")
+
+        # Save using shared utility
+        save_model_weights(parameters, weights_dir, param_names)
+
+    def load_weights(mut self, weights_dir: String) raises:
+        """Load model weights from directory.
+
+        Args:
+            weights_dir: Directory containing weight files.
+
+        Raises:
+            Error: If weight files are missing or have incompatible shapes.
+        """
+        # Get standard parameter names
+        var param_names = get_model_parameter_names("lenet5")
+
+        # Create empty list for loaded parameters
+        var loaded_params: List[AnyTensor] = []
+
+        # Load using shared utility
+        load_model_weights(loaded_params, weights_dir, param_names)
+
+        # Assign loaded parameters to model fields
+        self.conv1_kernel = loaded_params[0]
+        self.conv1_bias = loaded_params[1]
+        self.conv2_kernel = loaded_params[2]
+        self.conv2_bias = loaded_params[3]
+        self.fc1_weights = loaded_params[4]
+        self.fc1_bias = loaded_params[5]
+        self.fc2_weights = loaded_params[6]
+        self.fc2_bias = loaded_params[7]
+        self.fc3_weights = loaded_params[8]
+        self.fc3_bias = loaded_params[9]
+
+    def update_parameters(
+        mut self,
+        learning_rate: Float32,
+        grad_conv1_kernel: AnyTensor,
+        grad_conv1_bias: AnyTensor,
+        grad_conv2_kernel: AnyTensor,
+        grad_conv2_bias: AnyTensor,
+        grad_fc1_weights: AnyTensor,
+        grad_fc1_bias: AnyTensor,
+        grad_fc2_weights: AnyTensor,
+        grad_fc2_bias: AnyTensor,
+        grad_fc3_weights: AnyTensor,
+        grad_fc3_bias: AnyTensor,
+    ) raises:
+        """Update parameters using SGD.
+
+        Args:
+            learning_rate: Learning rate for gradient descent.
+            grad_conv1_kernel: Gradient for first convolution kernel.
+            grad_conv1_bias: Gradient for first convolution bias.
+            grad_conv2_kernel: Gradient for second convolution kernel.
+            grad_conv2_bias: Gradient for second convolution bias.
+            grad_fc1_weights: Gradient for first fully connected layer weights.
+            grad_fc1_bias: Gradient for first fully connected layer bias.
+            grad_fc2_weights: Gradient for second fully connected layer weights.
+            grad_fc2_bias: Gradient for second fully connected layer bias.
+            grad_fc3_weights: Gradient for third fully connected layer weights.
+            grad_fc3_bias: Gradient for third fully connected layer bias.
+        """
+        # SGD update: param = param - lr * grad
+        _sgd_update(self.conv1_kernel, grad_conv1_kernel, learning_rate)
+        _sgd_update(self.conv1_bias, grad_conv1_bias, learning_rate)
+        _sgd_update(self.conv2_kernel, grad_conv2_kernel, learning_rate)
+        _sgd_update(self.conv2_bias, grad_conv2_bias, learning_rate)
+        _sgd_update(self.fc1_weights, grad_fc1_weights, learning_rate)
+        _sgd_update(self.fc1_bias, grad_fc1_bias, learning_rate)
+        _sgd_update(self.fc2_weights, grad_fc2_weights, learning_rate)
+        _sgd_update(self.fc2_bias, grad_fc2_bias, learning_rate)
+        _sgd_update(self.fc3_weights, grad_fc3_weights, learning_rate)
+        _sgd_update(self.fc3_bias, grad_fc3_bias, learning_rate)
+
+    def parameters(self) raises -> List[AnyTensor]:
+        """Return all trainable parameters.
+
+        Returns:
+            List of parameter tensors (10 total: conv1/2 kernel/bias, fc1/2/3 weights/bias)
+
+        Note:
+            This method copies the parameter tensors. For in-place updates,
+            use update_parameters() instead.
+        """
+        var params: List[AnyTensor] = []
+        params.append(self.conv1_kernel)
+        params.append(self.conv1_bias)
+        params.append(self.conv2_kernel)
+        params.append(self.conv2_bias)
+        params.append(self.fc1_weights)
+        params.append(self.fc1_bias)
+        params.append(self.fc2_weights)
+        params.append(self.fc2_bias)
+        params.append(self.fc3_weights)
+        params.append(self.fc3_bias)
+        return params^
+
+    def zero_grad(mut self) raises:
+        """Reset all parameter gradients to zero.
+
+        Note:
+            LeNet5 uses manual gradient computation in compute_gradients().
+            Gradients are computed fresh each forward/backward pass, so this
+            is a no-op. Included for Model trait conformance.
+        """
+        # Gradients are computed fresh each batch in compute_gradients()
+        # No persistent gradient accumulators to reset
+        pass
+
+
+def _sgd_update(mut param: AnyTensor, grad: AnyTensor, lr: Float32) raises:
+    """SGD parameter update: param = param - lr * grad.
+
+    Deprecated: prefer AdamW via `update_parameters_adamw` for the grokking
+    experiment example. Retained for backward compatibility.
+    """
+    var numel = param.numel()
+    var param_data = param._data.bitcast[Float32]()
+    var grad_data = grad._data.bitcast[Float32]()
+
+    for i in range(numel):
+        param_data[i] -= lr * grad_data[i]
+
+
+# ============================================================================
+# AdamW Optimizer State
+# ============================================================================
+
+
+struct AdamWState(Movable):
+    """First and second moment buffers for AdamW, one (m, v) pair per parameter.
+
+    The buffers are zero-initialized to match each model parameter shape and
+    dtype. The caller (training loop) owns the timestep `t`.
+    """
+
+    var m_conv1_kernel: AnyTensor
+    var v_conv1_kernel: AnyTensor
+    var m_conv1_bias: AnyTensor
+    var v_conv1_bias: AnyTensor
+    var m_conv2_kernel: AnyTensor
+    var v_conv2_kernel: AnyTensor
+    var m_conv2_bias: AnyTensor
+    var v_conv2_bias: AnyTensor
+    var m_fc1_weights: AnyTensor
+    var v_fc1_weights: AnyTensor
+    var m_fc1_bias: AnyTensor
+    var v_fc1_bias: AnyTensor
+    var m_fc2_weights: AnyTensor
+    var v_fc2_weights: AnyTensor
+    var m_fc2_bias: AnyTensor
+    var v_fc2_bias: AnyTensor
+    var m_fc3_weights: AnyTensor
+    var v_fc3_weights: AnyTensor
+    var m_fc3_bias: AnyTensor
+    var v_fc3_bias: AnyTensor
+
+    def __init__(out self, model: LeNet5) raises:
+        self.m_conv1_kernel = zeros_like(model.conv1_kernel)
+        self.v_conv1_kernel = zeros_like(model.conv1_kernel)
+        self.m_conv1_bias = zeros_like(model.conv1_bias)
+        self.v_conv1_bias = zeros_like(model.conv1_bias)
+        self.m_conv2_kernel = zeros_like(model.conv2_kernel)
+        self.v_conv2_kernel = zeros_like(model.conv2_kernel)
+        self.m_conv2_bias = zeros_like(model.conv2_bias)
+        self.v_conv2_bias = zeros_like(model.conv2_bias)
+        self.m_fc1_weights = zeros_like(model.fc1_weights)
+        self.v_fc1_weights = zeros_like(model.fc1_weights)
+        self.m_fc1_bias = zeros_like(model.fc1_bias)
+        self.v_fc1_bias = zeros_like(model.fc1_bias)
+        self.m_fc2_weights = zeros_like(model.fc2_weights)
+        self.v_fc2_weights = zeros_like(model.fc2_weights)
+        self.m_fc2_bias = zeros_like(model.fc2_bias)
+        self.v_fc2_bias = zeros_like(model.fc2_bias)
+        self.m_fc3_weights = zeros_like(model.fc3_weights)
+        self.v_fc3_weights = zeros_like(model.fc3_weights)
+        self.m_fc3_bias = zeros_like(model.fc3_bias)
+        self.v_fc3_bias = zeros_like(model.fc3_bias)
+
+
+def update_parameters_adamw(
+    mut model: LeNet5,
+    mut state: AdamWState,
+    lr: Float64,
+    t: Int,
+    weight_decay: Float64,
+    grad_conv1_kernel: AnyTensor,
+    grad_conv1_bias: AnyTensor,
+    grad_conv2_kernel: AnyTensor,
+    grad_conv2_bias: AnyTensor,
+    grad_fc1_weights: AnyTensor,
+    grad_fc1_bias: AnyTensor,
+    grad_fc2_weights: AnyTensor,
+    grad_fc2_bias: AnyTensor,
+    grad_fc3_weights: AnyTensor,
+    grad_fc3_bias: AnyTensor,
+) raises:
+    """Apply AdamW update to all 10 parameters, mutating model and state."""
+    (model.conv1_kernel, state.m_conv1_kernel, state.v_conv1_kernel) = (
+        adamw_step(
+            model.conv1_kernel,
+            grad_conv1_kernel,
+            state.m_conv1_kernel,
+            state.v_conv1_kernel,
+            t,
+            lr,
+            weight_decay=weight_decay,
+        )
+    )
+    (model.conv1_bias, state.m_conv1_bias, state.v_conv1_bias) = adamw_step(
+        model.conv1_bias,
+        grad_conv1_bias,
+        state.m_conv1_bias,
+        state.v_conv1_bias,
+        t,
+        lr,
+        weight_decay=weight_decay,
+    )
+    (model.conv2_kernel, state.m_conv2_kernel, state.v_conv2_kernel) = (
+        adamw_step(
+            model.conv2_kernel,
+            grad_conv2_kernel,
+            state.m_conv2_kernel,
+            state.v_conv2_kernel,
+            t,
+            lr,
+            weight_decay=weight_decay,
+        )
+    )
+    (model.conv2_bias, state.m_conv2_bias, state.v_conv2_bias) = adamw_step(
+        model.conv2_bias,
+        grad_conv2_bias,
+        state.m_conv2_bias,
+        state.v_conv2_bias,
+        t,
+        lr,
+        weight_decay=weight_decay,
+    )
+    (model.fc1_weights, state.m_fc1_weights, state.v_fc1_weights) = adamw_step(
+        model.fc1_weights,
+        grad_fc1_weights,
+        state.m_fc1_weights,
+        state.v_fc1_weights,
+        t,
+        lr,
+        weight_decay=weight_decay,
+    )
+    (model.fc1_bias, state.m_fc1_bias, state.v_fc1_bias) = adamw_step(
+        model.fc1_bias,
+        grad_fc1_bias,
+        state.m_fc1_bias,
+        state.v_fc1_bias,
+        t,
+        lr,
+        weight_decay=weight_decay,
+    )
+    (model.fc2_weights, state.m_fc2_weights, state.v_fc2_weights) = adamw_step(
+        model.fc2_weights,
+        grad_fc2_weights,
+        state.m_fc2_weights,
+        state.v_fc2_weights,
+        t,
+        lr,
+        weight_decay=weight_decay,
+    )
+    (model.fc2_bias, state.m_fc2_bias, state.v_fc2_bias) = adamw_step(
+        model.fc2_bias,
+        grad_fc2_bias,
+        state.m_fc2_bias,
+        state.v_fc2_bias,
+        t,
+        lr,
+        weight_decay=weight_decay,
+    )
+    (model.fc3_weights, state.m_fc3_weights, state.v_fc3_weights) = adamw_step(
+        model.fc3_weights,
+        grad_fc3_weights,
+        state.m_fc3_weights,
+        state.v_fc3_weights,
+        t,
+        lr,
+        weight_decay=weight_decay,
+    )
+    (model.fc3_bias, state.m_fc3_bias, state.v_fc3_bias) = adamw_step(
+        model.fc3_bias,
+        grad_fc3_bias,
+        state.m_fc3_bias,
+        state.v_fc3_bias,
+        t,
+        lr,
+        weight_decay=weight_decay,
+    )

--- a/examples/grok/lenet_emnist/model.mojo
+++ b/examples/grok/lenet_emnist/model.mojo
@@ -534,16 +534,18 @@ def update_parameters_adamw(
     grad_fc3_bias: AnyTensor,
 ) raises:
     """Apply AdamW update to all 10 parameters, mutating model and state."""
-    (model.conv1_kernel, state.m_conv1_kernel, state.v_conv1_kernel) = (
-        adamw_step(
-            model.conv1_kernel,
-            grad_conv1_kernel,
-            state.m_conv1_kernel,
-            state.v_conv1_kernel,
-            t,
-            lr,
-            weight_decay=weight_decay,
-        )
+    (
+        model.conv1_kernel,
+        state.m_conv1_kernel,
+        state.v_conv1_kernel,
+    ) = adamw_step(
+        model.conv1_kernel,
+        grad_conv1_kernel,
+        state.m_conv1_kernel,
+        state.v_conv1_kernel,
+        t,
+        lr,
+        weight_decay=weight_decay,
     )
     (model.conv1_bias, state.m_conv1_bias, state.v_conv1_bias) = adamw_step(
         model.conv1_bias,
@@ -554,16 +556,18 @@ def update_parameters_adamw(
         lr,
         weight_decay=weight_decay,
     )
-    (model.conv2_kernel, state.m_conv2_kernel, state.v_conv2_kernel) = (
-        adamw_step(
-            model.conv2_kernel,
-            grad_conv2_kernel,
-            state.m_conv2_kernel,
-            state.v_conv2_kernel,
-            t,
-            lr,
-            weight_decay=weight_decay,
-        )
+    (
+        model.conv2_kernel,
+        state.m_conv2_kernel,
+        state.v_conv2_kernel,
+    ) = adamw_step(
+        model.conv2_kernel,
+        grad_conv2_kernel,
+        state.m_conv2_kernel,
+        state.v_conv2_kernel,
+        t,
+        lr,
+        weight_decay=weight_decay,
     )
     (model.conv2_bias, state.m_conv2_bias, state.v_conv2_bias) = adamw_step(
         model.conv2_bias,

--- a/examples/grok/lenet_emnist/run_infer.mojo
+++ b/examples/grok/lenet_emnist/run_infer.mojo
@@ -1,0 +1,371 @@
+"""CLI Wrapper for LeNet-5 Inference.
+
+Provides command-line interface for running inference with a trained LeNet-5 model.
+
+Usage:
+    mojo run examples/lenet_emnist/run_infer.mojo --checkpoint lenet5_weights --image test.png
+    mojo run examples/lenet_emnist/run_infer.mojo --checkpoint lenet5_weights --test-set
+
+Arguments:
+    --checkpoint DIR   Weights directory (required)
+    --image FILE       Single image file to classify (PNG/IDX format)
+    --test-set         Run evaluation on EMNIST test set
+    --data-dir DIR     EMNIST data directory (default: datasets/emnist)
+    --top-k N          Show top-k predictions (default: 5)
+"""
+
+from model import LeNet5
+from projectodyssey.data.constants import DatasetInfo
+from projectodyssey.data.formats import (
+    load_idx_images,
+    load_idx_labels,
+    normalize_images,
+)
+from projectodyssey.tensor.any_tensor import AnyTensor, zeros
+from projectodyssey.utils.arg_parser import ArgumentParser
+from projectodyssey.training.metrics import top1_accuracy, AccuracyMetric
+from std.collections import List
+
+
+# EMNIST Balanced class labels (47 classes)
+# 0-9: digits, 10-35: uppercase letters, 36-46: lowercase letters (excluding ambiguous)
+def get_class_label(class_idx: Int) -> String:
+    """Convert class index to human-readable label.
+
+    Args:
+        class_idx: Class index (0-46 for EMNIST Balanced).
+
+    Returns:
+        Character label.
+    """
+    if class_idx < 10:
+        # Digits 0-9
+        return String(class_idx)
+    elif class_idx < 36:
+        # Uppercase letters A-Z (indices 10-35)
+        var letter_idx = class_idx - 10
+        return chr(ord("A") + letter_idx)
+    else:
+        # Lowercase letters (indices 36-46)
+        # Only includes: a, b, d, e, f, g, h, n, q, r, t
+        var lower_idx = class_idx - 36
+        # EMNIST balanced lowercase: a, b, d, e, f, g, h, n, q, r, t
+        var lowercase_chars = "abdefghnqrt"
+        if lower_idx < lowercase_chars.byte_length():
+            return chr(Int(lowercase_chars.as_bytes()[lower_idx]))
+        else:
+            return "?"
+
+
+struct InferConfig(Movable):
+    """Inference configuration."""
+
+    var checkpoint_dir: String
+    var image_path: String
+    var run_test_set: Bool
+    var data_dir: String
+    var top_k: Int
+
+    def __init__(out self):
+        self.checkpoint_dir = ""
+        self.image_path = ""
+        self.run_test_set = False
+        self.data_dir = "datasets/emnist"
+        self.top_k = 5
+
+
+def parse_args() raises -> InferConfig:
+    """Parse command line arguments using enhanced argument parser."""
+    var parser = ArgumentParser()
+    parser.add_argument("checkpoint", "string", "")
+    parser.add_argument("image", "string", "")
+    parser.add_flag("test-set")
+    parser.add_argument("data-dir", "string", "datasets/emnist")
+    parser.add_argument("top-k", "int", "5")
+
+    var args = parser.parse()
+
+    var config = InferConfig()
+    config.checkpoint_dir = args.get_string("checkpoint", "")
+    config.image_path = args.get_string("image", "")
+    config.run_test_set = args.get_bool("test-set")
+    config.data_dir = args.get_string("data-dir", "datasets/emnist")
+    config.top_k = args.get_int("top-k", 5)
+
+    return config^
+
+
+def load_image(filepath: String) raises -> AnyTensor:
+    """Load image from file and normalize for model inference.
+
+    Currently supports IDX format (.idx3-ubyte for images). PNG support
+    requires external image processing libraries not yet integrated into
+    the Mojo standard library.
+
+    Image Format Requirements:
+        - IDX format: Standard binary format used by EMNIST dataset
+        - PNG format: Not yet supported (requires libpng or similar)
+        - Raw format: 28x28 grayscale images as hex-encoded binary
+
+    Expected Input Formats:
+        1. IDX (recommended): Single 28x28 grayscale image
+        2. Raw binary: Direct 784 bytes representing 28x28 image
+
+    Normalization:
+        - Input range: [0, 255] (standard image pixel values)
+        - Output range: [0, 1] (normalized for neural network)
+        - Formula: normalized_pixel = raw_pixel / 255.0
+
+    Args:
+        filepath: Path to image file (IDX or binary format).
+
+    Returns:
+        Normalized image tensor of shape (1, 1, 28, 28) ready for model input
+
+    Raises:
+        Error: If file not found, format is invalid, or size doesn't match 28x28
+
+    Note:
+        This is a placeholder implementation supporting IDX format only.
+        PNG support will be added when Mojo gains image processing capabilities.
+        For now, use EMNIST dataset files or convert PNG to IDX format offline.
+
+    Future Enhancement (awaiting Mojo stdlib):
+        PNG loading would be implemented as:
+        1. Decode PNG file using image library
+        2. Convert to grayscale if needed
+        3. Resize to 28x28 if needed
+        4. Normalize pixel values to [0, 1]
+        5. Reshape to (1, 1, 28, 28) batch format
+
+    Example:
+       ```mojo
+        # Load single image and run inference
+        var image = load_image("sample_digit.idx3-ubyte")
+        var logits = model.forward(image)
+        ```
+    """
+    # Create empty placeholder tensor
+    # In a real implementation, this would:
+    # 1. Check file extension and call appropriate loader
+    # 2. Validate image dimensions (must be 28x28)
+    # 3. Normalize to [0, 1] range
+    # 4. Reshape to (1, 1, 28, 28) batch format
+    var empty_shape: List[Int] = [1, 1, 28, 28]
+    var empty_tensor = zeros(empty_shape, DType.float32)
+    return empty_tensor
+
+
+def get_top_k_predictions(
+    logits: AnyTensor, k: Int
+) raises -> List[Tuple[Int, Float32]]:
+    """Get top-k predictions from logits.
+
+    Args:
+        logits: Model output logits (1, num_classes).
+        k: Number of top predictions to return.
+
+    Returns:
+        List of (class_idx, score) tuples sorted by score descending.
+    """
+    var logits_shape = logits.shape()
+    var num_classes = (
+        logits_shape[1] if len(logits_shape) > 1 else logits_shape[0]
+    )
+
+    # Extract all scores
+    var scores = List[Tuple[Int, Float32]]()
+    for i in range(num_classes):
+        var score = logits._data.bitcast[Float32]()[i]
+        scores.append((i, score))
+
+    # Simple bubble sort for top-k (sufficient for 47 classes)
+    for _ in range(min(k, len(scores))):
+        for j in range(len(scores) - 1):
+            if scores[j][1] < scores[j + 1][1]:
+                var temp = scores[j]
+                scores[j] = scores[j + 1]
+                scores[j + 1] = temp
+
+    # Return top-k
+    var result = List[Tuple[Int, Float32]]()
+    for i in range(min(k, len(scores))):
+        result.append(scores[i])
+
+    return result^
+
+
+def evaluate_test_set(
+    mut model: LeNet5, test_images: AnyTensor, test_labels: AnyTensor
+) raises -> Float32:
+    """Evaluate model on full test set.
+
+    Args:
+        model: Loaded LeNet-5 model.
+        test_images: Normalized test images (N, 1, 28, 28).
+        test_labels: Test labels (N,).
+
+    Returns:
+        Test accuracy (0.0 to 1.0).
+    """
+    var num_samples = test_images.shape()[0]
+    var correct = 0
+
+    print("Evaluating on", num_samples, "test samples...")
+
+    var eval_batch_size = 32
+    var num_batches = (num_samples + eval_batch_size - 1) // eval_batch_size
+
+    for batch_idx in range(num_batches):
+        var start_idx = batch_idx * eval_batch_size
+        var end_idx = min(start_idx + eval_batch_size, num_samples)
+
+        var batch_images = test_images.slice(start_idx, end_idx, axis=0)
+        var batch_labels = test_labels.slice(start_idx, end_idx, axis=0)
+
+        var actual_batch_size = end_idx - start_idx
+        for i in range(actual_batch_size):
+            var sample = batch_images.slice(i, i + 1, axis=0)
+            var pred_class = model.predict(sample)
+            var true_label = Int(batch_labels[i])
+
+            if pred_class == true_label:
+                correct += 1
+
+        # Progress update
+        if (batch_idx + 1) % 50 == 0:
+            print(
+                "  Processed",
+                (batch_idx + 1) * eval_batch_size,
+                "/",
+                num_samples,
+                "samples",
+            )
+
+    var accuracy = Float32(correct) / Float32(num_samples)
+    return accuracy
+
+
+def main() raises:
+    """Main inference entry point."""
+    print("=" * 60)
+    print("LeNet-5 Inference on EMNIST")
+    print("=" * 60)
+
+    # Parse arguments
+    var config = parse_args()
+
+    # Validate arguments
+    if config.checkpoint_dir.byte_length() == 0:
+        print("ERROR: --checkpoint is required")
+        print("\nUsage:")
+        print("  mojo run run_infer.mojo --checkpoint <weights_dir> --test-set")
+        print(
+            "  mojo run run_infer.mojo --checkpoint <weights_dir> --image"
+            " <image_path>"
+        )
+        return
+
+    if not config.run_test_set and config.image_path.byte_length() == 0:
+        print("ERROR: Either --test-set or --image is required")
+        print("\nUsage:")
+        print("  mojo run run_infer.mojo --checkpoint <weights_dir> --test-set")
+        print(
+            "  mojo run run_infer.mojo --checkpoint <weights_dir> --image"
+            " <image_path>"
+        )
+        return
+
+    print("\nConfiguration:")
+    print("  Checkpoint: ", config.checkpoint_dir)
+    if config.run_test_set:
+        print("  Mode: Test set evaluation")
+        print("  Data Directory: ", config.data_dir)
+    else:
+        print("  Mode: Single image inference")
+        print("  Image: ", config.image_path)
+    print()
+
+    # Initialize and load model
+    print("Loading model from", config.checkpoint_dir, "...")
+    var dataset_info = DatasetInfo("emnist_balanced")
+    var model = LeNet5(num_classes=dataset_info.num_classes())
+    model.load_weights(config.checkpoint_dir)
+    print("  Model loaded successfully")
+    print()
+
+    if config.run_test_set:
+        # Run evaluation on test set
+        print("Loading EMNIST test set...")
+        var test_images_path = (
+            config.data_dir + "/emnist-balanced-test-images-idx3-ubyte"
+        )
+        var test_labels_path = (
+            config.data_dir + "/emnist-balanced-test-labels-idx1-ubyte"
+        )
+
+        var test_images_raw = load_idx_images(test_images_path)
+        var test_labels = load_idx_labels(test_labels_path)
+        var test_images = normalize_images(test_images_raw)
+
+        print("  Test samples: ", test_images.shape()[0])
+        print()
+
+        var accuracy = evaluate_test_set(model, test_images, test_labels)
+
+        print()
+        print("=" * 60)
+        print("Test Set Results")
+        print("=" * 60)
+        print("  Accuracy: ", accuracy * 100.0, "%")
+        print(
+            "  Correct: ",
+            Int(accuracy * Float32(test_images.shape()[0])),
+            "/",
+            test_images.shape()[0],
+        )
+
+    else:
+        # Single image inference
+        print("Loading image from", config.image_path, "...")
+
+        # Load image (currently supports IDX format only)
+        # PNG/JPEG image loading requires external image processing libraries (Mojo v0.26.1).
+        # Mojo does not yet have native image decoding support in its stdlib.
+        # For now, convert images to IDX format using Python preprocessing scripts.
+        var image = load_image(config.image_path)
+
+        if image.shape()[0] == 0:
+            print("ERROR: Failed to load image")
+            return
+
+        print("  Image shape:", image.shape()[0], "x", image.shape()[1])
+        print()
+
+        # Run inference
+        print("Running inference...")
+        var logits = model.forward(image)
+
+        # Get top-k predictions
+        var top_k_preds = get_top_k_predictions(logits, config.top_k)
+
+        print()
+        print("=" * 60)
+        print("Inference Results")
+        print("=" * 60)
+        for i in range(len(top_k_preds)):
+            var class_idx, score = top_k_preds[i]
+            var label = get_class_label(class_idx)
+            print(
+                "  ",
+                i + 1,
+                ". ",
+                label,
+                " (class ",
+                class_idx,
+                ") - score: ",
+                score,
+            )
+
+    print()
+    print("Inference complete!")

--- a/examples/grok/lenet_emnist/run_train.mojo
+++ b/examples/grok/lenet_emnist/run_train.mojo
@@ -364,9 +364,7 @@ struct MultiMetricCheckpointer:
     var max_after_min_value: List[Float64]
     var max_after_min_epoch: List[Int]
 
-    def __init__(
-        out self, metrics: List[MetricMode], ckpt_dir: String
-    ) raises:
+    def __init__(out self, metrics: List[MetricMode], ckpt_dir: String) raises:
         self.metrics = metrics.copy()
         self.ckpt_dir = ckpt_dir
         self.best_max_value = List[Float64]()
@@ -443,16 +441,11 @@ struct MultiMetricCheckpointer:
                         subdir = name + "_best"
                     else:
                         subdir = name + "_min"
-                    self._save(
-                        model, subdir, name, "best", value, epoch
-                    )
+                    self._save(model, subdir, name, "best", value, epoch)
 
             # both: track min-after-max and max-after-min
             if mode == "both":
-                if (
-                    self.has_seen_max[i]
-                    and value < self.min_after_max_value[i]
-                ):
+                if self.has_seen_max[i] and value < self.min_after_max_value[i]:
                     self.min_after_max_value[i] = value
                     self.min_after_max_epoch[i] = epoch
                     self._save(
@@ -463,10 +456,7 @@ struct MultiMetricCheckpointer:
                         value,
                         epoch,
                     )
-                if (
-                    self.has_seen_min[i]
-                    and value > self.max_after_min_value[i]
-                ):
+                if self.has_seen_min[i] and value > self.max_after_min_value[i]:
                     self.max_after_min_value[i] = value
                     self.max_after_min_epoch[i] = epoch
                     self._save(
@@ -588,10 +578,7 @@ def main() raises:
     var test_images = normalize_images(test_images_raw)
 
     # Optional subset (memorization regime)
-    if (
-        config.subset_size > 0
-        and config.subset_size < train_images.shape()[0]
-    ):
+    if config.subset_size > 0 and config.subset_size < train_images.shape()[0]:
         train_images = train_images.slice(0, config.subset_size, axis=0)
         train_labels = train_labels.slice(0, config.subset_size, axis=0)
         print("  Subset: ", train_images.shape()[0], "samples")

--- a/examples/grok/lenet_emnist/run_train.mojo
+++ b/examples/grok/lenet_emnist/run_train.mojo
@@ -1,0 +1,675 @@
+"""
+CLI Wrapper for LeNet-5 Training (Grokking Experiment Variant).
+
+Fork of examples/lenet_emnist/run_train.mojo with:
+  * AdamW optimizer (Adam + decoupled weight decay) instead of SGD.
+  * --subset-size flag to train on a small fixed subset of EMNIST (memorization regime).
+  * --max-batches flag to cap batches per epoch (fast smoke tests).
+  * Per-epoch structured log line with train_loss / train_acc / test_loss /
+    test_acc / weight_l2_norm (regex-parseable by analyze_phases.py).
+  * MultiMetricCheckpointer: tracks best/min/min_after_max/max_after_min
+    per requested metric and writes weight + JSON sidecar.
+
+Autograd note: ProjectOdyssey's autograd substrate (Variable conv/pool/linear
+ops, automatic backward dispatch) is in-progress (see #5452). This example
+keeps the existing manual backward path; AdamW is wired in via the bare
+functional `adamw_step()` from `projectodyssey.training.optimizers.adamw`.
+
+Usage:
+    mojo run examples/grok/lenet_emnist/run_train.mojo \
+        --epochs 1000 --batch-size 64 --lr 0.001 --weight-decay 1.0 \
+        --subset-size 1000 \
+        --track-metric test_acc:max,test_loss:both,train_loss:min
+"""
+
+from model import LeNet5, AdamWState, update_parameters_adamw
+from projectodyssey.data.constants import DatasetInfo
+from projectodyssey.data.formats import (
+    load_idx_images,
+    load_idx_labels,
+    normalize_images,
+    one_hot_encode,
+)
+from projectodyssey.tensor.any_tensor import AnyTensor, zeros
+from projectodyssey.core.conv import conv2d, conv2d_backward
+from projectodyssey.core.pooling import maxpool2d, maxpool2d_backward
+from projectodyssey.core.linear import linear, linear_backward
+from projectodyssey.core.activation import relu, relu_backward
+from projectodyssey.core.loss import cross_entropy, cross_entropy_backward
+from projectodyssey.core.numerical_safety import compute_tensor_l2_norm
+from projectodyssey.training.evaluation import evaluate_model_simple
+from projectodyssey.utils.arg_parser import create_training_parser
+from std.collections import List, Dict
+
+
+struct TrainConfig(Movable):
+    """Training configuration for the grokking-experiment variant."""
+
+    var epochs: Int
+    var batch_size: Int
+    var learning_rate: Float64
+    var weight_decay: Float64
+    var subset_size: Int
+    var max_batches: Int
+    var log_every: Int
+    var checkpoint_every: Int
+    var track_metric: String
+    var data_dir: String
+    var weights_dir: String
+
+    def __init__(out self):
+        self.epochs = 10
+        self.batch_size = 32
+        self.learning_rate = 0.001
+        self.weight_decay = 0.01
+        self.subset_size = 0
+        self.max_batches = 0
+        self.log_every = 1
+        self.checkpoint_every = 1
+        self.track_metric = "test_acc:max"
+        self.data_dir = "datasets/emnist"
+        self.weights_dir = "lenet5_weights"
+
+
+def parse_args() raises -> TrainConfig:
+    """Parse command line arguments using enhanced argument parser."""
+    var parser = create_training_parser()
+    parser.add_argument("weights-dir", "string", "lenet5_weights")
+    parser.add_argument("data-dir", "string", "datasets/emnist")
+    parser.add_argument("weight-decay", "float", "0.01")
+    parser.add_argument("subset-size", "int", "0")
+    parser.add_argument("max-batches", "int", "0")
+    parser.add_argument("log-every", "int", "1")
+    parser.add_argument("checkpoint-every", "int", "1")
+    # NOTE: arg_parser does not support repeated flags; pass comma-separated
+    # list e.g. --track-metric test_acc:max,test_loss:both
+    parser.add_argument("track-metric", "string", "test_acc:max")
+
+    var args = parser.parse()
+
+    var config = TrainConfig()
+    config.epochs = args.get_int("epochs", 10)
+    config.batch_size = args.get_int("batch-size", 32)
+    config.learning_rate = args.get_float("lr", 0.001)
+    config.weight_decay = args.get_float("weight-decay", 0.01)
+    config.subset_size = args.get_int("subset-size", 0)
+    config.max_batches = args.get_int("max-batches", 0)
+    config.log_every = args.get_int("log-every", 1)
+    config.checkpoint_every = args.get_int("checkpoint-every", 1)
+    config.track_metric = args.get_string("track-metric", "test_acc:max")
+    config.data_dir = args.get_string("data-dir", "datasets/emnist")
+    config.weights_dir = args.get_string("weights-dir", "lenet5_weights")
+
+    return config^
+
+
+# ============================================================================
+# Forward + backward + gradient computation + AdamW update (fused)
+# ============================================================================
+
+
+def forward_backward_step(
+    mut model: LeNet5,
+    mut optim_state: AdamWState,
+    t: Int,
+    input: AnyTensor,
+    labels: AnyTensor,
+    learning_rate: Float64,
+    weight_decay: Float64,
+) raises -> Float32:
+    """Run forward + backward, return loss and gradients (no parameter update).
+
+    Manual gradient computation (autograd path is in-progress; see #5452).
+    """
+    # Conv1 + ReLU + MaxPool
+    var conv1_out = conv2d(
+        input, model.conv1_kernel, model.conv1_bias, stride=1, padding=0
+    )
+    var relu1_out = relu(conv1_out)
+    var pool1_out = maxpool2d(relu1_out, kernel_size=2, stride=2, padding=0)
+
+    # Conv2 + ReLU + MaxPool
+    var conv2_out = conv2d(
+        pool1_out, model.conv2_kernel, model.conv2_bias, stride=1, padding=0
+    )
+    var relu2_out = relu(conv2_out)
+    var pool2_out = maxpool2d(relu2_out, kernel_size=2, stride=2, padding=0)
+
+    # Flatten
+    var pool2_shape = pool2_out.shape()
+    var batch_size = pool2_shape[0]
+    var flattened_size = pool2_shape[1] * pool2_shape[2] * pool2_shape[3]
+    var flatten_shape: List[Int] = [batch_size, flattened_size]
+    var flattened = pool2_out.reshape(flatten_shape)
+
+    # FC1 + ReLU
+    var fc1_out = linear(flattened, model.fc1_weights, model.fc1_bias)
+    var relu3_out = relu(fc1_out)
+
+    # FC2 + ReLU
+    var fc2_out = linear(relu3_out, model.fc2_weights, model.fc2_bias)
+    var relu4_out = relu(fc2_out)
+
+    # FC3 (logits)
+    var logits = linear(relu4_out, model.fc3_weights, model.fc3_bias)
+
+    # Loss
+    var loss_tensor = cross_entropy(logits, labels)
+    var loss = loss_tensor._data.bitcast[Float32]()[0]
+
+    # Backward
+    var grad_output_shape: List[Int] = [1]
+    var grad_output = zeros(grad_output_shape, logits.dtype())
+    grad_output.set(0, Float32(1.0))
+    var grad_logits = cross_entropy_backward(grad_output, logits, labels)
+
+    var fc3_grads = linear_backward(grad_logits, relu4_out, model.fc3_weights)
+    var grad_fc2_out = relu_backward(fc3_grads.grad_input, fc2_out)
+    var fc2_grads = linear_backward(grad_fc2_out, relu3_out, model.fc2_weights)
+    var grad_fc1_out = relu_backward(fc2_grads.grad_input, fc1_out)
+    var fc1_grads = linear_backward(grad_fc1_out, flattened, model.fc1_weights)
+    var grad_pool2_out = fc1_grads.grad_input.reshape(pool2_shape)
+    var grad_relu2_out = maxpool2d_backward(
+        grad_pool2_out, relu2_out, kernel_size=2, stride=2, padding=0
+    )
+    var grad_conv2_out = relu_backward(grad_relu2_out, conv2_out)
+    var conv2_grads = conv2d_backward(
+        grad_conv2_out, pool1_out, model.conv2_kernel, stride=1, padding=0
+    )
+    var grad_relu1_out = maxpool2d_backward(
+        conv2_grads.grad_input, relu1_out, kernel_size=2, stride=2, padding=0
+    )
+    var grad_conv1_out = relu_backward(grad_relu1_out, conv1_out)
+    var conv1_grads = conv2d_backward(
+        grad_conv1_out, input, model.conv1_kernel, stride=1, padding=0
+    )
+
+    update_parameters_adamw(
+        model,
+        optim_state,
+        learning_rate,
+        t,
+        weight_decay,
+        conv1_grads.grad_weights^,
+        conv1_grads.grad_bias^,
+        conv2_grads.grad_weights^,
+        conv2_grads.grad_bias^,
+        fc1_grads.grad_weights^,
+        fc1_grads.grad_bias^,
+        fc2_grads.grad_weights^,
+        fc2_grads.grad_bias^,
+        fc3_grads.grad_weights^,
+        fc3_grads.grad_bias^,
+    )
+    return loss
+
+
+# ============================================================================
+# Helpers: train_acc / test_loss / weight_l2
+# ============================================================================
+
+
+def compute_train_accuracy(
+    mut model: LeNet5,
+    train_images: AnyTensor,
+    train_labels: AnyTensor,
+    batch_size: Int,
+    num_classes: Int,
+) raises -> Float32:
+    """Top-1 accuracy on the training set (or training subset)."""
+    return evaluate_model_simple(
+        model,
+        train_images,
+        train_labels,
+        batch_size=batch_size,
+        num_classes=num_classes,
+        verbose=False,
+    )
+
+
+def compute_test_loss(
+    mut model: LeNet5,
+    test_images: AnyTensor,
+    test_labels: AnyTensor,
+    batch_size: Int,
+    num_classes: Int,
+) raises -> Float32:
+    """Mean cross-entropy loss across the full test set."""
+    var num_samples = test_images.shape()[0]
+    var num_batches = (num_samples + batch_size - 1) // batch_size
+    var total = Float32(0.0)
+    var count = 0
+
+    for batch_idx in range(num_batches):
+        var start_idx = batch_idx * batch_size
+        var end_idx = min(start_idx + batch_size, num_samples)
+        var batch_images = test_images.slice(start_idx, end_idx, axis=0)
+        var batch_labels_int = test_labels.slice(start_idx, end_idx, axis=0)
+        var batch_labels = one_hot_encode(
+            batch_labels_int, num_classes=num_classes
+        )
+
+        var logits = model.forward(batch_images)
+        var loss_tensor = cross_entropy(logits, batch_labels)
+        total += loss_tensor._data.bitcast[Float32]()[0]
+        count += 1
+
+    if count == 0:
+        return Float32(0.0)
+    return total / Float32(count)
+
+
+def compute_weight_l2_norm(model: LeNet5) raises -> Float64:
+    """Sum of per-parameter L2 norms across all 10 weight tensors."""
+    var params = model.parameters()
+    var total = Float64(0.0)
+    for i in range(len(params)):
+        total += compute_tensor_l2_norm(params[i])
+    return total
+
+
+# ============================================================================
+# Multi-metric checkpointer (inline, scoped to this example)
+# ============================================================================
+
+
+struct MetricMode(Copyable, Movable):
+    """A metric to track and its mode of tracking.
+
+    mode is one of "max", "min", or "both".
+    """
+
+    var name: String
+    var mode: String
+
+    def __init__(out self, name: String, mode: String):
+        self.name = name
+        self.mode = mode
+
+
+def parse_track_metric(spec: String) raises -> List[MetricMode]:
+    """Parse a comma-separated list like "test_acc:max,test_loss:both"."""
+    var out = List[MetricMode]()
+    if spec.byte_length() == 0:
+        return out^
+    var parts = spec.split(",")
+    for ref part in parts:
+        var trimmed = String(part)
+        if trimmed.byte_length() == 0:
+            continue
+        var kv = trimmed.split(":")
+        if len(kv) != 2:
+            raise Error(
+                "Invalid --track-metric entry '"
+                + trimmed
+                + "' (expected 'name:mode')"
+            )
+        var name = String(kv[0])
+        var mode = String(kv[1])
+        if mode != "max" and mode != "min" and mode != "both":
+            raise Error(
+                "Invalid --track-metric mode '"
+                + mode
+                + "' (expected max, min, or both)"
+            )
+        out.append(MetricMode(name=name, mode=mode))
+    return out^
+
+
+def _write_sidecar(
+    path: String,
+    metric: String,
+    mode_kind: String,
+    value: Float64,
+    epoch: Int,
+) raises:
+    """Write a tiny JSON sidecar describing a checkpoint event."""
+    var body = (
+        '{"metric": "'
+        + metric
+        + '", "mode_kind": "'
+        + mode_kind
+        + '", "value": '
+        + String(value)
+        + ', "epoch": '
+        + String(epoch)
+        + "}\n"
+    )
+    with open(path, "w") as f:
+        f.write(body)
+
+
+struct MultiMetricCheckpointer:
+    """Track multiple metrics and write a separate checkpoint per (metric, kind).
+
+    For each metric in `metrics`:
+      mode == "max": save weights to `{ckpt_dir}/{name}_best/` when value rises
+      mode == "min": save weights to `{ckpt_dir}/{name}_best/` when value falls
+      mode == "both": save `{name}_best/` (max), `{name}_min/` (min),
+                      `{name}_min_after_max/`, `{name}_max_after_min/`
+    Each checkpoint directory contains the model's `.weights` files plus a
+    `meta.json` sidecar.
+    """
+
+    var metrics: List[MetricMode]
+    var ckpt_dir: String
+    var best_max_value: List[Float64]
+    var best_max_epoch: List[Int]
+    var best_min_value: List[Float64]
+    var best_min_epoch: List[Int]
+    var has_seen_max: List[Bool]
+    var has_seen_min: List[Bool]
+    var min_after_max_value: List[Float64]
+    var min_after_max_epoch: List[Int]
+    var max_after_min_value: List[Float64]
+    var max_after_min_epoch: List[Int]
+
+    def __init__(
+        out self, metrics: List[MetricMode], ckpt_dir: String
+    ) raises:
+        self.metrics = metrics.copy()
+        self.ckpt_dir = ckpt_dir
+        self.best_max_value = List[Float64]()
+        self.best_max_epoch = List[Int]()
+        self.best_min_value = List[Float64]()
+        self.best_min_epoch = List[Int]()
+        self.has_seen_max = List[Bool]()
+        self.has_seen_min = List[Bool]()
+        self.min_after_max_value = List[Float64]()
+        self.min_after_max_epoch = List[Int]()
+        self.max_after_min_value = List[Float64]()
+        self.max_after_min_epoch = List[Int]()
+        var n = len(metrics)
+        for _ in range(n):
+            self.best_max_value.append(Float64(-1.0e30))
+            self.best_max_epoch.append(-1)
+            self.best_min_value.append(Float64(1.0e30))
+            self.best_min_epoch.append(-1)
+            self.has_seen_max.append(False)
+            self.has_seen_min.append(False)
+            self.min_after_max_value.append(Float64(1.0e30))
+            self.min_after_max_epoch.append(-1)
+            self.max_after_min_value.append(Float64(-1.0e30))
+            self.max_after_min_epoch.append(-1)
+
+    def _save(
+        mut self,
+        mut model: LeNet5,
+        subdir: String,
+        metric_name: String,
+        mode_kind: String,
+        value: Float64,
+        epoch: Int,
+    ) raises:
+        var path = self.ckpt_dir + "/" + subdir
+        model.save_weights(path)
+        _write_sidecar(
+            path + "/meta.json", metric_name, mode_kind, value, epoch
+        )
+
+    def update(
+        mut self,
+        mut model: LeNet5,
+        epoch: Int,
+        metric_values: Dict[String, Float64],
+    ) raises:
+        for i in range(len(self.metrics)):
+            # Snapshot name/mode into locals so we don't alias self.metrics
+            # while passing `mut self` to `_save`.
+            var name = String(self.metrics[i].name)
+            var mode = String(self.metrics[i].mode)
+            if name not in metric_values:
+                continue
+            var value = metric_values[name]
+
+            # max-mode tracking (also active for "both")
+            if mode == "max" or mode == "both":
+                if value > self.best_max_value[i]:
+                    self.best_max_value[i] = value
+                    self.best_max_epoch[i] = epoch
+                    self.has_seen_max[i] = True
+                    self._save(
+                        model, name + "_best", name, "best", value, epoch
+                    )
+
+            # min-mode tracking (also active for "both")
+            if mode == "min" or mode == "both":
+                if value < self.best_min_value[i]:
+                    self.best_min_value[i] = value
+                    self.best_min_epoch[i] = epoch
+                    self.has_seen_min[i] = True
+                    var subdir: String
+                    if mode == "min":
+                        subdir = name + "_best"
+                    else:
+                        subdir = name + "_min"
+                    self._save(
+                        model, subdir, name, "best", value, epoch
+                    )
+
+            # both: track min-after-max and max-after-min
+            if mode == "both":
+                if (
+                    self.has_seen_max[i]
+                    and value < self.min_after_max_value[i]
+                ):
+                    self.min_after_max_value[i] = value
+                    self.min_after_max_epoch[i] = epoch
+                    self._save(
+                        model,
+                        name + "_min_after_max",
+                        name,
+                        "min_after_max",
+                        value,
+                        epoch,
+                    )
+                if (
+                    self.has_seen_min[i]
+                    and value > self.max_after_min_value[i]
+                ):
+                    self.max_after_min_value[i] = value
+                    self.max_after_min_epoch[i] = epoch
+                    self._save(
+                        model,
+                        name + "_max_after_min",
+                        name,
+                        "max_after_min",
+                        value,
+                        epoch,
+                    )
+
+
+# ============================================================================
+# Training loop
+# ============================================================================
+
+
+def train_epoch(
+    mut model: LeNet5,
+    mut optim_state: AdamWState,
+    mut t: Int,
+    train_images: AnyTensor,
+    train_labels: AnyTensor,
+    batch_size: Int,
+    learning_rate: Float64,
+    weight_decay: Float64,
+    num_classes: Int,
+    max_batches: Int,
+) raises -> Tuple[Float32, Int]:
+    """Train for one epoch with AdamW. Returns (avg_loss, new_timestep)."""
+    var num_samples = train_images.shape()[0]
+    var num_batches = (num_samples + batch_size - 1) // batch_size
+    var total_loss = Float32(0.0)
+    var processed = 0
+
+    for batch_idx in range(num_batches):
+        if max_batches > 0 and batch_idx >= max_batches:
+            break
+
+        var start_idx = batch_idx * batch_size
+        var end_idx = min(start_idx + batch_size, num_samples)
+
+        var batch_images = train_images.slice(start_idx, end_idx, axis=0)
+        var batch_labels_int = train_labels.slice(start_idx, end_idx, axis=0)
+        var batch_labels = one_hot_encode(
+            batch_labels_int, num_classes=num_classes
+        )
+
+        var batch_loss = forward_backward_step(
+            model,
+            optim_state,
+            t,
+            batch_images,
+            batch_labels,
+            learning_rate,
+            weight_decay,
+        )
+        total_loss += batch_loss
+        processed += 1
+        t += 1
+
+    var avg = total_loss / Float32(max(processed, 1))
+    return Tuple[Float32, Int](avg, t)
+
+
+def main() raises:
+    """Main training entry point."""
+    print("=" * 60)
+    print("LeNet-5 Grokking Experiment (AdamW + EMNIST)")
+    print("=" * 60)
+
+    var config = parse_args()
+    print("\nConfiguration:")
+    print("  Epochs: ", config.epochs)
+    print("  Batch Size: ", config.batch_size)
+    print("  Learning Rate: ", config.learning_rate)
+    print("  Weight Decay: ", config.weight_decay)
+    print("  Subset Size: ", config.subset_size, "(0 = full)")
+    print("  Max Batches: ", config.max_batches, "(0 = unlimited)")
+    print("  Log Every: ", config.log_every)
+    print("  Checkpoint Every: ", config.checkpoint_every)
+    print("  Track Metric: ", config.track_metric)
+    print("  Data Directory: ", config.data_dir)
+    print("  Weights Directory: ", config.weights_dir)
+    print()
+
+    # Initialize model
+    print("Initializing LeNet-5 model...")
+    var dataset_info = DatasetInfo("emnist_balanced")
+    var model = LeNet5(num_classes=dataset_info.num_classes())
+    print("  Model initialized with", model.num_classes, "classes")
+    print()
+
+    # AdamW optimizer state
+    var optim_state = AdamWState(model)
+    var t = 1
+
+    # Load dataset
+    print("Loading EMNIST dataset...")
+    var train_images_path = (
+        config.data_dir + "/emnist-balanced-train-images-idx3-ubyte"
+    )
+    var train_labels_path = (
+        config.data_dir + "/emnist-balanced-train-labels-idx1-ubyte"
+    )
+    var test_images_path = (
+        config.data_dir + "/emnist-balanced-test-images-idx3-ubyte"
+    )
+    var test_labels_path = (
+        config.data_dir + "/emnist-balanced-test-labels-idx1-ubyte"
+    )
+
+    var train_images_raw = load_idx_images(train_images_path)
+    var train_labels = load_idx_labels(train_labels_path)
+    var test_images_raw = load_idx_images(test_images_path)
+    var test_labels = load_idx_labels(test_labels_path)
+
+    var train_images = normalize_images(train_images_raw)
+    var test_images = normalize_images(test_images_raw)
+
+    # Optional subset (memorization regime)
+    if (
+        config.subset_size > 0
+        and config.subset_size < train_images.shape()[0]
+    ):
+        train_images = train_images.slice(0, config.subset_size, axis=0)
+        train_labels = train_labels.slice(0, config.subset_size, axis=0)
+        print("  Subset: ", train_images.shape()[0], "samples")
+
+    print("  Training samples: ", train_images.shape()[0])
+    print("  Test samples: ", test_images.shape()[0])
+    print()
+
+    # Parse metric spec, build checkpointer
+    var metric_modes = parse_track_metric(config.track_metric)
+    var checkpointer = MultiMetricCheckpointer(metric_modes, config.weights_dir)
+
+    print("Starting training...")
+    for epoch in range(1, config.epochs + 1):
+        var epoch_result = train_epoch(
+            model,
+            optim_state,
+            t,
+            train_images,
+            train_labels,
+            config.batch_size,
+            config.learning_rate,
+            config.weight_decay,
+            model.num_classes,
+            config.max_batches,
+        )
+        var train_loss = epoch_result[0]
+        t = epoch_result[1]
+
+        if epoch % config.log_every == 0 or epoch == config.epochs:
+            var train_acc = compute_train_accuracy(
+                model,
+                train_images,
+                train_labels,
+                100,
+                model.num_classes,
+            )
+            var test_acc = evaluate_model_simple(
+                model,
+                test_images,
+                test_labels,
+                batch_size=100,
+                num_classes=model.num_classes,
+                verbose=False,
+            )
+            var test_loss = compute_test_loss(
+                model, test_images, test_labels, 100, model.num_classes
+            )
+            var weight_l2 = compute_weight_l2_norm(model)
+
+            print(
+                "EPOCH",
+                epoch,
+                "train_loss=",
+                train_loss,
+                "train_acc=",
+                train_acc * 100.0,
+                "test_loss=",
+                test_loss,
+                "test_acc=",
+                test_acc * 100.0,
+                "weight_l2=",
+                weight_l2,
+            )
+
+            if epoch % config.checkpoint_every == 0 or epoch == config.epochs:
+                var metric_values = Dict[String, Float64]()
+                metric_values["train_loss"] = Float64(train_loss)
+                metric_values["train_acc"] = Float64(train_acc)
+                metric_values["test_loss"] = Float64(test_loss)
+                metric_values["test_acc"] = Float64(test_acc)
+                metric_values["weight_l2_norm"] = weight_l2
+                checkpointer.update(model, epoch, metric_values)
+
+    # Save final model
+    print("Saving final model weights...")
+    model.save_weights(config.weights_dir + "/final")
+    print("  Model saved to", config.weights_dir + "/final")
+    print()
+
+    print("Training complete!")

--- a/examples/grok/lenet_emnist/train.mojo
+++ b/examples/grok/lenet_emnist/train.mojo
@@ -1,0 +1,480 @@
+"""Training Script for LeNet-5 on EMNIST.
+
+Implements training with manual backward passes (no autograd).
+Uses SGD optimizer with simple training loop.
+
+Usage:
+    mojo run examples/lenet_emnist/train.mojo --epochs 10 --batch-size 32 --lr 0.01
+
+Requirements:
+    - EMNIST dataset downloaded (run: python scripts/download_emnist.py)
+    - Dataset location: datasets/emnist/
+
+References:
+    - LeCun, Y., Bottou, L., Bengio, Y., & Haffner, P. (1998).
+      Gradient-based learning applied to document recognition.
+    - Reference Implementation: https://github.com/mattwang44/LeNet-from-Scratch
+"""
+
+from model import (
+    LeNet5,
+    # Architecture constants for consistent forward/backward passes
+    CONV1_STRIDE,
+    CONV1_PADDING,
+    CONV2_STRIDE,
+    CONV2_PADDING,
+    POOL1_KERNEL_SIZE,
+    POOL1_STRIDE,
+    POOL1_PADDING,
+    POOL2_KERNEL_SIZE,
+    POOL2_STRIDE,
+    POOL2_PADDING,
+)
+from projectodyssey.data.formats import (
+    load_idx_images,
+    load_idx_labels,
+    normalize_images,
+    one_hot_encode,
+)
+from projectodyssey.tensor.any_tensor import AnyTensor, zeros
+from projectodyssey.core.conv import conv2d, conv2d_backward
+from projectodyssey.core.pooling import maxpool2d, maxpool2d_backward
+from projectodyssey.core.linear import linear, linear_backward
+from projectodyssey.core.activation import relu, relu_backward
+from projectodyssey.core.loss import cross_entropy, cross_entropy_backward
+from projectodyssey.utils.arg_parser import create_training_parser
+from projectodyssey.training.loops import TrainingLoop
+from projectodyssey.training.optimizers import sgd_step_simple
+from projectodyssey.training.metrics import (
+    top1_accuracy,
+    AccuracyMetric,
+    LossTracker,
+)
+from projectodyssey.training.evaluation import evaluate_model_simple
+from std.collections import List
+
+# Default number of classes for EMNIST Balanced dataset
+comptime DEFAULT_NUM_CLASSES = 47
+
+
+struct TrainConfig:
+    """Training configuration from command line arguments."""
+
+    var epochs: Int
+    var batch_size: Int
+    var learning_rate: Float32
+    var data_dir: String
+    var weights_dir: String
+
+    def __init__(
+        out self,
+        epochs: Int,
+        batch_size: Int,
+        learning_rate: Float32,
+        data_dir: String,
+        weights_dir: String,
+    ):
+        self.epochs = epochs
+        self.batch_size = batch_size
+        self.learning_rate = learning_rate
+        self.data_dir = data_dir
+        self.weights_dir = weights_dir
+
+
+def parse_args() raises -> TrainConfig:
+    """Parse command line arguments using enhanced argument parser.
+
+    Note: Early stopping arguments are parsed but not used in this example.
+    The create_training_parser() includes early stopping flags:
+        --use-early-stopping
+        --early-stopping-monitor (default: val_loss)
+        --early-stopping-patience (default: 5)
+        --early-stopping-min-delta (default: 0.0)
+        --early-stopping-mode (default: min)
+
+    Returns:
+        TrainConfig with parsed arguments.
+    """
+    var parser = create_training_parser()
+    parser.add_argument("weights-dir", "string", "lenet5_weights")
+    parser.add_argument("data-dir", "string", "datasets/emnist")
+
+    var args = parser.parse()
+
+    var epochs = args.get_int("epochs", 10)
+    var batch_size = args.get_int("batch-size", 32)
+    var learning_rate = Float32(args.get_float("lr", 0.001))
+    var data_dir = args.get_string("data-dir", "datasets/emnist")
+    var weights_dir = args.get_string("weights-dir", "lenet5_weights")
+
+    return TrainConfig(epochs, batch_size, learning_rate, data_dir, weights_dir)
+
+
+def compute_gradients(
+    mut model: LeNet5,
+    input: AnyTensor,
+    labels: AnyTensor,
+    learning_rate: Float32,
+) raises -> Float32:
+    """Compute gradients and update parameters for one batch.
+
+    This implements the full forward and backward pass manually.
+
+    Args:
+        model: LeNet-5 model.
+        input: Batch of images (batch, 1, 28, 28).
+        labels: One-hot encoded batch of labels (batch, num_classes).
+        learning_rate: Learning rate for SGD.
+
+    Returns:
+        Loss value for this batch.
+    """
+    # ========== Forward Pass (with caching) ==========
+
+    # Conv1 + ReLU + MaxPool
+    var conv1_out = conv2d(
+        input,
+        model.conv1_kernel,
+        model.conv1_bias,
+        stride=CONV1_STRIDE,
+        padding=CONV1_PADDING,
+    )
+    var relu1_out = relu(conv1_out)
+    var pool1_out = maxpool2d(
+        relu1_out,
+        kernel_size=POOL1_KERNEL_SIZE,
+        stride=POOL1_STRIDE,
+        padding=POOL1_PADDING,
+    )
+
+    # Conv2 + ReLU + MaxPool
+    var conv2_out = conv2d(
+        pool1_out,
+        model.conv2_kernel,
+        model.conv2_bias,
+        stride=CONV2_STRIDE,
+        padding=CONV2_PADDING,
+    )
+    var relu2_out = relu(conv2_out)
+    var pool2_out = maxpool2d(
+        relu2_out,
+        kernel_size=POOL2_KERNEL_SIZE,
+        stride=POOL2_STRIDE,
+        padding=POOL2_PADDING,
+    )
+
+    # Flatten
+    var pool2_shape = pool2_out.shape()
+    var batch_size = pool2_shape[0]
+    var flattened_size = pool2_shape[1] * pool2_shape[2] * pool2_shape[3]
+    var flatten_shape: List[Int] = [batch_size, flattened_size]
+    var flattened = pool2_out.reshape(flatten_shape)
+
+    # FC1 + ReLU
+    var fc1_out = linear(flattened, model.fc1_weights, model.fc1_bias)
+    var relu3_out = relu(fc1_out)
+
+    # FC2 + ReLU
+    var fc2_out = linear(relu3_out, model.fc2_weights, model.fc2_bias)
+    var relu4_out = relu(fc2_out)
+
+    # FC3 (logits)
+    var logits = linear(relu4_out, model.fc3_weights, model.fc3_bias)
+
+    # Compute loss
+    var loss_tensor = cross_entropy(logits, labels)
+    var loss = loss_tensor._data.bitcast[Float32]()[0]
+
+    # ========== Backward Pass ==========
+
+    # Start with gradient from loss
+    # For cross-entropy with mean reduction, the initial gradient is 1.0 / batch_size
+    var grad_output_shape = List[Int]()
+    grad_output_shape.append(1)
+    var grad_output = zeros(grad_output_shape, logits.dtype())
+    grad_output.set(0, Float32(1.0))
+    var grad_logits = cross_entropy_backward(grad_output, logits, labels)
+
+    # FC3 backward
+    var fc3_grads = linear_backward(grad_logits, relu4_out, model.fc3_weights)
+
+    # ReLU4 backward
+    var grad_fc2_out = relu_backward(fc3_grads.grad_input, fc2_out)
+
+    # FC2 backward
+    var fc2_grads = linear_backward(grad_fc2_out, relu3_out, model.fc2_weights)
+
+    # ReLU3 backward
+    var grad_fc1_out = relu_backward(fc2_grads.grad_input, fc1_out)
+
+    # FC1 backward
+    var fc1_grads = linear_backward(grad_fc1_out, flattened, model.fc1_weights)
+
+    # Unflatten gradient
+    var grad_pool2_out = fc1_grads.grad_input.reshape(pool2_shape)
+
+    # MaxPool2 backward
+    var grad_relu2_out = maxpool2d_backward(
+        grad_pool2_out,
+        relu2_out,
+        kernel_size=POOL2_KERNEL_SIZE,
+        stride=POOL2_STRIDE,
+        padding=POOL2_PADDING,
+    )
+
+    # ReLU2 backward
+    var grad_conv2_out = relu_backward(grad_relu2_out, conv2_out)
+
+    # Conv2 backward
+    var conv2_grads = conv2d_backward(
+        grad_conv2_out,
+        pool1_out,
+        model.conv2_kernel,
+        stride=CONV2_STRIDE,
+        padding=CONV2_PADDING,
+    )
+
+    # MaxPool1 backward
+    var grad_relu1_out = maxpool2d_backward(
+        conv2_grads.grad_input,
+        relu1_out,
+        kernel_size=POOL1_KERNEL_SIZE,
+        stride=POOL1_STRIDE,
+        padding=POOL1_PADDING,
+    )
+
+    # ReLU1 backward
+    var grad_conv1_out = relu_backward(grad_relu1_out, conv1_out)
+
+    # Conv1 backward
+    var conv1_grads = conv2d_backward(
+        grad_conv1_out,
+        input,
+        model.conv1_kernel,
+        stride=CONV1_STRIDE,
+        padding=CONV1_PADDING,
+    )
+
+    # ========== Parameter Update (SGD) ==========
+    model.update_parameters(
+        learning_rate,
+        conv1_grads.grad_weights^,
+        conv1_grads.grad_bias^,
+        conv2_grads.grad_weights^,
+        conv2_grads.grad_bias^,
+        fc1_grads.grad_weights^,
+        fc1_grads.grad_bias^,
+        fc2_grads.grad_weights^,
+        fc2_grads.grad_bias^,
+        fc3_grads.grad_weights^,
+        fc3_grads.grad_bias^,
+    )
+
+    return loss
+
+
+def train_epoch(
+    mut model: LeNet5,
+    train_images: AnyTensor,
+    train_labels: AnyTensor,
+    batch_size: Int,
+    learning_rate: Float32,
+    epoch: Int,
+    total_epochs: Int,
+) raises -> Float32:
+    """Train for one epoch using manual batch processing.
+
+    Args:
+        model: LeNet-5 model.
+        train_images: Training images (num_samples, 1, 28, 28).
+        train_labels: Integer training labels (num_samples,).
+        batch_size: Mini-batch size.
+        learning_rate: Learning rate for SGD.
+        epoch: Current epoch number (1-indexed).
+        total_epochs: Total number of epochs.
+
+    Returns:
+        Average loss for the epoch.
+    """
+    var num_samples = train_images.shape()[0]
+    var num_batches = (num_samples + batch_size - 1) // batch_size
+    var total_loss = Float32(0.0)
+
+    # Manual batch processing
+    for batch_idx in range(num_batches):
+        var start_idx = batch_idx * batch_size
+        var end_idx = min(start_idx + batch_size, num_samples)
+        var actual_batch_size = end_idx - start_idx
+
+        # Extract batch from training data
+        var batch_images_shape = List[Int]()
+        batch_images_shape.append(actual_batch_size)
+        batch_images_shape.append(train_images.shape()[1])
+        batch_images_shape.append(train_images.shape()[2])
+        batch_images_shape.append(train_images.shape()[3])
+        var batch_images = zeros(batch_images_shape, train_images.dtype())
+
+        var batch_labels_int_shape = List[Int]()
+        batch_labels_int_shape.append(actual_batch_size)
+        var batch_labels_int = zeros(
+            batch_labels_int_shape, train_labels.dtype()
+        )
+
+        # Copy data into batch tensors
+        for i in range(actual_batch_size):
+            var sample_idx = start_idx + i
+            # Copy image
+            for c in range(train_images.shape()[1]):
+                for h in range(train_images.shape()[2]):
+                    for w in range(train_images.shape()[3]):
+                        var src_idx = (
+                            sample_idx
+                            * train_images.shape()[1]
+                            * train_images.shape()[2]
+                            * train_images.shape()[3]
+                            + c
+                            * train_images.shape()[2]
+                            * train_images.shape()[3]
+                            + h * train_images.shape()[3]
+                            + w
+                        )
+                        var dst_idx = (
+                            i
+                            * train_images.shape()[1]
+                            * train_images.shape()[2]
+                            * train_images.shape()[3]
+                            + c
+                            * train_images.shape()[2]
+                            * train_images.shape()[3]
+                            + h * train_images.shape()[3]
+                            + w
+                        )
+                        (batch_images._data + dst_idx).store(
+                            (train_images._data + src_idx).load()
+                        )
+            # Copy label
+            (batch_labels_int._data + i).store(
+                (train_labels._data + sample_idx).load()
+            )
+
+        # Convert batch labels to one-hot encoding
+        var batch_labels = one_hot_encode(
+            batch_labels_int, num_classes=DEFAULT_NUM_CLASSES
+        )
+
+        # Compute gradients and update parameters
+        var batch_loss = compute_gradients(
+            model, batch_images, batch_labels, learning_rate
+        )
+        total_loss += batch_loss
+
+        # Log progress every 100 batches
+        if (batch_idx + 1) % 100 == 0:
+            var avg_loss_so_far = total_loss / Float32(batch_idx + 1)
+            print(
+                "  Epoch [",
+                epoch,
+                "/",
+                total_epochs,
+                "] Batch [",
+                batch_idx + 1,
+                "/",
+                num_batches,
+                "] Loss:",
+                avg_loss_so_far,
+            )
+
+    return total_loss / Float32(num_batches)
+
+
+def main() raises:
+    """Main training loop."""
+    print("=" * 60)
+    print("LeNet-5 Training on EMNIST Dataset")
+    print("=" * 60)
+
+    # Parse arguments
+    var config = parse_args()
+    var epochs = config.epochs
+    var batch_size = config.batch_size
+    var learning_rate = config.learning_rate
+    var data_dir = config.data_dir
+    var weights_dir = config.weights_dir
+
+    print("\nConfiguration:")
+    print("  Epochs: ", epochs)
+    print("  Batch Size: ", batch_size)
+    print("  Learning Rate: ", learning_rate)
+    print("  Data Directory: ", data_dir)
+    print("  Weights Directory: ", weights_dir)
+    print()
+
+    # Initialize model
+    print("Initializing LeNet-5 model...")
+    var model = LeNet5(num_classes=DEFAULT_NUM_CLASSES)
+    print("  Model initialized with", model.num_classes, "classes")
+    print()
+
+    # Load dataset
+    print("Loading EMNIST dataset...")
+    var train_images_path = (
+        data_dir + "/emnist-balanced-train-images-idx3-ubyte"
+    )
+    var train_labels_path = (
+        data_dir + "/emnist-balanced-train-labels-idx1-ubyte"
+    )
+    var test_images_path = data_dir + "/emnist-balanced-test-images-idx3-ubyte"
+    var test_labels_path = data_dir + "/emnist-balanced-test-labels-idx1-ubyte"
+
+    var train_images_raw = load_idx_images(train_images_path)
+    var train_labels = load_idx_labels(train_labels_path)
+    var test_images_raw = load_idx_images(test_images_path)
+    var test_labels = load_idx_labels(test_labels_path)
+
+    # Normalize images to [0, 1]
+    var train_images = normalize_images(train_images_raw)
+    var test_images = normalize_images(test_images_raw)
+
+    print("  Training samples: ", train_images.shape()[0])
+    print("  Test samples: ", test_images.shape()[0])
+    print()
+
+    # Training loop
+    print("Starting training...")
+    for epoch in range(1, epochs + 1):
+        var train_loss = train_epoch(
+            model,
+            train_images,
+            train_labels,
+            batch_size,
+            learning_rate,
+            epoch,
+            epochs,
+        )
+
+        # Evaluate every epoch using shared evaluation module
+        var test_acc = evaluate_model_simple(
+            model,
+            test_images,
+            test_labels,
+            batch_size=100,
+            num_classes=DEFAULT_NUM_CLASSES,
+            verbose=True,
+        )
+        print("  Test Accuracy: ", test_acc * 100.0, "%")
+        print()
+
+    # Save model
+    print("Saving model weights...")
+    model.save_weights(weights_dir)
+    print("  Model saved to", weights_dir)
+    print()
+
+    print("Training complete!")
+    print(
+        "\nNote: This implementation demonstrates the full training structure."
+    )
+    print(
+        "Batch processing will be more efficient when tensor slicing is"
+        " optimized."
+    )

--- a/examples/grok/lenet_emnist/train.sh
+++ b/examples/grok/lenet_emnist/train.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# train.sh — examples/grok/lenet_emnist/ grokking-experiment dispatcher.
+#
+# Three execution profiles:
+#   dry-run  ~30 s   : compile + 1 batch of 1 epoch; verifies the loop runs
+#                      end-to-end and writes a checkpoint set. Use after any
+#                      code change before committing.
+#   smoke    ~5-15 m : verify the memorization phase (train_acc -> 100%) is
+#                      reachable on a 1k-sample subset. Does NOT wait for
+#                      grokking. Pair with `analyze_phases.py --mode smoke`.
+#   full     hours   : real grokking attempt. 30k epochs on a 1k subset,
+#                      checkpoints every 500 epochs, log every 50.
+#
+# Extra args after the profile are appended to the mojo invocation, so e.g.
+#   ./train.sh smoke --weight-decay 0.5
+# overrides the default weight_decay for that run.
+#
+# Logs to stdout. Redirect for persistence:
+#   ./train.sh full > /tmp/grok_full.log 2>&1
+#
+# See README.md for the theory + phase interpretation guide.
+
+set -euo pipefail
+
+PROFILE="${1:?usage: $0 {dry-run|smoke|full} [extra mojo flags...]}"
+shift || true
+
+# Operate from the repo root so `-I src` resolves projectodyssey.* correctly.
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+case "$PROFILE" in
+  dry-run)
+    PROFILE_FLAGS=(
+      --subset-size 64
+      --epochs 1
+      --max-batches 1
+      --log-every 1
+      --checkpoint-every 1
+    )
+    ;;
+  smoke)
+    PROFILE_FLAGS=(
+      --subset-size 1000
+      --epochs 300
+      --log-every 10
+      --checkpoint-every 50
+    )
+    ;;
+  full)
+    PROFILE_FLAGS=(
+      --subset-size 1000
+      --epochs 30000
+      --log-every 50
+      --checkpoint-every 500
+    )
+    ;;
+  *)
+    echo "error: unknown profile '$PROFILE'" >&2
+    echo "usage: $0 {dry-run|smoke|full} [extra mojo flags...]" >&2
+    exit 2
+    ;;
+esac
+
+# Common defaults (grokking-aimed; overridable via "$@").
+COMMON_FLAGS=(
+  --lr 1e-3
+  --weight-decay 1.0
+  --batch-size 64
+  --track-metric test_acc:max
+  --track-metric test_loss:both
+  --track-metric train_loss:min
+  --track-metric weight_l2_norm:max
+  --data-dir datasets/emnist
+  --weights-dir "examples/grok/lenet_emnist/checkpoints"
+)
+
+echo "==> profile: $PROFILE"
+echo "==> command: pixi run mojo run -I src examples/grok/lenet_emnist/run_train.mojo ${COMMON_FLAGS[*]} ${PROFILE_FLAGS[*]} $*"
+echo
+
+exec pixi run mojo run -I src examples/grok/lenet_emnist/run_train.mojo \
+  "${COMMON_FLAGS[@]}" "${PROFILE_FLAGS[@]}" "$@"

--- a/examples/grok/lenet_emnist/train.sh
+++ b/examples/grok/lenet_emnist/train.sh
@@ -22,8 +22,12 @@
 
 set -euo pipefail
 
-PROFILE="${1:?usage: $0 {dry-run|smoke|full} [extra mojo flags...]}"
-shift || true
+if [ $# -lt 1 ]; then
+  echo "usage: $0 {dry-run|smoke|full} [extra mojo flags...]" >&2
+  exit 2
+fi
+PROFILE="$1"
+shift
 
 # Operate from the repo root so `-I src` resolves projectodyssey.* correctly.
 REPO_ROOT="$(git rev-parse --show-toplevel)"
@@ -67,10 +71,7 @@ COMMON_FLAGS=(
   --lr 1e-3
   --weight-decay 1.0
   --batch-size 64
-  --track-metric test_acc:max
-  --track-metric test_loss:both
-  --track-metric train_loss:min
-  --track-metric weight_l2_norm:max
+  --track-metric "test_acc:max,test_loss:both,train_loss:min,weight_l2_norm:max"
   --data-dir datasets/emnist
   --weights-dir "examples/grok/lenet_emnist/checkpoints"
 )


### PR DESCRIPTION
## Summary

New `examples/grok/lenet_emnist/` — a grokking-experiment scaffold for LeNet-5 on a subsampled EMNIST training set.

Built in response to a user training the standard `examples/lenet_emnist/` for 500 epochs hoping to observe grokking (Power et al. 2022) and observing textbook overfitting instead (peak test acc 86.72% @ ep 246, regressed to 85.91% @ ep 500 while training loss kept falling). Two skills were captured in [ProjectMnemosyne](https://github.com/HomericIntelligence/ProjectMnemosyne) documenting why (`training-diagnosis-loss-accuracy-decoupling-overfitting`) and what to do instead (`training-grokking-preconditions-and-vision-recipe`). This PR implements the latter.

## What's new

- **`examples/grok/lenet_emnist/`** — fork of `lenet_emnist/` with:
  - AdamW (decoupled weight decay) replacing SGD, used via the bare functional `adamw_step()`. Manual gradient flow retained because the autograd substrate isn't yet ready for convnets (see #5452).
  - `--subset-size N` flag to slice the train set (grokking requires a memorizable subset).
  - Per-epoch structured log line: `EPOCH N train_loss= ... train_acc= ... test_loss= ... test_acc= ... weight_l2= ...` (regex-parseable by the analyzer).
  - `MultiMetricCheckpointer` with `--track-metric NAME:MODE,NAME:MODE,...` supporting `max`/`min`/`both` modes; the `both` mode additionally tracks `min_after_max` and `max_after_min` so post-peak transitions (the grokking signal) aren't lost to trivial epoch-1 minima.
- **`train.sh`** — single-file dispatcher with three execution profiles:
  - `dry-run` (~30s): 1 batch of 1 epoch on a 64-sample subset
  - `smoke` (~5–15min): verify Phase 1 (train_acc -> 100%) is reachable on a 1k subset
  - `full` (~hours/day): real grokking attempt — 30k epochs, log every 50, ckpt every 500
- **`analyze_phases.py`** — post-hoc log analyzer that detects Phase 1 completion (train_acc ≥ 99% for ≥3 consecutive logged epochs), Phase 3 grokking onset (test_acc jumps ≥20pp within a 200-epoch window while train_acc stays ≥99%), and the loss-vs-accuracy decoupling fingerprint of late-stage overfitting.
- **`README.md`** — theory, realistic expectations (LeNet+EMNIST grokking is *unlikely* — convs encode a generalizing prior; calibrated probability table included), CLI surface, and links to the two source skills + the four related optimizer issues.

## Verification

- ✅ `train.sh dry-run` exits 0 in ~30s
- ✅ Single EPOCH log line emitted with all 5 metrics
- ✅ 7 checkpoint subdirectories created (`test_acc_best`, `test_loss_best`, `test_loss_min`, `test_loss_min_after_max`, `test_loss_max_after_min`, `train_loss_best`, `weight_l2_norm_best`) + `final/`, each with weights and a `meta.json` sidecar
- ✅ `analyze_phases.py --mode dry-run` parses the log cleanly and reports the 5 metrics
- ✅ `pixi run pre-commit run --files ...` clean

## Known caveats (filed/documented, not blocking)

- `weight_l2= 0.0` in dry-run output — silent-catch upstream bug in `compute_tensor_l2_norm`. Doesn't crash; analyzer NaN-guards it. Pre-existing.
- `--track-metric` accepts one comma-separated string rather than repeated flags (the project's `create_training_parser()` doesn't yet support list-typed args). Documented in CLI table.
- `examples/lenet_emnist/` (the SGD baseline) is **not** modified — intentional per scope.

## Related issues (filed alongside this PR)

- #5452 — `feat(autograd): complete autograd substrate for convnet training` (prerequisite for porting examples off manual gradients)
- #5449 — `feat(optim): add Muon optimizer`
- #5450 — `feat(optim): add NorMuon optimizer`
- #5451 — `feat(optim): add Lion and Shampoo`

Once #5452 lands, this example will be the natural first consumer of the autograd path. Once #5449–#5451 land, it'll be the natural benchmark for optimizer comparisons on a controlled small-data regime.

## Honest expectation about grokking

This scaffold creates the *necessary* conditions for grokking (small subset, AdamW, strong weight decay, long horizon, full instrumentation). It does **not** guarantee grokking will be observed — that depends on whether LeNet's conv inductive bias allows a memorize-then-grok dynamic at all on natural-image data, which the published literature suggests is unlikely. The README's "Realistic Expectations" section calibrates this honestly. The scaffold's value is to enable the experiment cleanly, not to manufacture a result.

## Test plan

- [ ] CI green
- [ ] `train.sh dry-run` runs end-to-end (verified locally before push)
- [ ] No regression in existing `examples/lenet_emnist/` (untouched)
- [ ] Markdown lint clean, pre-commit clean (verified locally before push)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>