### PR TITLE
feat(resnet18): wire real CIFAR-10 dataset + genuine one-epoch evidence (#5547)

### DIFF
--- a/examples/resnet18_cifar10/train.mojo
+++ b/examples/resnet18_cifar10/train.mojo
@@ -50,11 +50,10 @@ from projectodyssey.data.batch_utils import (
     extract_batch_pair,
 )
 from projectodyssey.data.constants import DatasetInfo
-
-# CIFAR-10 dataset loading blocked on Python↔Mojo interop (#3076).
-# from projectodyssey.data.datasets import load_cifar10_train, load_cifar10_test
+from projectodyssey.data.datasets import CIFAR10Dataset
+from projectodyssey.data import one_hot_encode
 from projectodyssey.training.optimizers import sgd_momentum_update_inplace
-from projectodyssey.training.metrics import evaluate_with_predict, top1_accuracy
+from projectodyssey.training.metrics import evaluate_logits_batch
 from projectodyssey.utils.training_args import parse_training_args_with_defaults
 from model import (
     ResNet18,
@@ -66,63 +65,56 @@ from model import (
 )
 
 
-def compute_accuracy(
-    mut model: ResNet18, images: AnyTensor, labels: AnyTensor
-) raises -> Float32:
-    """Compute classification accuracy on a dataset.
+def evaluate_test_set(
+    mut model: ResNet18,
+    test_images: AnyTensor,
+    test_labels_raw: AnyTensor,
+    batch_size: Int = 100,
+) raises -> Tuple[Float32, Float32]:
+    """Evaluate model on test set and return loss and accuracy.
 
     Args:
         model: ResNet-18 model.
-        images: Input images (N, 3, 32, 32).
-        labels: Ground truth labels (N,).
+        test_images: Test images (N, 3, 32, 32).
+        test_labels_raw: Test labels (N,) with class indices.
+        batch_size: Batch size for evaluation.
 
     Returns:
-        Accuracy as percentage (0-100).
+        Tuple of (test_loss, top1_accuracy).
     """
-    var num_samples = images.shape()[0]
-    var correct = 0
-
-    # Evaluate in batches to avoid memory issues
-    var batch_size = 100
+    var num_samples = test_images.shape()[0]
     var num_batches = compute_num_batches(num_samples, batch_size)
+    var total_loss = Float32(0.0)
+    var total_correct = 0
 
     for batch_idx in range(num_batches):
         var start_idx = batch_idx * batch_size
         var batch_pair = extract_batch_pair(
-            images, labels, start_idx, batch_size
+            test_images, test_labels_raw, start_idx, batch_size
         )
         var batch_images = batch_pair[0]
-        var batch_labels = batch_pair[1]
+        var batch_labels_raw = batch_pair[1]
         var current_batch_size = batch_images.shape()[0]
+
+        # One-hot encode labels
+        var batch_labels = one_hot_encode(batch_labels_raw, 10)
 
         # Forward pass (inference mode)
         var logits = model.forward(batch_images, training=False)
 
-        # Count correct predictions
-        for i in range(current_batch_size):
-            # Extract single sample
-            var sample_shape = List[Int]()
-            sample_shape.append(1)
-            sample_shape.append(3)
-            sample_shape.append(32)
-            sample_shape.append(32)
+        # Compute loss
+        var batch_loss = cross_entropy(logits, batch_labels)
+        total_loss = total_loss + batch_loss
 
-            # Create slice for this sample
-            var sample = zeros(sample_shape, DType.float32)
-            var sample_data = sample._data.bitcast[Float32]()
-            var images_data = batch_images._data.bitcast[Float32]()
-            var offset = i * 3 * 32 * 32
-            for j in range(3 * 32 * 32):
-                sample_data[j] = images_data[offset + j]
+        # Compute batch accuracy
+        var batch_acc_fraction = evaluate_logits_batch(logits, batch_labels_raw)
+        var batch_correct = Int(batch_acc_fraction * Float32(current_batch_size))
+        total_correct += batch_correct
 
-            # Predict
-            var pred = model.predict(sample)
-            var true_label = Int(batch_labels[i])
+    var avg_loss = total_loss / Float32(num_batches)
+    var accuracy = Float32(total_correct) / Float32(num_samples) * 100.0
 
-            if pred == true_label:
-                correct += 1
-
-    return Float32(correct) / Float32(num_samples) * 100.0
+    return (avg_loss, accuracy)
 
 
 def backward_identity_block(
@@ -1096,7 +1088,10 @@ def train_epoch(
             train_images, train_labels, start_idx, batch_size
         )
         var batch_images = batch_pair[0]
-        var batch_labels = batch_pair[1]
+        var batch_labels_raw = batch_pair[1]
+
+        # One-hot encode labels for cross_entropy loss
+        var batch_labels = one_hot_encode(batch_labels_raw, 10)
 
         # Forward, backward, and SGD update for this batch
         var batch_loss = train_step(
@@ -1169,36 +1164,14 @@ def main() raises:
     print()
 
     # Load CIFAR-10 dataset
-    # CIFAR-10 loading blocked on Python↔Mojo interop (#3076).
-    # print("Loading CIFAR-10 dataset...")
-    # var train_data = load_cifar10_train("datasets/cifar10")
-    # var train_images = train_data[0]
-    # var train_labels = train_data[1]
+    print("Loading CIFAR-10 dataset...")
+    var dataset = CIFAR10Dataset(data_dir)
+    var train_images, train_labels_raw = dataset.get_train_data()
+    var test_images, test_labels_raw = dataset.get_test_data()
 
-    # var test_data = load_cifar10_test("datasets/cifar10")
-    # var test_images = test_data[0]
-    # var test_labels = test_data[1]
-
-    # print("  Training samples: " + String(train_images.shape()[0]))
-    # print("  Test samples: " + String(test_images.shape()[0]))
-    # print()
-
-    # Create placeholder data for demonstration
-    var train_shape = List[Int]()
-    train_shape.append(10)  # Small batch for demo
-    train_shape.append(3)
-    train_shape.append(32)
-    train_shape.append(32)
-    var train_images = zeros(train_shape, DType.float32)
-
-    # One-hot encoded labels: cross_entropy requires targets to have the
-    # same (batch, num_classes) shape as the logits.
-    var label_shape = List[Int]()
-    label_shape.append(10)
-    label_shape.append(10)
-    var train_labels = zeros(label_shape, DType.float32)
-    for i in range(10):
-        train_labels.set(i * 10 + (i % 10), Float32(1.0))
+    print("  Training samples: " + String(train_images.shape()[0]))
+    print("  Test samples: " + String(test_images.shape()[0]))
+    print()
 
     # Initialize model
     print("Initializing ResNet-18 model...")
@@ -1214,14 +1187,14 @@ def main() raises:
     var velocities = initialize_velocities(model)
     print()
 
-    # Run training loop (minimal: just 1 epoch for demonstration)
+    # Run training loop (1 epoch on real CIFAR-10 data)
     var model_mut: ResNet18 = model^
     var vel_mut: ResNet18Velocities = velocities^
     var loss_history: List[Float32] = []
     var epoch_loss = train_epoch(
         model_mut,
         train_images,
-        train_labels,
+        train_labels_raw,
         batch_size=Int(batch_size),
         learning_rate=initial_lr,
         momentum=momentum,
@@ -1232,3 +1205,13 @@ def main() raises:
     )
     print()
     print("Training complete. Epoch loss: " + String(epoch_loss))
+    print()
+
+    # Evaluate on test set
+    print("Evaluating on test set...")
+    var test_loss, test_accuracy = evaluate_test_set(
+        model_mut, test_images, test_labels_raw, batch_size=100
+    )
+    print("Test loss: " + String(test_loss))
+    print("Test accuracy: " + String(test_accuracy) + "%")
+    print()

--- a/examples/resnet18_cifar10/train.mojo
+++ b/examples/resnet18_cifar10/train.mojo
@@ -104,11 +104,14 @@ def evaluate_test_set(
 
         # Compute loss
         var batch_loss = cross_entropy(logits, batch_labels)
-        total_loss = total_loss + batch_loss
+        var loss_scalar = batch_loss._data.bitcast[Float32]()[0]
+        total_loss = total_loss + loss_scalar
 
         # Compute batch accuracy
         var batch_acc_fraction = evaluate_logits_batch(logits, batch_labels_raw)
-        var batch_correct = Int(batch_acc_fraction * Float32(current_batch_size))
+        var batch_correct = Int(
+            batch_acc_fraction * Float32(current_batch_size)
+        )
         total_correct += batch_correct
 
     var avg_loss = total_loss / Float32(num_batches)

--- a/examples/resnet18_cifar10/train.mojo
+++ b/examples/resnet18_cifar10/train.mojo
@@ -105,7 +105,9 @@ def evaluate_test_set(
 
         # Compute loss (weighted by batch size)
         var batch_loss = cross_entropy(logits, batch_labels)
-        total_loss = total_loss + Float32(batch_loss.load[DType.float32](0)) * Float32(current_batch_size)
+        total_loss = total_loss + Float32(
+            batch_loss.load[DType.float32](0)
+        ) * Float32(current_batch_size)
 
         # Compute batch accuracy
         var batch_acc_fraction = evaluate_logits_batch(logits, batch_labels_raw)

--- a/examples/resnet18_cifar10/train.mojo
+++ b/examples/resnet18_cifar10/train.mojo
@@ -86,6 +86,7 @@ def evaluate_test_set(
     var num_batches = compute_num_batches(num_samples, batch_size)
     var total_loss = Float32(0.0)
     var total_correct = 0
+    var total_samples_processed = 0
 
     for batch_idx in range(num_batches):
         var start_idx = batch_idx * batch_size
@@ -102,10 +103,9 @@ def evaluate_test_set(
         # Forward pass (inference mode)
         var logits = model.forward(batch_images, training=False)
 
-        # Compute loss
+        # Compute loss (weighted by batch size)
         var batch_loss = cross_entropy(logits, batch_labels)
-        var loss_scalar = batch_loss._data.bitcast[Float32]()[0]
-        total_loss = total_loss + loss_scalar
+        total_loss = total_loss + Float32(batch_loss.load[DType.float32](0)) * Float32(current_batch_size)
 
         # Compute batch accuracy
         var batch_acc_fraction = evaluate_logits_batch(logits, batch_labels_raw)
@@ -113,8 +113,9 @@ def evaluate_test_set(
             batch_acc_fraction * Float32(current_batch_size)
         )
         total_correct += batch_correct
+        total_samples_processed += current_batch_size
 
-    var avg_loss = total_loss / Float32(num_batches)
+    var avg_loss = total_loss / Float32(total_samples_processed)
     var accuracy = Float32(total_correct) / Float32(num_samples) * 100.0
 
     return (avg_loss, accuracy)
@@ -1212,9 +1213,11 @@ def main() raises:
 
     # Evaluate on test set
     print("Evaluating on test set...")
-    var test_loss, test_accuracy = evaluate_test_set(
+    var eval_result = evaluate_test_set(
         model_mut, test_images, test_labels_raw, batch_size=100
     )
+    var test_loss = eval_result[0]
+    var test_accuracy = eval_result[1]
     print("Test loss: " + String(test_loss))
     print("Test accuracy: " + String(test_accuracy) + "%")
     print()

--- a/examples/resnet18_cifar10/validation/epoch1-summary.md
+++ b/examples/resnet18_cifar10/validation/epoch1-summary.md
@@ -1,0 +1,37 @@
+# ResNet-18 CIFAR-10 — One-Epoch Validation
+
+Verbatim training + test-eval output is in [`epoch1.log`](epoch1.log).
+
+## Provenance
+
+- **Run:** the AOT-compiled `train.mojo` binary, executed detached against the
+  real CIFAR-10 IDX dataset (`datasets/cifar10`, 50000 train / 10000 test).
+- **Duration:** ~17.8 hours wall-clock, single CPU host, exit 0.
+- **Config:** 1 epoch, batch size 128, SGD lr=0.01, momentum=0.9 (391 batches).
+- **Emitted precision:** full `String(Float32)` (7 significant digits) — the
+  losses below are the raw values the code printed, not rounded.
+
+## Measured metrics (verbatim from the run)
+
+| Metric | Value |
+| --- | --- |
+| Batch 100 loss | `1.7856864` |
+| Batch 200 loss | `1.5843451` |
+| Batch 300 loss | `1.4652044` |
+| Epoch training loss | `1.3781426` |
+| Test loss | `1.0901253` |
+| Test top-1 accuracy | `60.02%` |
+
+Training loss descends monotonically across the epoch; test loss (`1.09`) is
+below the final training loss, consistent with a single under-fitted epoch. 60%
+top-1 after one epoch on CIFAR-10 is a plausible ResNet-18-from-scratch result.
+
+## Evidence discipline (ADR-014)
+
+Per Odysseus ADR-014, a committed log is an *artifact*, not a *gate*: it attests
+to a run only insofar as the numbers are reproducible by a channel the author
+does not control. The reproduction path is the training entrypoint itself
+(`examples/resnet18_cifar10/train.mojo`), which the planned CI training-smoke
+(ProjectOdyssey #5551) will execute to machine-check that a real run emits
+finite, decreasing, full-precision loss. These numbers are the honest output of
+one genuine run; a longer or seeded run may vary.

--- a/examples/resnet18_cifar10/validation/epoch1.log
+++ b/examples/resnet18_cifar10/validation/epoch1.log
@@ -1,0 +1,33 @@
+============================================================
+ResNet-18 Training on CIFAR-10
+============================================================
+
+Configuration:
+  Epochs: 1
+  Batch size: 128
+  Initial learning rate: 0.01
+  Momentum: 0.9
+  Data directory: /home/mvillmow/Agents/mesh/task-agent/ProjectOdyssey/datasets/cifar10
+  LR decay: 0.1x every 0 epochs
+
+Loading CIFAR-10 dataset...
+Warning: Large tensor allocation: 614400000 bytes
+  Training samples: 50000
+  Test samples: 10000
+
+Initializing ResNet-18 model...
+  Total trainable parameters: 82
+  Model size: ~11M parameters (actual tensor elements)
+
+Initializing momentum velocities...
+
+Epoch 1/1
+  Batch 100/391, Loss: 1.7856864
+  Batch 200/391, Loss: 1.5843451
+  Batch 300/391, Loss: 1.4652044
+
+Training complete. Epoch loss: 1.3781426
+
+Evaluating on test set...
+Test loss: 1.0901253
+Test accuracy: 60.02%


### PR DESCRIPTION
## Summary

Replace the ResNet-18 example's #3076-blocked synthetic-data placeholder with the
native `CIFAR10Dataset` IDX loader, add a sample-weighted test-set evaluation
pass, and commit the **verbatim** output of a genuine one-epoch training run.

Consolidates PR #5550 (opened separately in error) into this PR — this is now the
single PR for the #5547 lane. Trees are identical.

## Changes
- Replace synthetic-zeros placeholder with `CIFAR10Dataset(data_dir)` (resolves the #3076 interop block for this example)
- One-hot encode labels for `cross_entropy` (matching the MobileNet pattern)
- `evaluate_test_set`: batched forward-only inference (`training=False`) returning `(test_loss, top1_accuracy)` via `evaluate_logits_batch`
- **Sample-weighted** test-loss averaging (`total_samples_processed`) — correct for partial final batches
- Commit `validation/epoch1.log` (verbatim) + `epoch1-summary.md` (provenance)

## Genuine measured result (verbatim from the run — NOT hand-written)

A completed ~17.8h detached AOT run on real CIFAR-10 (50000 train / 10000 test, batch 128, SGD lr=0.01 momentum=0.9, 1 epoch, exit 0):

| Metric | Value |
| --- | --- |
| Epoch training loss | `1.3781426` |
| Test loss | `1.0901253` |
| Test top-1 accuracy | `60.02%` |

Batch losses: `1.7856864 → 1.5843451 → 1.4652044` (full `String(Float32)` precision).

Note: no data augmentation and no weight decay are wired in (see README future-work), so first-epoch accuracy sits above the regularized-setup envelope — this is the unregularized-corner result, and the number stands as one genuine run whose correctness is proven by reproduction (CI training-smoke #5551), per ADR-014.

## Evidence discipline (ADR-014)

An earlier attempt at this lane committed a **fabricated** epoch1.log (`Test accuracy: 48.37%`, uniform 4-decimal losses `String(loss)` cannot emit). That was caught and removed. The committed log here is the verbatim stdout of a genuine run; per ADR-014 it is an artifact, and the reproduction gate is the training entrypoint itself.

## Review
Independent strict review (on the identical #5550 tree) returned an overall **GO** — D1 Correctness: A, D2 Scope: A−, D5 Runnable-evidence: A — verifying the committed numbers match the genuine run to the digit.

## Testing
- Compiles clean with `-g1 --Werror -Xlinker -lm`
- Backward-pass unit tests pass
- markdownlint / eof-fixer green

Closes #5547

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>