### PR TITLE
fix(ci): strip AVX-512 from example-backward mojo run (modular#6413 JIT crash)

### DIFF
--- a/justfile
+++ b/justfile
@@ -1322,16 +1322,14 @@ _test-example-backward-inner:
         # strip (defined justfile:52, wired into MOJO_ASAN/MOJO_TSAN at :54-55)
         # is the repo's fix for the same crash under sanitizers.
         #
-        # Whether `mojo run` (JIT) honors --target-features is not fully settled
-        # in-repo: notes/mojo-cpu-detection-source-review.md is internally
-        # uncertain (its abstract says the flag "only helps for AOT builds", its
-        # §4 says a `mojo run` inherits the driver-derived !kgen.target so it
-        # "would propagate — worth testing"). `--print-effective-target` confirms
-        # the strip removes every avx512* feature from the target; the strip is
-        # accepted by `mojo run` and both tests pass locally. This is the
-        # cheapest correct-direction fix; if the JIT ignores it and the flake
-        # persists, escalate to the coredump-capture path (comprehensive-tests
-        # workflow_dispatch input) / upstream. Harmless where AVX-512 is absent.
+        # `mojo run`'s in-process JIT DOES honor --target-features (proven: on an
+        # AVX-512-less host, forcing `--target-features +avx512f` makes `mojo run`
+        # emit AVX-512 and SIGILL with this same libKGENCompilerRTShared.so
+        # backtrace, while the strip below runs clean). This directly reproduces
+        # #6413 and confirms the strip removes the crashing codegen — not just an
+        # AOT-only flag (correcting the "only helps for AOT" hedge in
+        # notes/mojo-cpu-detection-source-review.md). Harmless where AVX-512 is
+        # absent (features are simply already-off).
         if ! pixi run mojo run --Werror {{MOJO_TARGET_CPU}} \
                 -I "$REPO_ROOT/src" -I "$REPO_ROOT" \
                 -I "$REPO_ROOT/examples/$ex" -Xlinker -lm "$f"; then

--- a/justfile
+++ b/justfile
@@ -1314,7 +1314,15 @@ _test-example-backward-inner:
         echo "=================================================="
         echo "Running example backward test: $f"
         echo "=================================================="
-        if ! pixi run mojo run --Werror \
+        # Strip AVX-512 from the JIT target (modular/modular#6413). `mojo run`
+        # JIT-compiles then executes; on AVX-512-masked GHA runners (Azure Zen4,
+        # Hyper-V masks the AVX-512 CPUID bits) the JIT still emits AVX-512
+        # encodings via --target-cpu fingerprinting and SIGILLs ("execution
+        # crashed" in libKGENCompilerRTShared.so). The driver-path fix only
+        # covers `mojo build`; this run path needs the same strip already
+        # applied to MOJO_ASAN/MOJO_TSAN (justfile:40-52). Harmless on hosts
+        # without AVX-512 (features are simply disabled).
+        if ! pixi run mojo run --Werror {{MOJO_TARGET_CPU}} \
                 -I "$REPO_ROOT/src" -I "$REPO_ROOT" \
                 -I "$REPO_ROOT/examples/$ex" -Xlinker -lm "$f"; then
             echo "FAILED: $f"

--- a/justfile
+++ b/justfile
@@ -1314,14 +1314,24 @@ _test-example-backward-inner:
         echo "=================================================="
         echo "Running example backward test: $f"
         echo "=================================================="
-        # Strip AVX-512 from the JIT target (modular/modular#6413). `mojo run`
-        # JIT-compiles then executes; on AVX-512-masked GHA runners (Azure Zen4,
-        # Hyper-V masks the AVX-512 CPUID bits) the JIT still emits AVX-512
-        # encodings via --target-cpu fingerprinting and SIGILLs ("execution
-        # crashed" in libKGENCompilerRTShared.so). The driver-path fix only
-        # covers `mojo build`; this run path needs the same strip already
-        # applied to MOJO_ASAN/MOJO_TSAN (justfile:40-52). Harmless on hosts
-        # without AVX-512 (features are simply disabled).
+        # Strip AVX-512 from the target (modular/modular#6413). The "Example
+        # Backward Tests" job flakes with "execution crashed" inside
+        # libKGENCompilerRTShared.so on AVX-512-masked GHA runners (Azure Zen4:
+        # Hyper-V masks the AVX-512 CPUID bits, but --target-cpu fingerprinting
+        # sees a Zen4 name and emits AVX-512 anyway → SIGILL). The MOJO_TARGET_CPU
+        # strip (defined justfile:52, wired into MOJO_ASAN/MOJO_TSAN at :54-55)
+        # is the repo's fix for the same crash under sanitizers.
+        #
+        # Whether `mojo run` (JIT) honors --target-features is not fully settled
+        # in-repo: notes/mojo-cpu-detection-source-review.md is internally
+        # uncertain (its abstract says the flag "only helps for AOT builds", its
+        # §4 says a `mojo run` inherits the driver-derived !kgen.target so it
+        # "would propagate — worth testing"). `--print-effective-target` confirms
+        # the strip removes every avx512* feature from the target; the strip is
+        # accepted by `mojo run` and both tests pass locally. This is the
+        # cheapest correct-direction fix; if the JIT ignores it and the flake
+        # persists, escalate to the coredump-capture path (comprehensive-tests
+        # workflow_dispatch input) / upstream. Harmless where AVX-512 is absent.
         if ! pixi run mojo run --Werror {{MOJO_TARGET_CPU}} \
                 -I "$REPO_ROOT/src" -I "$REPO_ROOT" \
                 -I "$REPO_ROOT/examples/$ex" -Xlinker -lm "$f"; then


### PR DESCRIPTION
## Symptom

The **Example Backward Tests** CI job flakes (~12% on main) with `mojo: error: execution crashed` — a crash **inside `libKGENCompilerRTShared.so`** (the JIT runtime), at **identical backtrace offsets** (`+0x7251b / +0x6f686 / +0x73307`) across *both* the googlenet (`test_concat_backward_roundtrip`) and resnet18 (`test_train_step_runs_without_error`) tests. Same JIT crash site, different tests.

## Root cause

Residual **[modular/modular#6413](https://github.com/modular/modular/issues/6413)** (AVX-512 mis-emission) on the JIT `mojo run` path.

GHA Azure runners are AMD Zen4 with **AVX-512 masked by Hyper-V CPUID**. `mojo run` JIT-compiles using `--target-cpu` *fingerprinting* (which sees a Zen4 name → assumes AVX-512), emits AVX-512 encodings, then **SIGILLs** on the masked hardware. Runner-dependent ⇒ non-deterministic: a rerun of the same commit passes, and it passes 100% on non-AVX-512 hosts.

The repo already documents #6413 (`justfile:40-52`) and defines the `MOJO_TARGET_CPU` AVX-512 strip — but wires it **only into `MOJO_ASAN`/`MOJO_TSAN`**. The driver-path fix (`mojo build --print-effective-target` downgrade) covers *compile* paths (so `just test-group`, which uses `mojo <file>`, does **not** flake), but the JIT `mojo run` path in `_test-example-backward-inner` was unprotected.

## Fix

Apply `{{MOJO_TARGET_CPU}}` to that recipe's `mojo run`, mirroring the sanitizer paths.

## Verification (reproduce-before-fix)

- **Deterministic mechanism proof:** `mojo build --print-effective-target` *without* the strip lists the full feature set; *with* the strip, every `avx512*` feature is disabled — removing the crash's **necessary condition by construction** (stronger than a probabilistic before/after rate).
- **Transient confirmed:** a `gh run rerun --failed` of the crashing commit → **PASS** (same code, different runner).
- **Fix passes in-container:** `mojo run` accepts `--target-features`, and both tests still pass with the strip (googlenet `2.4117308 → 0.033096313`; resnet18 all 3).
- **Local ground-truth:** passes 100% (this host has no AVX-512, so the condition is absent — corroborating the mechanism).

> A 100%-on-demand crash repro only exists on an AVX-512-masked GHA runner (not locally); the construction-proof + libKGEN backtrace + transient-rerun evidence establish the causal chain.

## Not a workaround

This is **not** a retry / `continue-on-error` (forbidden per Odysseus#280) — it removes the faulty codegen rather than masking the crash.

## Out of scope (noted)

**Three** other recipes use unstripped `mojo run` and carry the same latent #6413 exposure: `train` (justfile:587), `infer` (:597), and `infer`-image (:606). They are **not** in the per-PR gate (dataset-bound, run manually/weekly), so they have not surfaced as flakes and are left for a follow-up rather than fixed speculatively. Filing that follow-up is recommended if this fix proves out.

## JIT mechanism — PROVEN

The one open question (does `mojo run`'s in-process JIT actually honor `--target-features`, or only the AOT path?) is now **settled by a deterministic probe** that reproduces #6413 100% locally. On an AVX-512-**less** host, a pure-SIMD program run via `mojo run`:

| Invocation | Result |
|---|---|
| baseline (no flag) | `simd_width=8` → **PASS** |
| `--target-features +avx512f,…` | **CRASH** — `libKGENCompilerRTShared.so+0x7251b/+0x6f686/+0x73307`, `execution crashed` (identical backtrace to the CI flake) |
| `--target-features -avx512…` (this fix) | **PASS** |

Forcing AVX-512 **on** makes the JIT emit AVX-512 and SIGILL on hardware without it — reproducing the exact CI crash. This proves: (1) the root cause is AVX-512 mis-emission, (2) `mojo run`'s JIT **does** honor `--target-features` (the note's "only helps for AOT builds" hedge is wrong for `mojo run`), and (3) the strip removes the crashing codegen. The fix is confirmed effective, not merely correct-direction.
