### PR TITLE
feat(training): add atomic checkpoint saves and recovery mechanism

### DIFF
--- a/src/projectodyssey/training/checkpoint.mojo
+++ b/src/projectodyssey/training/checkpoint.mojo
@@ -5,10 +5,13 @@ keeping only N most recent checkpoints, and tracking the best model based on met
 
 Key Features:
 - Save checkpoints with epoch, metrics, and timestamp
+- Atomic tmp+rename saves prevent corruption if process is killed mid-write
+- Optimizer state persistence (List[List[AnyTensor]]) for full resume fidelity
 - Automatic cleanup of old checkpoints (keep only N most recent)
 - Track and save best model based on validation metric
-- Resume training from latest checkpoint
-- List all available checkpoints
+- Resume training from latest checkpoint with load_latest_with_optimizer
+- Partial-write recovery: skips epochs with missing metadata.txt
+- clear_checkpoints() supports --fresh flag (clear state, restart from scratch)
 
 Example:
     from projectodyssey.training.checkpoint import CheckpointManager
@@ -20,17 +23,22 @@ Example:
         var train_loss = train_epoch(...)
         var val_loss, val_acc = validate(...)
 
-        # Save checkpoint every epoch
-        ckpt_mgr.save_checkpoint(
+        # Save checkpoint with optimizer state (atomic write)
+        _ = ckpt_mgr.save_checkpoint(
             model_params, param_names, epoch,
-            train_loss=train_loss, val_loss=val_loss, val_acc=val_acc
+            train_loss=train_loss, val_loss=val_loss, val_acc=val_acc,
+            optimizer_state=opt_state, step=global_step,
         )
 
         # Track best model
         ckpt_mgr.save_best(model_params, param_names, epoch, val_loss)
 
-    # Resume training
-    var start_epoch = ckpt_mgr.load_latest(model_params, param_names)
+    # Resume training (loads weights + optimizer state)
+    var loaded_opt = List[List[AnyTensor]]()
+    var epoch_step = ckpt_mgr.load_latest_with_optimizer(
+        model_params, param_names, loaded_opt
+    )
+    # epoch_step[0] = last completed epoch, epoch_step[1] = global step
 """
 
 from projectodyssey.tensor.any_tensor import AnyTensor
@@ -43,7 +51,9 @@ from projectodyssey.utils.file_io import (
     file_exists,
     safe_write_file,
     safe_read_file,
+    remove_safely,
 )
+from projectodyssey.utils.serialization import save_tensor, load_tensor
 from std.collections import List
 
 
@@ -125,8 +135,16 @@ struct CheckpointManager:
         train_loss: Float32 = 0.0,
         val_loss: Float32 = 0.0,
         val_acc: Float32 = 0.0,
-    ) raises:
-        """Save checkpoint with model weights and metadata.
+        step: Int = 0,
+        optimizer_state: List[List[AnyTensor]] = List[List[AnyTensor]](),
+        config_snapshot: String = "",
+    ) raises -> String:
+        """Save checkpoint with model weights, optimizer state, and metadata.
+
+        Uses atomic write semantics (tmp file + rename) to prevent corruption
+        if the process is killed mid-write. Optimizer state is persisted as
+        a two-level on-disk layout: optimizer/param_<i>_slot_<j>.weights
+        with a slot_counts.txt sidecar for reconstruction.
 
         Args:
             parameters: List of model parameter tensors.
@@ -135,6 +153,14 @@ struct CheckpointManager:
             train_loss: Training loss for this epoch.
             val_loss: Validation loss for this epoch.
             val_acc: Validation accuracy for this epoch.
+            step: Global step count (sum of batches across all epochs so far).
+            optimizer_state: Nested optimizer state (outer=params, inner=slots).
+                Must have same outer length as param_names if non-empty.
+            config_snapshot: Config blob from TrainingConfig.to_snapshot_blob(),
+                embedded in metadata for incompatible-config detection on resume.
+
+        Returns:
+            Path to the saved checkpoint epoch directory.
 
         Raises:
             Error: If save fails.
@@ -148,14 +174,52 @@ struct CheckpointManager:
                 "Failed to create checkpoint epoch directory: " + epoch_dir
             )
 
-        # Save model weights
+        # Save model weights (uses safe_write_file which already does atomic writes)
         save_model_weights(parameters, epoch_dir, param_names)
 
-        # Save metadata
-        var metadata_path = epoch_dir + "/metadata.txt"
-        self._save_metadata(metadata_path, epoch, train_loss, val_loss, val_acc)
+        # Save optimizer state if provided
+        if len(optimizer_state) > 0:
+            if len(optimizer_state) != len(param_names):
+                raise Error(
+                    "optimizer_state outer length ("
+                    + String(len(optimizer_state))
+                    + ") must match param_names length ("
+                    + String(len(param_names))
+                    + ")"
+                )
+            var opt_dir = epoch_dir + "/optimizer"
+            if not create_directory(opt_dir):
+                raise Error("Failed to create optimizer dir: " + opt_dir)
+            for i in range(len(optimizer_state)):
+                var num_slots = len(optimizer_state[i])
+                for j in range(num_slots):
+                    var fname = (
+                        "param_" + String(i) + "_slot_" + String(j) + ".weights"
+                    )
+                    save_tensor(
+                        optimizer_state[i][j], opt_dir + "/" + fname, fname
+                    )
+            # Sidecar: slot counts per parameter, for load reconstruction
+            var slot_counts = String("")
+            for i in range(len(optimizer_state)):
+                var sc = len(optimizer_state[i])
+                slot_counts += String(sc) + "\n"
+            if not safe_write_file(opt_dir + "/slot_counts.txt", slot_counts):
+                raise Error("Failed to write optimizer slot_counts")
 
-        # Update checkpoint tracker
+        # Save metadata (v2 format with step and config snapshot)
+        var metadata_path = epoch_dir + "/metadata.txt"
+        self._save_metadata_v2(
+            metadata_path,
+            epoch,
+            step,
+            train_loss,
+            val_loss,
+            val_acc,
+            config_snapshot,
+        )
+
+        # Update checkpoint tracker (atomic via safe_write_file)
         var tracking_file = self.checkpoint_dir + "/checkpoint_tracker.txt"
         var tracking_content = (
             String("latest_epoch=") + String(epoch) + String("\n")
@@ -163,11 +227,155 @@ struct CheckpointManager:
         if not safe_write_file(tracking_file, tracking_content):
             raise Error("Failed to update checkpoint tracker")
 
-        print("Checkpoint saved: epoch " + String(epoch))
+        print(
+            "Checkpoint saved: epoch " + String(epoch) + " step " + String(step)
+        )
 
         # Cleanup old checkpoints if needed
         if self.max_to_keep > 0:
             self._cleanup_old_checkpoints()
+
+        return epoch_dir
+
+    def load_latest_with_optimizer(
+        mut self,
+        mut parameters: List[AnyTensor],
+        param_names: List[String],
+        mut optimizer_state: List[List[AnyTensor]],
+    ) raises -> Tuple[Int, Int]:
+        """Load the most recent valid checkpoint with optimizer state.
+
+        Implements partial-write recovery: if the tracker points to an epoch
+        directory without metadata.txt (indicating a crashed write), this method
+        logs a warning and falls back to returning (0, 0) so training starts fresh.
+
+        Args:
+            parameters: List to populate with loaded parameters.
+            param_names: List of parameter names to load.
+            optimizer_state: List to populate with loaded optimizer state.
+                After return: outer = params, inner = slots.
+
+        Returns:
+            Tuple[Int, Int] (epoch, step): last completed epoch and global step.
+            Returns Tuple(0, 0) if no valid checkpoint found.
+
+        Raises:
+            Error: If load of a valid checkpoint fails unexpectedly.
+        """
+        var latest_epoch = self._find_latest_epoch()
+
+        if latest_epoch < 0:
+            print("No checkpoint found, starting from scratch")
+            return Tuple[Int, Int](0, 0)
+
+        var epoch_dir = (
+            self.checkpoint_dir + "/checkpoint_epoch_" + String(latest_epoch)
+        )
+        var metadata_path = epoch_dir + "/metadata.txt"
+
+        # Partial-write recovery: check metadata exists before loading.
+        # If broken (no metadata.txt), try to find the previous valid epoch by
+        # scanning backwards from latest_epoch - 1 down to 0.
+        if not file_exists(metadata_path):
+            print(
+                "WARNING: Checkpoint at epoch "
+                + String(latest_epoch)
+                + " has no metadata.txt (partial write). Scanning for previous"
+                " valid checkpoint."
+            )
+            # Scan backwards for a valid checkpoint
+            var found_epoch = -1
+            for prev_epoch in range(latest_epoch - 1, -1, -1):
+                var prev_dir = (
+                    self.checkpoint_dir
+                    + "/checkpoint_epoch_"
+                    + String(prev_epoch)
+                )
+                var prev_meta = prev_dir + "/metadata.txt"
+                if file_exists(prev_meta):
+                    found_epoch = prev_epoch
+                    break
+            if found_epoch < 0:
+                print(
+                    "No valid previous checkpoint found. Starting from scratch."
+                )
+                return Tuple[Int, Int](0, 0)
+            # Reload pointing at the found epoch
+            print("Falling back to epoch " + String(found_epoch))
+            latest_epoch = found_epoch
+            epoch_dir = (
+                self.checkpoint_dir
+                + "/checkpoint_epoch_"
+                + String(latest_epoch)
+            )
+            metadata_path = epoch_dir + "/metadata.txt"
+
+        print("Loading checkpoint from epoch " + String(latest_epoch))
+
+        # Load weights
+        load_model_weights(parameters, epoch_dir, param_names)
+
+        # Load metadata to get step count
+        var step = self._load_metadata_step(metadata_path)
+
+        # Load optimizer state if present
+        var opt_dir = epoch_dir + "/optimizer"
+        var slot_counts_path = opt_dir + "/slot_counts.txt"
+        if file_exists(slot_counts_path):
+            # Clear existing optimizer state
+            while len(optimizer_state) > 0:
+                _ = optimizer_state.pop()
+
+            try:
+                var counts_content = safe_read_file(slot_counts_path)
+                var count_lines = counts_content.split("\n")
+                for i in range(len(param_names)):
+                    if i >= len(count_lines):
+                        break
+                    var line = String(count_lines[i])
+                    if line == "":
+                        break
+                    var num_slots = atol(line)
+                    var slots = List[AnyTensor]()
+                    for j in range(num_slots):
+                        var fname = (
+                            "param_"
+                            + String(i)
+                            + "_slot_"
+                            + String(j)
+                            + ".weights"
+                        )
+                        var tensor = load_tensor(opt_dir + "/" + fname)
+                        slots.append(tensor)
+                    optimizer_state.append(slots^)
+            except e:
+                print("WARNING: Failed to load optimizer state: " + String(e))
+
+        # Load metadata to update best metric
+        self._load_metadata(metadata_path)
+
+        return Tuple[Int, Int](latest_epoch, step)
+
+    def clear_checkpoints(self) raises:
+        """Clear checkpoint tracker to enable fresh training start.
+
+        Removes the checkpoint_tracker.txt file so load_latest / load_latest_with_optimizer
+        return epoch 0, causing training to start from scratch. Used by --fresh flag.
+
+        Note: Does not delete epoch directories — only the tracker reference.
+        Existing weight files are left in place to avoid large data deletion.
+
+        Raises:
+            Error: If tracker file exists but removal fails.
+        """
+        var tracking_file = self.checkpoint_dir + "/checkpoint_tracker.txt"
+        if file_exists(tracking_file):
+            if not remove_safely(tracking_file):
+                raise Error(
+                    "Failed to remove checkpoint tracker (--fresh): "
+                    + tracking_file
+                )
+            print("Checkpoint tracker cleared (fresh start)")
 
     def save_best(
         mut self,
@@ -379,3 +587,81 @@ struct CheckpointManager:
                 # but don't parse it back to Float32 due to lack of atof
                 # The CheckpointManager tracks best_metric_value separately
                 pass
+
+    def _save_metadata_v2(
+        self,
+        filepath: String,
+        epoch: Int,
+        step: Int,
+        train_loss: Float32,
+        val_loss: Float32,
+        val_acc: Float32,
+        config_snapshot: String = "",
+    ) raises:
+        """Save v2 checkpoint metadata including step count and config snapshot.
+
+        Format (versioned key-value pairs):
+            version=2
+            epoch=10
+            step=1400
+            train_loss=0.123
+            val_loss=0.456
+            val_acc=0.789
+            best_metric=0.456
+            config=epochs=50|batch_size=64|...
+
+        Uses atomic write semantics via safe_write_file.
+
+        Args:
+            filepath: Destination metadata path.
+            epoch: Completed epoch number.
+            step: Global step count.
+            train_loss: Training loss for this epoch.
+            val_loss: Validation loss for this epoch.
+            val_acc: Validation accuracy for this epoch.
+            config_snapshot: Optional config blob (from TrainingConfig.to_snapshot_blob()).
+
+        Raises:
+            Error: If write fails.
+        """
+        var content = String("version=2\n")
+        content += "epoch=" + String(epoch) + "\n"
+        content += "step=" + String(step) + "\n"
+        content += "train_loss=" + String(train_loss) + "\n"
+        content += "val_loss=" + String(val_loss) + "\n"
+        content += "val_acc=" + String(val_acc) + "\n"
+        content += "best_metric=" + String(self.best_metric_value) + "\n"
+        if config_snapshot != "":
+            content += "config=" + config_snapshot + "\n"
+
+        if not safe_write_file(filepath, content):
+            raise Error("Failed to write metadata file: " + filepath)
+
+    def _load_metadata_step(self, filepath: String) raises -> Int:
+        """Parse the step field from a metadata.txt file.
+
+        Supports both v1 (no step field, returns 0) and v2 formats.
+
+        Args:
+            filepath: Path to metadata.txt.
+
+        Returns:
+            Step count from metadata, or 0 if not present / parse error.
+        """
+        if not file_exists(filepath):
+            return 0
+        try:
+            var content = safe_read_file(filepath)
+            var lines = content.split("\n")
+            for i in range(len(lines)):
+                var line = String(lines[i])
+                if line.startswith("step="):
+                    var step_str = str_slice(
+                        line,
+                        ("step=").byte_length(),
+                        line.byte_length(),
+                    )
+                    return atol(step_str)
+            return 0
+        except e:
+            return 0

--- a/src/projectodyssey/training/config.mojo
+++ b/src/projectodyssey/training/config.mojo
@@ -87,7 +87,11 @@ struct TrainingConfig:
     var lr_gamma: Float32
     """Multiplicative factor for learning rate decay."""
     var checkpoint_every: Int
-    """Save checkpoint every N epochs (0 = only at end)."""
+    """Save checkpoint every N epochs (0 = only at end). Kept for compatibility."""
+    var checkpoint_every_n_epochs: Int
+    """Save checkpoint every N epochs (0 = only at end). Preferred over checkpoint_every."""
+    var checkpoint_dir: String
+    """Directory to store checkpoints ('' = disabled). Required for resume."""
     var validate_every: Int
     """Run validation every N epochs (1 = every epoch)."""
     var log_interval: Int
@@ -108,6 +112,8 @@ struct TrainingConfig:
         lr_step_size: Int = 60,
         lr_gamma: Float32 = 0.2,
         checkpoint_every: Int = 0,
+        checkpoint_every_n_epochs: Int = 0,
+        checkpoint_dir: String = "",
         validate_every: Int = 1,
         log_interval: Int = 10,
         max_wall_time_seconds: Int = 0,
@@ -124,7 +130,9 @@ struct TrainingConfig:
             lr_schedule_type: Schedule type - "none", "step", or "cosine".
             lr_step_size: Epochs between step decay reductions (default 60).
             lr_gamma: LR decay multiplier (default 0.2).
-            checkpoint_every: Save every N epochs (0 = only at end).
+            checkpoint_every: Save every N epochs (0 = only at end, kept for compatibility).
+            checkpoint_every_n_epochs: Save every N epochs (0 = only at end, preferred).
+            checkpoint_dir: Directory to store checkpoints ('' = disabled).
             validate_every: Validate every N epochs (default 1 = every epoch).
             log_interval: Log every N batches (default 10).
             max_wall_time_seconds: Max wall-clock seconds (0 = no limit, default).
@@ -139,6 +147,12 @@ struct TrainingConfig:
         self.lr_step_size = lr_step_size
         self.lr_gamma = lr_gamma
         self.checkpoint_every = checkpoint_every
+        # checkpoint_every_n_epochs defaults to checkpoint_every if not explicitly set
+        if checkpoint_every_n_epochs != 0:
+            self.checkpoint_every_n_epochs = checkpoint_every_n_epochs
+        else:
+            self.checkpoint_every_n_epochs = checkpoint_every
+        self.checkpoint_dir = checkpoint_dir
         self.validate_every = validate_every
         self.log_interval = log_interval
         self.max_wall_time_seconds = max_wall_time_seconds
@@ -224,16 +238,41 @@ struct TrainingConfig:
     def should_checkpoint(self, epoch: Int) -> Bool:
         """Check if checkpoint should be saved this epoch.
 
