### PR TITLE
fix(repro): restore non-#6413 reproducers over-deleted in Wave 2

### DIFF
--- a/.github/workflows/gradient-soak.yml
+++ b/.github/workflows/gradient-soak.yml
@@ -1,0 +1,81 @@
+name: Gradient Checker Soak Test
+
+# Soak test for issue #5170: runs the gradient-checking test group many times
+# in succession to build statistical confidence that the intermittent JIT
+# crash addressed by #5104 (per-element bitcast elimination) is eliminated.
+#
+# This is a SOAK test — deliberate repetition to *detect* a flake — not a
+# retry that masks one. It is scheduled (weekly) and manually dispatchable,
+# never run per-PR (it is long-running).
+#
+# REMOVE THIS WORKFLOW once enough consecutive clean runs have established
+# confidence that the gradient-checker JIT crash is gone (see #5170).
+
+on:
+  # Weekly, Sunday 05:00 UTC (after the Saturday model-e2e run).
+  schedule:
+    - cron: '0 5 * * 0'
+
+  # On-demand: lets a maintainer run the soak immediately and pick the
+  # iteration count.
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: 'Number of soak iterations'
+        required: false
+        type: string
+        default: '15'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  gradient-soak:
+    name: Gradient Checker Soak
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    # Scheduled runs only on main; workflow_dispatch from any branch.
+    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up container
+        uses: ./.github/actions/setup-container
+
+      - name: Run gradient-checker soak
+        env:
+          ITERATIONS: ${{ github.event.inputs.iterations || '15' }}
+        run: |
+          echo "Gradient-checker soak — $ITERATIONS iterations"
+          echo "Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+          echo ""
+
+          failures=0
+          for i in $(seq 1 "$ITERATIONS"); do
+            echo "=================================================="
+            echo "Soak iteration $i / $ITERATIONS"
+            echo "=================================================="
+            if ! just test-group "tests/projectodyssey/core" \
+                "test_gradient_checking_basic.mojo test_gradient_checking_dtype.mojo"; then
+              echo "Iteration $i FAILED"
+              failures=$((failures + 1))
+            fi
+          done
+
+          echo ""
+          echo "=================================================="
+          echo "Soak complete: $failures / $ITERATIONS iterations failed"
+          echo "=================================================="
+          if [ "$failures" -ne 0 ]; then
+            echo "Gradient-checker soak detected failures — the JIT crash"
+            echo "is NOT yet eliminated. Investigate before removing this job."
+            exit 1
+          fi
+          echo "All $ITERATIONS iterations passed."

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -18,6 +18,11 @@ https://github.com/org/repo/issues/XX
 # These are valid redirects, not broken links
 github\.com/HomericIntelligence/ProjectOdyssey
 
+# Ignore ProjectMnemosyne skill links — GitHub returns intermittent 404s to
+# unauthenticated lychee on org repos even when the file exists (verified via
+# `gh api repos/HomericIntelligence/ProjectMnemosyne/contents/skills/...`).
+github\.com/HomericIntelligence/ProjectMnemosyne
+
 # Ignore pytorch docs redirects (pytorch.org -> docs.pytorch.org)
 pytorch\.org/docs
 

--- a/repro/README.md
+++ b/repro/README.md
@@ -66,7 +66,7 @@ blanket delete to everything under `repro/` and `repro/issues/`. The audit-trail
 comment posted to issue #5108 listed all 22 deleted paths but did not
 distinguish #6413-specific from independent bugs.
 
-Restored in PR <this PR> from the last commit that touched all of these files
+Restored in PR #5464 from the last commit that touched all of these files
 together: `e8c5609a` (refactor(packaging): rename shared/ → src/projectodyssey/
 (PR 1 of 4)).
 

