### PR TITLE
Wave 1: validate Mojo nightly + demolish JIT-flakiness CI infrastructure (modular/modular#6413)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"c1e70650-1afc-4e7b-b2eb-985706236c40","pid":1497360,"procStart":"14813809","acquiredAt":1779168468293}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -238,24 +238,8 @@ jobs:
           # Create output directory inside container
           podman compose exec -T projectodyssey-dev bash -c "mkdir -p /tmp/benchmark-results"
 
-          # Retry for JIT crash resilience (issue #3329)
-          attempt=0
-          delay=1
-          while [ $attempt -lt 3 ]; do
-            attempt=$((attempt + 1))
-            if podman compose exec -T projectodyssey-dev bash -c 'pixi run mojo run -I . benchmarks/bench_simd.mojo' | tee builds/benchmarks/simd-output.txt; then
-              echo "✅ SIMD benchmarks completed successfully"
-              break
-            fi
-            if [ $attempt -lt 3 ]; then
-              echo "Attempt $attempt failed, retrying in ${delay}s..."
-              sleep $delay
-              delay=$((delay * 2))
-            else
-              echo "SIMD benchmarks failed after 3 attempts"
-              exit 1
-            fi
-          done
+          podman compose exec -T projectodyssey-dev bash -c 'pixi run mojo run -I . benchmarks/bench_simd.mojo' | tee builds/benchmarks/simd-output.txt
+          echo "✅ SIMD benchmarks completed successfully"
 
           # Copy results from container to host
           CONTAINER_ID=$(podman compose ps -q projectodyssey-dev)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,26 +230,31 @@ jobs:
           retention-days: 30
 
   # ============================================================================
-  # Run Tests — temporarily removed
+  # Run Tests
   # ============================================================================
-  # The `test` job (which ran the full Mojo suite via `just test-mojo`) was
-  # removed because an upstream Mojo JIT bug intermittently crashes large
-  # batches of unrelated tests with `mojo: error: execution crashed` (pure
-  # libc stack frames, no repo code). With 298 single-shot `mojo` invocations
-  # and no retry protection, a single transient JIT flake fails the entire
-  # release pipeline. The full Mojo suite still runs on every PR and on `main`
-  # via comprehensive-tests.yml (which is split into small retryable groups),
-  # so release builds are not shipping untested code.
-  #
-  # Restore a `test` job here once the upstream JIT crash is fixed (tracked
-  # by modular/modular#6413) — or add the standard retry wrapper to
-  # `_test-mojo-inner` so a single flake no longer fails the whole run.
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up container
+        uses: ./.github/actions/setup-container
+
+      - name: Set up just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
+
+      - name: Run full test suite
+        run: just test-mojo
 
   # ============================================================================
   # Create Release
   # ============================================================================
   create-release:
-    needs: [validate-version, build]
+    needs: [validate-version, build, test]
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,6 @@ gh pr merge --auto --rebase
 
 - [Mojo Syntax & Patterns](/.claude/shared/mojo-guidelines.md)
 - [Mojo Anti-Patterns](/.claude/shared/mojo-anti-patterns.md) - 64+ failure patterns
-- [Mojo JIT Crash Workaround](docs/dev/mojo-jit-crash-workaround.md) - `libKGENCompilerRTShared.so` flake
 - [Mojo UnsafePointer Memory Safety](docs/dev/mojo-memory-safety.md) - when/how to use UnsafePointer safely
 - [PR Workflow](/.claude/shared/pr-workflow.md)
 - [GitHub Issue Workflow](/.claude/shared/github-issue-workflow.md)
@@ -466,6 +465,12 @@ Official docs: <https://mojolang.org/docs/>
 - Invalid imports cause compilation to fail before any code executes
 - This differs from Python where import errors can be caught at runtime
 - Plan test coverage accordingly: only test valid imports that compile successfully
+
+**JIT stability**: Mojo JIT is stable as of `1.0.0b2.dev2026052506` (upstream fix for
+[modular/modular#6413](https://github.com/modular/modular/issues/6413)). Execution crashes
+(`mojo: error: execution crashed`, `libKGENCompilerRTShared.so` stack frames, SIGILL) are
+real bugs. Do NOT add retry loops, `continue-on-error: true`, or skip markers to work around
+them. File a minimal reproducer at modular/modular and fix forward.
 
 ## Environment Setup
 

--- a/justfile
+++ b/justfile
@@ -91,26 +91,10 @@ _run cmd:
 			# caches even when the container image was built with a different UID
 			# than the process UID (rootless Podman UID-mapping on CI runners).
 			# Also bump core ulimit unconditionally — compose-level `ulimits`
-			# does not propagate through `podman compose exec` invocations,
-			# and we need real cores when the libKGEN JIT crashes
-			# (modular/modular#6413). Pairs with the host-side core_pattern in
-			# .github/actions/coredump-capture/action.yml.
+			# does not propagate through `podman compose exec` invocations.
 			HOME_FIXUP='if [ ! -w "$HOME" ]; then export HOME="/tmp/mojo-home-$(id -u)"; mkdir -p "$HOME/.modular" "$HOME/.pixi"; fi; ulimit -c unlimited 2>/dev/null || echo "warn: ulimit -c rejected" >&2;'
-			# Forward CI/coredump env vars into the container. Without these
-			# -e passthroughs, MOJO_TEST_UNDER_GDB / CRASH_BUNDLE_DIR set on
-			# the GHA runner are NOT visible to the bash recipe inside the
-			# container, so the gdb wrapper would be silently skipped.
-			#
-			# NOTE: docker-compose (cli-plugin) rejects bare `-e VARNAME`
-			# (without `=value`) with "badly formed, must be key=value" — we
-			# must build the args conditionally with explicit values.
-			EXTRA_ENV=()
-			if [ -n "${MOJO_TEST_UNDER_GDB-}" ]; then EXTRA_ENV+=(-e "MOJO_TEST_UNDER_GDB=${MOJO_TEST_UNDER_GDB}"); fi
-			if [ -n "${MOJO_UNDER_GDB-}" ];      then EXTRA_ENV+=(-e "MOJO_UNDER_GDB=${MOJO_UNDER_GDB}"); fi
-			if [ -n "${CRASH_BUNDLE_DIR-}" ];    then EXTRA_ENV+=(-e "CRASH_BUNDLE_DIR=${CRASH_BUNDLE_DIR}"); fi
 			podman compose exec \
 				-e USER_ID={{USER_ID}} -e GROUP_ID={{GROUP_ID}} \
-				"${EXTRA_ENV[@]}" \
 				-T {{podman_service}} bash -c "$HOME_FIXUP {{cmd}}"
 		fi
 	else
@@ -877,9 +861,7 @@ _test-group-inner path pattern:
     failed_count=0
     failed_tests=""
 
-    # Enable core dumps so the libKGEN JIT crash (modular/modular#6413)
-    # produces a real coredump we can attach to gdb. Sandboxed runners may
-    # forbid raising ulimit — log and continue.
+    # Enable core dumps. Sandboxed runners may forbid raising ulimit — log and continue.
     if ! ulimit -c unlimited 2>/dev/null; then
         echo "warn: 'ulimit -c unlimited' rejected by environment; coredumps may be unavailable" >&2
     fi
@@ -920,11 +902,6 @@ _test-group-inner path pattern:
         exit 1
     fi
 
-    # gdb wrapper path: set MOJO_TEST_UNDER_GDB=1 in CI to intercept the
-    # in-process SIGABRT handler in libKGEN before it swallows the crash
-    # (modular/modular#6413). Default 0 so local dev runs mojo directly.
-    CORE_DIR="${CRASH_BUNDLE_DIR:-${REPO_ROOT}/crash-bundle/cores}"
-
     # Run each test file
     for test_file in $test_files; do
         if [ -f "$test_file" ]; then
@@ -936,21 +913,11 @@ _test-group-inner path pattern:
                 echo "warn: 'ulimit -v unlimited' rejected by environment" >&2
             fi
             test_exit=0
-            # gdb-wrapper branch (CI default): intercept libKGEN's in-process
-            # SIGABRT handler before it swallows the crash (modular/modular#6413).
-            # Local dev defaults to MOJO_TEST_UNDER_GDB=0 → direct mojo invocation.
             # {{MOJO_TARGET_CPU}} disables AVX-512 features so the JIT does
             # not emit AVX-512 encodings that SIGILL on runner cores without
             # AVX-512 (modular/modular#6413).
-            if [ "${MOJO_TEST_UNDER_GDB:-0}" = "1" ]; then
-                if ! bash "$REPO_ROOT/scripts/mojo-under-gdb.sh" "$CORE_DIR" \
-                        {{MOJO_TARGET_CPU}} --Werror -debug-level=line-tables -I "$REPO_ROOT/src" -I "$REPO_ROOT" -I . "$test_file"; then
-                    test_exit=$?
-                fi
-            else
-                if ! pixi run mojo {{MOJO_TARGET_CPU}} --Werror -debug-level=line-tables -I "$REPO_ROOT/src" -I "$REPO_ROOT" -I . "$test_file"; then
-                    test_exit=$?
-                fi
+            if ! pixi run mojo {{MOJO_TARGET_CPU}} --Werror -debug-level=line-tables -I "$REPO_ROOT/src" -I "$REPO_ROOT" -I . "$test_file"; then
+                test_exit=$?
             fi
             if [ "${test_exit}" -eq 0 ]; then
                 passed_count=$((passed_count + 1))

--- a/pixi.lock
+++ b/pixi.lock
@@ -100,7 +100,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py314h67df5f8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/marshmallow-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.4.0.dev2026050805-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.4.0.dev2026052506-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mergedeep-1.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.1-pyhcf101f3_0.conda
@@ -108,9 +108,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-get-deps-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-material-9.7.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-material-extensions-1.3.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b2.dev2026050805-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b2.dev2026050805-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b2.dev2026050805-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b2.dev2026052506-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b2.dev2026052506-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b2.dev2026052506-release.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.2-py314h9891dd4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.20.1-py314h5bd0f2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
@@ -410,7 +410,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.10.8-py314hdafbbf9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.8-py314h1194b4b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.4.0.dev2026050805-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.4.0.dev2026052506-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mergedeep-1.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.1-pyhcf101f3_0.conda
@@ -418,9 +418,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-get-deps-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-material-9.7.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-material-extensions-1.3.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b2.dev2026050805-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b2.dev2026050805-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b2.dev2026050805-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b2.dev2026052506-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b2.dev2026052506-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b2.dev2026052506-release.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.2-py314h9891dd4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.20.1-py314h5bd0f2a_0.conda
@@ -660,11 +660,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py314h67df5f8_1.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.4.0.dev2026050805-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.4.0.dev2026052506-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.1-pyhcf101f3_0.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b2.dev2026050805-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b2.dev2026050805-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b2.dev2026050805-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b2.dev2026052506-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b2.dev2026052506-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b2.dev2026052506-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.17.1-hb502eef_0.conda
@@ -3165,10 +3165,10 @@ packages:
   - pkg:pypi/matplotlib-inline?source=hash-mapping
   size: 15175
   timestamp: 1761214578417
-- conda: https://conda.modular.com/max-nightly/noarch/mblack-26.4.0.dev2026050805-release.conda
+- conda: https://conda.modular.com/max-nightly/noarch/mblack-26.4.0.dev2026052506-release.conda
   noarch: python
-  sha256: 954800b1f87869c3e7f1bbc4059f507231fd1ed5df9bdff2d448bade6c5db5f3
-  md5: 5452b60c450f6629f41758322cf55e3f
+  sha256: a0dfc9e66300ae8060f4084b3c152c4d68637d14b6b5d13cfb0f680b6600025c
+  md5: d806bf31c9b8feda65906fc13b05c35e
   depends:
   - python >=3.10
   - click >=8.0.0
@@ -3178,8 +3178,8 @@ packages:
   - platformdirs >=2
   - tomli >=1.1.0
   license: LicenseRef-Modular-Proprietary
-  size: 135068
-  timestamp: 1778219430292
+  size: 135025
+  timestamp: 1779691376792
 - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
   sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
   md5: 592132998493b3ff25fd7479396e8351
@@ -3293,34 +3293,34 @@ packages:
   - pkg:pypi/mkdocs-material-extensions?source=hash-mapping
   size: 16122
   timestamp: 1734641109286
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b2.dev2026050805-release.conda
-  sha256: 8b6f080d54b7c53185786a9a928afbfcf2fbb539d89c9d44da3b5b6700a8b6dc
-  md5: 990e93152a539cad71831e84090b6ad0
+- conda: https://conda.modular.com/max-nightly/linux-64/mojo-1.0.0b2.dev2026052506-release.conda
+  sha256: c793dba2e295074e7a325ce5e339b5b83d62d9fed464529ec63666ca82d1467b
+  md5: 779c24950c21256dfb94fae604a6fe8e
   depends:
   - python >=3.10
-  - mojo-compiler ==1.0.0b2.dev2026050805
-  - mblack ==26.4.0.dev2026050805
+  - mojo-compiler ==1.0.0b2.dev2026052506
+  - mblack ==26.4.0.dev2026052506
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 94333065
-  timestamp: 1778219634621
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b2.dev2026050805-release.conda
-  sha256: 7717dc214cb996d168ddb419a27203b6a547dcf06fa0916609a75c8ca1330ec1
-  md5: 4e731452b42cbb71a30721c53fb128f6
+  size: 96175963
+  timestamp: 1779691634998
+- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-1.0.0b2.dev2026052506-release.conda
+  sha256: 651f6a7ddaf8104e3dbdeea6af05f0662de664630768924e74ec05220f4c308f
+  md5: 5d760920d81279c47b67bb3ed1c443a8
   depends:
-  - mojo-python ==1.0.0b2.dev2026050805
+  - mojo-python ==1.0.0b2.dev2026052506
   license: LicenseRef-Modular-Proprietary
-  size: 89660938
-  timestamp: 1778219647057
-- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b2.dev2026050805-release.conda
+  size: 91475604
+  timestamp: 1779691633213
+- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-1.0.0b2.dev2026052506-release.conda
   noarch: python
-  sha256: 9ebe949d741fb04734922fc19ab77255268f3d965fbc657aea0feacf19038242
-  md5: eac15eb1269da84a66565aaf7b4b9bd1
+  sha256: a478a2c6c18b66a04c92e751d329a65bc05161dda2a23be1651db1ee38872df9
+  md5: 1103880ec01a5566fe768b27bff0aea2
   depends:
   - python >=3.10
   license: LicenseRef-Modular-Proprietary
-  size: 23189
-  timestamp: 1778219430248
+  size: 23190
+  timestamp: 1779691376732
 - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.2-py314h9891dd4_1.conda
   sha256: d41c2734d314303e329680aeef282766fe399a0ce63297a68a2f8f9b43b1b68a
   md5: c6752022dcdbf4b9ef94163de1ab7f03

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 # Language runtime
-mojo = "==1.0.0b2.dev2026050805"
+mojo = "==1.0.0b2.dev2026052506"
 
 # Core libraries
 numpy = ">=2.3.5,<3"

--- a/src/projectodyssey/base/memory_pool.mojo
+++ b/src/projectodyssey/base/memory_pool.mojo
@@ -362,11 +362,11 @@ struct _FreeListNode(Movable):
     at the beginning of each free block itself.
 
     Attributes:
-        next: Pointer to the next free block, or null if this is the last.
+        next: Pointer to the next free block, or None if this is the last.
     """
 
-    var next: UnsafePointer[_FreeListNode, MutAnyOrigin]
-    """Next block in free list, or null if last."""
+    var next: Optional[UnsafePointer[_FreeListNode, MutAnyOrigin]]
+    """Next block in free list, or None if last."""
 
 
 struct FreeList(Copyable, Movable):
@@ -376,13 +376,13 @@ struct FreeList(Copyable, Movable):
     Each block contains space for the linked list node at the beginning.
 
     Attributes:
-        head: Pointer to the first free block, or null if empty.
+        head: Pointer to the first free block, or None if empty.
         block_size: Size of each block managed by this free list.
         count: Number of blocks currently in the free list.
     """
 
-    var head: UnsafePointer[_FreeListNode, MutAnyOrigin]
-    """First node in free list, or null if empty."""
+    var head: Optional[UnsafePointer[_FreeListNode, MutAnyOrigin]]
+    """First node in free list, or None if empty."""
     var block_size: Int
     """Size of each block managed by this list."""
     var count: Int
@@ -394,7 +394,7 @@ struct FreeList(Copyable, Movable):
         Args:
             block_size: Size of each block this list will manage.
         """
-        self.head = UnsafePointer[_FreeListNode, MutAnyOrigin](_unsafe_null=())
+        self.head = None
         self.block_size = block_size
         self.count = 0
 
@@ -404,20 +404,17 @@ struct FreeList(Copyable, Movable):
         Returns:
             True if there are no free blocks available.
         """
-        return self.head == UnsafePointer[_FreeListNode, MutAnyOrigin](
-            _unsafe_null=()
-        )
+        return self.head is None
 
     def pop(mut self) -> UnsafePointer[UInt8, MutAnyOrigin]:
         """Remove and return a block from the free list.
 
         Returns:
-            UnsafePointer to the allocated block, or null if list is empty.
-        """
-        if self.is_empty():
-            return UnsafePointer[UInt8, MutAnyOrigin](_unsafe_null=())
+            UnsafePointer to the allocated block.
 
-        var node = self.head
+        Note: Caller must ensure the list is not empty before calling.
+        """
+        var node = self.head.value()
         self.head = node[].next
         self.count -= 1
 
@@ -429,15 +426,7 @@ struct FreeList(Copyable, Movable):
 
         Args:
             ptr: Pointer to the block to return to the pool.
-
-        Note: ptr must not be null. A null pointer indicates an allocation
-              failure and should not be returned to the pool.
         """
-        # Guard against null pointers (shouldn't happen in normal operation,
-        # but provides safety if allocate() somehow returns null)
-        if ptr == UnsafePointer[UInt8, MutAnyOrigin](_unsafe_null=()):
-            return
-
         var node = ptr.bitcast[_FreeListNode]()
         node[].next = self.head
         self.head = node


### PR DESCRIPTION
## Summary

Wave 1 of the JIT-flakiness demolition. Modular fixed the AVX-512 mis-emission bug
([modular/modular#6413](https://github.com/modular/modular/issues/6413)) on 2026-05-22.
This PR bumps the Mojo nightly past the fix and rips out the CI infrastructure that
existed solely to absorb the resulting JIT crashes.

Validation evidence: PR #5455 (the validation gate) — 47+ green required-check runs
on the new pin, full heavy Mojo test matrix passes cleanly, zero `libKGENCompilerRTShared`
frames anywhere.

## Commits (7)

1. `chore(mojo)`: bump Mojo to `1.0.0b2.dev2026052506` (3 days after fix landed)
2. `fix(base)`: migrate `FreeList` to `Optional[UnsafePointer]` — new nightly removed
   the internal `UnsafePointer(_unsafe_null=())` escape hatch
3. `ci(benchmark)`: remove the 3-attempt retry loop around SIMD benchmarks
4. `ci(release)`: re-enable the `test` job (previously commented out citing #6413)
5. `docs(claude)`: add JIT stability note + drop the now-dead jit-crash-workaround link
6. `chore`: untrack `.claude/scheduled_tasks.lock` (accidentally committed in #5456;
   missing trailing newline was failing pre-commit on every PR)
7. `build(justfile)`: remove the `MOJO_TEST_UNDER_GDB` gdb-wrapper plumbing
   (env passthroughs + conditional branch in `_test-group-inner`)

## Intentionally NOT in this PR

- **`MOJO_TARGET_CPU` AVX-512-feature stripper** — split into Wave 1.5
  (https://github.com/HomericIntelligence/ProjectOdyssey/pull/new/6413-jit-demolition-wave1p5)
  because removing it was NOT validated by #5455 (the validation pin still applied the
  flag throughout CI).
- **Scorched-earth doc/repro/ADR purge** + **`forbid-jit-workaround-strings` pre-commit guard** —
  Wave 2. The guard would fail until the ~30 files with stale `libKGEN*` references in
  `docs/`, `notes/`, `repro/`, and test-comment crud are deleted/scrubbed.
- **Deletion of `repro-6413.yml`, `gradient-soak.yml`, `scripts/mojo-under-gdb.sh`** —
  Wave 2 (these workflows still exist on disk; they are unreferenced after Wave 1's
  gdb-wrapper removal, so deletion is a documentation purge, not a CI infra change).
- **Memory/feedback updates** — Wave 3 (main agent edits user-specific memory directly).
- **Mnemosyne skill amendment** to v2.0.0 — Wave 4 (cross-repo PR).

## Test plan

- [ ] All required checks pass on this PR's CI matrix
- [ ] `release.yml` test job runs once via workflow_dispatch on this branch to confirm
      the re-enabled job is wired correctly
- [ ] Validation evidence at PR #5455 (preserved as the historical canary; close after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)