+        Uses checkpoint_every_n_epochs (preferred) with fallback to checkpoint_every.
+
         Args:
             epoch: Current epoch (0-indexed).
 
         Returns:
             True if checkpoint should be saved, False otherwise.
-            Note: Returns True for last epoch if checkpoint_every > 0.
+            Note: Returns True for last epoch if checkpoint_every_n_epochs > 0.
         """
-        if self.checkpoint_every == 0:
+        if self.checkpoint_every_n_epochs == 0:
             return False
-        return (epoch + 1) % self.checkpoint_every == 0
+        return (epoch + 1) % self.checkpoint_every_n_epochs == 0
+
+    def to_snapshot_blob(self) -> String:
+        """Produce single-line key=value snapshot for embedding in checkpoint metadata.
+
+        Used to detect incompatible-config restarts on resume.
+
+        Returns:
+            Pipe-separated key=value string of key hyperparameters.
+        """
+        return (
+            "epochs="
+            + String(self.epochs)
+            + "|batch_size="
+            + String(self.batch_size)
+            + "|learning_rate="
+            + String(self.learning_rate)
+            + "|momentum="
+            + String(self.momentum)
+            + "|weight_decay="
+            + String(self.weight_decay)
+            + "|lr_schedule_type="
+            + self.lr_schedule_type
+        )
 
     def to_string(self) -> String:
         """Format configuration as human-readable string.
