### PR TITLE
test(examples): run example backward tests in CI + fix latent ResNet-18 label bug

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -153,6 +153,32 @@ jobs:
           retention-days: 7
 
   # ============================================================================
+  # Example backward-pass tests - RUN (not just compile) the hand-written
+  # backward passes so a numerically-wrong gradient is caught, not just a
+  # syntax error. These live under examples/<model>/ and are excluded from the
+  # src coverage validator, so without this job they would execute nowhere.
+  # Synthetic data only (no dataset download); ~a few minutes.
+  # ============================================================================
+  example-backward-tests:
+    needs: [mojo-compilation]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    name: "Example Backward Tests"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Set up container
+        uses: ./.github/actions/setup-container
+
+      - name: Install Just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
+
+      - name: Run example backward-pass tests
+        run: just test-example-backward
+
+  # ============================================================================
   # Test Coverage Validation - Ensure all tests are discovered
   # ============================================================================
   validate-test-coverage:

--- a/examples/googlenet_cifar10/model.mojo
+++ b/examples/googlenet_cifar10/model.mojo
@@ -615,6 +615,15 @@ def concatenate_depthwise_backward(
         (batch, c1, H, W), (batch, c2, H, W), (batch, c3, H, W),
         (batch, c4, H, W).
     """
+    # Float32-only contract: the copy loops below reinterpret memory via
+    # bitcast[Float32]. A non-float32 grad_output would be silently
+    # type-confused, so fail loudly instead.
+    if grad_output.dtype() != DType.float32:
+        raise Error(
+            "concatenate_depthwise_backward requires float32 grad_output, got "
+            + String(grad_output.dtype())
+        )
+
     var batch_size = grad_output.shape()[0]
     var total_channels = grad_output.shape()[1]
     var height = grad_output.shape()[2]

--- a/examples/googlenet_cifar10/test_backward.mojo
+++ b/examples/googlenet_cifar10/test_backward.mojo
@@ -1,26 +1,151 @@
-"""Execution test: GoogLeNet backward pass reduces loss over training steps.
+"""Backward-pass correctness tests for the GoogLeNet CIFAR-10 example.
 
-Builds a small GoogLeNet, feeds a fixed synthetic batch whose samples span all
-10 classes (interleaved, so no single-class-batch degeneracy), and runs several
-SGD-momentum steps. Asserts the loss strictly decreases from first to last step
-— the proof that compute_gradients' backward pass and updates actually learn.
+Two independent layers of evidence for the hand-written 222-parameter backward:
+
+1. Direct unit tests of `concatenate_depthwise_backward` — the highest-risk
+   primitive (4-way channel split). These are fully deterministic (sentinel
+   tensors, no RNG) and assert the split is a TRUE value-exact inverse of the
+   forward concat, not merely shape-correct. A shape-correct-but-value-wrong
+   split (e.g. if `split_with_indices` had been used) would fail here even
+   though the convergence loop below might still trend downhill.
+
+2. A convergence test: several SGD-momentum steps on a fixed synthetic batch
+   spanning all 10 classes, asserting the loss is finite at every step, that a
+   representative weight actually changes, and that the final loss drops below
+   0.95 * the first (the same threshold the ResNet-18 sibling test uses) — not
+   just a bare `last < first` that a rounding jitter could satisfy.
 """
 
+from std.math import isnan, isinf
 from projectodyssey.tensor.any_tensor import AnyTensor
 from projectodyssey.tensor.tensor_creation import zeros
 from projectodyssey.data import one_hot_encode
-from model import GoogLeNet
+from model import GoogLeNet, concatenate_depthwise, concatenate_depthwise_backward
 from train import compute_gradients, initialize_velocities
 
 
-def main() raises:
+def assert_true(cond: Bool, msg: String) raises:
+    if not cond:
+        raise Error("assertion failed: " + msg)
+
+
+def _snapshot(t: AnyTensor) raises -> Float32:
+    # Safe scalar read via the sanctioned load API.
+    return Float32(t.load[DType.float32](0))
+
+
+def _make_sentinel(batch: Int, c: Int, hw: Int, base: Float32) raises -> AnyTensor:
+    """Build a (batch, c, 1, hw)-shaped tensor with a UNIQUE value per element.
+
+    value(b, ch, i) = base + b*1000 + ch*10 + i, so any misrouting of a
+    channel block (wrong offset, wrong batch stride) produces a detectable
+    mismatch rather than an accidental collision.
+    """
+    var t = zeros([batch, c, 1, hw], DType.float32)
+    var d = t._data.bitcast[Float32]()
+    for b in range(batch):
+        for ch in range(c):
+            for i in range(hw):
+                var idx = ((b * c + ch) * hw) + i
+                d[idx] = base + Float32(b) * 1000.0 + Float32(ch) * 10.0 + Float32(i)
+    return t^
+
+
+def test_concat_backward_split_exact() raises:
+    """Backward returns each input's channel block VERBATIM (value-exact split).
+
+    Build 4 sentinel tensors, concat them, then split the concatenated tensor
+    back via the backward. Because concat copies gradients through unchanged
+    (identity on values), each returned g_k must equal the ORIGINAL t_k
+    element-for-element.
+    """
+    var batch = 2
+    var hw = 3
+    var c1 = 1
+    var c2 = 2
+    var c3 = 1
+    var c4 = 2
+    var t1 = _make_sentinel(batch, c1, hw, base=1.0)
+    var t2 = _make_sentinel(batch, c2, hw, base=2.0)
+    var t3 = _make_sentinel(batch, c3, hw, base=3.0)
+    var t4 = _make_sentinel(batch, c4, hw, base=4.0)
+
+    var cat = concatenate_depthwise(t1, t2, t3, t4)
+    assert_true(cat.shape()[1] == c1 + c2 + c3 + c4, "concat channel count wrong")
+
+    var grads = concatenate_depthwise_backward(cat, c1, c2, c3, c4)
+    var g1 = grads[0]
+    var g2 = grads[1]
+    var g3 = grads[2]
+    var g4 = grads[3]
+
+    _assert_tensor_equal(g1, t1, "g1 != t1")
+    _assert_tensor_equal(g2, t2, "g2 != t2")
+    _assert_tensor_equal(g3, t3, "g3 != t3")
+    _assert_tensor_equal(g4, t4, "g4 != t4")
+
+
+def _assert_tensor_equal(a: AnyTensor, b: AnyTensor, msg: String) raises:
+    assert_true(a._numel == b._numel, msg + " (numel mismatch)")
+    var ad = a._data.bitcast[Float32]()
+    var bd = b._data.bitcast[Float32]()
+    for i in range(a._numel):
+        if ad[i] != bd[i]:
+            raise Error(
+                msg
+                + " at index "
+                + String(i)
+                + ": "
+                + String(ad[i])
+                + " != "
+                + String(bd[i])
+            )
+
+
+def test_concat_backward_roundtrip() raises:
+    """Re-concatenating the split pieces reconstructs the concatenated tensor.
+
+    Splitting a concatenated tensor and re-concatenating the pieces must be an
+    exact round trip — a stronger check that the split preserves the per-batch
+    channel-block layout across all 4 branches.
+    """
+    var batch = 2
+    var hw = 4
+    var c1 = 2
+    var c2 = 1
+    var c3 = 2
+    var c4 = 1
+    var t1 = _make_sentinel(batch, c1, hw, base=10.0)
+    var t2 = _make_sentinel(batch, c2, hw, base=20.0)
+    var t3 = _make_sentinel(batch, c3, hw, base=30.0)
+    var t4 = _make_sentinel(batch, c4, hw, base=40.0)
+
+    var cat = concatenate_depthwise(t1, t2, t3, t4)
+    var parts = concatenate_depthwise_backward(cat, c1, c2, c3, c4)
+    var recat = concatenate_depthwise(parts[0], parts[1], parts[2], parts[3])
+    _assert_tensor_equal(recat, cat, "round-trip concat(split(cat)) != cat")
+
+
+def test_concat_backward_rejects_non_float32() raises:
+    """Wrong dtype fails loudly (float32-only bitcast contract)."""
+    var bad = zeros([1, 4, 1, 1], DType.float64)
+    var raised = False
+    try:
+        _ = concatenate_depthwise_backward(bad, 1, 1, 1, 1)
+    except:
+        raised = True
+    assert_true(raised, "expected non-float32 grad_output to raise")
+
+
+def test_backward_converges() raises:
+    """Several SGD steps reduce loss by >5% with finite losses and changing weights."""
     var num_classes = 10
     var batch = 10  # one sample per class, interleaved
     var model = GoogLeNet(num_classes=num_classes)
     var velocities = initialize_velocities(model)
 
     # Synthetic images (batch, 3, 32, 32): class-correlated signal so the task
-    # is learnable but not trivial.
+    # is learnable but not trivial. Deterministic by construction.
     var images = zeros([batch, 3, 32, 32], DType.float32)
     var img_d = images._data.bitcast[Float32]()
     for s in range(batch):
@@ -30,7 +155,6 @@ def main() raises:
                 Float32(cls) * 0.05 + Float32(i % 5) * 0.01
             )
 
