### PR TITLE
fix(utils): honor caller default_weights_dir in training args (#5545)

### DIFF
--- a/src/projectodyssey/utils/__init__.mojo
+++ b/src/projectodyssey/utils/__init__.mojo
@@ -145,6 +145,7 @@ from projectodyssey.utils.training_args import (
     TrainingArgs,  # Training hyperparameters container
     parse_training_args,  # Parse common training arguments
     parse_training_args_with_defaults,  # Parse with custom defaults
+    resolve_training_args,  # Resolve pre-parsed args (argv-free, testable)
 )
 
 # Inference utilities

--- a/src/projectodyssey/utils/arg_parser.mojo
+++ b/src/projectodyssey/utils/arg_parser.mojo
@@ -197,50 +197,60 @@ struct ParsedArgs(Copyable, Movable):
         one exists), this honors the caller's `default` unless the user
         explicitly passed the flag on the command line — the correct behavior
         when a script supplies its own per-script default (#5545).
+
+        Args:
+            name: Argument name.
+            default: Caller's default, used unless the user passed the flag.
+
+        Returns:
+            The user-supplied value, or `default`.
+
+        Raises:
+            Error: If the stored value cannot be read.
         """
-        if name in self._user_supplied:
-            return self.values[name]
-        return default
+        if name not in self._user_supplied:
+            return default
+        return self.get_string(name, default)
 
     def resolve_int(self, name: String, default: Int) raises -> Int:
         """Return the CLI value if user-supplied, else the caller's default.
 
         Honors the caller's `default` unless the user explicitly passed the
         flag; see `resolve_string` (#5545).
+
+        Args:
+            name: Argument name.
+            default: Caller's default, used unless the user passed the flag.
+
+        Returns:
+            The user-supplied value parsed as Int, or `default`.
+
+        Raises:
+            Error: If a user-supplied value cannot be parsed as integer.
         """
         if name not in self._user_supplied:
             return default
-        var value = self.values[name]
-        try:
-            return Int(value)
-        except e:
-            raise Error(
-                "Cannot parse '"
-                + value
-                + "' as integer for argument '"
-                + name
-                + "'"
-            )
+        return self.get_int(name, default)
 
     def resolve_float(self, name: String, default: Float64) raises -> Float64:
         """Return the CLI value if user-supplied, else the caller's default.
 
         Honors the caller's `default` unless the user explicitly passed the
         flag; see `resolve_string` (#5545).
+
+        Args:
+            name: Argument name.
+            default: Caller's default, used unless the user passed the flag.
+
+        Returns:
+            The user-supplied value parsed as Float64, or `default`.
+
+        Raises:
+            Error: If a user-supplied value cannot be parsed as float.
         """
         if name not in self._user_supplied:
             return default
-        var value = self.values[name]
-        try:
-            return Float64(value)
-        except e:
-            raise Error(
-                "Cannot parse '"
-                + value
-                + "' as float for argument '"
-                + name
-                + "'"
-            )
+        return self.get_float(name, default)
 
     def get_bool(self, name: String) -> Bool:
         """Get boolean flag status.

--- a/src/projectodyssey/utils/arg_parser.mojo
+++ b/src/projectodyssey/utils/arg_parser.mojo
@@ -61,19 +61,38 @@ struct ParsedArgs(Copyable, Movable):
     """
 
     var values: Dict[String, String]
+    var _user_supplied: Dict[String, Bool]
 
     def __init__(out self):
         """Initialize empty parsed arguments."""
         self.values = Dict[String, String]()
+        self._user_supplied = Dict[String, Bool]()
 
     def set(mut self, name: String, value: String):
-        """Set an argument value.
+        """Set an argument value (from a registered default).
+
+        Use `set_user_supplied` for values parsed from the command line so
+        callers can distinguish an explicit value from a pre-populated default.
 
         Args:
             name: Argument name.
             value: Value as string.
         """
         self.values[name] = value
+
+    def set_user_supplied(mut self, name: String, value: String):
+        """Set an argument value that the user passed on the command line.
+
+        Marks the argument as user-supplied so `was_user_supplied` returns True
+        for it, which lets helpers honor a caller-provided default only when the
+        user did not explicitly pass the flag.
+
+        Args:
+            name: Argument name.
+            value: Value as string.
+        """
+        self.values[name] = value
+        self._user_supplied[name] = True
 
     def has(self, name: String) -> Bool:
         """Check if an argument was provided.
@@ -85,6 +104,20 @@ struct ParsedArgs(Copyable, Movable):
             True if argument exists, False otherwise.
         """
         return name in self.values
+
+    def was_user_supplied(self, name: String) -> Bool:
+        """Check if an argument was explicitly supplied on the command line.
+
+        Distinct from `has`, which is also True for pre-populated registered
+        defaults. Only True when the value came from argv.
+
+        Args:
+            name: Argument name.
+
+        Returns:
+            True if the user passed the argument on the command line.
+        """
+        return name in self._user_supplied
 
     def get_string(self, name: String, default: String = "") raises -> String:
         """Get argument value as string.
@@ -284,7 +317,7 @@ struct ArgumentParser(Copyable, Movable):
 
             # Handle flag arguments (early continue)
             if self.arguments[arg_name].is_flag:
-                result.set(arg_name, "true")
+                result.set_user_supplied(arg_name, "true")
                 i += 1
                 continue
 
@@ -292,7 +325,7 @@ struct ArgumentParser(Copyable, Movable):
             if i + 1 >= len(args):
                 raise Error("Missing value for argument: --" + arg_name)
 
-            result.set(arg_name, String(args[i + 1]))
+            result.set_user_supplied(arg_name, String(args[i + 1]))
             i += 2
 
         return result^

--- a/src/projectodyssey/utils/arg_parser.mojo
+++ b/src/projectodyssey/utils/arg_parser.mojo
@@ -23,7 +23,7 @@ Example:
 """
 
 from std.sys import argv
-from std.collections import Dict
+from std.collections import Dict, Set
 
 
 # ============================================================================
@@ -61,12 +61,12 @@ struct ParsedArgs(Copyable, Movable):
     """
 
     var values: Dict[String, String]
-    var _user_supplied: Dict[String, Bool]
+    var _user_supplied: Set[String]
 
     def __init__(out self):
         """Initialize empty parsed arguments."""
         self.values = Dict[String, String]()
-        self._user_supplied = Dict[String, Bool]()
+        self._user_supplied = Set[String]()
 
     def set(mut self, name: String, value: String):
         """Set an argument value (from a registered default).
@@ -92,7 +92,7 @@ struct ParsedArgs(Copyable, Movable):
             value: Value as string.
         """
         self.values[name] = value
-        self._user_supplied[name] = True
+        self._user_supplied.add(name)
 
     def has(self, name: String) -> Bool:
         """Check if an argument was provided.
@@ -177,6 +177,58 @@ struct ParsedArgs(Copyable, Movable):
             Error: If value cannot be parsed as float.
         """
         if name not in self.values:
+            return default
+        var value = self.values[name]
+        try:
+            return Float64(value)
+        except e:
+            raise Error(
+                "Cannot parse '"
+                + value
+                + "' as float for argument '"
+                + name
+                + "'"
+            )
+
+    def resolve_string(self, name: String, default: String) raises -> String:
+        """Return the CLI value if user-supplied, else the caller's default.
+
+        Unlike get_string (which returns a pre-populated registered default when
+        one exists), this honors the caller's `default` unless the user
+        explicitly passed the flag on the command line — the correct behavior
+        when a script supplies its own per-script default (#5545).
+        """
+        if name in self._user_supplied:
+            return self.values[name]
+        return default
+
+    def resolve_int(self, name: String, default: Int) raises -> Int:
+        """Return the CLI value if user-supplied, else the caller's default.
+
+        Honors the caller's `default` unless the user explicitly passed the
+        flag; see `resolve_string` (#5545).
+        """
+        if name not in self._user_supplied:
+            return default
+        var value = self.values[name]
+        try:
+            return Int(value)
+        except e:
+            raise Error(
+                "Cannot parse '"
+                + value
+                + "' as integer for argument '"
+                + name
+                + "'"
+            )
+
+    def resolve_float(self, name: String, default: Float64) raises -> Float64:
+        """Return the CLI value if user-supplied, else the caller's default.
+
+        Honors the caller's `default` unless the user explicitly passed the
+        flag; see `resolve_string` (#5545).
+        """
+        if name not in self._user_supplied:
             return default
         var value = self.values[name]
         try:

--- a/src/projectodyssey/utils/training_args.mojo
+++ b/src/projectodyssey/utils/training_args.mojo
@@ -27,6 +27,7 @@ from projectodyssey.utils.arg_parser import (
     validate_positive_int,
     validate_positive_float,
     validate_range_float,
+    ParsedArgs,
 )
 
 
@@ -165,42 +166,73 @@ def parse_training_args_with_defaults(
     """
     var parser = create_training_parser()
     var parsed = parser.parse()
+    return resolve_training_args(
+        parsed,
+        default_epochs=default_epochs,
+        default_batch_size=default_batch_size,
+        default_lr=default_lr,
+        default_momentum=default_momentum,
+        default_data_dir=default_data_dir,
+        default_weights_dir=default_weights_dir,
+        default_lr_decay_epochs=default_lr_decay_epochs,
+        default_lr_decay_factor=default_lr_decay_factor,
+    )
 
-    # Extract values, honoring each CALLER-supplied default over the parser's
-    # registered default. `create_training_parser` pre-populates every argument
-    # with a hardcoded registered default (e.g. weights-dir -> "weights", see
-    # arg_parser.mojo:394), so `parsed.has(name)` is always True and a plain
-    # `get_*(name, default_*)` would never fall back to `default_*` — the
-    # per-script default params would be dead code (#5545). Use the caller's
-    # default unless the user EXPLICITLY passed the flag on the command line.
-    var epochs = parsed.get_int(
-        "epochs", default_epochs
-    ) if parsed.was_user_supplied("epochs") else default_epochs
-    var batch_size = parsed.get_int(
-        "batch-size", default_batch_size
-    ) if parsed.was_user_supplied("batch-size") else default_batch_size
-    var learning_rate = parsed.get_float(
-        "lr", default_lr
-    ) if parsed.was_user_supplied("lr") else default_lr
-    var momentum = parsed.get_float(
-        "momentum", default_momentum
-    ) if parsed.was_user_supplied("momentum") else default_momentum
-    var data_dir = parsed.get_string(
-        "data-dir", default_data_dir
-    ) if parsed.was_user_supplied("data-dir") else default_data_dir
-    var weights_dir = parsed.get_string(
-        "weights-dir", default_weights_dir
-    ) if parsed.was_user_supplied("weights-dir") else default_weights_dir
-    var lr_decay_epochs = parsed.get_int(
+
+def resolve_training_args(
+    parsed: ParsedArgs,
+    default_epochs: Int = 10,
+    default_batch_size: Int = 32,
+    default_lr: Float64 = 0.01,
+    default_momentum: Float64 = 0.9,
+    default_data_dir: String = "datasets",
+    default_weights_dir: String = "weights",
+    default_lr_decay_epochs: Int = 0,
+    default_lr_decay_factor: Float64 = 0.1,
+) raises -> TrainingArgs:
+    """Resolve already-parsed args into a validated TrainingArgs.
+
+    Split from `parse_training_args_with_defaults` so the resolution logic is
+    testable WITHOUT controlling `argv()`: callers can pass a hand-built
+    `ParsedArgs`.
+
+    Honors each CALLER-supplied default over the parser's registered default.
+    `create_training_parser` pre-populates every argument with a hardcoded
+    registered default (e.g. weights-dir -> "weights", arg_parser.mojo:394), so
+    `parsed.has(name)` is always True and a plain `get_*(name, default_*)` would
+    never fall back to `default_*` — the per-script default params would be dead
+    code (#5545). `resolve_*` returns the caller's default unless the user
+    EXPLICITLY passed the flag on the command line.
+
+    Args:
+        parsed: Already-parsed arguments (from ArgumentParser.parse()).
+        default_epochs: Default number of epochs (must be positive).
+        default_batch_size: Default batch size (must be positive).
+        default_lr: Default learning rate (must be positive).
+        default_momentum: Default momentum (must be in [0.0, 1.0]).
+        default_data_dir: Default dataset directory.
+        default_weights_dir: Default weights directory.
+        default_lr_decay_epochs: Default LR decay interval (0 = disabled).
+        default_lr_decay_factor: Default LR decay multiplier (in (0.0, 1.0]).
+
+    Returns:
+        TrainingArgs struct with resolved and validated values.
+
+    Raises:
+        Error if argument validation fails.
+    """
+    var epochs = parsed.resolve_int("epochs", default_epochs)
+    var batch_size = parsed.resolve_int("batch-size", default_batch_size)
+    var learning_rate = parsed.resolve_float("lr", default_lr)
+    var momentum = parsed.resolve_float("momentum", default_momentum)
+    var data_dir = parsed.resolve_string("data-dir", default_data_dir)
+    var weights_dir = parsed.resolve_string("weights-dir", default_weights_dir)
+    var lr_decay_epochs = parsed.resolve_int(
         "lr-decay-epochs", default_lr_decay_epochs
-    ) if parsed.was_user_supplied(
-        "lr-decay-epochs"
-    ) else default_lr_decay_epochs
-    var lr_decay_factor = parsed.get_float(
+    )
+    var lr_decay_factor = parsed.resolve_float(
         "lr-decay-factor", default_lr_decay_factor
-    ) if parsed.was_user_supplied(
-        "lr-decay-factor"
-    ) else default_lr_decay_factor
+    )
     var verbose = parsed.get_bool("verbose")
 
     # Validate numeric arguments

--- a/src/projectodyssey/utils/training_args.mojo
+++ b/src/projectodyssey/utils/training_args.mojo
@@ -166,19 +166,41 @@ def parse_training_args_with_defaults(
     var parser = create_training_parser()
     var parsed = parser.parse()
 
-    # Extract values with defaults
-    var epochs = parsed.get_int("epochs", default_epochs)
-    var batch_size = parsed.get_int("batch-size", default_batch_size)
-    var learning_rate = parsed.get_float("lr", default_lr)
-    var momentum = parsed.get_float("momentum", default_momentum)
-    var data_dir = parsed.get_string("data-dir", default_data_dir)
-    var weights_dir = parsed.get_string("weights-dir", default_weights_dir)
+    # Extract values, honoring each CALLER-supplied default over the parser's
+    # registered default. `create_training_parser` pre-populates every argument
+    # with a hardcoded registered default (e.g. weights-dir -> "weights", see
+    # arg_parser.mojo:394), so `parsed.has(name)` is always True and a plain
+    # `get_*(name, default_*)` would never fall back to `default_*` — the
+    # per-script default params would be dead code (#5545). Use the caller's
+    # default unless the user EXPLICITLY passed the flag on the command line.
+    var epochs = parsed.get_int(
+        "epochs", default_epochs
+    ) if parsed.was_user_supplied("epochs") else default_epochs
+    var batch_size = parsed.get_int(
+        "batch-size", default_batch_size
+    ) if parsed.was_user_supplied("batch-size") else default_batch_size
+    var learning_rate = parsed.get_float(
+        "lr", default_lr
+    ) if parsed.was_user_supplied("lr") else default_lr
+    var momentum = parsed.get_float(
+        "momentum", default_momentum
+    ) if parsed.was_user_supplied("momentum") else default_momentum
+    var data_dir = parsed.get_string(
+        "data-dir", default_data_dir
+    ) if parsed.was_user_supplied("data-dir") else default_data_dir
+    var weights_dir = parsed.get_string(
+        "weights-dir", default_weights_dir
+    ) if parsed.was_user_supplied("weights-dir") else default_weights_dir
     var lr_decay_epochs = parsed.get_int(
         "lr-decay-epochs", default_lr_decay_epochs
-    )
+    ) if parsed.was_user_supplied(
+        "lr-decay-epochs"
+    ) else default_lr_decay_epochs
     var lr_decay_factor = parsed.get_float(
         "lr-decay-factor", default_lr_decay_factor
-    )
+    ) if parsed.was_user_supplied(
+        "lr-decay-factor"
+    ) else default_lr_decay_factor
     var verbose = parsed.get_bool("verbose")
 
     # Validate numeric arguments

--- a/tests/projectodyssey/utils/test_arg_parser.mojo
+++ b/tests/projectodyssey/utils/test_arg_parser.mojo
@@ -9,6 +9,7 @@ Tests basic argument parsing functionality including:
 
 from std.testing import assert_true, assert_equal
 from projectodyssey.utils import ArgumentParser, ArgumentSpec, ParsedArgs
+from projectodyssey.utils import resolve_training_args
 
 
 def test_argument_spec_creation() raises:
@@ -221,6 +222,52 @@ def test_registered_defaults_not_user_supplied() raises:
     assert_true(not result.was_user_supplied("epochs"))
 
 
+def test_resolve_honors_caller_default_when_absent() raises:
+    """Caller default is returned when the user omits the flag (#5545).
+
+    Simulates `parse_training_args_with_defaults(default_weights_dir="custom")`
+    with NO user-supplied flags: every registered default is present in the
+    ParsedArgs (via set), but since none was user-supplied, the caller's
+    per-script defaults must win — the exact regression #5545 describes.
+    """
+    var parsed = ParsedArgs()
+    # Registered defaults, as parse() would pre-populate them.
+    parsed.set("weights-dir", "weights")
+    parsed.set("epochs", "10")
+    parsed.set("lr", "0.01")
+
+    var args = resolve_training_args(
+        parsed,
+        default_epochs=100,
+        default_lr=0.005,
+        default_weights_dir="custom_weights",
+    )
+
+    # Caller defaults win because nothing was user-supplied.
+    assert_equal(args.weights_dir, "custom_weights")
+    assert_equal(args.epochs, 100)
+    assert_true(args.learning_rate > 0.0049 and args.learning_rate < 0.0051)
+
+
+def test_resolve_user_value_overrides_caller_default() raises:
+    """A user-supplied flag beats the caller's default in resolve_training_args.
+    """
+    var parsed = ParsedArgs()
+    parsed.set("weights-dir", "weights")  # registered default
+    parsed.set_user_supplied("weights-dir", "user_dir")  # user passed the flag
+    parsed.set_user_supplied("epochs", "7")
+
+    var args = resolve_training_args(
+        parsed,
+        default_epochs=100,
+        default_weights_dir="custom_weights",
+    )
+
+    # User-supplied values win over caller defaults.
+    assert_equal(args.weights_dir, "user_dir")
+    assert_equal(args.epochs, 7)
+
+
 def main() raises:
     """Run all test_arg_parser tests."""
     print("Running test_arg_parser tests...")
@@ -269,5 +316,11 @@ def main() raises:
 
     test_registered_defaults_not_user_supplied()
     print("✓ test_registered_defaults_not_user_supplied")
+
+    test_resolve_honors_caller_default_when_absent()
+    print("✓ test_resolve_honors_caller_default_when_absent")
+
+    test_resolve_user_value_overrides_caller_default()
+    print("✓ test_resolve_user_value_overrides_caller_default")
 
     print("\nAll test_arg_parser tests passed!")

--- a/tests/projectodyssey/utils/test_arg_parser.mojo
+++ b/tests/projectodyssey/utils/test_arg_parser.mojo
@@ -176,6 +176,51 @@ def test_parser_populates_defaults() raises:
     print("PASS: test_parser_populates_defaults")
 
 
+def test_parsed_args_user_supplied_vs_default() raises:
+    """User-supplied values are distinguished from registered defaults (#5545).
+
+    `set` records a registered default; `set_user_supplied` records a value the
+    user passed on the command line. `has` is True for both, but
+    `was_user_supplied` must be True only for the latter — this is what lets
+    parse_training_args_with_defaults honor a caller default only when the user
+    did not pass the flag.
+    """
+    var args = ParsedArgs()
+    args.set("weights-dir", "weights")  # registered default
+    args.set_user_supplied("epochs", "50")  # user passed --epochs 50
+
+    # Both are visible via has()...
+    assert_true(args.has("weights-dir"))
+    assert_true(args.has("epochs"))
+
+    # ...but only the user-supplied one is flagged as such.
+    assert_true(not args.was_user_supplied("weights-dir"))
+    assert_true(args.was_user_supplied("epochs"))
+    # An argument never set at all is neither.
+    assert_true(not args.has("missing"))
+    assert_true(not args.was_user_supplied("missing"))
+
+
+def test_registered_defaults_not_user_supplied() raises:
+    """Empty argv marks nothing as user-supplied even with defaults (#5545 guard).
+
+    The parser pre-populates every argument's registered default, so has() is
+    True for each; but since the user passed nothing, was_user_supplied() must
+    be False for all — proving a caller default would take effect.
+    """
+    var parser = ArgumentParser()
+    parser.add_argument("weights-dir", "string", "weights")
+    parser.add_argument("epochs", "int", "100")
+
+    var result = parser.parse()  # empty argv (test harness passes no flags)
+
+    assert_true(result.has("weights-dir"))
+    assert_true(result.has("epochs"))
+    # The regression: neither should count as user-supplied.
+    assert_true(not result.was_user_supplied("weights-dir"))
+    assert_true(not result.was_user_supplied("epochs"))
+
+
 def main() raises:
     """Run all test_arg_parser tests."""
     print("Running test_arg_parser tests...")
@@ -218,5 +263,11 @@ def main() raises:
 
     test_parser_populates_defaults()
     print("✓ test_parser_populates_defaults")
+
+    test_parsed_args_user_supplied_vs_default()
+    print("✓ test_parsed_args_user_supplied_vs_default")
+
+    test_registered_defaults_not_user_supplied()
+    print("✓ test_registered_defaults_not_user_supplied")
 
     print("\nAll test_arg_parser tests passed!")


### PR DESCRIPTION
## Problem

`create_training_parser` registers every argument with a hardcoded default (e.g. `weights-dir` → `"weights"`, `arg_parser.mojo:394`), and `parse()` pre-populates those into `ParsedArgs`. So `parsed.has(name)` was always `True`, and `parse_training_args_with_defaults`' `get_string("weights-dir", default_weights_dir)` (`training_args.mojo:175`) never fell back to the caller's default — the per-script `default_*` parameters were **dead code**, and every script saved to `weights/` regardless of what it requested.

This masked-default divergence is what made MobileNetV1's train (`weights/`) and inference (`mobilenetv1_weights/`) non-composable (#5543). Found by the strict review of #5544 (finding 3).

## Fix

Distinguish registered defaults from user-supplied values:

- **`ParsedArgs`**: add `set_user_supplied` + `was_user_supplied`. `parse()` records argv-driven values via `set_user_supplied`; registered defaults still go through `set`. `has()` is unchanged (True for both).
- **`parse_training_args_with_defaults`**: for each argument, use the caller's `default_*` unless the user **explicitly** passed the flag. Applied uniformly to all masked defaults (`epochs`/`batch-size`/`lr`/`momentum`/`data-dir`/`weights-dir`/`lr-decay-*`), since they share the bug.

**Backward-compatible:** existing callers behave identically when the user passes flags; the only change is that caller-provided defaults now actually take effect when the user does not.

## Tests / verification

- Two regression tests in `test_arg_parser.mojo`: `was_user_supplied` is False for registered defaults (empty argv) and True only for CLI-supplied values.
- Verified in-container: all **15** `test_arg_parser` tests pass; `examples/resnet18_cifar10/train.mojo` (a consumer) AOT-compiles clean with `--Werror`.

Closes #5545

🤖 Generated with [Claude Code](https://claude.com/claude-code)