@@ -252,6 +291,12 @@ struct TrainingConfig:
         result += "  lr_step_size: " + String(self.lr_step_size) + "\n"
         result += "  lr_gamma: " + String(self.lr_gamma) + "\n"
         result += "  checkpoint_every: " + String(self.checkpoint_every) + "\n"
+        result += (
+            "  checkpoint_every_n_epochs: "
+            + String(self.checkpoint_every_n_epochs)
+            + "\n"
+        )
+        result += "  checkpoint_dir: " + self.checkpoint_dir + "\n"
         result += "  validate_every: " + String(self.validate_every) + "\n"
         result += "  log_interval: " + String(self.log_interval) + "\n"
         result += (

--- a/src/projectodyssey/training/interruption.mojo
+++ b/src/projectodyssey/training/interruption.mojo
@@ -145,6 +145,25 @@ struct TrainingResult:
         self.checkpoint_path = checkpoint_path
         self.elapsed_seconds = elapsed_seconds
 
+    def exit_code(self) -> Int:
+        """Return the process exit code corresponding to the shutdown reason.
+
+        Exit code conventions:
+            0   = success (COMPLETED or MAX_EPOCHS)
+            1   = permanent error (reserved for future use)
+            2   = transient failure (TIMEOUT — safe to retry)
+            130 = SIGINT (Ctrl+C / SIGNAL)
+
+        Returns:
+            Integer exit code (0, 2, or 130).
+        """
+        if self.reason == ShutdownReason.signal():
+            return 130
+        elif self.reason == ShutdownReason.timeout():
+            return 2
+        else:
+            return 0
+
     def to_string(self) -> String:
         var result = String()
         result += "TrainingResult:\n"

--- a/tests/projectodyssey/training/test_checkpoint.mojo
+++ b/tests/projectodyssey/training/test_checkpoint.mojo
@@ -49,7 +49,7 @@ def test_save_and_load_checkpoint() raises:
     var param_names = create_param_names()
 
     # Save checkpoint at epoch 5
-    ckpt_mgr.save_checkpoint(
+    _ = ckpt_mgr.save_checkpoint(
         params,
         param_names,
         epoch=5,
@@ -98,19 +98,19 @@ def test_save_best_model() raises:
     var param_names = create_param_names()
 
     # Save checkpoint with val_loss=0.5
-    ckpt_mgr.save_checkpoint(
+    _ = ckpt_mgr.save_checkpoint(
         params, param_names, epoch=1, val_loss=0.5, val_acc=0.80
     )
     ckpt_mgr.save_best(params, param_names, epoch=1, metric_value=0.5)
 
     # Save checkpoint with val_loss=0.3 (better)
-    ckpt_mgr.save_checkpoint(
+    _ = ckpt_mgr.save_checkpoint(
         params, param_names, epoch=2, val_loss=0.3, val_acc=0.85
     )
     ckpt_mgr.save_best(params, param_names, epoch=2, metric_value=0.3)
 
     # Save checkpoint with val_loss=0.4 (worse, should not be best)
-    ckpt_mgr.save_checkpoint(
+    _ = ckpt_mgr.save_checkpoint(
         params, param_names, epoch=3, val_loss=0.4, val_acc=0.82
     )
     ckpt_mgr.save_best(params, param_names, epoch=3, metric_value=0.4)
@@ -139,7 +139,7 @@ def test_resume_training() raises:
         var val_loss = 0.9 / Float32(epoch)
         var val_acc = 0.7 + Float32(epoch) * 0.05
 
-        ckpt_mgr.save_checkpoint(
+        _ = ckpt_mgr.save_checkpoint(
             params,
             param_names,
             epoch=epoch,
@@ -167,7 +167,7 @@ def test_multiple_checkpoints() raises:
 
     # Save 10 checkpoints
     for epoch in range(1, 11):
-        ckpt_mgr.save_checkpoint(
+        _ = ckpt_mgr.save_checkpoint(
             params, param_names, epoch=epoch, train_loss=Float32(epoch) * 0.1
         )
 
@@ -192,13 +192,13 @@ def test_best_model_maximize_metric() raises:
     var param_names = create_param_names()
 
     # Save checkpoints with increasing accuracy
-    ckpt_mgr.save_checkpoint(params, param_names, epoch=1, val_acc=0.75)
+    _ = ckpt_mgr.save_checkpoint(params, param_names, epoch=1, val_acc=0.75)
     ckpt_mgr.save_best(params, param_names, epoch=1, metric_value=0.75)
 
-    ckpt_mgr.save_checkpoint(params, param_names, epoch=2, val_acc=0.85)
+    _ = ckpt_mgr.save_checkpoint(params, param_names, epoch=2, val_acc=0.85)
     ckpt_mgr.save_best(params, param_names, epoch=2, metric_value=0.85)
 
-    ckpt_mgr.save_checkpoint(params, param_names, epoch=3, val_acc=0.80)
+    _ = ckpt_mgr.save_checkpoint(params, param_names, epoch=3, val_acc=0.80)
     ckpt_mgr.save_best(
         params, param_names, epoch=3, metric_value=0.80
     )  # Should not update

--- a/tests/projectodyssey/training/test_checkpoint_resume.mojo
+++ b/tests/projectodyssey/training/test_checkpoint_resume.mojo
@@ -1,0 +1,368 @@
+"""Tests for checkpoint atomic save and resume mechanism.
+
+Verifies correctness of CheckpointManager extensions for:
+- Atomic save with step and optimizer state
+- Per-epoch incremental saves
+- Fresh flag behavior (clear existing checkpoint)
+- Resume loading with latest checkpoint
+- Partial write recovery (skips broken epochs without metadata)
+- Config snapshot round-trip
+- TrainingConfig new fields
+
+Test Coverage (Issue #5184):
+- AC1/AC2/AC6: save_and_load_with_optimizer_state
+- AC1 config: save_load_config_snapshot
+- AC3: training_config_has_new_fields
+- AC4: (integration test - covered in test_training_loop.mojo)
+- AC5: resume_loads_latest_checkpoint
+- Decision 9: partial_write_recovery_skips_broken_epoch
+"""
+
+from projectodyssey.tensor.any_tensor import AnyTensor
+from projectodyssey.tensor.tensor_creation import zeros, ones
+from projectodyssey.training.checkpoint import CheckpointManager
+from projectodyssey.training.config import TrainingConfig
+from projectodyssey.utils.file_io import (
+    file_exists,
+    create_directory,
+    safe_write_file,
+    safe_read_file,
+)
+from projectodyssey.testing.assertions import (
+    assert_true,
+    assert_equal_int,
+    assert_close_float,
+)
+from std.collections import List
+
+
+def create_test_params() raises -> List[AnyTensor]:
+    """Create simple test parameters (3 params for optimizer state tests)."""
+    var params = List[AnyTensor]()
+    params.append(ones([4, 4], DType.float32))  # param1
+    params.append(ones([4], DType.float32))  # param2
+    params.append(ones([2, 4], DType.float32))  # param3
+    return params^
+
+
+def create_param_names() -> List[String]:
+    """Create parameter names for test."""
+    var names = List[String]()
+    names.append("param1")
+    names.append("param2")
+    names.append("param3")
+    return names^
+
+
+def create_optimizer_state(
+    num_params: Int, num_slots: Int
+) raises -> List[List[AnyTensor]]:
+    """Create fake Adam-like optimizer state (m, v slots per parameter)."""
+    var opt_state = List[List[AnyTensor]]()
+    for _ in range(num_params):
+        var slots = List[AnyTensor]()
+        for _ in range(num_slots):
+            slots.append(zeros([4], DType.float32))
+        opt_state.append(slots^)
+    return opt_state^
+
+
+def test_save_and_load_with_optimizer_state() raises:
+    """Test saving and loading checkpoints with optimizer state.
+
+    Covers AC1 (weights + optimizer state), AC2 (step counter), AC6 (round-trip fidelity).
+    Saves weights + 2-slot Adam state (m, v) for 3 params at epoch 7, step 1400.
+    Reloads via load_latest_with_optimizer and asserts round-trip.
+    """
+    var ckpt_dir = "/tmp/test_ckpt_optimizer_state"
+    var ckpt_mgr = CheckpointManager(ckpt_dir, max_to_keep=5)
+
+    var params = create_test_params()
+    var param_names = create_param_names()
+    var opt_state = create_optimizer_state(3, 2)  # 3 params, 2 slots each
+
+    # Save checkpoint at epoch 7 with step 1400
+    var saved_path = ckpt_mgr.save_checkpoint(
+        params,
+        param_names,
+        epoch=7,
+        step=1400,
+        train_loss=0.25,
+        val_loss=0.30,
+        val_acc=0.88,
+        optimizer_state=opt_state,
+    )
+
+    assert_true(
+        file_exists(saved_path + "/metadata.txt"),
+        "metadata.txt should exist after save",
+    )
+    assert_true(
+        file_exists(saved_path + "/optimizer/slot_counts.txt"),
+        "optimizer/slot_counts.txt should exist after save",
+    )
+
+    # Load via load_latest_with_optimizer
+    var loaded_params = List[AnyTensor]()
+    var loaded_opt_state = List[List[AnyTensor]]()
+    var epoch_step = ckpt_mgr.load_latest_with_optimizer(
+        loaded_params, param_names, loaded_opt_state
+    )
+
+    assert_equal_int(epoch_step[0], 7, "Loaded epoch should be 7")
+    assert_equal_int(epoch_step[1], 1400, "Loaded step should be 1400")
+    assert_equal_int(len(loaded_params), 3, "Should load 3 parameters")
+    assert_equal_int(
+        len(loaded_opt_state), 3, "Optimizer state should have 3 params"
+    )
+    assert_equal_int(
+        len(loaded_opt_state[0]), 2, "Each param should have 2 slots"
+    )
+
+
+def test_save_load_config_snapshot() raises:
+    """Test config snapshot embedded in checkpoint metadata round-trips.
+
+    Covers AC1 config-snapshot bullet: config snapshot is saved and readable.
+    """
+    var ckpt_dir = "/tmp/test_ckpt_config_snapshot"
+    var ckpt_mgr = CheckpointManager(ckpt_dir, max_to_keep=5)
+
+    var params = create_test_params()
+    var param_names = create_param_names()
+
+    var config = TrainingConfig(
+        epochs=50,
+        batch_size=64,
+        learning_rate=0.001,
+        momentum=0.9,
+        checkpoint_every_n_epochs=5,
+        checkpoint_dir=ckpt_dir,
+    )
+    var snapshot = config.to_snapshot_blob()
+
+    var saved_path = ckpt_mgr.save_checkpoint(
+        params,
+        param_names,
+        epoch=1,
+        config_snapshot=snapshot,
+    )
+
+    # Verify metadata file contains the config snapshot
+    var metadata = safe_read_file(saved_path + "/metadata.txt")
+    assert_true(
+        metadata.find("config=") >= 0,
+        "metadata.txt should contain config= line",
+    )
+    assert_true(
+        metadata.find("epochs=50") >= 0,
+        "config snapshot should contain epochs=50",
+    )
+
+
+def test_training_config_has_new_fields() raises:
+    """Test TrainingConfig has checkpoint_every_n_epochs and checkpoint_dir.
+
+    Covers AC3: new fields exist and are correctly stored.
+    """
+    var config = TrainingConfig(
+        epochs=1,
+        batch_size=1,
+        checkpoint_dir="/tmp/my_checkpoints",
+        checkpoint_every_n_epochs=2,
+    )
+
+    assert_equal_int(
+        config.checkpoint_every_n_epochs,
+        2,
+        "checkpoint_every_n_epochs should be 2",
+    )
+    assert_true(
+        config.checkpoint_dir == "/tmp/my_checkpoints",
+        "checkpoint_dir should be '/tmp/my_checkpoints'",
+    )
+
+
+def test_fresh_flag_clears_checkpoint() raises:
+    """Test that fresh mode removes existing checkpoint tracker.
+
+    Covers the --fresh flag behavior: existing state is cleared on resume.
+    """
+    var ckpt_dir = "/tmp/test_ckpt_fresh"
+    var ckpt_mgr = CheckpointManager(ckpt_dir, max_to_keep=5)
+
+    var params = create_test_params()
+    var param_names = create_param_names()
+
+    # Save a checkpoint so tracker exists
+    _ = ckpt_mgr.save_checkpoint(params, param_names, epoch=3)
+
+    # Verify tracker exists
+    assert_true(
+        file_exists(ckpt_dir + "/checkpoint_tracker.txt"),
+        "tracker should exist before fresh",
+    )
+
+    # Apply fresh: should clear checkpoint tracker
+    ckpt_mgr.clear_checkpoints()
+
+    # After fresh, load_latest should return epoch 0
+    var loaded_params = List[AnyTensor]()
+    var epoch = ckpt_mgr.load_latest(loaded_params, param_names)
+    assert_equal_int(epoch, 0, "After clear, load_latest should return epoch 0")
+
+
+def test_resume_loads_latest_checkpoint() raises:
+    """Test that load_latest_with_optimizer returns the most recent epoch+step.
+
+    Covers AC5: resume loads from last completed epoch.
+    """
+    var ckpt_dir = "/tmp/test_ckpt_resume_latest"
+    var ckpt_mgr = CheckpointManager(ckpt_dir, max_to_keep=10)
+
+    var params = create_test_params()
+    var param_names = create_param_names()
+    var opt_state = create_optimizer_state(3, 2)
+
+    # Save multiple checkpoints
+    for epoch in range(1, 6):
+        _ = ckpt_mgr.save_checkpoint(
+            params,
+            param_names,
+            epoch=epoch,
+            step=epoch * 100,
+            optimizer_state=opt_state,
+        )
+
+    # Resume: should get epoch 5, step 500
+    var loaded_params = List[AnyTensor]()
+    var loaded_opt = List[List[AnyTensor]]()
+    var epoch_step = ckpt_mgr.load_latest_with_optimizer(
+        loaded_params, param_names, loaded_opt
+    )
+
+    assert_equal_int(epoch_step[0], 5, "Should resume from epoch 5")
+    assert_equal_int(epoch_step[1], 500, "Should resume from step 500")
+
+
+def test_partial_write_recovery_skips_broken_epoch() raises:
+    """Test that load_latest_with_optimizer skips epochs with missing metadata.
+
+    Covers Decision 9: partial write recovery falls back to prior epoch.
+    Creates checkpoint_epoch_5/ with weights but no metadata.txt,
+    and epoch_4/ with complete data. Asserts epoch_5 is skipped.
+    """
+    var ckpt_dir = "/tmp/test_ckpt_partial_recovery"
+    var ckpt_mgr = CheckpointManager(ckpt_dir, max_to_keep=10)
+
+    var params = create_test_params()
+    var param_names = create_param_names()
+    var opt_state = create_optimizer_state(3, 2)
+
+    # Save a good checkpoint at epoch 4
+    _ = ckpt_mgr.save_checkpoint(
+        params,
+        param_names,
+        epoch=4,
+        step=400,
+        optimizer_state=opt_state,
+    )
+
+    # Manually create a broken epoch 5 dir (weights, no metadata.txt)
+    var broken_dir = ckpt_dir + "/checkpoint_epoch_5"
+    if not create_directory(broken_dir):
+        raise Error("Failed to create broken_dir for test")
+    # Write weights but no metadata
+    _ = safe_write_file(broken_dir + "/param1.weights", "broken\n")
+    # Manually update tracker to point at epoch 5 (simulating crash after write)
+    _ = safe_write_file(
+        ckpt_dir + "/checkpoint_tracker.txt", "latest_epoch=5\n"
+    )
+
+    # load_latest_with_optimizer should detect missing metadata at epoch 5
+    # and fall back to epoch 4
+    var loaded_params = List[AnyTensor]()
+    var loaded_opt = List[List[AnyTensor]]()
+    var epoch_step = ckpt_mgr.load_latest_with_optimizer(
+        loaded_params, param_names, loaded_opt
+    )
+
+    assert_equal_int(
+        epoch_step[0], 4, "Should fall back to epoch 4 (skip broken epoch 5)"
+    )
+
+
+def test_exit_codes_via_training_result() raises:
+    """Test exit code constants are correct values.
+
+    Covers exit code AC: 0=success, 1=error, 2=transient, 130=SIGINT.
+    """
+    from projectodyssey.training.interruption import (
+        TrainingResult,
+        ShutdownReason,
+    )
+
+    # Success result -> exit code 0
+    var success = TrainingResult(
+        stopped_epoch=10,
+        reason=ShutdownReason.completed(),
+    )
+    assert_equal_int(
+        success.exit_code(), 0, "Completed should give exit code 0"
+    )
+
+    # Signal result -> exit code 130
+    var sigint = TrainingResult(
+        stopped_epoch=3,
+        reason=ShutdownReason.signal(),
+    )
+    assert_equal_int(
+        sigint.exit_code(), 130, "SIGINT should give exit code 130"
+    )
+
+    # Timeout result -> exit code 2 (transient)
+    var timeout = TrainingResult(
+        stopped_epoch=3,
+        reason=ShutdownReason.timeout(),
+    )
+    assert_equal_int(timeout.exit_code(), 2, "Timeout should give exit code 2")
+
+
+def main() raises:
+    """Run all checkpoint resume tests."""
+    print("Testing Checkpoint Save/Load and Recovery (Issue #5184)...")
+    print("=" * 70)
+
+    print("\n[1/7] Testing save and load with optimizer state...")
+    test_save_and_load_with_optimizer_state()
+    print("PASSED")
+
+    print("[2/7] Testing config snapshot round-trip...")
+    test_save_load_config_snapshot()
+    print("PASSED")
+
+    print("[3/7] Testing TrainingConfig new fields...")
+    test_training_config_has_new_fields()
+    print("PASSED")
+
+    print("[4/7] Testing fresh flag clears checkpoint...")
+    test_fresh_flag_clears_checkpoint()
+    print("PASSED")
+
+    print("[5/7] Testing resume loads latest checkpoint...")
+    test_resume_loads_latest_checkpoint()
+    print("PASSED")
+
+    print("[6/7] Testing partial write recovery skips broken epoch...")
+    test_partial_write_recovery_skips_broken_epoch()
+    print("PASSED")
+
+    print("[7/7] Testing exit codes via TrainingResult...")
+    test_exit_codes_via_training_result()
+    print("PASSED")
+
+    print("\n" + "=" * 70)
+    print("All 7 checkpoint resume tests PASSED!")
+    print(
+        "Atomic save, optimizer state, recovery, and resume working correctly."
+    )


### PR DESCRIPTION
## Summary
- Atomic tmp+rename saves prevent corruption on crash/SIGINT (via existing `safe_write_file` pattern)
- Per-epoch incremental checkpoint writes with `step` counter for exact training resume
- Optimizer state persistence (`List[List[AnyTensor]]` outer=params, inner=slots) saved to `optimizer/param_<i>_slot_<j>.weights` with `slot_counts.txt` sidecar
- `load_latest_with_optimizer()` returns `Tuple[Int, Int](epoch, step)` for full resume fidelity
- `clear_checkpoints()` supports `--fresh` flag (removes tracker, preserves weight dirs)
- Partial-write recovery: scans backwards when latest epoch lacks `metadata.txt`, falls back to last valid epoch
- `TrainingResult.exit_code()`: 0=success, 2=timeout (transient), 130=SIGINT
- `TrainingConfig`: adds `checkpoint_every_n_epochs`, `checkpoint_dir`, `to_snapshot_blob()`

## Test plan
- [x] All 6 existing checkpoint tests pass with `--Werror`
- [x] All 7 new tests in `test_checkpoint_resume.mojo` pass with `--Werror`
- [x] Package builds with `mojo package --Werror`
- [x] `mojo format` applied to all changed files
- [x] Pre-commit clean

Closes #5184