--- a/repro/README.md
+++ b/repro/README.md
@@ -1,0 +1,85 @@
+# Crash Reproducers — Triage Pending
+
+These minimal reproducers were **restored** on 2026-05-26 after Wave 2 of the
+[modular/modular#6413](https://github.com/modular/modular/issues/6413)
+demolition (PR #5460) over-deleted them.
+
+The `#6413` issue (AVX-512 mis-emission causing SIGILL via
+`libKGENCompilerRTShared.so`) was fixed in Mojo `1.0.0b2.dev2026052506`. Wave 2's
+scorched-earth purge correctly removed `#6413`-specific artifacts
+(`repro_6413_*.mojo`, `notes/modular-6413-avx512-finding.md`,
+`.github/workflows/repro-6413.yml`), but **also deleted reproducers for several
+distinct upstream bugs** that share the `libKGEN`/JIT-crash surface but are
+independent issues.
+
+> **Status of every file here: TRIAGE-PENDING.** None has been re-validated
+> against Mojo `1.0.0b2.dev2026052506`. The `#6413` fix may have incidentally
+> resolved some, none, or all of them — that determination requires running each
+> reproducer and is tracked in the follow-up issue list below.
+
+## Files in this directory
+
+| Reproducer | Issue file | Suspected bug class | Status |
+| --- | --- | --- | --- |
+| `repro_libkgen_crash.mojo` | `issues/libkgen-heap-corruption-crash.md` | Allocator heap corruption via AnyTensor + conv2d | TRIAGE-PENDING |
+| `repro_libasyncrt_crash.mojo` | `issues/libasyncrt-vgg16-training-crash.md` | `libAsyncRTRuntimeGlobals.so` crash in VGG16 training | TRIAGE-PENDING |
+| `repro_jit_volume_crash.mojo` | `issues/jit-virtual-memory-exhaustion.md` | JIT virtual-memory exhaustion at high module volume | TRIAGE-PENDING |
+| `kgen_jit_overflow_minimal.mojo` | `issues/jit-compilation-volume-crash.md` | KGEN JIT buffer overflow at compilation volume | TRIAGE-PENDING |
+| `repro_jit_fortify_crash.mojo` | `issues/jit-fortify-buffer-overflow.md` | `__fortify_fail_abort` buffer overflow | TRIAGE-PENDING |
+| `repro_parametric_monomorphization_crash.mojo` | (no issue file) | Parametric monomorphization crash | TRIAGE-PENDING |
+| `repro_module_import_crash.mojo` + `_fixed.mojo` | `issues/jit-targeted-imports-still-crashes.md` | Module-level import chain crash | TRIAGE-PENDING |
+| `repro_jit_targeted_imports_crash.mojo` | `issues/jit-targeted-imports-still-crashes.md` | Targeted import chain crash | TRIAGE-PENDING |
+| `repro_jit_heavy_import_test.mojo` | (no issue file) | Heavy import volume crash | TRIAGE-PENDING |
+| `repro_import_chain_synthetic.mojo` | (no issue file) | Synthetic import-chain crash | TRIAGE-PENDING |
+| `repro_crash_standalone.mojo` | (no issue file) | Standalone crash variant | TRIAGE-PENDING |
+| `configs_kgen_crash.mojo` | (no issue file) | KGEN crash in configs subsystem | TRIAGE-PENDING |
+| `run_all_experiments.sh` | — | Driver script to run all reproducers | — |
+| `repro_hello.mojo` | — | Sanity-check (pre-existing, never deleted) | — |
+| `spinlock_deadlock.mojo`, `spinlock_race_condition.mojo` | — | Concurrency repros (pre-existing) | — |
+| `investigate_import_threshold.sh`, `bug_repro_*.mojo.bug` | — | Pre-existing investigation artifacts | — |
+
+## Triage protocol (per file)
+
+For each `TRIAGE-PENDING` entry, run:
+
+```bash
+# Inside the Podman container (matches CI runner GLIBC):
+just shell
+mojo build --print-effective-target repro/<file>.mojo   # verify codegen
+mojo run repro/<file>.mojo                              # run 10× to test determinism
+```
+
+Outcomes:
+
+- **Reproduces**: file an upstream issue at `modular/modular` if one isn't already
+  open (check the `issues/*.md` file for any prior filing); update this README
+  with the issue link and change status to `OPEN-#NNNN`.
+- **Fixed by Mojo dev2026052506+**: delete the reproducer in a per-file commit
+  citing the validation run hash.
+- **Cannot reproduce / nondeterministic on new Mojo**: keep the file with status
+  `INTERMITTENT — needs longer soak`; consider whether to file or defer.
+
+## Why these were restored
+
+Wave 2 of the `#6413` demolition (PR #5460, commit `f5de5894`) applied a
+blanket delete to everything under `repro/` and `repro/issues/`. The audit-trail
+comment posted to issue #5108 listed all 22 deleted paths but did not
+distinguish #6413-specific from independent bugs.
+
+Restored in PR <this PR> from the last commit that touched all of these files
+together: `e8c5609a` (refactor(packaging): rename shared/ → src/projectodyssey/
+(PR 1 of 4)).
+
+The same PR also restored `.github/workflows/gradient-soak.yml` (from commit
+`7cde386d` — the issue #5170 gradient-checker soak workflow). That workflow
+addresses a different intermittent JIT crash (#5170 / #5104, per-element bitcast
+elimination), not #6413, and its own header instructs removal only after
+"enough consecutive clean runs" — a decision that requires separate validation
+on the post-#6413-fix Mojo, not bundling into the #6413 demolition.
+
+**Lesson for future demolitions**: when a "scorched-earth" purge targets a bug
+class, partition the affected files into (a) the bug itself, (b) bugs with
+overlapping symptoms but distinct root causes. Validate (b) independently
+before deleting. Captured as a follow-up amendment to the
+[`workaround-demolition-wave-strategy`](https://github.com/HomericIntelligence/ProjectMnemosyne/blob/main/skills/workaround-demolition-wave-strategy.md)
+skill.

--- a/repro/configs_kgen_crash.mojo
+++ b/repro/configs_kgen_crash.mojo
@@ -1,0 +1,26 @@
+"""Minimal reproducer for Configs group 100% KGEN crash.
+
+Every test in tests/configs/ crashes at libKGENCompilerRTShared.so+0x6d4ab
+before any output. This file isolates the minimum import that triggers it.
+
+The crash is a KGEN JIT buffer overflow during compilation of projectodyssey.utils.config,
+which imports std.python (CPython interop) and defines Dict[String, ConfigValue]
+with ConfigValue containing List[String]. The combination triggers the same
+__fortify_fail_abort seen across the project.
+
+Run:
+    pixi run mojo repro/configs_kgen_crash.mojo
+
+Expected: Either runs successfully (KGEN doesn't overflow) or crashes with
+    libKGENCompilerRTShared.so execution crashed
+before any output, confirming the compilation-phase KGEN overflow.
+"""
+
+from projectodyssey.utils.config import Config
+
+
+def main() raises:
+    print("If you see this, the KGEN crash did NOT occur on this run.")
+    var c = Config()
+    c.set("key", "value")
+    print("Config created successfully:", c.get_string("key"))

--- a/repro/issues/jit-compilation-volume-crash.md
+++ b/repro/issues/jit-compilation-volume-crash.md
@@ -1,0 +1,56 @@
+# [BUG] Non-deterministic JIT compilation crash in large Mojo test files
+
+## Environment
+
+- Mojo version: 0.26.3 (dev2026040705)
+- OS: Ubuntu 24.04 (GitHub Actions runner)
+- GLIBC: 2.39
+
+## Description
+
+Mojo JIT compilation crashes non-deterministically when test files have many test
+functions (>20) or import from many submodules simultaneously. The crash occurs BEFORE
+any test output, indicating a JIT compilation failure rather than a runtime failure.
+
+## Crash Signature
+
+```text
+/path/to/mojo: error: execution crashed
+```
+
+Stack trace (without symbol names):
+
+```text
+#0 libKGENCompilerRTShared.so+0x...
+#1 libKGENCompilerRTShared.so+0x...
+#2 libc.so.6+0x45330
+```
+
+## Observed Pattern
+
+Files that reliably trigger this crash:
+
+- Test files with >20 test functions AND heavy imports from ML submodules
+- Benchmark files with 100+ iteration loops over ML operations
+- Test files importing from 5+ submodules simultaneously
+
+The crash is non-deterministic: the same file may pass on one CI run and crash on the next.
+
+## Expected Behavior
+
+JIT compilation completes successfully and tests run to completion.
+
+## Actual Behavior
+
+`error: execution crashed` before any test output, indicating a failure during JIT
+compilation.
+
+## Minimal Reproducer
+
+See `repro/repro_jit_volume_crash.mojo` for a minimal reproducer.
+
+## Relationship
+
+This appears to be the same underlying JIT compiler issue as modular/modular#6187, but
+triggered by compilation volume (many functions) rather than the ASAP destruction +
+bitcast UAF runtime pattern.

--- a/repro/issues/jit-fortify-buffer-overflow.md
+++ b/repro/issues/jit-fortify-buffer-overflow.md
@@ -1,0 +1,137 @@
+# [BUG] JIT Compiler __fortify_fail_abort in CI (libKGENCompilerRTShared.so)
+
+## Environment
+
+- Mojo version: 0.26.3.0.dev2026040705 (69cac1bd)
+- OS: Ubuntu 24.04.3 LTS (Noble Numbat)
+- GLIBC: 2.39 (Ubuntu GLIBC 2.39-0ubuntu8.7)
+- Container: projectodyssey:dev (Podman rootless, UID 1001 on CI runners, UID 1000 locally)
+- CI runner: GitHub Actions `ubuntu-latest`
+
+## Description
+
+All 97 affected test files pass locally (including under ASAN, which reports only memory
+leaks — no heap corruption or buffer overflows). In CI, a subset crash with
+`error: execution crashed` before producing any test output. The stack trace implicates
+`__fortify_fail_abort` in glibc, which is triggered by glibc's stack-smash / buffer-overflow
+detection (`__stack_chk_fail` / `__fortify_fail`) inside the JIT compiler itself.
+
+## Stack Trace
+
+```text
+#0  libKGENCompilerRTShared.so  +0x6d4ab  (within .text section 0x24230-0x96b3b)
+#1  libKGENCompilerRTShared.so  +0x6a686
+#2  libKGENCompilerRTShared.so  +0x6e157
+#3  libc.so.6                   +0x45330  (__fortify_fail_abort)
+#4  JIT compiled code
+error: execution crashed
+```
+
+`libc.so.6+0x45330` resolves to `__fortify_fail_abort` in glibc 2.39. This is the landing
+pad for glibc's buffer-overflow canary checks (`__stack_chk_fail`) and bounds-checked string
+functions (`__fortify_fail`). Frame #4 in JIT compiled code (not in an allocator library)
+confirms the overflow is detected inside the JIT, not during heap allocation.
+
+## Isolation Experiments
+
+| Variant | Crashes? | Conclusion |
+| --- | --- | --- |
+| Run locally, same Docker image, UID 1000 | No | Not a code or library bug |
+| Run locally under ASAN | No heap errors; only memory leaks | No buffer overflow in our code |
+| ASAN on test_arithmetic.mojo | PASSED clean | Core tensor ops are ASAN-clean |
+| ASAN on test_activations.mojo | PASSED clean | Activation functions are ASAN-clean |
+| ASAN on test_broadcasting.mojo | PASSED clean | Broadcasting logic is ASAN-clean |
+| ASAN on test_training_loop.mojo | Leaks only (5120B + 24B × 5) | Leaks in pooled_alloc, no overflow |
+| CI run, fresh pixi volumes, UID 1001 | Crashes (~97 files) | Environment-specific |
+
+## Memory Leak Detail (ASAN, test_training_loop.mojo)
+
+ASAN detects **leak-only** errors (no heap-use-after-free, no buffer overflow). The leaks
+originate in `shared::base::memory_pool::pooled_alloc` and surface through
+`AnyTensor::__init__` → `zeros`/`ones` in test setup. These are pre-existing leaks from the
+memory pool's intentional slab-based design, not related to the CI crash.
+
+```text
+SUMMARY: AddressSanitizer: 7000 byte(s) leaked in 6 allocation(s)
+  - 5120B: pooled_alloc → AnyTensor::__init__ → ones → test_training_loop::main()
+  - 24B × 5: pooled_alloc → AnyTensor::__init__ → zeros → test_training_loop::main()
+```
+
+## Relationship to #6187
+
+This is a **different crash** from modular/modular#6187 (heap corruption via bitcast UAF):
+
+| Property | #6187 crash | This crash |
+| --- | --- | --- |
+| Offsets | `libKGENCompilerRTShared.so +0x3cb78b` | `+0x6d4ab` (much smaller) |
+| Frame #4 | `libAsyncRTRuntimeGlobals.so +0x416ba` (heap allocator) | JIT compiled code |
+| libc frame | `+0x45330` (sigaction) | `+0x45330` (**fortify_fail_abort**) |
+| Root cause | Heap corruption (UAF via bitcast) | Stack/buffer overflow in JIT |
+| Reproducible locally | Yes (deterministic) | No (CI-only) |
+
+Note: `libc.so.6+0x45330` appears in both traces but resolves differently. In #6187 the
+process received `SIGSEGV` from the allocator; glibc's signal handler happened to be at that
+offset. In this crash the same offset is `__fortify_fail_abort` invoked proactively by glibc's
+own overflow checks. The identical numeric offset is coincidental given the same GLIBC 2.39
+binary on both systems.
+
+## CI-Specific Factors
+
+Three factors present in CI but absent locally:
+
+1. **Fresh named volumes on every run** — `pixi-cache` and `workspace-pixi` volumes are
+   created empty. Pixi runs a full cold install of Mojo 0.26.3 on each CI job. Locally the
+   volumes persist between runs and the pixi environment is warm.
+
+2. **UID mismatch** — CI runners are `ubuntu-latest` with the default runner user at UID 1001.
+   The container image is built for UID 1000 (`dev`). `docker-compose.yml` passes
+   `user: "${USER_ID}:${GROUP_ID}"` into the container, so the container runs with UID 1001
+   but `HOME=/home/dev` (owned by UID 1000). The `pixi-cache` volume is mounted at
+   `/home/dev/.pixi` but the running user's home is effectively mismatched.
+   Locally UID matches the container image (both 1000).
+
+3. **No TTY (`-T` flag)** — `just _run` routes all commands through
+   `podman compose exec -T projectodyssey-dev bash -c "..."`. The `-T` flag disables TTY
+   allocation. Some JIT compiler code paths differ when stdin/stdout are not a terminal
+   (e.g., signal handling, SIGPIPE disposition, terminal query sequences in LLVM/MLIR).
+
+## Root Cause Hypothesis
+
+The JIT compiler (`libKGENCompilerRTShared.so`) contains an internal buffer (likely in an MLIR
+pass, codegen pipeline, or symbol table) whose size is computed or allocated based on environment
+state. When pixi runs a cold install (fresh volume), the Mojo stdlib package (`.mojopkg`) is
+unpacked and compiled for the first time. The resulting `.pixi` directory is owned by UID 1000
+but the process runs as UID 1001, which may cause cache-miss paths through the compiler that
+exercise a larger number of compilation units concurrently.
+
+The combination of (a) large compilation scope from many test functions/imports, (b) fresh cache
+forcing full JIT recompilation, and (c) potential UID-induced permission fallback paths in the
+pixi/Mojo cache layer pushes an internal JIT buffer past its fixed capacity, triggering glibc's
+stack canary or `__fortify_fail` check.
+
+The `__fortify_fail_abort` in frame #3 (not frame #0) means the crash was not an OS signal —
+the glibc hardened libc code detected the overflow proactively and called `abort()`.
+
+## Expected Behavior
+
+JIT compilation completes successfully regardless of pixi cache state, UID of the running
+process, or TTY availability.
+
+## Actual Behavior
+
+`error: execution crashed` with `__fortify_fail_abort` in `libc.so.6+0x45330`, only in CI
+(fresh pixi volumes + UID 1001 + no TTY), for approximately 97 test files that all pass
+locally.
+
+## Workaround
+
+The crash is non-blocking: CI is configured with `continue-on-error: true` for affected test
+groups (see `comprehensive-tests.yml` lines 254, 331, 337, 353). All tests pass locally and
+under ASAN.
+
+## Minimal Reproducer Attempt
+
+See `repro/repro_jit_fortify_crash.mojo`. The reproducer does NOT reproduce the crash locally
+(by definition of this being a CI-only issue), but documents the JIT stress patterns that
+correlate with the crash: large struct count, many generic instantiations, deep SIMD nesting,
+and heavy type parameter permutations.

--- a/repro/issues/jit-targeted-imports-still-crashes.md
+++ b/repro/issues/jit-targeted-imports-still-crashes.md
@@ -1,0 +1,53 @@
+# [BUG] JIT crash persists after targeted import conversion (ADR-015)
+
+## Environment
+
+- Mojo version: 0.26.3 (dev2026040705)
+- OS: Ubuntu 24.04 (GitHub Actions runner)
+- GLIBC: 2.39
+- Runner UID: 1001
+
+## Description
+
+After converting all test files from package-level imports (`from projectodyssey.core import …`)
+to targeted submodule imports (`from projectodyssey.core.layers.linear import Linear`), JIT
+compilation crashes are still observed intermittently on CI for the Core Layers test group.
+
+This is significant because ADR-015's hypothesis was that import volume caused the crash.
+If crashes persist with targeted imports, the root cause is elsewhere.
+
+## Crash Signature
+
+```text
+/path/to/mojo: error: execution crashed
+```
+
+Stack (no symbols):
+
+```text
+#0 libKGENCompilerRTShared.so+0x6d4ab
+#1 libKGENCompilerRTShared.so+0x6a686
+#2 libKGENCompilerRTShared.so+0x6e157
+#3 libc.so.6+0x45330
+```
+
+## Minimal Reproducer
+
+See `repro/repro_jit_targeted_imports_crash.mojo`.
+
+```bash
+mojo repro/repro_jit_targeted_imports_crash.mojo
+```
+
+## Observed Pattern
+
+- Occurs on GitHub Actions Ubuntu 24.04 runners
+- Non-deterministic: same file may pass one run and crash the next
+- ASAN tests (AOT compilation path) pass on the same SHA — confirms JIT-specific
+- Crash occurs before any test output (during JIT compilation startup)
+
+## Relationship
+
+- Successor to modular/modular#6187 (bitcast UAF JIT crash)
+- ADR-015 targeted-import conversion did not eliminate the crash
+- May be UID-mismatch HOME directory permission issue (runner UID 1001, image built for UID 1000)

--- a/repro/issues/jit-virtual-memory-exhaustion.md
+++ b/repro/issues/jit-virtual-memory-exhaustion.md
@@ -1,0 +1,133 @@
+# Mojo JIT maps ~3.5GB virtual address space per compiler invocation
+
+## Environment
+
+- Mojo 0.26.3.0.dev2026040705 (69cac1bd)
+- GLIBC 2.39-0ubuntu8.7 (Ubuntu 24.04)
+- Linux x86_64, 16GB RAM (confirmed passes), 7GB RAM (crashes)
+
+## Summary
+
+Every `mojo run` / `mojo build` invocation maps approximately **3.5GB of virtual
+address space** regardless of the source file's complexity. This exceeds the
+available virtual address space on GitHub Actions free-tier runners (7GB total)
+when multiple `mojo` processes run concurrently, causing OOM crashes.
+
+## Reproduction
+
+Requires Docker or Podman. The commands below use Podman — replace `podman` with
+`docker` if preferred.
+
+```bash
+# 1. Clone the repo (contains the minimal reproducer and Dockerfile)
+git clone https://github.com/HomericIntelligence/ProjectOdyssey.git
+cd ProjectOdyssey
+REPO_ROOT="$(pwd)"
+
+# 2. Install the Mojo toolchain into the pixi environment
+pixi install
+
+# 3. Build the container image from the repo's Dockerfile
+podman build -t projectodyssey:repro .
+
+# 4. Crash case: virtual limit below mojo's reservation (~3.5GB)
+podman run --rm \
+  -v "$REPO_ROOT:$REPO_ROOT:z" \
+  --user "$(id -u):$(id -g)" \
+  projectodyssey:repro \
+  bash -c "ulimit -v 3500000 && MODULAR_HOME=$REPO_ROOT/.pixi/envs/default/share/max $REPO_ROOT/.pixi/envs/default/bin/mojo run $REPO_ROOT/repro/repro_hello.mojo"
+
+# Expected output:
+# JIT session error: Cannot allocate memory
+# mojo: error: Failed to materialize symbols: { (exec, { main }) }
+
+# 5. Pass case: virtual limit above mojo's reservation
+podman run --rm \
+  -v "$REPO_ROOT:$REPO_ROOT:z" \
+  --user "$(id -u):$(id -g)" \
+  projectodyssey:repro \
+  bash -c "ulimit -v 4000000 && MODULAR_HOME=$REPO_ROOT/.pixi/envs/default/share/max $REPO_ROOT/.pixi/envs/default/bin/mojo run $REPO_ROOT/repro/repro_hello.mojo"
+
+# Expected output:
+# hello
+```
+
+The minimal reproducer file (`repro/repro_hello.mojo`) contains only:
+
+```mojo
+def main() raises:
+    print("hello")
+```
+
+## Measured Data
+
+VmPeak / VmRSS measured via `/proc/$PID/status` polling during a normal (no ulimit) run:
+
+| Metric | Value |
+| --- | --- |
+| VmPeak (virtual peak) | 3,705,232 kB (~3.53 GB) |
+| VmRSS (physical RAM) | ~321,000 kB (~314 MB) |
+
+Virtual address space crash threshold (5 runs each):
+
+| `ulimit -v` (kB) | Pass rate | Notes |
+| --- | --- | --- |
+| 3,500,000 | 0/5 (0%) | Reliable crash — use for repro |
+| 3,700,000 | 1/5 (20%) | Non-deterministic (ASLR variance) |
+| 3,750,000 | 4/5 (80%) | Non-deterministic |
+| 3,800,000 | 5/5 (100%) | Reliable pass |
+| 4,000,000 | 5/5 (100%) | Reliable pass — use for repro |
+
+Source file characteristics that do NOT affect the threshold:
+
+- Line count (10 vs 1000 functions): same threshold
+- Monomorphization count (1 vs 300 DType variants): same threshold
+- Module-level vs per-function imports: same threshold
+- Presence or absence of heavy cross-module import chains: same threshold
+
+## Impact
+
+On GitHub Actions free-tier runners (7GB total RAM, 2 cores):
+
+- OS + runner + pixi env ≈ 2-3GB
+- Available for `mojo` processes: 4-5GB
+- If 2+ concurrent `mojo` processes overlap (each needing ~3.5GB virtual):
+  combined demand: 7GB+ → OOM crash
+
+This affects any workflow that runs Mojo tests in a matrix with parallel jobs.
+
+## Error Message
+
+When the crash is triggered by `ulimit -v`, the output is:
+
+```text
+JIT session error: Cannot allocate memory
+mojo: error: Failed to materialize symbols: { (exec, { main }) }
+```
+
+In CI without `ulimit`, the process is OOM-killed by the kernel and the signal
+is caught by `libKGENCompilerRTShared.so`, producing a stack trace like:
+
+```text
+#0  0x00007f9999f4d4ab in libKGENCompilerRTShared.so (+0x6d4ab)
+#1  0x00007f9999f4a686 in libKGENCompilerRTShared.so (+0x6a686)
+#2  0x00007f9999f4e157 in libKGENCompilerRTShared.so (+0x6e157)
+#3  0x00007f999b145330 in libc.so.6 (sigaction wrapper)
+```
+
+## Workarounds
+
+1. **Limit concurrent Mojo test jobs** in CI matrix: `max-parallel: 2`
+2. **Use larger runners** (16GB) for Mojo test matrix
+3. **Reduce compilation time per process** via per-function imports in library modules —
+   shorter compile = shorter window when multiple mojo processes overlap
+
+## Notes
+
+- Physical RSS is only ~314MB even on complex files — the issue is **virtual** address
+  space reservation by the JIT compiler, not actual physical memory usage
+- The non-determinism in the 3.7–3.75GB range is caused by ASLR shifting the base
+  addresses of mmap regions between runs
+- The crash is non-deterministic across CI runs depending on runner load and job overlap
+- Related to #6187 (runtime allocator crash) but distinct cause: this is JIT initialization
+  mapping virtual pages, not a use-after-free

--- a/repro/issues/libasyncrt-vgg16-training-crash.md
+++ b/repro/issues/libasyncrt-vgg16-training-crash.md
@@ -1,0 +1,130 @@
+# [BUG] Deterministic heap corruption crash during VGG16-style training loop
+
+Repeated function-scoped forward passes + bitcast target write crashes libAsyncRTRuntimeGlobals.so.
+
+## Environment
+
+- **Mojo version**: 0.26.1.0 (156d3ac6)
+- **OS**: Linux 6.6.87.2-microsoft-standard-WSL2 x86_64 (Ubuntu 24.04)
+- **GLIBC**: 2.39
+- **CPU**: x86_64
+
+## Description
+
+A **100% deterministic** runtime crash occurs in `libAsyncRTRuntimeGlobals.so`
+(the Mojo allocator) during a VGG16-style training loop. After 2-3 function-scoped
+VGG16 forward passes that free hundreds of intermediate tensors, the next
+forward pass that also creates a small training target tensor with a bitcast write
+triggers a crash in the allocator.
+
+This is a more realistic variant of modular/modular#6187: same root cause (heap
+corruption from `List[Int]`-containing struct churn + UnsafePointer.bitcast write),
+but triggered through a full 13-conv-layer + 3-FC-layer deep learning architecture.
+
+Stack trace offsets are **identical across all runs**, confirming deterministic heap
+metadata corruption.
+
+## Stack Trace (identical across all runs)
+
+```text
+VGG16 forward pass 1... OK
+VGG16 forward pass 2... OK
+VGG16 forward pass 3 with training target...
+#0 libKGENCompilerRTShared.so  +0x3cb78b
+#1 libKGENCompilerRTShared.so  +0x3c93c6
+#2 libKGENCompilerRTShared.so  +0x3cc397
+#3 libc.so.6                   +0x45330   (sigaction)
+#4 libAsyncRTRuntimeGlobals.so +0x416ba   (allocator — crash origin)
+error: execution crashed
+```
+
+Identical stack offsets to modular/modular#6187 — same allocator corruption path.
+
+## Reproducer
+
+See `repro/repro_libasyncrt_crash.mojo` for the full reproducer. It requires
+ProjectOdyssey's `shared` library (AnyTensor, conv2d, linear, relu, maxpool2d).
+
+**Key sequence:**
+
+```mojo
+def vgg16_forward(input: AnyTensor) raises -> AnyTensor:
+    """13 conv layers + 3 FC layers = ~100+ intermediate AnyTensors per call."""
+    var x = conv_block(input, 64, 2)
+    var x = maxpool2d(x, 2, 2)
+    # ... 5 conv blocks + 5 maxpools + 3 FC layers total
+    return output
+
+def train_step_with_target(epoch: Int) raises:
+    """Forward pass + create training target with bitcast write -> CRASH."""
+    var input = ones([2, 3, 224, 224], DType.float32)
+    var output = vgg16_forward(input)
+    # === TRIGGER ===
+    var target = zeros([2], DType.float32)
+    var td = target._data.bitcast[Float32]()
+    td[0] = 0.0
+    td[1] = Float32(epoch % 10)
+    # === END TRIGGER ===
+    return output
+
+def main() raises:
+    vgg16_forward(ones([2, 3, 224, 224], DType.float32))  # Pass 1: primes heap
+    vgg16_forward(ones([2, 3, 224, 224], DType.float32))  # Pass 2: more churn
+    train_step_with_target(1)                              # Pass 3: CRASH
+```
+
+## Isolation Experiments
+
+| Variant | Crashes? | Conclusion |
+| --- | --- | --- |
+| Full reproducer (3 passes + bitcast) | **YES (100%)** | Baseline |
+| Remove bitcast write from train_step | NO | Bitcast write is the trigger |
+| Only 1 prior forward pass (not 2) | NO | Requires sufficient prior churn |
+| train_step_with_target() alone (no priors) | NO | Prior heap state required |
+| 20 forward passes in a loop in main() (no function scope) | NO | Function-scoped destruction required |
+| Smaller input (32x32 instead of 224x224) | Flaky (less reliable) | Volume matters |
+| Fewer conv blocks (2 blocks vs 5) | NO | Insufficient tensor churn |
+
+## Relationship to #6187
+
+This is the **same heap corruption bug** as modular/modular#6187, reproduced through:
+
+- A realistic VGG16-style deep learning architecture with 13 conv layers
+- Full end-to-end training step pattern (forward pass + target creation)
+- Real-world tensor counts: ~100+ intermediate `AnyTensor` objects per forward
+  pass, each containing `_shape: List[Int]`
+
+The identical stack trace offsets confirm the same allocator corruption root cause.
+
+## Root Cause (from #6187 investigation)
+
+All three conditions must be present simultaneously:
+
+1. Struct with `List[Int]` field — `AnyTensor._shape: List[Int]`
+2. Heavy alloc/free churn of many such structs — VGG16 creates ~100 per pass,
+   all freed when the function-scoped forward pass returns
+3. `UnsafePointer.bitcast` write — creating the training target and writing
+   through a bitcast pointer exposes the corrupted heap state
+
+Removing any single condition prevents the crash.
+
+## Impact
+
+This crash blocks training loop implementation for deep architectures. Any
+training loop that:
+
+- Creates model predictions via function-scoped forward pass
+- Creates training targets via separate tensor allocation with element assignment
+- Runs for more than 2-3 steps
+
+...will crash deterministically.
+
+## Expected Behavior
+
+Training loop runs for all epochs without crashing. All tensor operations are
+within bounds and refcounts are balanced.
+
+## Actual Behavior
+
+Deterministic crash in the allocator on step 3, when the training target's
+bitcast write is followed by another allocation inside the VGG16 forward pass.

--- a/repro/issues/libkgen-heap-corruption-crash.md
+++ b/repro/issues/libkgen-heap-corruption-crash.md
@@ -1,0 +1,109 @@
+# [BUG] Deterministic heap corruption in libKGENCompilerRTShared.so after tensor alloc/free churn
+
+AnyTensor variant: UnsafePointer.bitcast write triggers allocator crash after List[Int] churn.
+
+## Environment
+
+- **Mojo version**: 0.26.1.0 (156d3ac6)
+- **OS**: Linux 6.6.87.2-microsoft-standard-WSL2 x86_64 (Ubuntu 24.04)
+- **GLIBC**: 2.39
+- **CPU**: x86_64
+
+## Description
+
+A **100% deterministic** runtime crash occurs in `libAsyncRTRuntimeGlobals.so`
+(the Mojo allocator) when using `AnyTensor` from a shared library with conv2d
+operations. The crash pattern is identical to modular/modular#6187 but triggered
+through a higher-level API (AnyTensor + shared library conv2d) rather than an
+inlined minimal struct.
+
+The stack trace offsets are **identical across all runs**, indicating deterministic
+heap metadata corruption rather than a race condition.
+
+## Stack Trace (identical across all runs)
+
+```text
+Step A: conv2d heap churn... OK
+Step B: bitcast write + conv2d...
+#0 libKGENCompilerRTShared.so  +0x3cb78b
+#1 libKGENCompilerRTShared.so  +0x3c93c6
+#2 libKGENCompilerRTShared.so  +0x3cc397
+#3 libc.so.6                   +0x45330   (sigaction)
+#4 libAsyncRTRuntimeGlobals.so +0x416ba   (allocator — crash origin)
+error: execution crashed
+```
+
+Same stack offsets as modular/modular#6187 — confirms same root cause.
+
+## Reproducer
+
+See `repro/repro_libkgen_crash.mojo` for the full reproducer. It requires
+ProjectOdyssey's `shared` library (AnyTensor, conv2d, relu).
+
+**Key sequence:**
+
+```mojo
+def step_a() raises:
+    """2x conv2d creates ~20 intermediate AnyTensors, freed on return."""
+    var x = ones([2, 3, 32, 32], DType.float32)
+    x = conv2d(x, ones([16, 3, 3, 3], DType.float32), ...)
+    x = relu(x)
+    x = conv2d(x, ones([16, 16, 3, 3], DType.float32), ...)
+    _ = relu(x)
+
+def step_b() raises:
+    """Bitcast write to small tensor then conv2d -> CRASH."""
+    var target = zeros([2], DType.float32)
+    # === TRIGGER ===
+    var td = target._data.bitcast[Float32]()
+    td[0] = 0.0
+    td[1] = 1.0
+    # === END TRIGGER ===
+    var x = ones([2, 3, 32, 32], DType.float32)
+    x = conv2d(x, ones([16, 3, 3, 3], DType.float32), ...)
+    _ = relu(x)
+
+def main() raises:
+    step_a()   # heap churn
+    step_b()   # crash
+```
+
+## Isolation Experiments
+
+| Variant | Crashes? | Conclusion |
+| --- | --- | --- |
+| Full reproducer | **YES (100%)** | Baseline |
+| Remove bitcast write (3 lines) | NO | Bitcast write is the trigger |
+| step_b() alone (no prior step_a()) | NO | Prior heap churn required |
+| Operations inline in main() (no function scope) | NO | Function-scoped destruction required |
+| Smaller tensors (8x8 spatial) | NO | Insufficient allocation volume |
+| Full code from repro_crash_standalone.mojo (zero dependencies) | **YES** | Same root cause, confirmed |
+
+## Relationship to #6187
+
+This is the **same heap corruption bug** as modular/modular#6187, reproduced through:
+
+- `AnyTensor` (reference-counted, contains `List[Int]` shape field) instead of a
+  minimal inline struct
+- The `shared` library's conv2d (which creates intermediate `AnyTensor` objects
+  with their `List[Int]` shape fields) instead of an inlined loop
+
+The identical stack trace offsets confirm the same allocator corruption path.
+
+## Root Cause (from #6187 investigation)
+
+The crash requires all three conditions simultaneously:
+
+1. A struct containing `List[Int]` field (`AnyTensor` has `_shape: List[Int]`)
+2. Heavy alloc/free churn creating and destroying many such structs (step_a)
+3. `UnsafePointer.bitcast` write that exposes corrupted heap state (step_b)
+
+## Expected Behavior
+
+Program completes without crashing. All operations are within bounds and
+refcounts are balanced.
+
+## Actual Behavior
+
+100% deterministic crash in allocator during a subsequent `alloc` call inside
+`step_b()`, after the bitcast write.

--- a/repro/kgen_jit_overflow_minimal.mojo
+++ b/repro/kgen_jit_overflow_minimal.mojo
@@ -1,0 +1,149 @@
+"""Minimal self-contained reproducer for KGEN JIT buffer overflow.
+
+This file is a self-contained reproducer for a KGEN JIT crash that
+occurs when compiling a module that:
+  1. Imports std.python (CPython interop)
+  2. Defines a struct with a List[String] field
+  3. Defines multiple overloaded __init__ constructors (6+)
+  4. Uses Dict[String, <that struct>]
+
+The crash manifests as:
+    mojo: error: execution crashed with signal: Aborted
+    Aborted (core dumped)
+    ... libKGENCompilerRTShared.so ...
+
+The crash happens at JIT *compilation time* -- before main() is entered
+and before any output is printed. This means:
+  - It is NOT a runtime error in user code
+  - It is NOT a logic bug in the module
+  - It IS a KGEN internal buffer overflow (__fortify_fail_abort)
+
+## Environment
+
+- Mojo version: 0.26.3
+- Platform: Linux x86_64 (GitHub Actions ubuntu-latest runner, ~7 GB RAM)
+- Reproduces: 100% of the time in CI; 0% locally on developer machines
+  (CI resource constraints appear to be required to trigger the overflow)
+
+## Crash trace (from CI logs)
+
+    mojo: error: execution crashed with signal: Aborted
+    Aborted (core dumped)
+    /proc/self/fd/3:
+    #0  libKGENCompilerRTShared.so+0x6d4ab(__fortify_fail_abort+0x1b)
+    #1  libKGENCompilerRTShared.so+0x6d461(__fortify_fail+0x21)
+    #2  libKGENCompilerRTShared.so+0x6d419 (...)
+    #3  libKGENCompilerRTShared.so+0x15f5a (...)
+    ...
+
+## How to run
+
+    pixi run mojo repro/kgen_jit_overflow_minimal.mojo
+
+Expected (CI): crash before any output with Aborted/libKGENCompilerRTShared.so trace
+Expected (local): may run successfully (resource constraints differ from CI)
+"""
+
+from std.python import Python, PythonObject
+
+
+struct Value(Copyable, Movable):
+    """A union-like value type with multiple overloaded constructors."""
+
+    var type_tag: String
+    var int_val: Int
+    var float_val: Float64
+    var str_val: String
+    var bool_val: Bool
+    var list_val: List[String]
+
+    def __init__(out self, value: Int):
+        self.type_tag = "int"
+        self.int_val = value
+        self.float_val = 0.0
+        self.str_val = ""
+        self.bool_val = False
+        self.list_val = List[String]()
+
+    def __init__(out self, value: Float64):
+        self.type_tag = "float"
+        self.int_val = 0
+        self.float_val = value
+        self.str_val = ""
+        self.bool_val = False
+        self.list_val = List[String]()
+
+    def __init__(out self, value: String):
+        self.type_tag = "string"
+        self.int_val = 0
+        self.float_val = 0.0
+        self.str_val = value
+        self.bool_val = False
+        self.list_val = List[String]()
+
+    def __init__(out self, value: Bool):
+        self.type_tag = "bool"
+        self.int_val = 0
+        self.float_val = 0.0
+        self.str_val = ""
+        self.bool_val = value
+        self.list_val = List[String]()
+
+    def __init__(out self, var value: List[String]):
+        self.type_tag = "list"
+        self.int_val = 0
+        self.float_val = 0.0
+        self.str_val = ""
+        self.bool_val = False
+        self.list_val = value^
+
+    def __init__(out self, value: List[Int]):
+        self.type_tag = "list"
+        self.int_val = 0
+        self.float_val = 0.0
+        self.str_val = ""
+        self.bool_val = False
+        self.list_val = List[String]()
+        for i in range(len(value)):
+            self.list_val.append(String(value[i]))
+
+
+struct Container(Copyable, Movable):
+    """Container backed by Dict[String, Value]."""
+
+    var data: Dict[String, Value]
+
+    def __init__(out self):
+        self.data = Dict[String, Value]()
+
+    def set(mut self, key: String, value: Int):
+        self.data[key] = Value(value)
+
+    def set(mut self, key: String, value: Float64):
+        self.data[key] = Value(value)
+
+    def set(mut self, key: String, value: String):
+        self.data[key] = Value(value)
+
+    def set(mut self, key: String, value: Bool):
+        self.data[key] = Value(value)
+
+    def get_int(self, key: String) raises -> Int:
+        return self.data[key].int_val
+
+    def get_string(self, key: String) raises -> String:
+        return self.data[key].str_val
+
+    def use_python_interop(self) raises:
+        """Exercises the std.python import that is referenced at module level."""
+        var builtins = Python.import_module("builtins")
+        _ = builtins.str("test")
+
+
+def main() raises:
+    print("If you see this, the KGEN crash did NOT occur.")
+    var c = Container()
+    c.set("lr", Float64(0.001))
+    c.set("name", "test")
+    c.set("epochs", 10)
+    print("Container works, lr =", c.get_string("name"))

--- a/repro/repro_crash_standalone.mojo
+++ b/repro/repro_crash_standalone.mojo
@@ -1,0 +1,223 @@
+"""Self-contained Mojo v0.26.1 runtime crash reproducer.
+
+NO external dependencies. Copy this single file to any Mojo 0.26.1 install.
+
+Environment: Mojo 0.26.1 (156d3ac6), GLIBC 2.39, Linux 6.6.87 x86_64 (WSL2)
+
+Reproduces a deterministic crash in the Mojo runtime allocator triggered by:
+1. step_a(): Heavy alloc/free churn (conv2d creates many intermediate tensors,
+   all freed when the function returns)
+2. step_b(): Create a small tensor, write via UnsafePointer.bitcast, then do
+   another conv2d -> CRASH in libAsyncRTRuntimeGlobals.so
+
+Removing the bitcast write in step_b() prevents the crash.
+
+Stack trace:
+  #0 libKGENCompilerRTShared.so  +0x3cb78b
+  #1 libKGENCompilerRTShared.so  +0x3c93c6
+  #2 libKGENCompilerRTShared.so  +0x3cc397
+  #3 libc.so.6                   +0x45330
+  #4 libAsyncRTRuntimeGlobals.so +0x416ba  (allocator - crash origin)
+"""
+
+from std.memory import UnsafePointer, memset_zero, alloc, memcpy
+from std.collections import List
+
+
+# ============================================================================
+# Minimal tensor struct (inlined from AnyTensor)
+# ============================================================================
+
+
+struct Tensor(Movable, Copyable):
+    var _data: UnsafePointer[UInt8, origin=MutAnyOrigin]
+    var _shape: List[Int]
+    var _numel: Int
+    var _refcount: UnsafePointer[Int, origin=MutAnyOrigin]
+    var _alloc_size: Int
+
+    def __init__(out self, shape: List[Int]) raises:
+        self._shape = List[Int]()
+        self._numel = 1
+        for i in range(len(shape)):
+            self._shape.append(shape[i])
+            self._numel *= shape[i]
+        self._alloc_size = self._numel * 4  # float32 = 4 bytes
+        self._data = alloc[UInt8](self._alloc_size)
+        memset_zero(self._data, self._alloc_size)
+        self._refcount = alloc[Int](1)
+        self._refcount[] = 1
+
+    def __init__(out self, *, copy: Self):
+        self._data = copy._data
+        self._shape = copy._shape.copy()
+        self._numel = copy._numel
+        self._refcount = copy._refcount
+        self._alloc_size = copy._alloc_size
+        if self._refcount:
+            self._refcount[] += 1
+
+    def __init__(out self, *, deinit take: Self):
+        self._data = take._data
+        self._shape = take._shape.copy()
+        self._numel = take._numel
+        self._refcount = take._refcount
+        self._alloc_size = take._alloc_size
+
+    def __del__(deinit self):
+        if self._refcount:
+            self._refcount[] -= 1
+            if self._refcount[] == 0:
+                self._data.free()
+                self._refcount.free()
+
+    def fp(self) -> UnsafePointer[Float32, origin=MutAnyOrigin]:
+        return self._data.bitcast[Float32]()
+
+
+def zeros(shape: List[Int]) raises -> Tensor:
+    return Tensor(shape)
+
+
+def ones(shape: List[Int]) raises -> Tensor:
+    var t = Tensor(shape)
+    var p = t.fp()
+    for i in range(t._numel):
+        p[i] = 1.0
+    return t^
+
+
+def shape4(a: Int, b: Int, c: Int, d: Int) -> List[Int]:
+    var s = List[Int]()
+    s.append(a)
+    s.append(b)
+    s.append(c)
+    s.append(d)
+    return s^
+
+
+def shape1(a: Int) -> List[Int]:
+    var s = List[Int]()
+    s.append(a)
+    return s^
+
+
+# ============================================================================
+# Inlined conv2d (sequential, float32 only, stride=1, padding=1)
+# ============================================================================
+
+
+def conv2d(
+    x: Tensor,
+    kernel: Tensor,
+    bias: Tensor,
+) raises -> Tensor:
+    var batch = x._shape[0]
+    var in_ch = x._shape[1]
+    var in_h = x._shape[2]
+    var in_w = x._shape[3]
+    var out_ch = kernel._shape[0]
+    var kH = kernel._shape[2]
+    var kW = kernel._shape[3]
+    # padding=1, stride=1
+    var out_h = in_h
+    var out_w = in_w
+
+    var output = zeros(shape4(batch, out_ch, out_h, out_w))
+    var out_p = output.fp()
+    var x_p = x.fp()
+    var k_p = kernel.fp()
+    var b_p = bias.fp()
+
+    for b in range(batch):
+        for oc in range(out_ch):
+            for oh in range(out_h):
+                for ow in range(out_w):
+                    var sum_val = Float32(0.0)
+                    var in_h_start = oh - 1  # padding=1
+                    var in_w_start = ow - 1
+                    for ic in range(in_ch):
+                        for kh in range(kH):
+                            for kw in range(kW):
+                                var ih = in_h_start + kh
+                                var iw = in_w_start + kw
+                                if (
+                                    ih >= 0
+                                    and ih < in_h
+                                    and iw >= 0
+                                    and iw < in_w
+                                ):
+                                    var in_idx = (
+                                        b * (in_ch * in_h * in_w)
+                                        + ic * (in_h * in_w)
+                                        + ih * in_w
+                                        + iw
+                                    )
+                                    var k_idx = (
+                                        oc * (in_ch * kH * kW)
+                                        + ic * (kH * kW)
+                                        + kh * kW
+                                        + kw
+                                    )
+                                    sum_val += x_p[in_idx] * k_p[k_idx]
+                    sum_val += b_p[oc]
+                    var out_idx = (
+                        b * (out_ch * out_h * out_w)
+                        + oc * (out_h * out_w)
+                        + oh * out_w
+                        + ow
+                    )
+                    out_p[out_idx] = sum_val
+    return output^
+
+
+# ============================================================================
+# Inlined ReLU
+# ============================================================================
+
+
+def relu(t: Tensor) raises -> Tensor:
+    var out = Tensor(t._shape)
+    var ip = t.fp()
+    var op = out.fp()
+    for i in range(t._numel):
+        op[i] = max(Float32(0), ip[i])
+    return out^
+
+
+# ============================================================================
+# Crash reproducer
+# ============================================================================
+
+
+def step_a() raises:
+    """Heavy alloc/free via 2x conv+relu. ~20 tensors freed on return."""
+    var x = ones(shape4(2, 3, 32, 32))
+    # Conv 1: 3->16
+    x = conv2d(x, ones(shape4(16, 3, 3, 3)), zeros(shape1(16)))
+    x = relu(x)
+    # Conv 2: 16->16
+    x = conv2d(x, ones(shape4(16, 16, 3, 3)), zeros(shape1(16)))
+    _ = relu(x)
+
+
+def step_b() raises:
+    """Bitcast write then conv2d -> CRASH."""
+    var target = zeros(shape1(2))
+    # === TRIGGER: comment these 3 lines to prevent crash ===
+    var td = target._data.bitcast[Float32]()
+    td[0] = 0.0
+    td[1] = 1.0
+    # === END TRIGGER ===
+    var x = ones(shape4(2, 3, 32, 32))
+    x = conv2d(x, ones(shape4(16, 3, 3, 3)), zeros(shape1(16)))
+    _ = relu(x)
+
+
+def main() raises:
+    print("Step A: conv2d heap churn...", end="")
+    step_a()
+    print(" OK")
+    print("Step B: bitcast write + conv2d...", end="")
+    step_b()
+    print(" OK — no crash (bug may be environment-dependent)")

--- a/repro/repro_import_chain_synthetic.mojo
+++ b/repro/repro_import_chain_synthetic.mojo
@@ -1,0 +1,44 @@
+"""Self-contained synthetic reproducer for module-level import chain JIT crash.
+
+NO external dependencies beyond Mojo stdlib. This file creates synthetic
+"heavy" modules in the same directory to simulate the import chain pattern
+that crashes in ProjectOdyssey (1000-1500 line modules imported transitively
+at module level).
+
+HOW TO REPRODUCE (requires files repro_heavy_A.mojo and repro_heavy_B.mojo
+in the same directory — see generate_synthetic_chain.sh):
+
+  $ mojo test repro_import_chain_synthetic.mojo   # Expected: crash
+  $ mojo test repro_import_chain_synthetic_fixed.mojo  # Expected: PASS
+
+IMPORT CHAIN STRUCTURE:
+  repro_import_chain_synthetic.mojo  (this file)
+    → repro_heavy_B.mojo             (1400+ lines, module level import)
+      → repro_heavy_A.mojo           (1400+ lines, module level import)
+
+CRASH DIAGNOSIS:
+  If the file crashes before printing "Running..." it is a module-level
+  import explosion (compile time). If it prints "Running..." then crashes,
+  the issue is different (runtime or accumulation).
+
+ENVIRONMENT:
+  Mojo 0.26.3 (dev2026040705), GLIBC 2.39, Linux 6.6.87 x86_64
+"""
+
+# Module-level imports — triggers compilation of the full chain at parse time
+from repro_heavy_B import heavy_b_op_1, heavy_b_op_2
+
+
+def test_module_level_import() raises:
+    print("test_module_level_import: Reached test body")
+    var result = heavy_b_op_1(42)
+    var result2 = heavy_b_op_2(result)
+    if result2 >= 0:
+        print("test_module_level_import: PASS")
+    else:
+        print("test_module_level_import: FAIL")
+
+
+def main() raises:
+    print("Running: repro_import_chain_synthetic (module-level imports)")
+    test_module_level_import()

--- a/repro/repro_jit_fortify_crash.mojo
+++ b/repro/repro_jit_fortify_crash.mojo
@@ -1,0 +1,606 @@
+"""Reproducer attempt for JIT __fortify_fail_abort in CI.
+
+Environment: Mojo 0.26.3.0.dev2026040705 (69cac1bd), GLIBC 2.39, Ubuntu 24.04
+
+This file attempts to reproduce the JIT buffer overflow (libKGENCompilerRTShared.so
+offsets 0x6d4ab / 0x6a686 / 0x6e157) seen in CI by stressing the JIT compiler with:
+
+  1. Many large structs with complex trait implementations
+  2. Many generic functions with multiple type parameters
+  3. Deep nesting of SIMD type instantiations
+  4. Heavy compile-time integer arithmetic and conditional traits
+
+The crash is CI-only (fresh pixi volumes + UID mismatch + no TTY). Running this
+file locally will almost certainly succeed — that is expected. The file exists to:
+  a) Document the stress patterns that correlate with the CI crash
+  b) Provide a starting point if the JIT bug is ever made locally reproducible
+  c) Confirm no user-code memory errors (ASAN reports clean on this file)
+
+Local result: RUNS CLEAN (no crash, no ASAN errors)
+CI result:    UNKNOWN — may trigger the crash if environment conditions align
+
+See: repro/issues/jit-fortify-buffer-overflow.md
+"""
+
+from std.testing import assert_equal, assert_almost_equal, assert_true
+
+# ============================================================================
+# Stress Pattern 1: Many large structs with trait implementations
+# Each struct forces the JIT to instantiate a separate vtable + method table.
+# ============================================================================
+
+trait Computable:
+    def compute(self) -> Float32: ...
+    def size(self) -> Int: ...
+    def name(self) -> String: ...
+
+
+struct Block0(Computable):
+    var data: SIMD[DType.float32, 16]
+
+    def __init__(out self, val: Float32):
+        self.data = SIMD[DType.float32, 16](val)
+
+    def compute(self) -> Float32:
+        return self.data.reduce_add()
+
+    def size(self) -> Int:
+        return 16
+
+    def name(self) -> String:
+        return "Block0"
+
+
+struct Block1(Computable):
+    var data: SIMD[DType.float32, 16]
+
+    def __init__(out self, val: Float32):
+        self.data = SIMD[DType.float32, 16](val)
+
+    def compute(self) -> Float32:
+        return self.data.reduce_add()
+
+    def size(self) -> Int:
+        return 16
+
+    def name(self) -> String:
+        return "Block1"
+
+
+struct Block2(Computable):
+    var data: SIMD[DType.float32, 16]
+
+    def __init__(out self, val: Float32):
+        self.data = SIMD[DType.float32, 16](val)
+
+    def compute(self) -> Float32:
+        return self.data.reduce_add()
+
+    def size(self) -> Int:
+        return 16
+
+    def name(self) -> String:
+        return "Block2"
+
+
+struct Block3(Computable):
+    var data: SIMD[DType.float32, 16]
+
+    def __init__(out self, val: Float32):
+        self.data = SIMD[DType.float32, 16](val)
+
+    def compute(self) -> Float32:
+        return self.data.reduce_add()
+
+    def size(self) -> Int:
+        return 16
+
+    def name(self) -> String:
+        return "Block3"
+
+
+struct Block4(Computable):
+    var data: SIMD[DType.float32, 16]
+
+    def __init__(out self, val: Float32):
+        self.data = SIMD[DType.float32, 16](val)
+
+    def compute(self) -> Float32:
+        return self.data.reduce_add()
+
+    def size(self) -> Int:
+        return 16
+
+    def name(self) -> String:
+        return "Block4"
+
+
+struct Block5(Computable):
+    var data: SIMD[DType.float32, 16]
+
+    def __init__(out self, val: Float32):
+        self.data = SIMD[DType.float32, 16](val)
+
+    def compute(self) -> Float32:
+        return self.data.reduce_add()
+
+    def size(self) -> Int:
+        return 16
+
+    def name(self) -> String:
+        return "Block5"
+
+
+struct Block6(Computable):
+    var data: SIMD[DType.float32, 16]
+
+    def __init__(out self, val: Float32):
+        self.data = SIMD[DType.float32, 16](val)
+
+    def compute(self) -> Float32:
+        return self.data.reduce_add()
+
+    def size(self) -> Int:
+        return 16
+
+    def name(self) -> String:
+        return "Block6"
+
+
+struct Block7(Computable):
+    var data: SIMD[DType.float32, 16]
+
+    def __init__(out self, val: Float32):
+        self.data = SIMD[DType.float32, 16](val)
+
+    def compute(self) -> Float32:
+        return self.data.reduce_add()
+
+    def size(self) -> Int:
+        return 16
+
+    def name(self) -> String:
+        return "Block7"
+
+
+struct Block8(Computable):
+    var data: SIMD[DType.float32, 16]
+
+    def __init__(out self, val: Float32):
+        self.data = SIMD[DType.float32, 16](val)
+
+    def compute(self) -> Float32:
+        return self.data.reduce_add()
+
+    def size(self) -> Int:
+        return 16
+
+    def name(self) -> String:
+        return "Block8"
+
+
+struct Block9(Computable):
+    var data: SIMD[DType.float32, 16]
+
+    def __init__(out self, val: Float32):
+        self.data = SIMD[DType.float32, 16](val)
+
+    def compute(self) -> Float32:
+        return self.data.reduce_add()
+
+    def size(self) -> Int:
+        return 16
+
+    def name(self) -> String:
+        return "Block9"
+
+
+struct Block10(Computable):
+    var data: SIMD[DType.float32, 16]
+
+    def __init__(out self, val: Float32):
+        self.data = SIMD[DType.float32, 16](val)
+
+    def compute(self) -> Float32:
+        return self.data.reduce_add()
+
+    def size(self) -> Int:
+        return 16
+
+    def name(self) -> String:
+        return "Block10"
+
+
+struct Block11(Computable):
+    var data: SIMD[DType.float32, 16]
+
+    def __init__(out self, val: Float32):
+        self.data = SIMD[DType.float32, 16](val)
+
+    def compute(self) -> Float32:
+        return self.data.reduce_add()
+
+    def size(self) -> Int:
+        return 16
+
+    def name(self) -> String:
+        return "Block11"
+
+
+struct Block12(Computable):
+    var data: SIMD[DType.float32, 16]
+
+    def __init__(out self, val: Float32):
+        self.data = SIMD[DType.float32, 16](val)
+
+    def compute(self) -> Float32:
+        return self.data.reduce_add()
+
+    def size(self) -> Int:
+        return 16
+
+    def name(self) -> String:
+        return "Block12"
+
+
+struct Block13(Computable):
+    var data: SIMD[DType.float32, 16]
+
+    def __init__(out self, val: Float32):
+        self.data = SIMD[DType.float32, 16](val)
+
+    def compute(self) -> Float32:
+        return self.data.reduce_add()
+
+    def size(self) -> Int:
+        return 16
+
+    def name(self) -> String:
+        return "Block13"
+
+
+struct Block14(Computable):
+    var data: SIMD[DType.float32, 16]
+
+    def __init__(out self, val: Float32):
+        self.data = SIMD[DType.float32, 16](val)
+
+    def compute(self) -> Float32:
+        return self.data.reduce_add()
+
+    def size(self) -> Int:
+        return 16
+
+    def name(self) -> String:
+        return "Block14"
+
+
+struct Block15(Computable):
+    var data: SIMD[DType.float32, 16]
+
+    def __init__(out self, val: Float32):
+        self.data = SIMD[DType.float32, 16](val)
+
+    def compute(self) -> Float32:
+        return self.data.reduce_add()
+
+    def size(self) -> Int:
+        return 16
+
+    def name(self) -> String:
+        return "Block15"
+
+
+# ============================================================================
+# Stress Pattern 2: Generic functions with multiple SIMD type permutations
+# Forces JIT to instantiate many specializations of the same function body.
+# ============================================================================
+
+def simd_sum[dtype: DType, width: Int](v: SIMD[dtype, width]) -> SIMD[dtype, 1]:
+    return v.reduce_add()
+
+
+def simd_max[dtype: DType, width: Int](v: SIMD[dtype, width]) -> SIMD[dtype, 1]:
+    return v.reduce_max()
+
+
+def simd_min[dtype: DType, width: Int](v: SIMD[dtype, width]) -> SIMD[dtype, 1]:
+    return v.reduce_min()
+
+
+def dot2[dtype: DType, width: Int](
+    a: SIMD[dtype, width], b: SIMD[dtype, width]
+) -> SIMD[dtype, 1]:
+    return (a * b).reduce_add()
+
+
+# ============================================================================
+# Stress Pattern 3: Deep compile-time nesting via parametric wrapper structs
+# ============================================================================
+
+struct Scaled[dtype: DType, width: Int, factor: Int]:
+    var v: SIMD[Self.dtype, Self.width]
+
+    def __init__(out self, base: SIMD[Self.dtype, Self.width]):
+        self.v = base * SIMD[Self.dtype, Self.width](Self.factor)
+
+    def sum(self) -> SIMD[Self.dtype, 1]:
+        return self.v.reduce_add()
+
+
+struct NormedScaled[dtype: DType, width: Int, factor: Int, norm: Int]:
+    var inner: Scaled[Self.dtype, Self.width, Self.factor]
+
+    def __init__(out self, base: SIMD[Self.dtype, Self.width]):
+        self.inner = Scaled[Self.dtype, Self.width, Self.factor](base)
+
+    def value(self) -> SIMD[Self.dtype, 1]:
+        return self.inner.sum() / SIMD[Self.dtype, 1](Self.norm)
+
+
+# ============================================================================
+# Stress Pattern 4: Many test functions (mimics CI-crashing test files)
+# ============================================================================
+
+def test_block0() raises:
+    var b = Block0(1.0)
+    assert_almost_equal(b.compute(), 16.0, atol=1e-5)
+    assert_equal(b.size(), 16)
+
+
+def test_block1() raises:
+    var b = Block1(2.0)
+    assert_almost_equal(b.compute(), 32.0, atol=1e-5)
+    assert_equal(b.size(), 16)
+
+
+def test_block2() raises:
+    var b = Block2(0.5)
+    assert_almost_equal(b.compute(), 8.0, atol=1e-5)
+
+
+def test_block3() raises:
+    var b = Block3(-1.0)
+    assert_almost_equal(b.compute(), -16.0, atol=1e-5)
+
+
+def test_block4() raises:
+    var b = Block4(0.0)
+    assert_almost_equal(b.compute(), 0.0, atol=1e-5)
+
+
+def test_block5() raises:
+    var b = Block5(1.5)
+    assert_almost_equal(b.compute(), 24.0, atol=1e-5)
+
+
+def test_block6() raises:
+    var b = Block6(3.0)
+    assert_almost_equal(b.compute(), 48.0, atol=1e-5)
+
+
+def test_block7() raises:
+    var b = Block7(0.25)
+    assert_almost_equal(b.compute(), 4.0, atol=1e-5)
+
+
+def test_block8() raises:
+    var b = Block8(10.0)
+    assert_almost_equal(b.compute(), 160.0, atol=1e-5)
+
+
+def test_block9() raises:
+    var b = Block9(-0.5)
+    assert_almost_equal(b.compute(), -8.0, atol=1e-5)
+
+
+def test_block10() raises:
+    var b = Block10(100.0)
+    assert_almost_equal(b.compute(), 1600.0, atol=1e-5)
+
+
+def test_block11() raises:
+    var b = Block11(0.1)
+    assert_almost_equal(b.compute(), 1.6, atol=1e-4)
+
+
+def test_block12() raises:
+    var b = Block12(0.0)
+    assert_almost_equal(b.compute(), 0.0, atol=1e-5)
+    assert_equal(b.name(), "Block12")
+
+
+def test_block13() raises:
+    var b = Block13(1.0)
+    assert_almost_equal(b.compute(), 16.0, atol=1e-5)
+    assert_equal(b.name(), "Block13")
+
+
+def test_block14() raises:
+    var b = Block14(2.5)
+    assert_almost_equal(b.compute(), 40.0, atol=1e-5)
+    assert_equal(b.name(), "Block14")
+
+
+def test_block15() raises:
+    var b = Block15(-2.0)
+    assert_almost_equal(b.compute(), -32.0, atol=1e-5)
+    assert_equal(b.name(), "Block15")
+
+
+def test_simd_sum_f32_4() raises:
+    var v = SIMD[DType.float32, 4](1.0, 2.0, 3.0, 4.0)
+    assert_almost_equal(simd_sum(v)[0], 10.0, atol=1e-5)
+
+
+def test_simd_sum_f32_8() raises:
+    var v = SIMD[DType.float32, 8](1.0)
+    assert_almost_equal(simd_sum(v)[0], 8.0, atol=1e-5)
+
+
+def test_simd_sum_f32_16() raises:
+    var v = SIMD[DType.float32, 16](1.0)
+    assert_almost_equal(simd_sum(v)[0], 16.0, atol=1e-5)
+
+
+def test_simd_max_f32_4() raises:
+    var v = SIMD[DType.float32, 4](1.0, 4.0, 2.0, 3.0)
+    assert_almost_equal(simd_max(v)[0], 4.0, atol=1e-5)
+
+
+def test_simd_min_f32_4() raises:
+    var v = SIMD[DType.float32, 4](1.0, 4.0, -2.0, 3.0)
+    assert_almost_equal(simd_min(v)[0], -2.0, atol=1e-5)
+
+
+def test_dot2_f32_4() raises:
+    var a = SIMD[DType.float32, 4](1.0, 2.0, 3.0, 4.0)
+    var b = SIMD[DType.float32, 4](4.0, 3.0, 2.0, 1.0)
+    assert_almost_equal(dot2(a, b)[0], 20.0, atol=1e-5)
+
+
+def test_scaled_f32_8_factor2() raises:
+    var base = SIMD[DType.float32, 8](1.0)
+    var s = Scaled[DType.float32, 8, 2](base)
+    assert_almost_equal(s.sum()[0], 16.0, atol=1e-5)
+
+
+def test_scaled_f32_8_factor4() raises:
+    var base = SIMD[DType.float32, 8](1.0)
+    var s = Scaled[DType.float32, 8, 4](base)
+    assert_almost_equal(s.sum()[0], 32.0, atol=1e-5)
+
+
+def test_normed_scaled_f32_8_factor2_norm2() raises:
+    var base = SIMD[DType.float32, 8](1.0)
+    var ns = NormedScaled[DType.float32, 8, 2, 2](base)
+    assert_almost_equal(ns.value()[0], 8.0, atol=1e-5)
+
+
+def test_normed_scaled_f32_16_factor4_norm8() raises:
+    var base = SIMD[DType.float32, 16](1.0)
+    var ns = NormedScaled[DType.float32, 16, 4, 8](base)
+    assert_almost_equal(ns.value()[0], 8.0, atol=1e-5)
+
+
+def test_simd_sum_f64_4() raises:
+    var v = SIMD[DType.float64, 4](1.0, 2.0, 3.0, 4.0)
+    assert_almost_equal(simd_sum(v)[0], 10.0, atol=1e-10)
+
+
+def test_dot2_f64_8() raises:
+    var a = SIMD[DType.float64, 8](2.0)
+    var b = SIMD[DType.float64, 8](3.0)
+    assert_almost_equal(dot2(a, b)[0], 48.0, atol=1e-10)
+
+
+def test_simd_max_f64_8() raises:
+    var v = SIMD[DType.float64, 8](0.0, 5.0, -1.0, 3.0, 7.0, 2.0, -4.0, 1.0)
+    assert_almost_equal(simd_max(v)[0], 7.0, atol=1e-10)
+
+
+def test_simd_min_f64_8() raises:
+    var v = SIMD[DType.float64, 8](0.0, 5.0, -1.0, 3.0, 7.0, 2.0, -4.0, 1.0)
+    assert_almost_equal(simd_min(v)[0], -4.0, atol=1e-10)
+
+
+def test_all_blocks_positive() raises:
+    assert_true(Block0(1.0).compute() > 0.0)
+    assert_true(Block1(1.0).compute() > 0.0)
+    assert_true(Block2(1.0).compute() > 0.0)
+    assert_true(Block3(1.0).compute() > 0.0)
+    assert_true(Block4(1.0).compute() > 0.0)
+    assert_true(Block5(1.0).compute() > 0.0)
+    assert_true(Block6(1.0).compute() > 0.0)
+    assert_true(Block7(1.0).compute() > 0.0)
+    assert_true(Block8(1.0).compute() > 0.0)
+    assert_true(Block9(1.0).compute() > 0.0)
+    assert_true(Block10(1.0).compute() > 0.0)
+    assert_true(Block11(1.0).compute() > 0.0)
+    assert_true(Block12(1.0).compute() > 0.0)
+    assert_true(Block13(1.0).compute() > 0.0)
+    assert_true(Block14(1.0).compute() > 0.0)
+    assert_true(Block15(1.0).compute() > 0.0)
+
+
+def test_all_blocks_size_16() raises:
+    assert_equal(Block0(0.0).size(), 16)
+    assert_equal(Block1(0.0).size(), 16)
+    assert_equal(Block2(0.0).size(), 16)
+    assert_equal(Block3(0.0).size(), 16)
+    assert_equal(Block4(0.0).size(), 16)
+    assert_equal(Block5(0.0).size(), 16)
+    assert_equal(Block6(0.0).size(), 16)
+    assert_equal(Block7(0.0).size(), 16)
+    assert_equal(Block8(0.0).size(), 16)
+    assert_equal(Block9(0.0).size(), 16)
+    assert_equal(Block10(0.0).size(), 16)
+    assert_equal(Block11(0.0).size(), 16)
+    assert_equal(Block12(0.0).size(), 16)
+    assert_equal(Block13(0.0).size(), 16)
+    assert_equal(Block14(0.0).size(), 16)
+    assert_equal(Block15(0.0).size(), 16)
+
+
+def test_scaled_width4_all_factors() raises:
+    var base = SIMD[DType.float32, 4](1.0)
+    assert_almost_equal(Scaled[DType.float32, 4, 1](base).sum()[0], 4.0, atol=1e-5)
+    assert_almost_equal(Scaled[DType.float32, 4, 2](base).sum()[0], 8.0, atol=1e-5)
+    assert_almost_equal(Scaled[DType.float32, 4, 3](base).sum()[0], 12.0, atol=1e-5)
+    assert_almost_equal(Scaled[DType.float32, 4, 4](base).sum()[0], 16.0, atol=1e-5)
+    assert_almost_equal(Scaled[DType.float32, 4, 8](base).sum()[0], 32.0, atol=1e-5)
+
+
+def main():
+    print("repro_jit_fortify_crash: stress-testing JIT compiler...")
+    print("")
+
+    try:
+        test_block0()
+        test_block1()
+        test_block2()
+        test_block3()
+        test_block4()
+        test_block5()
+        test_block6()
+        test_block7()
+        test_block8()
+        test_block9()
+        test_block10()
+        test_block11()
+        test_block12()
+        test_block13()
+        test_block14()
+        test_block15()
+        print("  [PASS] Block struct tests (16 structs, 16 instantiations)")
+
+        test_simd_sum_f32_4()
+        test_simd_sum_f32_8()
+        test_simd_sum_f32_16()
+        test_simd_max_f32_4()
+        test_simd_min_f32_4()
+        test_dot2_f32_4()
+        test_simd_sum_f64_4()
+        test_dot2_f64_8()
+        test_simd_max_f64_8()
+        test_simd_min_f64_8()
+        print("  [PASS] SIMD generic function tests (f32+f64, width 4/8/16)")
+
+        test_scaled_f32_8_factor2()
+        test_scaled_f32_8_factor4()
+        test_scaled_width4_all_factors()
+        test_normed_scaled_f32_8_factor2_norm2()
+        test_normed_scaled_f32_16_factor4_norm8()
+        print("  [PASS] Parametric wrapper struct tests (Scaled + NormedScaled)")
+
+        test_all_blocks_positive()
+        test_all_blocks_size_16()
+        print("  [PASS] Cross-struct aggregate tests")
+
+        print("")
+        print("All tests passed — crash NOT reproduced locally (expected).")
+        print("See repro/issues/jit-fortify-buffer-overflow.md for CI-only context.")
+    except e:
+        print("FAILED:", e)
+        print("If this is 'error: execution crashed' with __fortify_fail_abort,")
+        print("the CI-only JIT buffer overflow has been reproduced locally.")

--- a/repro/repro_jit_heavy_import_test.mojo
+++ b/repro/repro_jit_heavy_import_test.mojo
@@ -1,0 +1,33 @@
+# Reproducer: JIT crash via package-level import volume (projectodyssey.core).
+#
+# ADR-015: This file was moved from tests/shared/core/test_jit_crash_heavy_import.mojo
+# to repro/ because its purpose IS to reproduce the crash, not to test production logic.
+# It MUST NOT be converted to targeted imports — keeping the package-level import is
+# the entire point.
+#
+# Background: `from projectodyssey.core import` forces the Mojo JIT to compile all 37K+ lines
+# across 60+ modules via __init__.mojo. Run 30+ times to observe intermittent
+# 'execution crashed' (libKGENCompilerRTShared.so+0x6d4ab/+0x6a686/+0x6e157).
+#
+# See docs/dev/mojo-jit-crash-workaround.md for root-cause analysis.
+# See repro/issues/jit-compilation-volume-crash.md for upstream issue template.
+#
+# To run: mojo repro/repro_jit_heavy_import_test.mojo
+# Expected (bug): error: execution crashed (before any output, intermittent)
+# Expected (fixed): prints "PASS"
+"""JIT crash reproduction: heavy import via projectodyssey.core (package-level)."""
+from projectodyssey.tensor.any_tensor import AnyTensor, zeros, ones, full, arange
+from projectodyssey.core import relu, sigmoid, matmul, softmax
+from std.testing import assert_true
+
+
+def test_basic_tensor_creation() raises:
+    var t = zeros([2, 3], DType.float32)
+    assert_true(t.shape()[0] == 2, "shape[0] should be 2")
+    assert_true(t.shape()[1] == 3, "shape[1] should be 3")
+
+
+def main() raises:
+    print("Running JIT crash heavy import test...")
+    test_basic_tensor_creation()
+    print("PASS")

--- a/repro/repro_jit_targeted_imports_crash.mojo
+++ b/repro/repro_jit_targeted_imports_crash.mojo
@@ -1,0 +1,74 @@
+# Reproducer for JIT crash with targeted submodule imports.
+#
+# Background: ADR-015 action #1 converted package-level imports to
+# targeted submodule imports to reduce JIT compilation volume. However,
+# crash pattern libKGENCompilerRTShared.so+0x6d4ab/+0x6a686/+0x6e157
+# is still observed intermittently on CI even after the conversion.
+#
+# This reproducer attempts to trigger the crash using only targeted imports
+# (no package-level from projectodyssey.core import / from projectodyssey import) to isolate
+# whether the crash is import-volume-triggered or something else.
+#
+# Environment: Ubuntu 24.04, GLIBC 2.39, Mojo 0.26.3 (dev2026040705)
+# Runner UID: 1001 (GitHub Actions standard runner)
+#
+# To run: mojo repro/repro_jit_targeted_imports_crash.mojo
+# Expected (bug): error: execution crashed (before any output)
+# Expected (fixed): prints test results normally
+
+from std.testing import assert_true
+from projectodyssey.tensor.any_tensor import AnyTensor, zeros, ones
+from projectodyssey.core.layers.linear import Linear
+from projectodyssey.core.layers.conv2d import Conv2dLayer
+from projectodyssey.core.layers.dropout import DropoutLayer
+from projectodyssey.core.layers.relu import ReLULayer
+from projectodyssey.core.activation import relu, sigmoid
+from projectodyssey.core.matrix import matmul
+from projectodyssey.core.shape import as_contiguous, reshape
+
+
+fn test_linear() raises:
+    print("test_linear: start")
+    var t = zeros([4, 8], DType.float32)
+    assert_true(t.shape()[0] == 4, "shape[0] should be 4")
+    print("test_linear: pass")
+
+
+fn test_conv2d() raises:
+    print("test_conv2d: start")
+    var t = zeros([1, 3, 8, 8], DType.float32)
+    assert_true(t.shape()[1] == 3, "channels should be 3")
+    print("test_conv2d: pass")
+
+
+fn test_dropout() raises:
+    print("test_dropout: start")
+    var t = ones([2, 4], DType.float32)
+    assert_true(t.shape()[0] == 2, "shape[0] should be 2")
+    print("test_dropout: pass")
+
+
+fn test_relu_activation() raises:
+    print("test_relu_activation: start")
+    var t = zeros([3, 3], DType.float32)
+    var out = relu(t)
+    assert_true(out.shape()[0] == 3, "relu output shape[0] should be 3")
+    print("test_relu_activation: pass")
+
+
+fn test_reshape() raises:
+    print("test_reshape: start")
+    var t = zeros([2, 6], DType.float32)
+    var r = reshape(t, [3, 4])
+    assert_true(r.shape()[0] == 3, "reshaped shape[0] should be 3")
+    print("test_reshape: pass")
+
+
+fn main() raises:
+    print("=== repro_jit_targeted_imports_crash: start ===")
+    test_linear()
+    test_conv2d()
+    test_dropout()
+    test_relu_activation()
+    test_reshape()
+    print("=== All reproducer tests passed ===")

--- a/repro/repro_jit_volume_crash.mojo
+++ b/repro/repro_jit_volume_crash.mojo
@@ -1,0 +1,768 @@
+"""Non-deterministic JIT compilation volume crash reproducer.
+
+NO external dependencies. Copy this single file to any Mojo 0.26.3 install.
+
+Environment: Mojo 0.26.3 (dev2026040705), GLIBC 2.39, Linux 6.6.87 x86_64
+
+Reproduces a non-deterministic crash in the Mojo JIT compiler when:
+1. A single file has 30+ functions
+2. Each function performs heavy alloc/free cycles (many UnsafePointer ops)
+3. Multiple imports from different stdlib modules are used
+
+The crash occurs BEFORE any output, indicating JIT compilation failure rather
+than a runtime failure. This differs from modular/modular#6187 which is a
+runtime use-after-free.
+
+This reproducer is non-deterministic — it may pass or crash depending on
+system load, memory fragmentation, and JIT compiler scheduling. Run multiple
+times to increase likelihood of triggering the crash.
+
+Stack trace pattern:
+  #0 libKGENCompilerRTShared.so  +0x... (varies with each crash)
+  #1 libKGENCompilerRTShared.so  +0x...
+  #2 libc.so.6                   +0x... (signal handler)
+"""
+
+from std.memory import alloc, UnsafePointer, memset_zero
+from std.collections import List
+
+
+# ============================================================================
+# Minimal floating-point array operations
+# ============================================================================
+
+
+struct FloatArray(Movable):
+    """Simple float array for heavy alloc/free cycles."""
+    var data: UnsafePointer[Float32, MutAnyOrigin]
+    var size: Int
+
+    def __init__(out self, size: Int) raises:
+        self.data = alloc[Float32](size)
+        self.size = size
+        for i in range(size):
+            self.data[i] = Float32(0.0)
+
+    def __init__(out self, *, deinit take: Self):
+        self.data = take.data
+        self.size = take.size
+
+    def __del__(deinit self):
+        self.data.free()
+
+    def fill(self, value: Float32):
+        for i in range(self.size):
+            self.data[i] = value
+
+    def sum(self) -> Float32:
+        var total = Float32(0.0)
+        for i in range(self.size):
+            total += self.data[i]
+        return total
+
+
+# ============================================================================
+# 30+ test functions with heavy alloc/free cycles
+# Each allocates 10-20 FloatArrays and performs operations
+# ============================================================================
+
+
+def step_01() raises:
+    """Allocate 15 float arrays of size 1024."""
+    var arr1 = FloatArray(1024)
+    var arr2 = FloatArray(1024)
+    var arr3 = FloatArray(1024)
+    var arr4 = FloatArray(1024)
+    var arr5 = FloatArray(1024)
+    var arr6 = FloatArray(1024)
+    var arr7 = FloatArray(1024)
+    var arr8 = FloatArray(1024)
+    var arr9 = FloatArray(1024)
+    var arr10 = FloatArray(1024)
+    var arr11 = FloatArray(1024)
+    var arr12 = FloatArray(1024)
+    var arr13 = FloatArray(1024)
+    var arr14 = FloatArray(1024)
+    var arr15 = FloatArray(1024)
+    arr1.fill(1.0)
+    _ = arr1.sum() + arr2.sum() + arr3.sum()
+
+
+def step_02() raises:
+    var arr1 = FloatArray(2048)
+    var arr2 = FloatArray(2048)
+    var arr3 = FloatArray(2048)
+    var arr4 = FloatArray(2048)
+    var arr5 = FloatArray(2048)
+    var arr6 = FloatArray(2048)
+    var arr7 = FloatArray(2048)
+    var arr8 = FloatArray(2048)
+    var arr9 = FloatArray(2048)
+    var arr10 = FloatArray(2048)
+    var arr11 = FloatArray(512)
+    var arr12 = FloatArray(512)
+    var arr13 = FloatArray(512)
+    var arr14 = FloatArray(512)
+    var arr15 = FloatArray(512)
+    arr1.fill(2.0)
+    _ = arr1.sum()
+
+
+def step_03() raises:
+    var arr1 = FloatArray(512)
+    var arr2 = FloatArray(512)
+    var arr3 = FloatArray(512)
+    var arr4 = FloatArray(512)
+    var arr5 = FloatArray(512)
+    var arr6 = FloatArray(512)
+    var arr7 = FloatArray(512)
+    var arr8 = FloatArray(512)
+    var arr9 = FloatArray(512)
+    var arr10 = FloatArray(512)
+    var arr11 = FloatArray(1024)
+    var arr12 = FloatArray(1024)
+    var arr13 = FloatArray(1024)
+    var arr14 = FloatArray(1024)
+    var arr15 = FloatArray(1024)
+    arr1.fill(3.0)
+    _ = arr2.sum() + arr3.sum()
+
+
+def step_04() raises:
+    var arr1 = FloatArray(256)
+    var arr2 = FloatArray(256)
+    var arr3 = FloatArray(256)
+    var arr4 = FloatArray(256)
+    var arr5 = FloatArray(256)
+    var arr6 = FloatArray(256)
+    var arr7 = FloatArray(256)
+    var arr8 = FloatArray(256)
+    var arr9 = FloatArray(256)
+    var arr10 = FloatArray(256)
+    var arr11 = FloatArray(4096)
+    var arr12 = FloatArray(4096)
+    var arr13 = FloatArray(4096)
+    var arr14 = FloatArray(4096)
+    var arr15 = FloatArray(4096)
+    _ = arr1.sum() + arr11.sum()
+
+
+def step_05() raises:
+    var arr1 = FloatArray(768)
+    var arr2 = FloatArray(768)
+    var arr3 = FloatArray(768)
+    var arr4 = FloatArray(768)
+    var arr5 = FloatArray(768)
+    var arr6 = FloatArray(768)
+    var arr7 = FloatArray(768)
+    var arr8 = FloatArray(768)
+    var arr9 = FloatArray(768)
+    var arr10 = FloatArray(768)
+    var arr11 = FloatArray(1536)
+    var arr12 = FloatArray(1536)
+    var arr13 = FloatArray(1536)
+    var arr14 = FloatArray(1536)
+    var arr15 = FloatArray(1536)
+    arr1.fill(5.0)
+    _ = arr15.sum()
+
+
+def step_06() raises:
+    var arr1 = FloatArray(1024)
+    var arr2 = FloatArray(1024)
+    var arr3 = FloatArray(1024)
+    var arr4 = FloatArray(1024)
+    var arr5 = FloatArray(1024)
+    var arr6 = FloatArray(1024)
+    var arr7 = FloatArray(1024)
+    var arr8 = FloatArray(1024)
+    var arr9 = FloatArray(1024)
+    var arr10 = FloatArray(1024)
+    var arr11 = FloatArray(2048)
+    var arr12 = FloatArray(2048)
+    var arr13 = FloatArray(2048)
+    var arr14 = FloatArray(2048)
+    var arr15 = FloatArray(2048)
+    _ = arr1.sum() + arr6.sum()
+
+
+def step_07() raises:
+    var arr1 = FloatArray(512)
+    var arr2 = FloatArray(512)
+    var arr3 = FloatArray(512)
+    var arr4 = FloatArray(512)
+    var arr5 = FloatArray(512)
+    var arr6 = FloatArray(512)
+    var arr7 = FloatArray(512)
+    var arr8 = FloatArray(512)
+    var arr9 = FloatArray(512)
+    var arr10 = FloatArray(512)
+    var arr11 = FloatArray(8192)
+    var arr12 = FloatArray(8192)
+    var arr13 = FloatArray(8192)
+    var arr14 = FloatArray(8192)
+    var arr15 = FloatArray(8192)
+    arr1.fill(7.0)
+    _ = arr10.sum()
+
+
+def step_08() raises:
+    var arr1 = FloatArray(256)
+    var arr2 = FloatArray(256)
+    var arr3 = FloatArray(256)
+    var arr4 = FloatArray(256)
+    var arr5 = FloatArray(256)
+    var arr6 = FloatArray(256)
+    var arr7 = FloatArray(256)
+    var arr8 = FloatArray(256)
+    var arr9 = FloatArray(256)
+    var arr10 = FloatArray(256)
+    var arr11 = FloatArray(4096)
+    var arr12 = FloatArray(4096)
+    var arr13 = FloatArray(4096)
+    var arr14 = FloatArray(4096)
+    var arr15 = FloatArray(4096)
+    _ = arr5.sum() + arr12.sum()
+
+
+def step_09() raises:
+    var arr1 = FloatArray(1024)
+    var arr2 = FloatArray(1024)
+    var arr3 = FloatArray(1024)
+    var arr4 = FloatArray(1024)
+    var arr5 = FloatArray(1024)
+    var arr6 = FloatArray(1024)
+    var arr7 = FloatArray(1024)
+    var arr8 = FloatArray(1024)
+    var arr9 = FloatArray(1024)
+    var arr10 = FloatArray(1024)
+    var arr11 = FloatArray(2048)
+    var arr12 = FloatArray(2048)
+    var arr13 = FloatArray(2048)
+    var arr14 = FloatArray(2048)
+    var arr15 = FloatArray(2048)
+    arr1.fill(9.0)
+    _ = arr1.sum() + arr14.sum()
+
+
+def step_10() raises:
+    var arr1 = FloatArray(512)
+    var arr2 = FloatArray(512)
+    var arr3 = FloatArray(512)
+    var arr4 = FloatArray(512)
+    var arr5 = FloatArray(512)
+    var arr6 = FloatArray(512)
+    var arr7 = FloatArray(512)
+    var arr8 = FloatArray(512)
+    var arr9 = FloatArray(512)
+    var arr10 = FloatArray(512)
+    var arr11 = FloatArray(768)
+    var arr12 = FloatArray(768)
+    var arr13 = FloatArray(768)
+    var arr14 = FloatArray(768)
+    var arr15 = FloatArray(768)
+    _ = arr1.sum() + arr10.sum() + arr15.sum()
+
+
+def step_11() raises:
+    var arr1 = FloatArray(2048)
+    var arr2 = FloatArray(2048)
+    var arr3 = FloatArray(2048)
+    var arr4 = FloatArray(2048)
+    var arr5 = FloatArray(2048)
+    var arr6 = FloatArray(2048)
+    var arr7 = FloatArray(2048)
+    var arr8 = FloatArray(2048)
+    var arr9 = FloatArray(2048)
+    var arr10 = FloatArray(2048)
+    var arr11 = FloatArray(1024)
+    var arr12 = FloatArray(1024)
+    var arr13 = FloatArray(1024)
+    var arr14 = FloatArray(1024)
+    var arr15 = FloatArray(1024)
+    arr1.fill(11.0)
+    _ = arr2.sum()
+
+
+def step_12() raises:
+    var arr1 = FloatArray(256)
+    var arr2 = FloatArray(256)
+    var arr3 = FloatArray(256)
+    var arr4 = FloatArray(256)
+    var arr5 = FloatArray(256)
+    var arr6 = FloatArray(256)
+    var arr7 = FloatArray(256)
+    var arr8 = FloatArray(256)
+    var arr9 = FloatArray(256)
+    var arr10 = FloatArray(256)
+    var arr11 = FloatArray(4096)
+    var arr12 = FloatArray(4096)
+    var arr13 = FloatArray(4096)
+    var arr14 = FloatArray(4096)
+    var arr15 = FloatArray(4096)
+    arr1.fill(12.0)
+    _ = arr8.sum() + arr14.sum()
+
+
+def step_13() raises:
+    var arr1 = FloatArray(1024)
+    var arr2 = FloatArray(1024)
+    var arr3 = FloatArray(1024)
+    var arr4 = FloatArray(1024)
+    var arr5 = FloatArray(1024)
+    var arr6 = FloatArray(1024)
+    var arr7 = FloatArray(1024)
+    var arr8 = FloatArray(1024)
+    var arr9 = FloatArray(1024)
+    var arr10 = FloatArray(1024)
+    var arr11 = FloatArray(3072)
+    var arr12 = FloatArray(3072)
+    var arr13 = FloatArray(3072)
+    var arr14 = FloatArray(3072)
+    var arr15 = FloatArray(3072)
+    _ = arr1.sum() + arr5.sum() + arr11.sum()
+
+
+def step_14() raises:
+    var arr1 = FloatArray(512)
+    var arr2 = FloatArray(512)
+    var arr3 = FloatArray(512)
+    var arr4 = FloatArray(512)
+    var arr5 = FloatArray(512)
+    var arr6 = FloatArray(512)
+    var arr7 = FloatArray(512)
+    var arr8 = FloatArray(512)
+    var arr9 = FloatArray(512)
+    var arr10 = FloatArray(512)
+    var arr11 = FloatArray(512)
+    var arr12 = FloatArray(512)
+    var arr13 = FloatArray(512)
+    var arr14 = FloatArray(512)
+    var arr15 = FloatArray(512)
+    arr1.fill(14.0)
+    _ = arr9.sum()
+
+
+def step_15() raises:
+    var arr1 = FloatArray(256)
+    var arr2 = FloatArray(256)
+    var arr3 = FloatArray(256)
+    var arr4 = FloatArray(256)
+    var arr5 = FloatArray(256)
+    var arr6 = FloatArray(256)
+    var arr7 = FloatArray(256)
+    var arr8 = FloatArray(256)
+    var arr9 = FloatArray(256)
+    var arr10 = FloatArray(256)
+    var arr11 = FloatArray(8192)
+    var arr12 = FloatArray(8192)
+    var arr13 = FloatArray(8192)
+    var arr14 = FloatArray(8192)
+    var arr15 = FloatArray(8192)
+    _ = arr10.sum() + arr11.sum()
+
+
+def step_16() raises:
+    var arr1 = FloatArray(1024)
+    var arr2 = FloatArray(1024)
+    var arr3 = FloatArray(1024)
+    var arr4 = FloatArray(1024)
+    var arr5 = FloatArray(1024)
+    var arr6 = FloatArray(1024)
+    var arr7 = FloatArray(1024)
+    var arr8 = FloatArray(1024)
+    var arr9 = FloatArray(1024)
+    var arr10 = FloatArray(1024)
+    var arr11 = FloatArray(512)
+    var arr12 = FloatArray(512)
+    var arr13 = FloatArray(512)
+    var arr14 = FloatArray(512)
+    var arr15 = FloatArray(512)
+    arr1.fill(16.0)
+    _ = arr3.sum() + arr15.sum()
+
+
+def step_17() raises:
+    var arr1 = FloatArray(2048)
+    var arr2 = FloatArray(2048)
+    var arr3 = FloatArray(2048)
+    var arr4 = FloatArray(2048)
+    var arr5 = FloatArray(2048)
+    var arr6 = FloatArray(2048)
+    var arr7 = FloatArray(2048)
+    var arr8 = FloatArray(2048)
+    var arr9 = FloatArray(2048)
+    var arr10 = FloatArray(2048)
+    var arr11 = FloatArray(1536)
+    var arr12 = FloatArray(1536)
+    var arr13 = FloatArray(1536)
+    var arr14 = FloatArray(1536)
+    var arr15 = FloatArray(1536)
+    _ = arr1.sum() + arr7.sum() + arr13.sum()
+
+
+def step_18() raises:
+    var arr1 = FloatArray(512)
+    var arr2 = FloatArray(512)
+    var arr3 = FloatArray(512)
+    var arr4 = FloatArray(512)
+    var arr5 = FloatArray(512)
+    var arr6 = FloatArray(512)
+    var arr7 = FloatArray(512)
+    var arr8 = FloatArray(512)
+    var arr9 = FloatArray(512)
+    var arr10 = FloatArray(512)
+    var arr11 = FloatArray(4096)
+    var arr12 = FloatArray(4096)
+    var arr13 = FloatArray(4096)
+    var arr14 = FloatArray(4096)
+    var arr15 = FloatArray(4096)
+    arr1.fill(18.0)
+    _ = arr4.sum() + arr12.sum()
+
+
+def step_19() raises:
+    var arr1 = FloatArray(1024)
+    var arr2 = FloatArray(1024)
+    var arr3 = FloatArray(1024)
+    var arr4 = FloatArray(1024)
+    var arr5 = FloatArray(1024)
+    var arr6 = FloatArray(1024)
+    var arr7 = FloatArray(1024)
+    var arr8 = FloatArray(1024)
+    var arr9 = FloatArray(1024)
+    var arr10 = FloatArray(1024)
+    var arr11 = FloatArray(768)
+    var arr12 = FloatArray(768)
+    var arr13 = FloatArray(768)
+    var arr14 = FloatArray(768)
+    var arr15 = FloatArray(768)
+    _ = arr2.sum() + arr8.sum() + arr14.sum()
+
+
+def step_20() raises:
+    var arr1 = FloatArray(256)
+    var arr2 = FloatArray(256)
+    var arr3 = FloatArray(256)
+    var arr4 = FloatArray(256)
+    var arr5 = FloatArray(256)
+    var arr6 = FloatArray(256)
+    var arr7 = FloatArray(256)
+    var arr8 = FloatArray(256)
+    var arr9 = FloatArray(256)
+    var arr10 = FloatArray(256)
+    var arr11 = FloatArray(2048)
+    var arr12 = FloatArray(2048)
+    var arr13 = FloatArray(2048)
+    var arr14 = FloatArray(2048)
+    var arr15 = FloatArray(2048)
+    arr1.fill(20.0)
+    _ = arr6.sum() + arr11.sum()
+
+
+def step_21() raises:
+    var arr1 = FloatArray(1024)
+    var arr2 = FloatArray(1024)
+    var arr3 = FloatArray(1024)
+    var arr4 = FloatArray(1024)
+    var arr5 = FloatArray(1024)
+    var arr6 = FloatArray(1024)
+    var arr7 = FloatArray(1024)
+    var arr8 = FloatArray(1024)
+    var arr9 = FloatArray(1024)
+    var arr10 = FloatArray(1024)
+    var arr11 = FloatArray(3072)
+    var arr12 = FloatArray(3072)
+    var arr13 = FloatArray(3072)
+    var arr14 = FloatArray(3072)
+    var arr15 = FloatArray(3072)
+    _ = arr1.sum() + arr9.sum()
+
+
+def step_22() raises:
+    var arr1 = FloatArray(512)
+    var arr2 = FloatArray(512)
+    var arr3 = FloatArray(512)
+    var arr4 = FloatArray(512)
+    var arr5 = FloatArray(512)
+    var arr6 = FloatArray(512)
+    var arr7 = FloatArray(512)
+    var arr8 = FloatArray(512)
+    var arr9 = FloatArray(512)
+    var arr10 = FloatArray(512)
+    var arr11 = FloatArray(1024)
+    var arr12 = FloatArray(1024)
+    var arr13 = FloatArray(1024)
+    var arr14 = FloatArray(1024)
+    var arr15 = FloatArray(1024)
+    arr1.fill(22.0)
+    _ = arr7.sum() + arr15.sum()
+
+
+def step_23() raises:
+    var arr1 = FloatArray(2048)
+    var arr2 = FloatArray(2048)
+    var arr3 = FloatArray(2048)
+    var arr4 = FloatArray(2048)
+    var arr5 = FloatArray(2048)
+    var arr6 = FloatArray(2048)
+    var arr7 = FloatArray(2048)
+    var arr8 = FloatArray(2048)
+    var arr9 = FloatArray(2048)
+    var arr10 = FloatArray(2048)
+    var arr11 = FloatArray(512)
+    var arr12 = FloatArray(512)
+    var arr13 = FloatArray(512)
+    var arr14 = FloatArray(512)
+    var arr15 = FloatArray(512)
+    _ = arr1.sum() + arr10.sum() + arr15.sum()
+
+
+def step_24() raises:
+    var arr1 = FloatArray(256)
+    var arr2 = FloatArray(256)
+    var arr3 = FloatArray(256)
+    var arr4 = FloatArray(256)
+    var arr5 = FloatArray(256)
+    var arr6 = FloatArray(256)
+    var arr7 = FloatArray(256)
+    var arr8 = FloatArray(256)
+    var arr9 = FloatArray(256)
+    var arr10 = FloatArray(256)
+    var arr11 = FloatArray(8192)
+    var arr12 = FloatArray(8192)
+    var arr13 = FloatArray(8192)
+    var arr14 = FloatArray(8192)
+    var arr15 = FloatArray(8192)
+    arr1.fill(24.0)
+    _ = arr11.sum() + arr13.sum()
+
+
+def step_25() raises:
+    var arr1 = FloatArray(1024)
+    var arr2 = FloatArray(1024)
+    var arr3 = FloatArray(1024)
+    var arr4 = FloatArray(1024)
+    var arr5 = FloatArray(1024)
+    var arr6 = FloatArray(1024)
+    var arr7 = FloatArray(1024)
+    var arr8 = FloatArray(1024)
+    var arr9 = FloatArray(1024)
+    var arr10 = FloatArray(1024)
+    var arr11 = FloatArray(1536)
+    var arr12 = FloatArray(1536)
+    var arr13 = FloatArray(1536)
+    var arr14 = FloatArray(1536)
+    var arr15 = FloatArray(1536)
+    _ = arr1.sum() + arr12.sum()
+
+
+def step_26() raises:
+    var arr1 = FloatArray(512)
+    var arr2 = FloatArray(512)
+    var arr3 = FloatArray(512)
+    var arr4 = FloatArray(512)
+    var arr5 = FloatArray(512)
+    var arr6 = FloatArray(512)
+    var arr7 = FloatArray(512)
+    var arr8 = FloatArray(512)
+    var arr9 = FloatArray(512)
+    var arr10 = FloatArray(512)
+    var arr11 = FloatArray(2048)
+    var arr12 = FloatArray(2048)
+    var arr13 = FloatArray(2048)
+    var arr14 = FloatArray(2048)
+    var arr15 = FloatArray(2048)
+    arr1.fill(26.0)
+    _ = arr3.sum() + arr14.sum()
+
+
+def step_27() raises:
+    var arr1 = FloatArray(2048)
+    var arr2 = FloatArray(2048)
+    var arr3 = FloatArray(2048)
+    var arr4 = FloatArray(2048)
+    var arr5 = FloatArray(2048)
+    var arr6 = FloatArray(2048)
+    var arr7 = FloatArray(2048)
+    var arr8 = FloatArray(2048)
+    var arr9 = FloatArray(2048)
+    var arr10 = FloatArray(2048)
+    var arr11 = FloatArray(4096)
+    var arr12 = FloatArray(4096)
+    var arr13 = FloatArray(4096)
+    var arr14 = FloatArray(4096)
+    var arr15 = FloatArray(4096)
+    _ = arr1.sum() + arr11.sum()
+
+
+def step_28() raises:
+    var arr1 = FloatArray(256)
+    var arr2 = FloatArray(256)
+    var arr3 = FloatArray(256)
+    var arr4 = FloatArray(256)
+    var arr5 = FloatArray(256)
+    var arr6 = FloatArray(256)
+    var arr7 = FloatArray(256)
+    var arr8 = FloatArray(256)
+    var arr9 = FloatArray(256)
+    var arr10 = FloatArray(256)
+    var arr11 = FloatArray(512)
+    var arr12 = FloatArray(512)
+    var arr13 = FloatArray(512)
+    var arr14 = FloatArray(512)
+    var arr15 = FloatArray(512)
+    arr1.fill(28.0)
+    _ = arr9.sum() + arr15.sum()
+
+
+def step_29() raises:
+    var arr1 = FloatArray(1024)
+    var arr2 = FloatArray(1024)
+    var arr3 = FloatArray(1024)
+    var arr4 = FloatArray(1024)
+    var arr5 = FloatArray(1024)
+    var arr6 = FloatArray(1024)
+    var arr7 = FloatArray(1024)
+    var arr8 = FloatArray(1024)
+    var arr9 = FloatArray(1024)
+    var arr10 = FloatArray(1024)
+    var arr11 = FloatArray(2048)
+    var arr12 = FloatArray(2048)
+    var arr13 = FloatArray(2048)
+    var arr14 = FloatArray(2048)
+    var arr15 = FloatArray(2048)
+    _ = arr1.sum() + arr15.sum()
+
+
+def step_30() raises:
+    var arr1 = FloatArray(512)
+    var arr2 = FloatArray(512)
+    var arr3 = FloatArray(512)
+    var arr4 = FloatArray(512)
+    var arr5 = FloatArray(512)
+    var arr6 = FloatArray(512)
+    var arr7 = FloatArray(512)
+    var arr8 = FloatArray(512)
+    var arr9 = FloatArray(512)
+    var arr10 = FloatArray(512)
+    var arr11 = FloatArray(768)
+    var arr12 = FloatArray(768)
+    var arr13 = FloatArray(768)
+    var arr14 = FloatArray(768)
+    var arr15 = FloatArray(768)
+    arr1.fill(30.0)
+    _ = arr1.sum() + arr10.sum() + arr15.sum()
+
+
+def step_31() raises:
+    var arr1 = FloatArray(256)
+    var arr2 = FloatArray(256)
+    var arr3 = FloatArray(256)
+    var arr4 = FloatArray(256)
+    var arr5 = FloatArray(256)
+    var arr6 = FloatArray(256)
+    var arr7 = FloatArray(256)
+    var arr8 = FloatArray(256)
+    var arr9 = FloatArray(256)
+    var arr10 = FloatArray(256)
+    var arr11 = FloatArray(4096)
+    var arr12 = FloatArray(4096)
+    var arr13 = FloatArray(4096)
+    var arr14 = FloatArray(4096)
+    var arr15 = FloatArray(4096)
+    _ = arr5.sum() + arr11.sum() + arr15.sum()
+
+
+def step_32() raises:
+    var arr1 = FloatArray(1024)
+    var arr2 = FloatArray(1024)
+    var arr3 = FloatArray(1024)
+    var arr4 = FloatArray(1024)
+    var arr5 = FloatArray(1024)
+    var arr6 = FloatArray(1024)
+    var arr7 = FloatArray(1024)
+    var arr8 = FloatArray(1024)
+    var arr9 = FloatArray(1024)
+    var arr10 = FloatArray(1024)
+    var arr11 = FloatArray(3072)
+    var arr12 = FloatArray(3072)
+    var arr13 = FloatArray(3072)
+    var arr14 = FloatArray(3072)
+    var arr15 = FloatArray(3072)
+    arr1.fill(32.0)
+    _ = arr10.sum() + arr13.sum()
+
+
+# ============================================================================
+# Main: Call all 32 steps sequentially
+# ============================================================================
+
+
+def main() raises:
+    """Run all 32 test steps. May crash during JIT compilation (non-deterministic)."""
+    print("Running JIT volume crash reproducer (32 heavy alloc/free steps)...", end="")
+    step_01()
+    print(".", end="")
+    step_02()
+    print(".", end="")
+    step_03()
+    print(".", end="")
+    step_04()
+    print(".", end="")
+    step_05()
+    print(".", end="")
+    step_06()
+    print(".", end="")
+    step_07()
+    print(".", end="")
+    step_08()
+    print(".", end="")
+    step_09()
+    print(".", end="")
+    step_10()
+    print(".", end="")
+    step_11()
+    print(".", end="")
+    step_12()
+    print(".", end="")
+    step_13()
+    print(".", end="")
+    step_14()
+    print(".", end="")
+    step_15()
+    print(".", end="")
+    step_16()
+    print(".", end="")
+    step_17()
+    print(".", end="")
+    step_18()
+    print(".", end="")
+    step_19()
+    print(".", end="")
+    step_20()
+    print(".", end="")
+    step_21()
+    print(".", end="")
+    step_22()
+    print(".", end="")
+    step_23()
+    print(".", end="")
+    step_24()
+    print(".", end="")
+    step_25()
+    print(".", end="")
+    step_26()
+    print(".", end="")
+    step_27()
+    print(".", end="")
+    step_28()
+    print(".", end="")
+    step_29()
+    print(".", end="")
+    step_30()
+    print(".", end="")
+    step_31()
+    print(".", end="")
+    step_32()
+    print(" OK — no crash")

--- a/repro/repro_libasyncrt_crash.mojo
+++ b/repro/repro_libasyncrt_crash.mojo
@@ -1,0 +1,159 @@
+"""Mojo v0.26.1 runtime crash: heap corruption via cumulative conv2d operations.
+
+Environment: Mojo 0.26.1 (156d3ac6), GLIBC 2.39, Linux 6.6.87 x86_64 (WSL2)
+
+This is a variant of the heap corruption crash that demonstrates the bug
+through cumulative tensor operations rather than bitcast writes.
+
+In this variant, the VGG16-style forward pass (13 conv layers + 3 FC layers)
+is called multiple times in separate functions. After ~3 function-scoped
+forward passes, the allocator state becomes corrupted and the next forward
+pass that also creates additional small tensors (like training targets)
+triggers a crash.
+
+This is the SAME underlying bug as repro_libkgen_crash.mojo — heap
+corruption in the Mojo runtime allocator — but exposed through a more
+realistic deep learning workflow: repeated forward passes in a training loop.
+
+Key observations:
+- Forward pass alone can be called 20+ times in a loop without crashing
+- Crash requires function-scoped calls (tensor destructor ordering matters)
+- Crash requires creating a small tensor with bitcast write between forward passes
+- Same stack trace as repro_libkgen_crash.mojo (same root cause)
+
+Stack trace (constant across runs):
+  #0 libKGENCompilerRTShared.so +0x3cb78b  (crash handler)
+  #1 libKGENCompilerRTShared.so +0x3c93c6  (crash handler)
+  #2 libKGENCompilerRTShared.so +0x3cc397  (crash handler)
+  #3 libc.so.6                  +0x45330   (sigaction)
+  #4 libAsyncRTRuntimeGlobals.so +0x416ba  (allocator — crash origin)
+"""
+
+from projectodyssey.tensor.any_tensor import AnyTensor, zeros, ones
+from projectodyssey.core.conv import conv2d
+from projectodyssey.core.linear import linear
+from projectodyssey.core.activation import relu
+from projectodyssey.core.pooling import maxpool2d
+
+
+def conv_block(
+    input_tensor: AnyTensor,
+    out_channels: Int,
+    num_convs: Int,
+) raises -> AnyTensor:
+    """VGG-style conv block: N sequential conv+relu layers."""
+    var in_channels = input_tensor.shape()[1]
+    var result = input_tensor
+    for _ in range(num_convs):
+        var ks = List[Int]()
+        ks.append(out_channels)
+        ks.append(in_channels)
+        ks.append(3)
+        ks.append(3)
+        var kernel = ones(ks, DType.float32)
+        var bs = List[Int]()
+        bs.append(out_channels)
+        var bias = zeros(bs, DType.float32)
+        result = conv2d(result, kernel, bias, 1, 1)
+        result = relu(result)
+        in_channels = out_channels
+    return result
+
+
+def vgg16_forward(input_tensor: AnyTensor) raises -> AnyTensor:
+    """Full VGG-16 forward pass: 13 conv layers + 3 FC layers."""
+    var x = input_tensor
+    x = conv_block(x, 64, 2)
+    x = maxpool2d(x, 2, 2)
+    x = conv_block(x, 128, 2)
+    x = maxpool2d(x, 2, 2)
+    x = conv_block(x, 256, 3)
+    x = maxpool2d(x, 2, 2)
+    x = conv_block(x, 512, 3)
+    x = maxpool2d(x, 2, 2)
+    x = conv_block(x, 512, 3)
+    x = maxpool2d(x, 2, 2)
+
+    var batch_size = x.shape()[0]
+    var fs = List[Int]()
+    fs.append(batch_size)
+    fs.append(512)
+    var x_flat = x.reshape(fs)
+
+    # FC layers
+    var w1 = List[Int]()
+    w1.append(256)
+    w1.append(512)
+    var b1 = List[Int]()
+    b1.append(256)
+    x = linear(x_flat, ones(w1, DType.float32), zeros(b1, DType.float32))
+    x = relu(x)
+    var w2 = List[Int]()
+    w2.append(256)
+    w2.append(256)
+    x = linear(x, ones(w2, DType.float32), zeros(b1, DType.float32))
+    x = relu(x)
+    var w3 = List[Int]()
+    w3.append(10)
+    w3.append(256)
+    var b3 = List[Int]()
+    b3.append(10)
+    x = linear(x, ones(w3, DType.float32), zeros(b3, DType.float32))
+    return x
+
+
+def make_input(batch_size: Int) raises -> AnyTensor:
+    var s = List[Int]()
+    s.append(batch_size)
+    s.append(3)
+    s.append(32)
+    s.append(32)
+    return ones(s, DType.float32)
+
+
+def test_inference(batch_size: Int) raises:
+    """Inference test: forward pass + shape check."""
+    var output = vgg16_forward(make_input(batch_size))
+    var s = output.shape()
+    if s[0] != batch_size or s[1] != 10:
+        raise "bad shape"
+
+
+def test_training_step() raises:
+    """Training step: create targets with bitcast, then forward pass.
+
+    This function triggers the crash because it:
+    1. Creates a small target tensor
+    2. Writes to it via bitcast (corrupts heap metadata)
+    3. Calls vgg16_forward which does a large allocation -> CRASH
+    """
+    var input = make_input(2)
+
+    # Create training targets with bitcast write
+    var ts = List[Int]()
+    ts.append(2)
+    var target = zeros(ts, DType.float32)
+    var td = target._data.bitcast[Float32]()
+    td[0] = 0.0  # Class 0
+    td[1] = 1.0  # Class 1
+
+    # Forward pass -> crashes here
+    var logits = vgg16_forward(input)
+    if logits.shape()[0] != 2 or logits.shape()[1] != 10:
+        raise "bad shape"
+
+
+def main() raises:
+    # These inference tests pass fine
+    print("Inference batch=4...", end="")
+    test_inference(4)
+    print(" OK")
+
+    print("Inference batch=2...", end="")
+    test_inference(2)
+    print(" OK")
+
+    # This training step crashes
+    print("Training step...", end="")
+    test_training_step()
+    print(" OK — no crash (bug may be environment-dependent)")

--- a/repro/repro_libkgen_crash.mojo
+++ b/repro/repro_libkgen_crash.mojo
@@ -1,0 +1,128 @@
+"""Mojo v0.26.1 runtime crash: heap corruption after tensor alloc/free churn.
+
+Environment: Mojo 0.26.1 (156d3ac6), GLIBC 2.39, Linux 6.6.87 x86_64 (WSL2)
+
+This reproduces a deterministic crash in libKGENCompilerRTShared.so /
+libAsyncRTRuntimeGlobals.so triggered by the following sequence:
+
+1. step_a(): Run conv2d operations that allocate and free many intermediate
+   tensors (~20+ alloc/free cycles). When the function returns, all local
+   AnyTensor objects are destroyed, freeing their backing memory.
+
+2. step_b(): Create a small tensor, obtain a bitcast pointer to its data,
+   write through that pointer, then run another conv2d operation.
+   The conv2d crashes during internal allocation.
+
+Key observations:
+- Crash is 100% deterministic (same stack offsets every run)
+- Removing the bitcast write in step_b prevents the crash
+- Creating the small tensor WITHOUT writing through bitcast does NOT crash
+- Running the same sequence inline in main() (not via function calls)
+  does NOT crash — function-scope destruction is part of the trigger
+- Fewer conv2d ops (smaller tensors, e.g. 8x8) do NOT crash
+- The crash occurs in the allocator (libAsyncRTRuntimeGlobals.so +0x416ba)
+  during a subsequent allocation after the bitcast write
+
+This suggests the heavy alloc/free churn in step_a() corrupts heap metadata,
+and the bitcast write to a small tensor hits the corrupted region, causing
+the next large allocation to crash.
+
+Stack trace (constant across runs):
+  #0 libKGENCompilerRTShared.so +0x3cb78b  (crash handler)
+  #1 libKGENCompilerRTShared.so +0x3c93c6  (crash handler)
+  #2 libKGENCompilerRTShared.so +0x3cc397  (crash handler)
+  #3 libc.so.6                  +0x45330   (sigaction)
+  #4 libAsyncRTRuntimeGlobals.so +0x416ba  (allocator — crash origin)
+
+NOTE: This reproducer requires ProjectOdyssey's projectodyssey.core library (AnyTensor,
+conv2d, relu). The crash is in the Mojo runtime allocator, not in our library
+code. A fully self-contained reproducer would require reimplementing conv2d
+(~200 lines) which defeats the purpose of minimality.
+"""
+
+from projectodyssey.tensor.any_tensor import AnyTensor, zeros, ones
+from projectodyssey.core.conv import conv2d
+from projectodyssey.core.activation import relu
+
+
+def step_a() raises:
+    """Heavy tensor alloc/free churn via conv2d.
+
+    Two conv2d+relu operations create many intermediate tensors.
+    All are freed when this function returns (AnyTensor destructor
+    decrements refcount, frees when refcount reaches 0).
+    """
+    # Input: (batch=2, channels=3, height=32, width=32)
+    var is_ = List[Int]()
+    is_.append(2)
+    is_.append(3)
+    is_.append(32)
+    is_.append(32)
+    var x = ones(is_, DType.float32)
+
+    # Kernel: (out_ch=16, in_ch=3, kH=3, kW=3)
+    var ks = List[Int]()
+    ks.append(16)
+    ks.append(3)
+    ks.append(3)
+    ks.append(3)
+    var bs = List[Int]()
+    bs.append(16)
+
+    # Conv 1: 3 -> 16 channels
+    x = conv2d(x, ones(ks, DType.float32), zeros(bs, DType.float32), 1, 1)
+    x = relu(x)
+
+    # Conv 2: 16 -> 16 channels
+    var ks2 = List[Int]()
+    ks2.append(16)
+    ks2.append(16)
+    ks2.append(3)
+    ks2.append(3)
+    x = conv2d(x, ones(ks2, DType.float32), zeros(bs, DType.float32), 1, 1)
+    _ = relu(x)
+    # ~20+ tensors freed here
+
+
+def step_b() raises:
+    """Bitcast write on small tensor, then conv2d -> CRASH.
+
+    The bitcast write is the trigger. Commenting out the 3 lines marked
+    TRIGGER below prevents the crash.
+    """
+    # Small 2-element tensor
+    var ts = List[Int]()
+    ts.append(2)
+    var target = zeros(ts, DType.float32)
+
+    # === TRIGGER: comment out these 3 lines to prevent crash ===
+    var td = target._data.bitcast[Float32]()
+    td[0] = 0.0
+    td[1] = 1.0
+    # === END TRIGGER ===
+
+    # This conv2d crashes during internal allocation
+    var is_ = List[Int]()
+    is_.append(2)
+    is_.append(3)
+    is_.append(32)
+    is_.append(32)
+    var x = ones(is_, DType.float32)
+    var ks = List[Int]()
+    ks.append(16)
+    ks.append(3)
+    ks.append(3)
+    ks.append(3)
+    var bs = List[Int]()
+    bs.append(16)
+    x = conv2d(x, ones(ks, DType.float32), zeros(bs, DType.float32), 1, 1)
+    _ = relu(x)
+
+
+def main() raises:
+    print("Step A: conv2d heap churn...", end="")
+    step_a()
+    print(" OK")
+    print("Step B: bitcast write + conv2d...", end="")
+    step_b()
+    print(" OK — no crash (bug may be environment-dependent)")

--- a/repro/repro_module_import_crash.mojo
+++ b/repro/repro_module_import_crash.mojo
@@ -1,0 +1,70 @@
+"""Deterministic JIT crash via module-level import chain explosion.
+
+Environment: Mojo 0.26.3 (dev2026040705), GLIBC 2.39, Linux 6.6.87 x86_64
+
+CRASH MECHANISM (DETERMINISTIC):
+  When a test file imports a library module, Mojo compiles ALL module-level
+  imports of that module at parse time. If the transitive import chain
+  exceeds the JIT compiler's internal buffer, libKGENCompilerRTShared.so
+  crashes before any test output is produced.
+
+  This is DISTINCT from Category 2 (non-deterministic volume crash):
+  - Category 2: Non-deterministic, depends on system load / memory fragmentation
+  - THIS BUG: Deterministic, triggered by specific import depth, crashes
+    EVERY TIME the same import chain is compiled.
+
+CRASH PATTERN:
+  $ mojo test repro_module_import_crash.mojo
+  Running: repro_module_import_crash.mojo...
+  [crash — no test output]
+
+  Stack trace:
+    #0 libKGENCompilerRTShared.so+0x6d4ab
+    #1 libKGENCompilerRTShared.so+0x6a686
+    #2 libKGENCompilerRTShared.so+0x6e157
+    #3 libc.so.6 (sigaction / signal handler)
+
+IMPORT CHAIN THAT TRIGGERS CRASH:
+  test_file.mojo
+    → src/projectodyssey/core/loss_utils.mojo        (module-level)
+      → src/projectodyssey/core/elementwise.mojo     (module-level, 1650 lines)
+        → src/projectodyssey/core/dtype_dispatch.mojo (module-level, 1520 lines, 176+ mono)
+
+  OR:
+  test_file.mojo
+    → src/projectodyssey/core/reduction.mojo         (module-level)
+      → src/projectodyssey/core/shape.mojo           (module-level, 1371 lines)
+
+FIX: See repro_module_import_crash_fixed.mojo — move heavy imports
+  from module level into the function bodies that use them.
+"""
+
+# This import chain triggers the crash:
+#   loss_utils → elementwise (1650 lines) → dtype_dispatch (1520 lines)
+from projectodyssey.core.loss_utils import clip_predictions
+from projectodyssey.core.reduction import sum as reduce_sum
+
+
+def test_clip_is_bounded() raises:
+    from projectodyssey.tensor.any_tensor import AnyTensor, zeros, ones
+    var shape = List[Int]()
+    shape.append(4)
+    var t = ones(shape, DType.float32)
+    var clipped = clip_predictions(t)
+    print("test_clip_is_bounded: PASS")
+
+
+def test_reduce_sum_basic() raises:
+    from projectodyssey.tensor.any_tensor import AnyTensor, zeros, ones
+    var shape = List[Int]()
+    shape.append(3)
+    var t = ones(shape, DType.float32)
+    var result = reduce_sum(t)
+    print("test_reduce_sum_basic: PASS")
+
+
+def main() raises:
+    # Expected: crash before reaching here due to module-level import chain
+    # If we reach here, the JIT buffer happened not to overflow this run
+    test_clip_is_bounded()
+    test_reduce_sum_basic()

--- a/repro/repro_module_import_crash_fixed.mojo
+++ b/repro/repro_module_import_crash_fixed.mojo
@@ -1,0 +1,59 @@
+"""Fixed version: per-function imports eliminate module-level compilation chain.
+
+Same tests as repro_module_import_crash.mojo but imports moved into function
+bodies. This compiles reliably because heavy modules (elementwise, dtype_dispatch,
+shape) are not compiled at module load time — only when the calling function
+is actually invoked.
+
+RESULT: Passes 100% of the time.
+
+FIX PATTERN:
+  BEFORE (module level — compiled for all importers at parse time):
+    from projectodyssey.core.loss_utils import clip_predictions
+
+  AFTER (per-function — compiled lazily only when function executes):
+    def my_test():
+        from projectodyssey.core.loss_utils import clip_predictions
+        ...
+
+WHY THIS WORKS:
+  Mojo compiles module-level imports eagerly and transitively. Per-function
+  imports are compiled only when the function's code is reached at runtime.
+  Moving a heavy import from module level to the first line of the function
+  that uses it eliminates the transitive compilation chain from the module's
+  compilation unit.
+
+NOTE: This workaround is valid for test files. Library modules should also
+  move heavy imports into the specific functions that use them (see
+  src/projectodyssey/core/reduction.mojo, conv.mojo, loss_utils.mojo for examples).
+"""
+
+
+def test_clip_is_bounded() raises:
+    # Import moved here — NOT at module level
+    from projectodyssey.core.loss_utils import clip_predictions
+    from projectodyssey.tensor.any_tensor import ones
+
+    var shape = List[Int]()
+    shape.append(4)
+    var t = ones(shape, DType.float32)
+    var clipped = clip_predictions(t)
+    print("test_clip_is_bounded: PASS")
+
+
+def test_reduce_sum_basic() raises:
+    # Import moved here — NOT at module level
+    from projectodyssey.core.reduction import sum as reduce_sum
+    from projectodyssey.tensor.any_tensor import ones
+
+    var shape = List[Int]()
+    shape.append(3)
+    var t = ones(shape, DType.float32)
+    var result = reduce_sum(t)
+    print("test_reduce_sum_basic: PASS")
+
+
+def main() raises:
+    # Reaches here reliably — no module-level import chain to overflow JIT
+    test_clip_is_bounded()
+    test_reduce_sum_basic()

--- a/repro/repro_parametric_monomorphization_crash.mojo
+++ b/repro/repro_parametric_monomorphization_crash.mojo
@@ -1,0 +1,340 @@
+"""Deterministic JIT crash via parametric monomorphization explosion.
+
+NO external dependencies. Copy this single file to any Mojo 0.26.3 install.
+
+Environment: Mojo 0.26.3 (dev2026040705), GLIBC 2.39, Linux 6.6.87 x86_64
+
+ROOT CAUSE HYPOTHESIS:
+  The crash is NOT caused by line count alone. It is caused by parametric
+  functions (generics) that generate many monomorphizations at compile time.
+
+  In ProjectOdyssey, dtype_dispatch.mojo has:
+  - ~130 parametric functions
+  - Each instantiated for 12+ DType variants
+  - = 1500+ monomorphized instances compiled when the module is imported
+
+  A module-level import of dtype_dispatch.mojo forces ALL of these
+  monomorphizations to be compiled when ANY file importing elementwise.mojo
+  (which imports dtype_dispatch.mojo at module level) is compiled.
+
+THIS REPRODUCER:
+  Creates a similar pattern using Mojo's built-in DType parameter.
+  Each fn[dtype: DType] generates one monomorphization per DType value.
+  With 12 DType values and 130 functions, we get ~1560 monomorphizations.
+
+EXPECTED BEHAVIOR:
+  The crash should occur BEFORE any test output if the monomorphization
+  count exceeds the JIT compiler's internal compilation unit buffer.
+  If main() is reached, the bug did not trigger on this run.
+
+COMPARISON: See repro_parametric_monomorphization_fixed.mojo which moves
+  the module-level import into function bodies — eliminating the crash.
+"""
+
+from std.memory import UnsafePointer
+
+# ============================================================================
+# Parametric helper — generates one monomorphization per DType call site
+# ============================================================================
+
+fn typed_fill[dtype: DType](ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin], size: Int, value: Scalar[dtype]):
+    for i in range(size):
+        ptr[i] = value
+
+fn typed_sum[dtype: DType](ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin], size: Int) -> Scalar[dtype]:
+    var total = Scalar[dtype](0)
+    for i in range(size):
+        total += ptr[i]
+    return total
+
+fn typed_scale[dtype: DType](ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin], size: Int, scale: Scalar[dtype]):
+    for i in range(size):
+        ptr[i] *= scale
+
+fn typed_add[dtype: DType](
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    b: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    out: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    size: Int
+):
+    for i in range(size):
+        out[i] = a[i] + b[i]
+
+fn typed_sub[dtype: DType](
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    b: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    out: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    size: Int
+):
+    for i in range(size):
+        out[i] = a[i] - b[i]
+
+fn typed_mul[dtype: DType](
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    b: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    out: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    size: Int
+):
+    for i in range(size):
+        out[i] = a[i] * b[i]
+
+fn typed_max[dtype: DType](ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin], size: Int) -> Scalar[dtype]:
+    var result = ptr[0]
+    for i in range(1, size):
+        if ptr[i] > result:
+            result = ptr[i]
+    return result
+
+fn typed_min[dtype: DType](ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin], size: Int) -> Scalar[dtype]:
+    var result = ptr[0]
+    for i in range(1, size):
+        if ptr[i] < result:
+            result = ptr[i]
+    return result
+
+fn typed_abs[dtype: DType](
+    src: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    dst: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    size: Int
+):
+    for i in range(size):
+        var v = src[i]
+        dst[i] = v if v >= Scalar[dtype](0) else -v
+
+fn typed_clamp[dtype: DType](
+    src: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    dst: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    lo: Scalar[dtype],
+    hi: Scalar[dtype],
+    size: Int
+):
+    for i in range(size):
+        var v = src[i]
+        if v < lo:
+            dst[i] = lo
+        elif v > hi:
+            dst[i] = hi
+        else:
+            dst[i] = v
+
+fn typed_dot[dtype: DType](
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    b: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    size: Int
+) -> Scalar[dtype]:
+    var total = Scalar[dtype](0)
+    for i in range(size):
+        total += a[i] * b[i]
+    return total
+
+fn typed_norm_sq[dtype: DType](ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin], size: Int) -> Scalar[dtype]:
+    var total = Scalar[dtype](0)
+    for i in range(size):
+        total += ptr[i] * ptr[i]
+    return total
+
+fn typed_copy[dtype: DType](
+    src: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    dst: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    size: Int
+):
+    for i in range(size):
+        dst[i] = src[i]
+
+
+# ============================================================================
+# Test functions — each call site forces a new set of monomorphizations
+# (float32, float64, int32, int64, float16, int8, int16, uint8, uint16,
+#  uint32, uint64, int32 again, bfloat16)
+# ============================================================================
+
+def test_float32_ops() raises:
+    var N = 64
+    var a = UnsafePointer[Float32].alloc(N)
+    var b = UnsafePointer[Float32].alloc(N)
+    var c = UnsafePointer[Float32].alloc(N)
+    typed_fill[DType.float32](a, N, Float32(1.5))
+    typed_fill[DType.float32](b, N, Float32(2.0))
+    typed_add[DType.float32](a, b, c, N)
+    _ = typed_sum[DType.float32](c, N)
+    typed_scale[DType.float32](c, N, Float32(0.5))
+    typed_abs[DType.float32](c, a, N)
+    typed_clamp[DType.float32](a, b, Float32(0.0), Float32(2.0), N)
+    _ = typed_max[DType.float32](b, N)
+    _ = typed_min[DType.float32](b, N)
+    _ = typed_dot[DType.float32](a, b, N)
+    _ = typed_norm_sq[DType.float32](a, N)
+    typed_sub[DType.float32](a, b, c, N)
+    typed_mul[DType.float32](a, b, c, N)
+    typed_copy[DType.float32](a, b, N)
+    a.free(); b.free(); c.free()
+
+def test_float64_ops() raises:
+    var N = 64
+    var a = UnsafePointer[Float64].alloc(N)
+    var b = UnsafePointer[Float64].alloc(N)
+    var c = UnsafePointer[Float64].alloc(N)
+    typed_fill[DType.float64](a, N, Float64(1.5))
+    typed_fill[DType.float64](b, N, Float64(2.0))
+    typed_add[DType.float64](a, b, c, N)
+    _ = typed_sum[DType.float64](c, N)
+    typed_scale[DType.float64](c, N, Float64(0.5))
+    typed_abs[DType.float64](c, a, N)
+    typed_clamp[DType.float64](a, b, Float64(0.0), Float64(2.0), N)
+    _ = typed_max[DType.float64](b, N)
+    _ = typed_min[DType.float64](b, N)
+    _ = typed_dot[DType.float64](a, b, N)
+    _ = typed_norm_sq[DType.float64](a, N)
+    typed_sub[DType.float64](a, b, c, N)
+    typed_mul[DType.float64](a, b, c, N)
+    typed_copy[DType.float64](a, b, N)
+    a.free(); b.free(); c.free()
+
+def test_int32_ops() raises:
+    var N = 64
+    var a = UnsafePointer[Int32].alloc(N)
+    var b = UnsafePointer[Int32].alloc(N)
+    var c = UnsafePointer[Int32].alloc(N)
+    typed_fill[DType.int32](a, N, Int32(3))
+    typed_fill[DType.int32](b, N, Int32(7))
+    typed_add[DType.int32](a, b, c, N)
+    _ = typed_sum[DType.int32](c, N)
+    _ = typed_max[DType.int32](b, N)
+    _ = typed_min[DType.int32](b, N)
+    typed_sub[DType.int32](a, b, c, N)
+    typed_mul[DType.int32](a, b, c, N)
+    typed_copy[DType.int32](a, b, N)
+    a.free(); b.free(); c.free()
+
+def test_int64_ops() raises:
+    var N = 64
+    var a = UnsafePointer[Int64].alloc(N)
+    var b = UnsafePointer[Int64].alloc(N)
+    var c = UnsafePointer[Int64].alloc(N)
+    typed_fill[DType.int64](a, N, Int64(100))
+    typed_fill[DType.int64](b, N, Int64(200))
+    typed_add[DType.int64](a, b, c, N)
+    _ = typed_sum[DType.int64](c, N)
+    _ = typed_max[DType.int64](b, N)
+    _ = typed_min[DType.int64](b, N)
+    typed_sub[DType.int64](a, b, c, N)
+    typed_mul[DType.int64](a, b, c, N)
+    typed_copy[DType.int64](a, b, N)
+    a.free(); b.free(); c.free()
+
+def test_uint8_ops() raises:
+    var N = 64
+    var a = UnsafePointer[UInt8].alloc(N)
+    var b = UnsafePointer[UInt8].alloc(N)
+    var c = UnsafePointer[UInt8].alloc(N)
+    typed_fill[DType.uint8](a, N, UInt8(10))
+    typed_fill[DType.uint8](b, N, UInt8(20))
+    typed_add[DType.uint8](a, b, c, N)
+    _ = typed_sum[DType.uint8](c, N)
+    _ = typed_max[DType.uint8](b, N)
+    _ = typed_min[DType.uint8](b, N)
+    typed_copy[DType.uint8](a, b, N)
+    a.free(); b.free(); c.free()
+
+def test_int8_ops() raises:
+    var N = 64
+    var a = UnsafePointer[Int8].alloc(N)
+    var b = UnsafePointer[Int8].alloc(N)
+    var c = UnsafePointer[Int8].alloc(N)
+    typed_fill[DType.int8](a, N, Int8(5))
+    typed_fill[DType.int8](b, N, Int8(10))
+    typed_add[DType.int8](a, b, c, N)
+    _ = typed_sum[DType.int8](c, N)
+    _ = typed_max[DType.int8](b, N)
+    _ = typed_min[DType.int8](b, N)
+    typed_copy[DType.int8](a, b, N)
+    a.free(); b.free(); c.free()
+
+def test_int16_ops() raises:
+    var N = 64
+    var a = UnsafePointer[Int16].alloc(N)
+    var b = UnsafePointer[Int16].alloc(N)
+    var c = UnsafePointer[Int16].alloc(N)
+    typed_fill[DType.int16](a, N, Int16(50))
+    typed_fill[DType.int16](b, N, Int16(100))
+    typed_add[DType.int16](a, b, c, N)
+    _ = typed_sum[DType.int16](c, N)
+    _ = typed_max[DType.int16](b, N)
+    _ = typed_min[DType.int16](b, N)
+    typed_copy[DType.int16](a, b, N)
+    a.free(); b.free(); c.free()
+
+def test_uint16_ops() raises:
+    var N = 64
+    var a = UnsafePointer[UInt16].alloc(N)
+    var b = UnsafePointer[UInt16].alloc(N)
+    var c = UnsafePointer[UInt16].alloc(N)
+    typed_fill[DType.uint16](a, N, UInt16(50))
+    typed_fill[DType.uint16](b, N, UInt16(100))
+    typed_add[DType.uint16](a, b, c, N)
+    _ = typed_sum[DType.uint16](c, N)
+    _ = typed_max[DType.uint16](b, N)
+    _ = typed_min[DType.uint16](b, N)
+    typed_copy[DType.uint16](a, b, N)
+    a.free(); b.free(); c.free()
+
+def test_uint32_ops() raises:
+    var N = 64
+    var a = UnsafePointer[UInt32].alloc(N)
+    var b = UnsafePointer[UInt32].alloc(N)
+    var c = UnsafePointer[UInt32].alloc(N)
+    typed_fill[DType.uint32](a, N, UInt32(1000))
+    typed_fill[DType.uint32](b, N, UInt32(2000))
+    typed_add[DType.uint32](a, b, c, N)
+    _ = typed_sum[DType.uint32](c, N)
+    _ = typed_max[DType.uint32](b, N)
+    _ = typed_min[DType.uint32](b, N)
+    typed_copy[DType.uint32](a, b, N)
+    a.free(); b.free(); c.free()
+
+def test_uint64_ops() raises:
+    var N = 64
+    var a = UnsafePointer[UInt64].alloc(N)
+    var b = UnsafePointer[UInt64].alloc(N)
+    var c = UnsafePointer[UInt64].alloc(N)
+    typed_fill[DType.uint64](a, N, UInt64(1000000))
+    typed_fill[DType.uint64](b, N, UInt64(2000000))
+    typed_add[DType.uint64](a, b, c, N)
+    _ = typed_sum[DType.uint64](c, N)
+    _ = typed_max[DType.uint64](b, N)
+    _ = typed_min[DType.uint64](b, N)
+    typed_copy[DType.uint64](a, b, N)
+    a.free(); b.free(); c.free()
+
+
+# ============================================================================
+# Main
+# ============================================================================
+
+def main() raises:
+    # If we reach here, the JIT compiled all 14 parametric functions × 10 DType
+    # variants = 140 monomorphizations without crashing.
+    # If the file crashes BEFORE this print, the monomorphization count alone
+    # triggers the JIT overflow at module load / compilation time.
+    print("Running: repro_parametric_monomorphization_crash")
+    test_float32_ops()
+    print("float32: PASS")
+    test_float64_ops()
+    print("float64: PASS")
+    test_int32_ops()
+    print("int32: PASS")
+    test_int64_ops()
+    print("int64: PASS")
+    test_uint8_ops()
+    print("uint8: PASS")
+    test_int8_ops()
+    print("int8: PASS")
+    test_int16_ops()
+    print("int16: PASS")
+    test_uint16_ops()
+    print("uint16: PASS")
+    test_uint32_ops()
+    print("uint32: PASS")
+    test_uint64_ops()
+    print("uint64: PASS")
+    print("ALL PASS — no crash (14 fns × 10 dtypes = 140 monomorphizations)")

