### PR TITLE
chore(mypy): tighten per-module ignore_errors with disable_error_code (#5041)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Separated host/container pixi envs (detached-environments) to prevent bind-mount collisions;
   removed superseded ADR-009 ([#5348](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5348))
 - Separated dev from production dependencies in `pixi.toml` ([#5337](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5337))
+- Replace blanket `ignore_errors = True` in mypy.ini per-module sections (tests/, tools/, notebooks/) with
+  targeted `disable_error_code` lists, so new genuine type errors surface while pre-existing patterns remain
+  suppressed ([#5041](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5041))
 
 ### Fixed
 
@@ -48,6 +51,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `just train lenet fp16 200` end-to-end failure inside Podman ([#5351](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5351))
 - mypy type errors resolved by adding `hephaestus` as explicit dependency ([#5341](https://github.com/HomericIntelligence/ProjectOdyssey/pull/5341))
 - SpinLock unlock race: replaced `store(0)` with `fetch_add(-1)` in memory-pool
+
+### Documentation
+
+- Closed audit umbrella issue #5048: 11 of 13 sub-issues resolved and closed
+  ([#5036](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5036),
+  [#5037](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5037),
+  [#5038](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5038),
+  [#5039](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5039),
+  [#5041](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5041),
+  [#5042](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5042),
+  [#5043](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5043),
+  [#5044](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5044),
+  [#5045](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5045),
+  [#5046](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5046),
+  [#5047](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5047)).
+  Mojo coverage tooling ([#5040](https://github.com/HomericIntelligence/ProjectOdyssey/issues/5040)) tracked separately.
 
 ## [0.2.0-dev] - 2025-11-08 to 2026-03-25
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -22,12 +22,16 @@ exclude = ^scripts/agents/playground/|^examples/alexnet_cifar10/download_cifar10
 # Per-module options - start with already-typed modules
 # Note: Add more strict sections as modules are typed
 
-# Baseline suppression for tests/, tools/, notebooks/ — fix incrementally (see #3368)
+# Per-module suppression — each module's error codes disabled explicitly rather than blanket ignore_errors.
+# Tests use loose typing patterns (fixtures, mocks, assertion helpers).
+# Specific codes disabled rather than blanket-ignoring all errors (#5041).
 [mypy-tests.*]
-ignore_errors = True
+disable_error_code = var-annotated, union-attr, arg-type, return-value, index, assignment, operator, attr-defined
 
+# Tools are scripts with informal typing; tighten gradually.
 [mypy-tools.*]
-ignore_errors = True
+disable_error_code = index
 
+# Notebooks are exploratory and not part of the typed public API.
 [mypy-notebooks.*]
-ignore_errors = True
+disable_error_code = var-annotated, assignment, operator, attr-defined


### PR DESCRIPTION
## Summary

Closes #5048 
Resolves #5041

Replaces blanket `ignore_errors = True` in mypy.ini per-module sections with targeted `disable_error_code` lists, enabling new genuine type errors to surface while pre-existing patterns remain suppressed.

## Changes Made

- **mypy.ini**: Replaced three blanket `ignore_errors = True` directives with per-module `disable_error_code` lists
  - `[mypy-tests.*]`: 8 error codes (var-annotated, union-attr, arg-type, return-value, index, assignment, operator, attr-defined)
  - `[mypy-tools.*]`: 1 error code (index - paper-scaffold indexing on Optional values)
  - `[mypy-notebooks.*]`: 4 error codes (var-annotated, assignment, operator, attr-defined - exploratory, not part of typed public API)

- **CHANGELOG.md**: Added entry documenting mypy configuration tightening and audit umbrella closure

## Verification

✅ All 11 resolved sub-issues verified closed via `gh issue list`
✅ Issue #5040 (Mojo coverage) remains OPEN and tracked separately  
✅ Pre-commit mypy hook passes with targeted suppression
✅ Per-module mypy validation successful

## Sub-issues Status

Audit umbrella #5048: 11 of 13 sub-issues closed
- ✅ #5036, #5037, #5038, #5039, #5041, #5042, #5043, #5044, #5045, #5046, #5047 (CLOSED)
- 🔄 #5040 (Mojo coverage - tracked separately, OPEN)