### PR TITLE
docs(tsan): document tcmalloc/ThreadSanitizer incompatibility

### DIFF
--- a/.claude-followup-5391.json
+++ b/.claude-followup-5391.json
@@ -1,0 +1,17 @@
+[
+  {
+    "title": "File upstream tcmalloc/TSAN issue at modular/modular",
+    "body": "Issue #5391 documents the tcmalloc/ThreadSanitizer incompatibility. The doc includes a template for filing at https://github.com/modular/modular/issues. Once filed, update docs/dev/mojo-tsan-tcmalloc-incompatibility.md Tracking section with the actual upstream issue number and remove the 'not yet filed' fallback clause.",
+    "labels": ["documentation", "research"]
+  },
+  {
+    "title": "Add TSAN abort pattern to mojo-anti-patterns.md",
+    "body": "Document the tcmalloc MmapAligned() abort as a known failure pattern when building with --sanitize thread. Link to docs/dev/mojo-tsan-tcmalloc-incompatibility.md. This helps developers encountering the error quickly find the explanation.",
+    "labels": ["documentation", "enhancement"]
+  },
+  {
+    "title": "Update justfile once modular/modular fixes tcmalloc/TSAN",
+    "body": "When Modular reconciles the tcmalloc/ThreadSanitizer incompatibility upstream, re-run `just test-mojo-tsan` to verify all 298 tests pass. If passing, remove the ⚠️ caveat from the test-mojo-tsan comment block, update the doc's Status section, and simplify the scoped comment in _test-mojo-sanitized-inner.",
+    "labels": ["documentation", "testing"]
+  }
+]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ gh pr merge --auto --rebase
 - [Mojo Syntax & Patterns](/.claude/shared/mojo-guidelines.md)
 - [Mojo Anti-Patterns](/.claude/shared/mojo-anti-patterns.md) - 64+ failure patterns
 - [Mojo UnsafePointer Memory Safety](docs/dev/mojo-memory-safety.md) - when/how to use UnsafePointer safely