-    # Raw class-index labels -> one-hot
     var labels_raw = zeros([batch], DType.uint8)
     var lbl_d = labels_raw._data.bitcast[UInt8]()
     for s in range(batch):
@@ -40,6 +164,9 @@ def main() raises:
     var lr = Float32(0.01)
     var momentum = Float32(0.9)
 
+    # Snapshot one representative weight to prove SGD actually updates params.
+    var w_before = _snapshot(model.fc_weights)
+
     var first_loss = Float32(0.0)
     var last_loss = Float32(0.0)
     var steps = 15
@@ -47,26 +174,53 @@ def main() raises:
         var loss = compute_gradients(
             model, images, labels, lr, momentum, velocities
         )
+        assert_true(not isnan(loss), "loss is NaN at step " + String(step + 1))
+        assert_true(not isinf(loss), "loss is Inf at step " + String(step + 1))
         if step == 0:
             first_loss = loss
         last_loss = loss
         print(
-            "  Step "
-            + String(step + 1)
-            + "/"
-            + String(steps)
-            + ", Loss: "
-            + String(loss)
+            "  Step " + String(step + 1) + "/" + String(steps)
+            + ", Loss: " + String(loss)
         )
 
+    var w_after = _snapshot(model.fc_weights)
+    assert_true(
+        w_before != w_after,
+        "fc_weights did not change — SGD update not applied",
+    )
+
     print("first=" + String(first_loss) + " last=" + String(last_loss))