--- a/repro/run_all_experiments.sh
+++ b/repro/run_all_experiments.sh
@@ -1,0 +1,229 @@
+#!/bin/bash
+# run_all_experiments.sh — validates every claim in the Day 53 blog post
+#
+# Usage: cd ProjectOdyssey && bash repro/run_all_experiments.sh
+#
+# Runs each experiment and prints the command, expected outcome, and PASS/FAIL.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+TOTAL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+# --- Helpers ---
+
+run_test() {
+    local name="$1"
+    local expected="$2"  # "crash", "pass", "asan_uaf", "asan_clean"
+    local cmd="$3"
+    TOTAL=$((TOTAL + 1))
+
+    echo "  [$name]"
+    echo "  Repro: $cmd"
+    echo "  Expected: $expected"
+
+    local output exit_code
+    set +e
+    output=$(eval "$cmd" 2>&1)
+    exit_code=$?
+    set -e
+
+    if [ "$expected" = "crash" ]; then
+        if [ $exit_code -ne 0 ] && echo "$output" | grep -q "libKGENCompilerRTShared.so\|execution crashed"; then
+            echo "  Result: Crashed (exit=$exit_code)"
+            PASS=$((PASS + 1))
+        else
+            echo "  Result: Did NOT crash (exit=$exit_code) — UNEXPECTED"
+            FAIL=$((FAIL + 1))
+        fi
+    elif [ "$expected" = "pass" ]; then
+        if [ $exit_code -eq 0 ]; then
+            echo "  Result: Completed successfully"
+            PASS=$((PASS + 1))
+        else
+            echo "  Result: Failed (exit=$exit_code) — UNEXPECTED"
+            echo "  Output: $(echo "$output" | tail -3)"
+            FAIL=$((FAIL + 1))
+        fi
+    elif [ "$expected" = "asan_uaf" ]; then
+        if echo "$output" | grep -q "heap-use-after-free"; then
+            echo "  Result: ASAN detected heap-use-after-free"
+            PASS=$((PASS + 1))
+        else
+            echo "  Result: ASAN did NOT detect heap-use-after-free — UNEXPECTED"
+            FAIL=$((FAIL + 1))
+        fi
+    elif [ "$expected" = "asan_clean" ]; then
+        if [ $exit_code -eq 0 ] && ! echo "$output" | grep -q "AddressSanitizer"; then
+            echo "  Result: ASAN clean (no errors)"
+            PASS=$((PASS + 1))
+        else
+            echo "  Result: ASAN reported errors — UNEXPECTED"
+            FAIL=$((FAIL + 1))
+        fi
+    fi
+    echo ""
+}
+
+echo "========================================"
+echo "  Day 53 Blog Post Experiment Validator"
+echo "========================================"
+echo "  Repo root: $REPO_ROOT"
+echo "  Artifacts: $SCRIPT_DIR"
+echo ""
+
+# ==========================================================================
+echo "--- 1. Standalone Reproducer Crashes (no ASAN) ---"
+echo ""
+# ==========================================================================
+
+run_test \
+    "Standalone reproducer crashes" \
+    "crash" \
+    "pixi run mojo run $SCRIPT_DIR/repro_crash_standalone.mojo"
+
+# ==========================================================================
+echo "--- 2. ASAN Proves Heap-Use-After-Free ---"
+echo ""
+# ==========================================================================
+
+echo "  Building: pixi run mojo build --sanitize address -g -o $SCRIPT_DIR/repro_asan $SCRIPT_DIR/repro_crash_standalone.mojo"
+pixi run mojo build --sanitize address -g \
+    -o "$SCRIPT_DIR/repro_asan" \
+    "$SCRIPT_DIR/repro_crash_standalone.mojo" 2>&1 | tail -3
+echo ""
+
+run_test \
+    "ASAN detects use-after-free" \
+    "asan_uaf" \
+    "$SCRIPT_DIR/repro_asan"
+
+# ==========================================================================
+echo "--- 3. Keepalive Fix Eliminates ASAN Error ---"
+echo ""
+# ==========================================================================
+
+# Create fixed version: insert "_ = target  # keepalive" after the last "_ = relu(x)"
+awk '
+/_ = relu\(x\)/ { last_line = NR; last_content = $0 }
+{ lines[NR] = $0 }
+END {
+    for (i = 1; i <= NR; i++) {
+        print lines[i]
+        if (i == last_line) print "    _ = target  # keepalive"
+    }
+}
+' "$SCRIPT_DIR/repro_crash_standalone.mojo" > "$SCRIPT_DIR/repro_fixed.mojo"
+
+echo "  Building: pixi run mojo build --sanitize address -g -o $SCRIPT_DIR/repro_fixed_bin $SCRIPT_DIR/repro_fixed.mojo"
+pixi run mojo build --sanitize address -g \
+    -o "$SCRIPT_DIR/repro_fixed_bin" \
+    "$SCRIPT_DIR/repro_fixed.mojo" 2>&1 | tail -3
+echo ""
+
+run_test \
+    "ASAN clean with keepalive fix" \
+    "asan_clean" \
+    "$SCRIPT_DIR/repro_fixed_bin"
+
+# Clean up generated files
+rm -f "$SCRIPT_DIR/repro_asan" "$SCRIPT_DIR/repro_fixed.mojo" "$SCRIPT_DIR/repro_fixed_bin"
+
+# ==========================================================================
+echo "--- 4. Pre-Workaround VGG16 Test Crashes ---"
+echo ""
+# ==========================================================================
+
+# Copy pre-workaround test into tests/models/ so imports resolve
+cp "$SCRIPT_DIR/bug_repro_vgg16_e2e_part1_pre_fix.mojo.bug" \
+    "$REPO_ROOT/tests/models/_tmp_pre_fix_part1.mojo"
+
+run_test \
+    "Pre-workaround VGG16 part1 crashes" \
+    "crash" \
+    "pixi run mojo run tests/models/_tmp_pre_fix_part1.mojo"
+
+rm -f "$REPO_ROOT/tests/models/_tmp_pre_fix_part1.mojo"
+
+# ==========================================================================
+echo "--- 5. Post-Workaround VGG16 Tests Pass ---"
+echo ""
+# ==========================================================================
+
+run_test \
+    "Fixed VGG16 part1 passes" \
+    "pass" \
+    "pixi run mojo run tests/models/test_vgg16_e2e_part1.mojo"
+
+run_test \
+    "Fixed VGG16 part2 passes" \
+    "pass" \
+    "pixi run mojo run tests/models/test_vgg16_e2e_part2.mojo"
+
+run_test \
+    "Fixed VGG16 layers part2 passes" \
+    "pass" \
+    "pixi run mojo run tests/models/test_vgg16_layers_part2.mojo"
+
+# ==========================================================================
+echo "--- 6. Project-Import Reproducers Crash ---"
+echo ""
+# ==========================================================================
+
+run_test \
+    "repro_libkgen_crash.mojo crashes" \
+    "crash" \
+    "pixi run mojo run $SCRIPT_DIR/repro_libkgen_crash.mojo"
+
+run_test \
+    "repro_libasyncrt_crash.mojo crashes" \
+    "crash" \
+    "pixi run mojo run $SCRIPT_DIR/repro_libasyncrt_crash.mojo"
+
+# ==========================================================================
+echo "--- 7. LeNet-5 Monolithic File Crashes (ADR-009 — Same Bug) ---"
+echo ""
+# ==========================================================================
+
+# The original 24-test monolithic file from Dec 2025 (Issue #2942).
+# This requires the shared library to be built. If not available, skip gracefully.
+echo "  Note: This test requires 'pixi run just build' to have been run first."
+echo "  The monolithic file uses project imports (from projectodyssey.core.*)."
+echo ""
+
+run_test \
+    "LeNet-5 monolithic (24 tests) crashes after ~15" \
+    "crash" \
+    "cp $SCRIPT_DIR/bug_repro_lenet5_layers_monolithic.mojo.bug $REPO_ROOT/tests/models/_tmp_lenet5_monolithic.mojo && pixi run mojo run tests/models/_tmp_lenet5_monolithic.mojo; ret=\$?; rm -f $REPO_ROOT/tests/models/_tmp_lenet5_monolithic.mojo; exit \$ret"
+
+# ==========================================================================
+echo "--- 8. LeNet-5 Split Files Pass (ADR-009 Workaround) ---"
+echo ""
+# ==========================================================================
+
+# Run each of the 5 split files — all should pass
+run_test \
+    "LeNet-5 conv layers (6 tests) passes" \
+    "pass" \
+    "pixi run mojo run tests/models/test_lenet5_conv_layers.mojo"
+
+run_test \
+    "LeNet-5 activation layers (3 tests) passes" \
+    "pass" \
+    "pixi run mojo run tests/models/test_lenet5_activation_layers.mojo"
+
+# ==========================================================================
+echo "========================================"
+echo "  $TOTAL experiments, $FAIL unexpected results"
+echo "========================================"
+
+if [ $FAIL -gt 0 ]; then
+    exit 1
+else
+    exit 0
+fi


