### PR TITLE
docs(check_coverage): Add issue #3079 tracking reference to TODO

### DIFF
--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -116,7 +116,7 @@ def parse_coverage_report(coverage_file: Path) -> Optional[float]:
     # - CI test validation still runs (ensures tests execute, just no coverage metrics)
     #
     # BLOCKED BY: Mojo team (external dependency)
-    # REFERENCE: Issue #2583, Issue #2612, ADR-008
+    # REFERENCE: Issue #2583, Issue #2612, Issue #3079 (tracking), ADR-008
     print()
     print("⚠️" + "=" * 68)
     print("⚠️  WARNING: COVERAGE PARSING NOT IMPLEMENTED!")


### PR DESCRIPTION
## Summary

Documentation-only cleanup for issue #3079 — tracking the single `TODO(#2583)` marker in the codebase that is blocked by Mojo team's unreleased coverage instrumentation tooling.

## Changes Made

- Added cross-reference to issue #3079 in the TODO comment block at `scripts/check_coverage.py:119`
- Updated REFERENCE line to include "Issue #3079 (tracking)" for bidirectional tracing
- No functional changes — the TODO correctly remains in code until Mojo releases coverage tooling

## Files Modified

- `scripts/check_coverage.py` — 1 line change (comment text only)

## Verification

- ✅ All 7 tests in `tests/scripts/test_check_coverage.py` pass
- ✅ Issue #3079 comment posted with TODO inventory and resolution criteria
- ✅ Issue #3059 (parent tracker) comment posted with status update
- ✅ Commit follows conventional commits format with `Closes #3079`
- ✅ No functional behavior changes — `parse_coverage_report()` unchanged

## Context

Per ADR-008 and issue #3079, this TODO is a **valid external blocker** and should remain in code until:

1. Mojo team releases coverage instrumentation tooling (issue #2583)
2. Actual coverage parsing is implemented
3. TODO marker is removed

Closes #3079

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>