### PR TITLE
chore(tensor): retag stale TODO markers to live tracking issues (#3059)

### DIFF
--- a/src/projectodyssey/tensor/any_tensor.mojo
+++ b/src/projectodyssey/tensor/any_tensor.mojo
@@ -842,9 +842,10 @@ struct AnyTensor(
     # ===----------------------------------------------------------------------===#
     # set() — type-safe element assignment
     #
-    # TODO: Remove these set() overloads once Tensor[dtype] with proper typed
-    # __setitem__ is used everywhere. Currently still needed because AnyTensor
-    # is used in metrics, normalization, dropout, attention, and other modules.
+    # TODO(#5565): Remove these set() overloads once Tensor[dtype] with proper
+    # typed __setitem__ is used everywhere. Currently still needed because
+    # AnyTensor is used in metrics, normalization, dropout, attention, and
+    # other modules.
     #
     # Mojo does NOT dispatch `obj[i] = val` to __setitem__; it treats
     # `obj[i]` as an lvalue via __getitem__ (returns Float32), so
@@ -2171,7 +2172,7 @@ struct AnyTensor(
 
         Note: bfloat16 passes the outer guard but raises in the inner dispatch.
         This asymmetry is a pre-existing bug preserved verbatim.
-        TODO(#5181-followup): fix bfloat16 guard for block-quant methods.
+        TODO(#5564): fix bfloat16 guard for block-quant methods.
         """
         from .tensor_dtype_conv import _convert_to_block_quant_impl
 

--- a/src/projectodyssey/tensor/tensor.mojo
+++ b/src/projectodyssey/tensor/tensor.mojo
@@ -471,7 +471,7 @@ struct Tensor[dtype: DType = DType.float32](
         (data freed, refcount freed) before fields are replaced with shared
         pointers from this Tensor.
 
-        TODO(#5005): Replace with AnyTensor internal constructor once available,
+        TODO(#5566): Replace with AnyTensor internal constructor once available,
         eliminating the allocate-then-free overhead and fragile field surgery.
 
         Returns:

--- a/src/projectodyssey/tensor/tensor_dtype_conv.mojo
+++ b/src/projectodyssey/tensor/tensor_dtype_conv.mojo
@@ -252,10 +252,10 @@ def _convert_to_block_quant_impl[
 
     Note: bfloat16 passes the outer guard but raises in the inner dispatch.
     This asymmetry is a pre-existing bug preserved verbatim.
-    TODO(#5181-followup): fix bfloat16 guard for block-quant methods.
+    TODO(#5564): fix bfloat16 guard for block-quant methods.
     """
     # Verify source is floating point (bfloat16 outer guard passes; inner raises).
-    # TODO(#5181-followup): the bfloat16 outer guard accepts but inner raises;
+    # TODO(#5564): the bfloat16 outer guard accepts but inner raises;
     # this asymmetry is preserved verbatim as a pre-existing bug.
     if not (
         tensor._dtype == DType.float16


### PR DESCRIPTION
## Why

Follow-up to the #3059 marker audit. The audit found the production library's genuine TODO surface is just 6 markers — three of which referenced **dead or placeholder** issues, so the debt they describe was effectively untracked. This PR makes every remaining library TODO traceable to a live issue.

## Changes (comment-only, no behavior change)

| Location | Was | Now |
|---|---|---|
| `tensor_dtype_conv.mojo:255,258`, `any_tensor.mojo:2175` | `TODO(#5181-followup)` (placeholder suffix; #5181 closed) | **#5564** — bfloat16 block-quant guard asymmetry (real bug) |
| `any_tensor.mojo:845` | untagged `TODO` | **#5565** — remove `set()` overloads once typed `Tensor[dtype]` `__setitem__` is universal |
| `tensor.mojo:474` | `TODO(#5005)` (#5005 merged) | **#5566** — `AnyTensor` internal constructor |

`toml_loader.mojo:115` (`TODO: Add list handling if needed`) is left as a speculative/YAGNI inline hint — not tracked debt.

## Verification

`mojo-format` passes on all three files. No logic touched — only TODO comment text.

Refs #3059

🤖 Generated with [Claude Code](https://claude.com/claude-code)