-    if last_loss < first_loss:
-        print("GOOGLENET_BWD_CONVERGES: PASS")
-    else:
-        print("GOOGLENET_BWD_CONVERGES: FAIL (loss did not decrease)")
-        raise Error(
-            "Loss did not decrease: first="
-            + String(first_loss)
-            + " last="
-            + String(last_loss)
-        )
+    # Hard floor first (clear signal if loss went UP), then the 5% threshold
+    # the ResNet-18 sibling test also enforces.
+    assert_true(
+        last_loss < first_loss,
+        "Loss did NOT decrease: first="
+        + String(first_loss)
+        + " last="
+        + String(last_loss),
+    )
+    assert_true(
+        last_loss < first_loss * Float32(0.95),
+        "Loss decrease < 5%: first="
+        + String(first_loss)
+        + " last="
+        + String(last_loss),
+    )
+    print("GOOGLENET_BWD_CONVERGES: PASS")
+
+
+def main() raises:
+    print("test_concat_backward_split_exact...", end="")
+    test_concat_backward_split_exact()
+    print(" PASS")
+    print("test_concat_backward_roundtrip...", end="")
+    test_concat_backward_roundtrip()
+    print(" PASS")
+    print("test_concat_backward_rejects_non_float32...", end="")
+    test_concat_backward_rejects_non_float32()
+    print(" PASS")
+    print("test_backward_converges...")
+    test_backward_converges()
+    print("test_backward_converges PASS")
+    print("ALL GOOGLENET BACKWARD TESTS PASSED")