-- [Mojo TSAN/tcmalloc Incompatibility](docs/dev/mojo-tsan-tcmalloc-incompatibility.md) - why `just test-mojo-tsan` aborts at startup
+- [Mojo TSAN/tcmalloc Incompatibility](docs/dev/mojo-tsan-tcmalloc-incompatibility.md) - why test-mojo-tsan aborts
 - [PR Workflow](/.claude/shared/pr-workflow.md)
 - [GitHub Issue Workflow](/.claude/shared/github-issue-workflow.md)
 - [Common Constraints](/.claude/shared/common-constraints.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ gh pr merge --auto --rebase
 - [Mojo Syntax & Patterns](/.claude/shared/mojo-guidelines.md)
 - [Mojo Anti-Patterns](/.claude/shared/mojo-anti-patterns.md) - 64+ failure patterns
 - [Mojo UnsafePointer Memory Safety](docs/dev/mojo-memory-safety.md) - when/how to use UnsafePointer safely
+- [Mojo TSAN/tcmalloc Incompatibility](docs/dev/mojo-tsan-tcmalloc-incompatibility.md) - why `just test-mojo-tsan` aborts at startup
 - [PR Workflow](/.claude/shared/pr-workflow.md)
 - [GitHub Issue Workflow](/.claude/shared/github-issue-workflow.md)
 - [Common Constraints](/.claude/shared/common-constraints.md)

--- a/docs/dev/mojo-tsan-tcmalloc-incompatibility.md
+++ b/docs/dev/mojo-tsan-tcmalloc-incompatibility.md
@@ -1,0 +1,152 @@
+# Mojo ThreadSanitizer / tcmalloc Incompatibility
+
+## Status
+
+`just test-mojo-tsan` compiles all tests cleanly under `--sanitize thread`, but
+every resulting binary aborts at startup with a tcmalloc `MmapAligned()` failure.
+This is a **known incompatibility between ThreadSanitizer's shadow-memory layout
+and Google tcmalloc** (the allocator linked into Mojo's runtime).
+
+**Current:** Not functional — every `--sanitize thread` binary aborts before any
+user code runs.
+
+**When resolved:** Re-run `just test-mojo-tsan`. If it passes 298/298 tests, the
+incompatibility has been reconciled upstream. Remove the inline justfile caveat
+at that time and update this doc's Status section.
+
+## Tracking
+
+**ProjectOdyssey Issues & PRs:**
+
+- Issue #5391 — TSAN runtime fails universally: tcmalloc/ThreadSanitizer
+  incompatibility
+- PR #5389 — added `just test-mojo-tsan` and documented this finding in commit
+  message
+
+**Upstream tracking:** Upstream issue **not yet filed** as of 2026-05-29. This
+abort should be reported at [modular/modular issues](https://github.com/modular/modular/issues)
+with the title and reproduction steps below. Until filed, track locally via
+ProjectOdyssey #5391.
+
+## Root Cause
+
+ThreadSanitizer allocates a large shadow-memory region in the virtual address
+space, typically in the high-address range (0x400000000000+). Google tcmalloc
+(Mojo's linked allocator) also assumes it can mmap large regions in high memory
+for its internal arena structure. When both are linked together, tcmalloc's mmap
+attempts collide with TSAN's shadow memory layout, causing tcmalloc to fail
+during initialization before any user code runs.
+
+The abort occurs in `external/tcmalloc+/tcmalloc/internal/system_allocator.h`
+during `MmapAligned()`, before Mojo's JIT or test framework execute.
+
+## Symptom
+
+Every `--sanitize thread` binary aborts at startup with:
+
+```text
+FATAL: ThreadSanitizer: unexpected memory mapping 0x<addr>-0x<addr>
+<pid> external/tcmalloc+/tcmalloc/internal/system_allocator.h:585]
+  MmapAligned() failed - unable to allocate with tag
+  (hint=0x<addr>, size=1073741824, alignment=1073741824)
+  - is something limiting address placement?
+<pid> external/tcmalloc+/tcmalloc/internal/system_allocator.h:592]
+  Note: the allocation may have failed because TCMalloc assumes a 48-bit
+  virtual address space size; you may need to rebuild TCMalloc with
+  TCMALLOC_ADDRESS_BITS defined to your system's virtual address space size
+<pid> external/tcmalloc+/tcmalloc/arena.cc:59] CHECK in Alloc:
+  FATAL ERROR: Out of memory trying to allocate internal tcmalloc data
+  (bytes=131072, object-size=16384);
+  is something preventing mmap from succeeding (sandbox, VSS limitations)?
+Aborted (core dumped)
+```
+
+This happens even with a minimal `print("hello")` program.
+
+## Evidence
+
+From the sweep in PR #5389:
+
+- **Tests attempted:** 298
+- **Tests compiling cleanly:** 298/298 (100%)
+- **Tests aborting at startup:** 298/298 (100%)
+- **Distinct ThreadSanitizer race reports:** 0 (no test code runs)
+- **Root of abort:** `external/tcmalloc+/...` (direct evidence tcmalloc is
+  linked)
+
+The abort message itself names `external/tcmalloc+/...` in the stack trace —
+this is direct evidence that tcmalloc is the allocator linked into Mojo's
+runtime.
+
+## Reproduction
+
+```bash
+just podman-up
+
+# Minimal reproduction: build a Mojo program with --sanitize thread
+podman compose exec -T projectodyssey-dev bash -c \
+  "cd /workspace && pixi run mojo build --sanitize thread --Werror -j1 \
+   -I /workspace -Xlinker -lm tests/configs/test_env_vars.mojo \
+   -o /tmp/tsan_test && /tmp/tsan_test"
+
+# Expected output: binary aborts with MmapAligned() FATAL error
+# (not a test failure — the runtime itself aborts before test code runs)
+```
+
+## Why This Repo Cannot Fix It
+
+- tcmalloc is linked by Modular's Mojo runtime, not built in this repo
+- The abort precedes any user code execution (happens during runtime
+  initialization)
+- This repo has no control over Mojo's allocator selection or configuration
+- ThreadSanitizer's shadow-memory layout is fixed by the TSAN runtime, not user
+  code
+
+## Upstream Fix Paths
+
+Either:
+
+1. **Rebuild Mojo's tcmalloc with `TCMALLOC_ADDRESS_BITS`** configured to match
+   the runtime's actual virtual address space size (64-bit systems typically need
+   48–52 bits, not the default 48), or
+
+2. **Link Mojo's `--sanitize thread` builds against the system allocator** (or
+   libtsan's wrapper) instead of tcmalloc, for that specific build mode.
+
+Both require Modular-side changes to Mojo's build system and runtime
+configuration.
+
+## Filing the Upstream Issue
+
+When filing at [modular/modular issues](https://github.com/modular/modular/issues),
+use:
+
+**Title:** ThreadSanitizer builds abort at startup: tcmalloc MmapAligned()
+shadow-memory conflict
+
+**Description:**
+
+Every Mojo binary built with `--sanitize thread --Werror -j1` aborts at startup
+with a tcmalloc MmapAligned() FATAL error, before any test or user code runs.
+This is a known incompatibility: ThreadSanitizer's shadow-memory layout
+(high-address regions) collides with tcmalloc's mmap attempts.
+
+**Evidence:** All 298 tests compile cleanly under `--sanitize thread` (codegen is
+correct), but 298/298 binaries abort identically with the MmapAligned() error.
+Zero ThreadSanitizer race reports (no test code reaches execution). The abort
+message itself cites external/tcmalloc+/...
+
+**Reproduction:** Build and run any Mojo program under `--sanitize thread`:
+
+```bash
+mojo build --sanitize thread hello.mojo -o hello && ./hello
+```
+
+**Expected:** races detected or test passes.
+
+**Actual:** FATAL: ThreadSanitizer: unexpected memory mapping ... MmapAligned()
+failed ...
+
+**Mojo version:** 1.0.0b2 (from ProjectOdyssey CI)
+
+**Upstream tracking:** ProjectOdyssey #5391, PR #5389.

--- a/justfile
+++ b/justfile
@@ -1056,6 +1056,13 @@ test-mojo-asan:
 # Uses -j1 codegen for stability under thread sanitizer. Note: each compile
 # is ~5min and holds 3-6GB; on memory-limited hosts, prefer `test-group-asan`
 # on individual groups.
+#
+# ⚠️  NOT CURRENTLY FUNCTIONAL: All 298 test binaries compile cleanly but every
+# binary aborts at startup with a tcmalloc MmapAligned() failure (0 race reports).
+# This is a known tcmalloc/ThreadSanitizer incompatibility in Mojo's runtime —
+# TSAN's shadow-memory layout collides with tcmalloc's high-address mmap regions.
+# See docs/dev/mojo-tsan-tcmalloc-incompatibility.md and #5391.
+# Recipe retained — it works once Modular reconciles tcmalloc/TSAN upstream.
 test-mojo-tsan:
     @just _run "just _test-mojo-sanitized-inner thread"
 
@@ -1092,6 +1099,11 @@ _test-mojo-sanitized-inner sanitizer:
 
         BINARY=$(mktemp /tmp/mojo-san-XXXXXX)
         echo "Testing ($SANITIZER): $test_file"
+        # For --sanitize thread, the binary aborts at startup before any test code
+        # runs (tcmalloc/TSAN incompatibility in Mojo runtime — see #5391 and
+        # docs/dev/mojo-tsan-tcmalloc-incompatibility.md). This is an upstream
+        # runtime limitation, not a test or codegen defect. ASAN binaries run
+        # normally. Both are compiled here for coverage and upstream tracking.
         if pixi run mojo build $SAN_FLAGS --Werror $JOBS \
                 -I "$REPO_ROOT/src" -I "$REPO_ROOT" -I . -Xlinker -lm \
                 "$test_file" -o "$BINARY" 2>&1 \


### PR DESCRIPTION
## Summary

Documents why `just test-mojo-tsan` (added in PR #5389) is not currently functional: every `--sanitize thread` binary aborts at startup with a tcmalloc `MmapAligned()` failure — a known incompatibility between ThreadSanitizer's shadow-memory layout and the allocator linked in Mojo's runtime.

## Changes Made

- **docs/dev/mojo-tsan-tcmalloc-incompatibility.md** (new): canonical developer doc with root cause, evidence (298/298 abort, 0 race reports), reproduction steps, and upstream fix paths. Includes template for filing at modular/modular.
- **justfile** (test-mojo-tsan): expanded comment block warning that recipe is not currently functional + links to new doc and #5391.
- **justfile** (_test-mojo-sanitized-inner): scoped comment clarifying that --sanitize thread aborts at runtime startup (upstream limitation, not test/codegen defect).
- **CLAUDE.md**: added Quick Links entry for the new doc.

Recipe retained — it works once Modular reconciles tcmalloc/TSAN.

## Verification

- ✅ Markdown linting: `markdownlint-cli2` passes (0 errors)
- ✅ justfile parsing: `just --list | grep test-mojo-tsan` confirms recipe with updated comment
- ✅ File changes: only justfile comments and new doc; no logic changes
- ✅ CLAUDE.md anchor: inserted at correct location (line 110, after UnsafePointer entry)

Related: PR #5389 (introduced `just test-mojo-tsan`), issue #5391

Closes #5391

🤖 Generated with [Claude Code](https://claude.com/claude-code)