### PR TITLE
fix(ci): unblock main — publish ci image, fix pip-audit & markdownlint

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -263,7 +263,14 @@ jobs:
           python-version: '3.11'
 
       - name: Install pip-audit
-        run: pip install pip-audit
+        # Upgrade pip first so the audited environment does not carry the
+        # runner's pre-installed vulnerable pip (PYSEC-2026-196 affects pip
+        # 26.1.1, fixed in 26.1.2). pip-audit scans the whole environment, so
+        # a stale runner pip would otherwise fail the scan on a vuln unrelated
+        # to this project's declared dependencies.
+        run: |
+          python -m pip install --upgrade pip
+          pip install pip-audit
 
       - name: Run pip-audit against pyproject.toml dependencies
         id: pip-audit

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -161,7 +161,7 @@ jobs:
             .
 
       - name: Push images
-        if: (github.event_name != 'pull_request' || github.event.inputs.push == 'true') && matrix.target != 'ci'
+        if: github.event_name != 'pull_request' || github.event.inputs.push == 'true'
         run: |
           for tag in ${{ steps.tags.outputs.tags }}; do
             echo "Pushing $tag..."

--- a/PHASE_G_CORRECTED_PLAN.md
+++ b/PHASE_G_CORRECTED_PLAN.md
@@ -24,7 +24,7 @@ The previous plan contained factual errors that have been corrected:
 **Current Backlog (30 open issues)**:
 
 | Tier | Count | Issues | Status |
-|------|-------|--------|--------|
+| ------ | ----- | ------ | ------ |
 | EASY | 2 | #3740, #5153 | Ready for dispatch |
 | MEDIUM | 6 | #5132, #5134, #5135, #5141, #5157, #3684 | Ready for dispatch |
 | HARD | 12 | #3181, #3184, #3187, #5040, #5156, #5159, #5181, #5182, #5183, #5184, #5316, #5391 | Deferred |


### PR DESCRIPTION
## Summary

Three independent failures were keeping `main` red and blocking the entire open-PR queue. This PR fixes all three (one commit each).

## Changes Made

1. **`security/dependency-scan` (required check) — `.github/workflows/_required.yml`**
   `pip-audit` scans the whole environment and flagged the runner's pre-installed `pip 26.1.1` (PYSEC-2026-196, fixed in 26.1.2) — a vuln unrelated to this project's declared dependencies. Now upgrade pip before the audit. This has failed on **every** main commit and gates all PRs.

2. **`markdownlint` (required check) — `PHASE_G_CORRECTED_PLAN.md`**
   The standalone `markdownlint-cli2` job (v0.40.0, enforces MD060) failed on the backlog table's delimiter row (`|------|` vs the configured `compact` style's `| ------ |`). The pre-commit markdownlint hook uses an older version that doesn't flag MD060, so it slipped onto main. Fixed the delimiter row.

3. **`Container Build and Publish` nightly — `.github/workflows/container-publish.yml`**
   The `Push images` step excluded the `ci` matrix target, so `...:main-ci` was built but never pushed; the `test-images` non-root smoke test (#5147) then failed with `manifest unknown`. Removed the exclusion so `main-ci` is published, matching the documented contract (`CLAUDE.md`, `docs/dev/containers.md`, the workflow's own summary table).

## Verification

- `markdownlint-cli2` against the repo tree → `0 error(s)` after the fix.
- pip-audit now runs against a patched pip; PYSEC-2026-196 no longer applies.
- Container workflow dispatched on this branch with `push=true` to confirm `test-images` pulls `main-ci`.

Closes #5147

🤖 Generated with [Claude Code](https://claude.com/claude-code)