--- a/examples/googlenet_cifar10/test_backward.mojo
+++ b/examples/googlenet_cifar10/test_backward.mojo
@@ -10,17 +10,22 @@ Two independent layers of evidence for the hand-written 222-parameter backward:
    though the convergence loop below might still trend downhill.
 
 2. A convergence test: several SGD-momentum steps on a fixed synthetic batch
-   spanning all 10 classes, asserting the loss is finite at every step, that a
-   representative weight actually changes, and that the final loss drops below
-   0.95 * the first (the same threshold the ResNet-18 sibling test uses) — not
-   just a bare `last < first` that a rounding jitter could satisfy.
+   spanning all 10 classes, asserting the loss is finite at every step, that
+   BOTH the last layer (fc) and the first layer (initial conv) weights change
+   — so gradients demonstrably flow end-to-end — and that the final loss drops
+   below 0.95 * the first (the same threshold the ResNet-18 sibling test uses)
+   — not just a bare `last < first` that a rounding jitter could satisfy.
 """
 
 from std.math import isnan, isinf
 from projectodyssey.tensor.any_tensor import AnyTensor
 from projectodyssey.tensor.tensor_creation import zeros
 from projectodyssey.data import one_hot_encode
-from model import GoogLeNet, concatenate_depthwise, concatenate_depthwise_backward
+from model import (
+    GoogLeNet,
+    concatenate_depthwise,
+    concatenate_depthwise_backward,
+)
 from train import compute_gradients, initialize_velocities
 
 
@@ -34,7 +39,9 @@ def _snapshot(t: AnyTensor) raises -> Float32:
     return Float32(t.load[DType.float32](0))
 
 
-def _make_sentinel(batch: Int, c: Int, hw: Int, base: Float32) raises -> AnyTensor:
+def _make_sentinel(
+    batch: Int, c: Int, hw: Int, base: Float32
+) raises -> AnyTensor:
     """Build a (batch, c, 1, hw)-shaped tensor with a UNIQUE value per element.
 
     value(b, ch, i) = base + b*1000 + ch*10 + i, so any misrouting of a
@@ -47,7 +54,9 @@ def _make_sentinel(batch: Int, c: Int, hw: Int, base: Float32) raises -> AnyTens
         for ch in range(c):
             for i in range(hw):
                 var idx = ((b * c + ch) * hw) + i
-                d[idx] = base + Float32(b) * 1000.0 + Float32(ch) * 10.0 + Float32(i)
+                d[idx] = (
+                    base + Float32(b) * 1000.0 + Float32(ch) * 10.0 + Float32(i)
+                )
     return t^
 
 
@@ -71,7 +80,9 @@ def test_concat_backward_split_exact() raises:
     var t4 = _make_sentinel(batch, c4, hw, base=4.0)
 
     var cat = concatenate_depthwise(t1, t2, t3, t4)
-    assert_true(cat.shape()[1] == c1 + c2 + c3 + c4, "concat channel count wrong")
+    assert_true(
+        cat.shape()[1] == c1 + c2 + c3 + c4, "concat channel count wrong"
+    )
 
     var grads = concatenate_depthwise_backward(cat, c1, c2, c3, c4)
     var g1 = grads[0]
@@ -138,7 +149,12 @@ def test_concat_backward_rejects_non_float32() raises:
 
 
 def test_backward_converges() raises:
-    """Several SGD steps reduce loss by >5% with finite losses and changing weights."""
+    """Reduce loss by >5% with finite losses and both end-layers updating.
+
+    Runs several SGD-momentum steps: asserts finite loss each step, that the
+    final loss is < 0.95 * the first, and that BOTH fc (last) and initial-conv
+    (first) weights changed — proving gradients reach both ends of the net.
+    """
     var num_classes = 10
     var batch = 10  # one sample per class, interleaved
     var model = GoogLeNet(num_classes=num_classes)
@@ -164,8 +180,12 @@ def test_backward_converges() raises:
     var lr = Float32(0.01)
     var momentum = Float32(0.9)
 
-    # Snapshot one representative weight to prove SGD actually updates params.
-    var w_before = _snapshot(model.fc_weights)
+    # Snapshot one weight from the LAST layer (fc) and one from the FIRST
+    # (initial conv) so the check proves gradients flow end-to-end. A backward
+    # bug that zeroes early-stage gradients while still updating fc would pass
+    # an fc-only check but fail the initial-conv one.
+    var fc_before = _snapshot(model.fc_weights)
+    var conv_before = _snapshot(model.initial_conv_weights)
 
     var first_loss = Float32(0.0)
     var last_loss = Float32(0.0)
@@ -180,14 +200,24 @@ def test_backward_converges() raises:
             first_loss = loss
         last_loss = loss
         print(
-            "  Step " + String(step + 1) + "/" + String(steps)
-            + ", Loss: " + String(loss)
+            "  Step "
+            + String(step + 1)
+            + "/"
+            + String(steps)
+            + ", Loss: "
+            + String(loss)
         )
 
-    var w_after = _snapshot(model.fc_weights)
     assert_true(
-        w_before != w_after,
-        "fc_weights did not change — SGD update not applied",
+        _snapshot(model.fc_weights) != fc_before,
+        "fc_weights did not change — SGD update not applied to last layer",
+    )
+    assert_true(
+        _snapshot(model.initial_conv_weights) != conv_before,
+        (
+            "initial_conv_weights did not change — gradient did not reach the"
+            " first layer"
+        ),
     )
 
     print("first=" + String(first_loss) + " last=" + String(last_loss))

--- a/examples/googlenet_cifar10/train.mojo
+++ b/examples/googlenet_cifar10/train.mojo
@@ -49,8 +49,6 @@ from projectodyssey.core.activation import relu, relu_backward
 from projectodyssey.core.linear import linear, linear_backward
 from projectodyssey.core.dropout import dropout, dropout_backward
 from projectodyssey.core.loss import cross_entropy, cross_entropy_backward
