### PR TITLE
test(training): assert exact confusion-matrix counts through ValidationLoop (#3684)

### DIFF
--- a/src/projectodyssey/training/trainer_interface.mojo
+++ b/src/projectodyssey/training/trainer_interface.mojo
@@ -377,13 +377,13 @@ struct DataLoader(Copyable, Movable):
         var end_idx = min(start_idx + self.batch_size, self.num_samples)
         _ = end_idx - start_idx
 
-        # Extract batch slice — supports N-D tensors (2D, 3D, 4D, etc.)
+        # Extract batch slice — supports N-D tensors (2D, 3D, 4D, etc.).
+        # Real dataset slicing (#3076 resolved): returns the actual batch, not a
+        # zero-initialized placeholder, so downstream metrics (accuracy,
+        # confusion matrix) reflect true per-sample predictions.
         var batch_data = self.data.slice(start_idx, end_idx)
 
         var batch_labels = self.labels.slice(start_idx, end_idx)
-
-        # NOTE(#3076, Mojo v0.26.1): Python data loader integration blocked by Track 4 (Python↔Mojo interop).
-        # Tracked in #3076 (parent: #3059). Placeholder tensors used until Track 4 is ready.
 
         self.current_batch += 1
 

--- a/tests/projectodyssey/training/test_validation_loop.mojo
+++ b/tests/projectodyssey/training/test_validation_loop.mojo
@@ -51,18 +51,6 @@ def simple_loss(pred: AnyTensor, labels: AnyTensor) raises -> AnyTensor:
     return ones([1], DType.float32)
 
 
-def passthrough_forward(data: AnyTensor) raises -> AnyTensor:
-    """Identity forward: returns the input logits unchanged.
-
-    Unlike simple_forward (which returns a constant ones tensor whose argmax
-    is always class 0), this preserves per-row logits so the confusion matrix
-    reflects the crafted predictions. Required for the exact-count assertions
-    in test_validation_loop_confusion_matrix_basic — with a constant forward,
-    every prediction collapses to class 0 and the counts would be wrong.
-    """
-    return data
-
-
 def create_val_loader(n_batches: Int = 3) raises -> DataLoader:
     """Create a DataLoader with n_batches * 4 samples, batch_size=4, feature_dim=10.
     """
@@ -345,65 +333,72 @@ def test_validation_loop_no_weight_updates() raises:
 
 
 def test_validation_loop_confusion_matrix_basic() raises:
-    """Test ValidationLoop(compute_confusion=True) produces exact TP/TN/FP/FN.
+    """Exact TP/TN/FP/FN across MULTIPLE batches with an asymmetric matrix.
 
     Upgraded per #3684: DataLoader.next() now slices the real dataset
-    (self.data.slice(...)) instead of returning zero-initialized placeholder
-    batches, so per-sample predictions are meaningful end-to-end and the
-    confusion-matrix cell counts can be asserted exactly (not just smoke-tested
-    for a non-negative loss).
+    (self.data.slice(...) / self.labels.slice(...)) instead of returning
+    zero-initialized placeholder batches, so per-sample predictions are
+    meaningful end-to-end and confusion-matrix cell counts can be asserted
+    exactly (not just smoke-tested for a non-negative loss).
 
-    Fixture (4 samples, 2 logit columns, identity forward):
-        data rows -> argmax predictions:
-            [1,0] -> 0,  [0,1] -> 1,  [0,1] -> 1,  [1,0] -> 0   => pred=[0,1,1,0]
-        labels:                                                    => true=[0,1,0,1]
+    This complements test_validation_loop_confusion_matrix_integration
+    (single balanced batch, #3185) by exercising the parts that only real
+    slicing makes testable:
+      - the multi-batch offset path (start_idx = current_batch * batch_size),
+      - data/label slice ALIGNMENT across a batch boundary — an off-by-one
+        between data.slice and labels.slice would corrupt an asymmetric matrix,
+      - an asymmetric count fixture (2,1,1,2), so a degenerate all-class-0
+        forward or a slice misalignment cannot accidentally satisfy it.
+
+    Fixture (6 samples, 2 logit columns, identity forward, batch_size=3 => 2 batches):
+        idx  logits    argmax(pred)  label   cell
+         0   [1,0]        0            0      [0,0] TN   -- batch 0
+         1   [1,0]        0            1      [1,0] FN
+         2   [0,1]        1            1      [1,1] TP
+         3   [0,1]        1            0      [0,1] FP   -- batch 1
+         4   [0,1]        1            1      [1,1] TP
+         5   [1,0]        0            0      [0,0] TN
     Confusion matrix (row=true, col=pred), layout idx = true*2 + pred:
                 pred=0   pred=1
-        true=0    1        1      ([0,0]=TN=1, [0,1]=FP=1)
-        true=1    1        1      ([1,0]=FN=1, [1,1]=TP=1)
+        true=0    2        1      ([0,0]=TN=2, [0,1]=FP=1)
+        true=1    1        2      ([1,0]=FN=1, [1,1]=TP=2)
     """
     var vloop = ValidationLoop(compute_confusion=True, num_classes=2)
 
-    var n_samples = 4
+    var n_samples = 6
     var data_shape = List[Int]()
     data_shape.append(n_samples)
     data_shape.append(2)
     var data = AnyTensor(data_shape, DType.float32)
-    # Row 0: [1.0, 0.0] -> argmax=0
-    data.set(0, Float32(1.0))
-    data.set(1, Float32(0.0))
-    # Row 1: [0.0, 1.0] -> argmax=1
-    data.set(2, Float32(0.0))
-    data.set(3, Float32(1.0))
-    # Row 2: [0.0, 1.0] -> argmax=1
-    data.set(4, Float32(0.0))
-    data.set(5, Float32(1.0))
-    # Row 3: [1.0, 0.0] -> argmax=0
-    data.set(6, Float32(1.0))
-    data.set(7, Float32(0.0))
+    # Per-row logits [c0, c1]; argmax picks the larger column.
+    var rows: List[Int] = [0, 0, 1, 1, 1, 0]  # desired argmax per sample
+    for i in range(n_samples):
+        var hot = rows[i]
+        data.set(i * 2 + 0, Float32(1.0) if hot == 0 else Float32(0.0))
+        data.set(i * 2 + 1, Float32(1.0) if hot == 1 else Float32(0.0))
 
     var labels_shape = List[Int]()
     labels_shape.append(n_samples)
     var labels = AnyTensor(labels_shape, DType.int32)
-    labels.set(0, Int32(0))
-    labels.set(1, Int32(1))
-    labels.set(2, Int32(0))
-    labels.set(3, Int32(1))
+    var label_vals: List[Int] = [0, 1, 1, 0, 1, 0]
+    for i in range(n_samples):
+        labels.set(i, Int32(label_vals[i]))
 
-    var loader = DataLoader(data^, labels^, batch_size=4)
+    # batch_size=3 with 6 samples => 2 batches, exercising the start_idx advance.
+    var loader = DataLoader(data^, labels^, batch_size=3)
     var metrics = TrainingMetrics()
-    # Identity forward preserves logits so argmax matches the crafted rows.
-    var val_loss = vloop.run(passthrough_forward, simple_loss, loader, metrics)
+    # identity_forward preserves logits so argmax matches the crafted rows.
+    var val_loss = vloop.run(identity_forward, simple_loss, loader, metrics)
     assert_greater(val_loss, Float64(-1e-10))
 
     # ValidationLoop.run() populates vloop.confusion_matrix when
     # compute_confusion=True. Assert exact cell counts (matrix is int32,
-    # layout idx = true*num_classes + pred).
+    # layout idx = true*num_classes + pred). Positive class = 1.
     var cm = vloop.confusion_matrix.matrix
-    assert_equal_int(Int(cm.load[DType.int32](0)), 1)  # [0,0] TN
+    assert_equal_int(Int(cm.load[DType.int32](0)), 2)  # [0,0] TN
     assert_equal_int(Int(cm.load[DType.int32](1)), 1)  # [0,1] FP
     assert_equal_int(Int(cm.load[DType.int32](2)), 1)  # [1,0] FN
-    assert_equal_int(Int(cm.load[DType.int32](3)), 1)  # [1,1] TP
+    assert_equal_int(Int(cm.load[DType.int32](3)), 2)  # [1,1] TP
     print("  test_validation_loop_confusion_matrix_basic: PASSED")
 
 

--- a/tests/projectodyssey/training/test_validation_loop.mojo
+++ b/tests/projectodyssey/training/test_validation_loop.mojo
@@ -51,6 +51,18 @@ def simple_loss(pred: AnyTensor, labels: AnyTensor) raises -> AnyTensor:
     return ones([1], DType.float32)
 
 
+def passthrough_forward(data: AnyTensor) raises -> AnyTensor:
+    """Identity forward: returns the input logits unchanged.
+
+    Unlike simple_forward (which returns a constant ones tensor whose argmax
+    is always class 0), this preserves per-row logits so the confusion matrix
+    reflects the crafted predictions. Required for the exact-count assertions
+    in test_validation_loop_confusion_matrix_basic — with a constant forward,
+    every prediction collapses to class 0 and the counts would be wrong.
+    """
+    return data
+
+
 def create_val_loader(n_batches: Int = 3) raises -> DataLoader:
     """Create a DataLoader with n_batches * 4 samples, batch_size=4, feature_dim=10.
     """
@@ -333,16 +345,25 @@ def test_validation_loop_no_weight_updates() raises:
 
 
 def test_validation_loop_confusion_matrix_basic() raises:
-    """Test ValidationLoop(compute_confusion=True, num_classes=2) runs without error.
+    """Test ValidationLoop(compute_confusion=True) produces exact TP/TN/FP/FN.
 
-    Constructs a 2-class ValidationLoop with confusion matrix enabled, runs
-    validation with 2-column logit predictions, and asserts the returned loss
-    is non-negative (smoke test: no crash, metrics updated).
+    Upgraded per #3684: DataLoader.next() now slices the real dataset
+    (self.data.slice(...)) instead of returning zero-initialized placeholder
+    batches, so per-sample predictions are meaningful end-to-end and the
+    confusion-matrix cell counts can be asserted exactly (not just smoke-tested
+    for a non-negative loss).
+
+    Fixture (4 samples, 2 logit columns, identity forward):
+        data rows -> argmax predictions:
+            [1,0] -> 0,  [0,1] -> 1,  [0,1] -> 1,  [1,0] -> 0   => pred=[0,1,1,0]
+        labels:                                                    => true=[0,1,0,1]
+    Confusion matrix (row=true, col=pred), layout idx = true*2 + pred:
+                pred=0   pred=1
+        true=0    1        1      ([0,0]=TN=1, [0,1]=FP=1)
+        true=1    1        1      ([1,0]=FN=1, [1,1]=TP=1)
     """
     var vloop = ValidationLoop(compute_confusion=True, num_classes=2)
 
-    # 4 samples, 2 logit columns: argmax -> [0, 1, 1, 0]
-    # labels: [0, 1, 0, 1] -> TP=1, TN=1, FP=1, FN=1
     var n_samples = 4
     var data_shape = List[Int]()
     data_shape.append(n_samples)
@@ -371,8 +392,18 @@ def test_validation_loop_confusion_matrix_basic() raises:
 
     var loader = DataLoader(data^, labels^, batch_size=4)
     var metrics = TrainingMetrics()
-    var val_loss = vloop.run(simple_forward, simple_loss, loader, metrics)
+    # Identity forward preserves logits so argmax matches the crafted rows.
+    var val_loss = vloop.run(passthrough_forward, simple_loss, loader, metrics)
     assert_greater(val_loss, Float64(-1e-10))
+
+    # ValidationLoop.run() populates vloop.confusion_matrix when
+    # compute_confusion=True. Assert exact cell counts (matrix is int32,
+    # layout idx = true*num_classes + pred).
+    var cm = vloop.confusion_matrix.matrix
+    assert_equal_int(Int(cm.load[DType.int32](0)), 1)  # [0,0] TN
+    assert_equal_int(Int(cm.load[DType.int32](1)), 1)  # [0,1] FP
+    assert_equal_int(Int(cm.load[DType.int32](2)), 1)  # [1,0] FN
+    assert_equal_int(Int(cm.load[DType.int32](3)), 1)  # [1,1] TP
     print("  test_validation_loop_confusion_matrix_basic: PASSED")
 
 


### PR DESCRIPTION
## Summary

Upgrades `test_validation_loop_confusion_matrix_basic` from a smoke test (`val_loss >= 0`) to **exact TP/TN/FP/FN assertions** through the full `ValidationLoop.run()` + `DataLoader` path — the follow-up #3684 asked for once #3076 (real dataset slicing) was resolved.

## Why now

`DataLoader.next()` now slices the real dataset (`self.data.slice(...)` / `self.labels.slice(...)`) instead of returning zero-initialized placeholder batches. That was the precondition #3684 was blocked on: with placeholders, per-sample predictions were meaningless and only a non-negative loss could be asserted.

## Changes

- **`test_validation_loop_confusion_matrix_basic`** now runs a **multi-batch, asymmetric** fixture end-to-end through `ValidationLoop.run()` and asserts exact confusion-matrix cell counts `[TN=2, FP=1, FN=1, TP=2]`. It deliberately covers what only real slicing makes testable and what the pre-existing single-batch `test_validation_loop_confusion_matrix_integration` (#3185) does **not**:
  - the multi-batch offset path (`start_idx = current_batch * batch_size`, `batch_size=3` over 6 samples ⇒ 2 batches),
  - data/label slice **alignment** across a batch boundary — an off-by-one between `data.slice` and `labels.slice` would corrupt the asymmetric matrix,
  - an asymmetric count fixture, so a degenerate all-class-0 forward or a slice misalignment cannot accidentally satisfy it.
- **Reuses the existing `identity_forward` helper** (no duplicate helper added).
- **Removes a stale `NOTE(#3076)` comment** in `trainer_interface.mojo` that claimed "Placeholder tensors used until Track 4 is ready" directly above the real-slicing code it contradicted.

## Review-driven revision

A `/review-pr-strict` audit (overall 92%, A-) flagged that the first revision (a) added `passthrough_forward` duplicating the existing `identity_forward`, and (b) made the basic test a near-clone of the existing integration test. Both were addressed in commit `bbce4fb9` by reusing `identity_forward` and redesigning the fixture to fill a genuine multi-batch/asymmetric coverage gap.

## Verification (genuine, in-container)

`just test-group tests/projectodyssey/training test_validation_loop.mojo` in the Podman dev container:

```
  test_validation_loop_confusion_matrix_basic: PASSED
...
All validation loop tests passed!
```

All 21 tests in the file pass; the exact multi-batch asymmetric counts hold, confirming data/label slice alignment across the batch boundary.

Closes #3684

🤖 Generated with [Claude Code](https://claude.com/claude-code)