### PR DESCRIPTION
## Summary

Wave 2 of the `modular/modular#6413` demolition (PR #5460) applied a blanket
delete to `repro/` and `.github/workflows/gradient-soak.yml`. The `#6413` fix
correctly closed the `#6413`-specific files, but **also deleted reproducers for
several distinct upstream bugs** that share the libKGEN / JIT-crash surface.
None of those were re-validated against Mojo `1.0.0b2.dev2026052506` before
deletion.

This PR restores 20 files from `e8c5609a` (last commit with all of them on
disk together) plus `gradient-soak.yml` from its original-author commit
`7cde386d`. All marked **TRIAGE-PENDING** in the new `repro/README.md`, which
documents the per-file validation protocol.

## Why each restored file is NOT #6413

| File | Distinct bug |
| --- | --- |
| `repro_libkgen_crash.mojo` | Allocator heap corruption via AnyTensor + conv2d (deterministic; identical stack across runs) |
| `repro_libasyncrt_crash.mojo` | `libAsyncRTRuntimeGlobals.so` crash in VGG16 training — different runtime lib |
| `repro_jit_volume_crash.mojo` + `kgen_jit_overflow_minimal.mojo` | JIT virtual-memory exhaustion / KGEN buffer overflow at compilation volume — symptom, not AVX-512 mis-emission |
| `repro_jit_fortify_crash.mojo` | `__fortify_fail_abort` buffer overflow |
| `repro_parametric_monomorphization_crash.mojo` | Parametric monomorphization crash |
| `repro_module_import_crash*.mojo`, `repro_jit_targeted_imports_crash.mojo`, `repro_jit_heavy_import_test.mojo`, `repro_import_chain_synthetic.mojo` | Module-level import-chain crashes |
| `repro_crash_standalone.mojo`, `configs_kgen_crash.mojo` | Standalone / configs-specific KGEN crashes |
| `.github/workflows/gradient-soak.yml` | Soak test for issue #5170 / #5104 (per-element bitcast elimination) — explicitly a different bug class |

## What was correctly deleted (NOT restored)

- `repro/repro_6413_assert_almost_equal.mojo`, `repro_6413_python_import_os.mojo`
- `notes/modular-6413-avx512-finding.md`
- `.github/workflows/repro-6413.yml`
- `scripts/mojo-under-gdb.sh` (gdb wrapper specific to the `#6413` SIGABRT handler)

These are unambiguously `#6413`-class and the upstream fix obsoletes them.

## Triage protocol

Per `repro/README.md`, each restored file requires:
1. Run `mojo build --print-effective-target` to verify codegen on the new pin.
2. Run the reproducer 10× to test determinism.
3. If reproduces → file/update upstream issue, mark `OPEN-#NNNN`.
4. If fixed → delete in a per-file commit citing the validation run.
5. If intermittent → mark `INTERMITTENT — needs longer soak`.

Triage is deferred to follow-up issues — this PR only restores the artifacts
and documents the gap.

## Test Plan

- [x] All restored files render correctly (`cat` check on each)
- [x] `repro/README.md` accurately enumerates restored files
- [x] No `#6413`-specific artifacts re-introduced
- [ ] CI passes (no functional code changes; reproducers are standalone)

## Follow-ups

- Open per-bug triage issues for each `TRIAGE-PENDING` reproducer
- Amend the `workaround-demolition-wave-strategy` Mnemosyne skill with a
  "partition by bug, not by directory" lesson

🤖 Generated with [Claude Code](https://claude.com/claude-code)