-from projectodyssey.core.shape import split_with_indices
-from projectodyssey.core.arithmetic import add, add_backward
 from projectodyssey.training.schedulers import step_lr
 from projectodyssey.data.batch_utils import (
     compute_num_batches,
@@ -64,10 +62,8 @@ from projectodyssey.training.optimizers import sgd_momentum_update_inplace
 from model import (
     GoogLeNet,
     InceptionModule,
-    concatenate_depthwise,
     inception_forward_cached,
     inception_backward,
-    InceptionCache,
     InceptionGradients,
 )
 
@@ -464,6 +460,14 @@ def compute_gradients(
     var drop_out = drop_result[0]
     var drop_mask = drop_result[1]
     var logits = linear(drop_out, model.fc_weights, model.fc_bias)
+    # Float32-only contract: the scalar-loss read and grad_ones write below
+    # reinterpret memory via bitcast[Float32]. Guard so a non-float32 logits
+    # tensor fails loudly instead of silently miscomputing.
+    if logits.dtype() != DType.float32:
+        raise Error(
+            "compute_gradients requires float32 logits, got "
+            + String(logits.dtype())
+        )
     var loss_tensor = cross_entropy(logits, labels)
     var loss = loss_tensor._data.bitcast[Float32]()[0]
 

--- a/examples/resnet18_cifar10/test_backward.mojo
+++ b/examples/resnet18_cifar10/test_backward.mojo
@@ -9,7 +9,6 @@ from model import (
     initialize_velocities,
 )
 from train import train_step, train_epoch
-from projectodyssey.data.formats.idx_loader import one_hot_encode
 
 
 def assert_true(cond: Bool, msg: String) raises:
@@ -96,10 +95,16 @@ def test_every_stage_receives_nonzero_gradient() raises:
 def _build_separable_batch(
     samples_per_class: Int, num_classes: Int, seed: Int
 ) raises -> Tuple[AnyTensor, AnyTensor]:
-    """Build (images, one_hot_labels) with strong per-class channel bias.
+    """Build (images, raw_uint8_labels) with strong per-class channel bias.
 
     Bias = 2.0 * c/num_classes - 1.0 ∈ [-1.0, +0.8], added to every pixel.
     Dominates N(0,1) noise → linearly separable at conv1+BN.
+
+    Labels are returned RAW (shape [N], uint8), NOT one-hot: `train_epoch`
+    one-hot-encodes each batch internally (train.mojo:1100). Passing already-
+    one-hot labels here makes it re-encode one-hot rows as raw indices and
+    crash with "Label index out of range". `train_step` (used by the other
+    tests) takes one-hot directly, so those build labels separately.
     """
     var total = num_classes * samples_per_class
     var img_shape = List[Int]()
@@ -128,8 +133,7 @@ def _build_separable_batch(
                 var cur = images.load[DType.float32](base + k)
                 images.store[DType.float32](base + k, cur + bias)
 
-    var labels_one_hot = one_hot_encode(labels_int, num_classes=num_classes)
-    return (images, labels_one_hot)
+    return (images, labels_int^)
 
 
 def test_loss_decreases_over_steps() raises:

--- a/justfile
+++ b/justfile
@@ -1301,10 +1301,14 @@ _test-example-backward-inner:
     set -euo pipefail
     REPO_ROOT="$(pwd)"
     fail=0
+    # Expected backward tests — each MUST exist and run. A missing file is a
+    # hard failure (regression signal), not a silent skip: if a test is
+    # renamed or deleted, this job must go red rather than pass green.
     for ex in googlenet_cifar10 resnet18_cifar10; do
         f="examples/$ex/test_backward.mojo"
         if [ ! -f "$f" ]; then
-            echo "skip: $f not found"
+            echo "MISSING (expected): $f"
+            fail=1
             continue
         fi
         echo "=================================================="

--- a/justfile
+++ b/justfile
@@ -1285,3 +1285,36 @@ bump-version new_version:
     sed -i 's/^\(version\s*=\s*\)"[^"]*"/\1"{{new_version}}"/' mojo.toml
     echo "All files updated. Verifying sync..."
     python3 scripts/check_version_sync.py
+
+# Run example backward-pass tests (GoogLeNet + ResNet-18) from their example
+# dirs. These live under examples/<model>/ (import `from model`/`from train`),
+# so they cannot run via `test-group` (which targets tests/). They are excluded
+# from the src coverage validator but MUST execute somewhere — this recipe is
+# the per-PR runner wired into comprehensive-tests.yml. Synthetic data only, no
+# dataset download. Fails (non-zero exit) if any test's assertions fail.
+test-example-backward:
+    @just _run "just _test-example-backward-inner"
+
+[private]
+_test-example-backward-inner:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    REPO_ROOT="$(pwd)"
+    fail=0
+    for ex in googlenet_cifar10 resnet18_cifar10; do
+        f="examples/$ex/test_backward.mojo"
+        if [ ! -f "$f" ]; then
+            echo "skip: $f not found"
+            continue
+        fi
+        echo "=================================================="
+        echo "Running example backward test: $f"
+        echo "=================================================="
+        if ! pixi run mojo run --Werror \
+                -I "$REPO_ROOT/src" -I "$REPO_ROOT" \
+                -I "$REPO_ROOT/examples/$ex" -Xlinker -lm "$f"; then
+            echo "FAILED: $f"
+            fail=1
+        fi
+    done
+    exit $fail

--- a/scripts/validate_test_coverage.py
+++ b/scripts/validate_test_coverage.py
@@ -58,10 +58,13 @@ def find_test_files(root_dir: Path) -> List[Path]:
         "examples/resnet18_cifar10/test_model.mojo",
         "examples/resnet18_cifar10/test_forward_cache_velocities.mojo",
         "examples/resnet18_cifar10/test_backward.mojo",
-        # GoogLeNet backward convergence test (#3184): full 9-module
-        # forward+backward, too heavy for the per-PR matrix; same handling
-        # as the ResNet-18 test_backward above. Runs standalone (synthetic
-        # interleaved-class data, no dataset download).
+        # GoogLeNet backward tests (#3184): concatenate_depthwise_backward
+        # SPLIT_EXACT/round-trip unit tests + a full 9-module convergence run.
+        # Excluded from the SRC coverage validator (an example-dir test, not a
+        # src/ unit test), but EXECUTED per-PR by the "example-backward-tests"
+        # job in .github/workflows/comprehensive-tests.yml via
+        # `just test-example-backward` — it uses synthetic interleaved-class
+        # data with no dataset download.
         "examples/googlenet_cifar10/test_backward.mojo",
         # Conda recipe smoke test — executed by rattler-build's `tests:`
         # block when the package is built (see conda.recipe/recipe.yaml),


### PR DESCRIPTION
## Why

A strict PR review of the already-merged GoogLeNet backward-pass work (PR #5552, which closed #5520 / #3184) surfaced one well-evidenced systemic gap: the example backward tests for **both** `googlenet_cifar10` and `resnet18_cifar10` were excluded from the `scripts/validate_test_coverage.py` validator with a "Runs standalone" comment **and** wired into no CI job. They only ever **compiled** — their assertions never **executed**. The sole correctness proof for two hand-written backward passes ran nowhere (the ADR-014 "runnable evidence" anti-pattern).

## What this proved immediately

Making these tests actually run caught a **latent runtime bug** that had been dormant since the test was written: ResNet-18's `test_loss_decreases_over_steps` passed already-one-hot labels to `train_epoch`, which one-hot-encodes each batch **internally** (`train.mojo:1100`). It therefore re-interpreted one-hot rows as raw label indices and crashed with `Label index out of range: 128`.

## Changes

- **justfile**: new `test-example-backward` recipe (+ private inner) that RUNS both example backward tests from their example dirs on synthetic data (no dataset download); non-zero exit on any assertion failure.
- **.github/workflows/comprehensive-tests.yml**: new `example-backward-tests` job invoking the recipe on every PR, so these tests gate merges instead of only compiling.
- **examples/resnet18_cifar10/test_backward.mojo**: `_build_separable_batch` now returns RAW `uint8` labels (shape `[N]`) matching `train_epoch`'s contract; dropped the now-unused `one_hot_encode` import.
- **examples/googlenet_cifar10/test_backward.mojo**: strengthened from a compile smoke test to real assertions — direct `concatenate_depthwise_backward` SPLIT_EXACT + round-trip + dtype-rejection unit tests (highest-risk primitive), NaN/Inf guards, a representative-weight-changed check, and a `last < first*0.95` convergence threshold matching the ResNet-18 sibling.
- **examples/googlenet_cifar10/{model,train}.mojo**: float32 dtype guards on `concatenate_depthwise_backward` and `compute_gradients` (fail loudly instead of a bad bitcast); removed dead imports in `train.mojo`.
- **scripts/validate_test_coverage.py**: corrected the false "Runs standalone" exclusion comment to point at the new CI job.

## Verification

Verified in-container end-to-end via the new recipe (exit 0):
- **GoogLeNet**: all 4 tests pass; convergence `2.4117308 → 0.033096313`.
- **ResNet-18**: all 3 tests pass, including the previously-crashing `test_loss_decreases_over_steps`.

Refs #5520 #3184 #5552

🤖 Generated with [Claude Code](https://claude.com/claude-code)