### PR TITLE
fix(core): guard argmax/top_k/argsort against strided views (#5572)

### DIFF
--- a/src/projectodyssey/core/utils.mojo
+++ b/src/projectodyssey/core/utils.mojo
@@ -11,6 +11,19 @@ All functions work with AnyTensor and follow the pure functional design pattern
 
 from std.collections import List
 from projectodyssey.tensor.any_tensor import AnyTensor
+from projectodyssey.core.shape import as_contiguous
+
+
+def _as_contiguous_view(tensor: AnyTensor) raises -> AnyTensor:
+    """Return a contiguous equivalent, materializing only if strided.
+
+    The index ops below read the raw buffer via `_get_float64(linear_idx)` with
+    strides synthesized under a row-major-contiguous assumption. A strided
+    (non-contiguous) view — e.g. from `slice(..., axis=1)` — would be misread
+    (#5572), so callers must operate on a contiguous copy. This mirrors the same
+    guard in core/reduction.mojo (`_dispatch_reduce_*`).
+    """
+    return tensor if tensor.is_contiguous() else as_contiguous(tensor)
 
 
 def argmax(tensor: AnyTensor) raises -> Int:
@@ -34,11 +47,12 @@ def argmax(tensor: AnyTensor) raises -> Int:
     if tensor.numel() == 0:
         raise Error("argmax: tensor is empty")
 
-    var max_val = tensor._get_float64(0)
+    var t = _as_contiguous_view(tensor)
+    var max_val = t._get_float64(0)
     var max_idx = 0
 
-    for i in range(1, tensor.numel()):
-        var val = tensor._get_float64(i)
+    for i in range(1, t.numel()):
+        var val = t._get_float64(i)
         if val > max_val:
             max_val = val
             max_idx = i
@@ -74,17 +88,22 @@ def argmax(tensor: AnyTensor, axis: Int) raises -> AnyTensor:
             + " dimensions"
         )
 
+    # Materialize a contiguous copy if the input is a strided view (#5572):
+    # the row-major strides synthesized below are only valid for contiguous
+    # layout, so `_get_float64` must read from `t`, not the raw strided view.
+    var t = _as_contiguous_view(tensor)
+
     # Build result shape
     var result_shape = List[Int]()
-    for i in range(tensor.dim()):
+    for i in range(t.dim()):
         if i != axis:
-            result_shape.append(tensor.shape()[i])
+            result_shape.append(t.shape()[i])
 
     var result = AnyTensor(result_shape, DType.int64)
 
     # Compute strides for indexing
-    var input_shape = tensor.shape()
-    var ndim = tensor.dim()
+    var input_shape = t.shape()
+    var ndim = t.dim()
     var strides = List[Int]()
     for _ in range(ndim):
         strides.append(0)
@@ -108,7 +127,7 @@ def argmax(tensor: AnyTensor, axis: Int) raises -> AnyTensor:
             temp_idx //= result.shape()[i]
 
         # Map result coordinates to input coordinates (accounting for reduced axis)
-        var tensor_dim = tensor.dim()
+        var tensor_dim = t.dim()
         var input_coords = List[Int]()
         for _ in range(tensor_dim):
             input_coords.append(0)
@@ -123,9 +142,9 @@ def argmax(tensor: AnyTensor, axis: Int) raises -> AnyTensor:
         # Find argmax along the reduction axis
         input_coords[axis] = 0
         var linear_idx = 0
-        for i in range(tensor.dim()):
+        for i in range(t.dim()):
             linear_idx += input_coords[i] * strides[i]
-        var max_val = tensor._get_float64(linear_idx)
+        var max_val = t._get_float64(linear_idx)
         var max_idx = 0
 
         # Compare with remaining values
@@ -134,10 +153,10 @@ def argmax(tensor: AnyTensor, axis: Int) raises -> AnyTensor:
 
             # Convert coordinates to linear index
             linear_idx = 0
-            for i in range(tensor.dim()):
+            for i in range(t.dim()):
                 linear_idx += input_coords[i] * strides[i]
 
-            var val = tensor._get_float64(linear_idx)
+            var val = t._get_float64(linear_idx)
             if val > max_val:
                 max_val = val
                 max_idx = k
@@ -179,12 +198,13 @@ def top_k_indices(tensor: AnyTensor, k: Int) raises -> List[Int]:
     if tensor.numel() == 0:
         raise Error("top_k_indices: tensor is empty")
 
-    var numel = tensor.numel()
+    var t = _as_contiguous_view(tensor)
+    var numel = t.numel()
 
     # Create list of (value, index) pairs
     var pairs = List[Tuple[Float64, Int]]()
     for i in range(numel):
-        var val = tensor._get_float64(i)
+        var val = t._get_float64(i)
         pairs.append((val, i))
 
     # Simple selection sort to find top k (not the most efficient, but correct)
@@ -233,14 +253,18 @@ def top_k(tensor: AnyTensor, k: Int) raises -> Tuple[AnyTensor, List[Int]]:
     """
     var indices = top_k_indices(tensor, k)
 
+    # top_k_indices returns indices into the CONTIGUOUS logical order, so read
+    # values from the same contiguous view (#5572) rather than the raw input.
+    var t = _as_contiguous_view(tensor)
+
     # Create result tensor for values
     var values_shape = List[Int]()
     values_shape.append(k)
-    var values = AnyTensor(values_shape, tensor.dtype())
+    var values = AnyTensor(values_shape, t.dtype())
 
     for i in range(k):
         var idx = indices[i]
-        var val = tensor._get_float64(idx)
+        var val = t._get_float64(idx)
         values._set_float64(i, val)
 
     return (values, indices^)
@@ -268,12 +292,13 @@ def argsort(tensor: AnyTensor, descending: Bool = False) raises -> List[Int]:
     if tensor.numel() == 0:
         raise Error("argsort: tensor is empty")
 
-    var numel = tensor.numel()
+    var t = _as_contiguous_view(tensor)
+    var numel = t.numel()
 
     # Create list of (value, index) pairs
     var pairs = List[Tuple[Float64, Int]]()
     for i in range(numel):
-        var val = tensor._get_float64(i)
+        var val = t._get_float64(i)
         pairs.append((val, i))
 
     # Bubble sort (simple and correct, not the most efficient)

--- a/src/projectodyssey/training/metrics/accuracy.mojo
+++ b/src/projectodyssey/training/metrics/accuracy.mojo
@@ -252,7 +252,13 @@ def get_topk_indices(
     Raises:
             Error: If operation fails.
     """
-    var shape_vec = predictions.shape()
+    # Reads below use flat `offset + c` indexing, which assumes a row-major-
+    # contiguous layout; materialize a contiguous copy so a strided predictions
+    # view is not misread (#5572, same class as the argmax fix above).
+    var preds = predictions if predictions.is_contiguous() else as_contiguous(
+        predictions
+    )
+    var shape_vec = preds.shape()
     var num_classes = shape_vec[1]
     var offset = batch_idx * num_classes
 
@@ -262,10 +268,10 @@ def get_topk_indices(
 
     for c in range(num_classes):
         var idx = offset + c
-        if predictions._dtype == DType.float32:
-            values.append(Float64(predictions.load[DType.float32](idx)))
+        if preds._dtype == DType.float32:
+            values.append(Float64(preds.load[DType.float32](idx)))
         else:
-            values.append(Float64(predictions.load[DType.float64](idx)))
+            values.append(Float64(preds.load[DType.float64](idx)))
         indices.append(c)
 
     # Simple selection: repeatedly find max and swap to front

--- a/src/projectodyssey/training/metrics/accuracy.mojo
+++ b/src/projectodyssey/training/metrics/accuracy.mojo
@@ -16,6 +16,7 @@ Type support:
 from projectodyssey.tensor.any_tensor import AnyTensor
 from std.collections import List
 from projectodyssey.training.metrics.base import Metric
+from projectodyssey.core.shape import as_contiguous
 
 
 # ============================================================================
@@ -111,6 +112,12 @@ def argmax(var tensor: AnyTensor, axis: Int) raises -> AnyTensor:
     var shape_vec = tensor.shape()
     if axis < 0 or axis >= len(shape_vec):
         raise Error("argmax: axis out of bounds")
+
+    # Reads below use flat `b * num_classes + c` offsets, which assume a
+    # row-major-contiguous layout; materialize a contiguous copy first so a
+    # strided view is not misread (#5572).
+    if not tensor.is_contiguous():
+        tensor = as_contiguous(tensor)
 
     if axis == 1 and len(shape_vec) == 2:
         # Common case: [batch_size, num_classes] -> [batch_size]

--- a/tests/projectodyssey/core/test_utils_noncontiguous.mojo
+++ b/tests/projectodyssey/core/test_utils_noncontiguous.mojo
@@ -18,6 +18,7 @@ from tests.projectodyssey.conftest import (
 from projectodyssey.tensor.any_tensor import AnyTensor
 from projectodyssey.tensor.tensor_creation import zeros
 from projectodyssey.core.utils import argmax, top_k_indices, top_k, argsort
+from projectodyssey.training.metrics.accuracy import argmax as metrics_argmax
 
 
 def _make_strided_2x4() raises -> AnyTensor:
@@ -31,9 +32,9 @@ def _make_strided_2x4() raises -> AnyTensor:
     reader would read row 1 at flat offset 4 (the 9.0, outside the slice).
     """
     var t = zeros([2, 8], DType.float32)
-    t[1] = Float32(5.0)  # row 0, col 1  (inside slice)
-    t[4] = Float32(9.0)  # row 0, col 4  (OUTSIDE slice — the trap)
-    t[10] = Float32(7.0)  # row 1, col 2  (inside slice)
+    t.set(1, Float32(5.0))  # row 0, col 1  (inside slice)
+    t.set(4, Float32(9.0))  # row 0, col 4  (OUTSIDE slice — the trap)
+    t.set(10, Float32(7.0))  # row 1, col 2  (inside slice)
     var view = t.slice(0, 4, axis=1)
     assert_false(view.is_contiguous(), "fixture must be non-contiguous")
     return view^
@@ -94,11 +95,32 @@ def test_argsort_noncontiguous() raises:
     assert_equal_int(idx[1], 1)
 
 
+def test_argsort_ascending_noncontiguous() raises:
+    """Ascending argsort on a strided view puts the true max last."""
+    var view = _make_strided_2x4()
+    # Logical: [0,5,0,0, 0,0,7,0]. Ascending -> zeros first, then 5.0 (idx 1),
+    # then the max 7.0 (idx 6) last.
+    var idx = argsort(view, descending=False)
+    assert_equal_int(len(idx), 8)
+    assert_equal_int(idx[len(idx) - 1], 6)
+    assert_equal_int(idx[len(idx) - 2], 1)
+
+
+def test_metrics_argmax_noncontiguous() raises:
+    """Metrics argmax also guards strided views (#5572, same class)."""
+    var view = _make_strided_2x4()
+    var pred = metrics_argmax(view, axis=1)
+    assert_equal_int(pred.shape()[0], 2)
+    # Row 0 max is 5.0 at col 1; row 1 max is 7.0 at col 2 (result dtype int32).
+    assert_equal_int(Int(pred.load[DType.int32](0)), 1)
+    assert_equal_int(Int(pred.load[DType.int32](1)), 2)
+
+
 def test_contiguous_baseline_unchanged() raises:
     """Contiguous inputs still behave correctly (guard is a no-op for them)."""
     var t = zeros([2, 4], DType.float32)
-    t[1] = Float32(5.0)  # row 0, col 1
-    t[6] = Float32(7.0)  # row 1, col 2
+    t.set(1, Float32(5.0))  # row 0, col 1
+    t.set(6, Float32(7.0))  # row 1, col 2
     assert_true(t.is_contiguous(), "baseline fixture must be contiguous")
     var pred = argmax(t, axis=1)
     assert_equal_int(Int(pred.load[DType.int64](0)), 1)
@@ -120,6 +142,12 @@ def main() raises:
     print(" PASS")
     print("test_argsort_noncontiguous...", end="")
     test_argsort_noncontiguous()
+    print(" PASS")
+    print("test_argsort_ascending_noncontiguous...", end="")
+    test_argsort_ascending_noncontiguous()
+    print(" PASS")
+    print("test_metrics_argmax_noncontiguous...", end="")
+    test_metrics_argmax_noncontiguous()
     print(" PASS")
     print("test_contiguous_baseline_unchanged...", end="")
     test_contiguous_baseline_unchanged()

--- a/tests/projectodyssey/core/test_utils_noncontiguous.mojo
+++ b/tests/projectodyssey/core/test_utils_noncontiguous.mojo
@@ -1,0 +1,127 @@
+"""Tests for core.utils index ops on non-contiguous (strided) tensors.
+
+Verifies argmax (flat + axis), top_k_indices, top_k, and argsort produce
+correct results on a strided AnyTensor view (e.g. from slice(..., axis=1)).
+Without the as_contiguous() guard these ops synthesize row-major strides and
+read the raw buffer via _get_float64, silently returning wrong indices.
+
+Regression test for #5572.
+"""
+
+
+from tests.projectodyssey.conftest import (
+    assert_equal_int,
+    assert_almost_equal,
+    assert_false,
+    assert_true,
+)
+from projectodyssey.tensor.any_tensor import AnyTensor
+from projectodyssey.tensor.tensor_creation import zeros
+from projectodyssey.core.utils import argmax, top_k_indices, top_k, argsort
+
+
+def _make_strided_2x4() raises -> AnyTensor:
+    """Columns 0..3 of a (2, 8) buffer — a non-contiguous inner-axis view.
+
+    (2, 8) row-major buffer:
+        row 0: [0, 5, 0, 0, 9, 0, 0, 0]
+        row 1: [0, 0, 7, 0, 0, 0, 0, 0]
+    The slice [:, 0:4] is logically [[0, 5, 0, 0], [0, 0, 7, 0]] but keeps the
+    parent's stride of 8, so row 1 starts at flat offset 8 (not 4). A buggy
+    reader would read row 1 at flat offset 4 (the 9.0, outside the slice).
+    """
+    var t = zeros([2, 8], DType.float32)
+    t[1] = Float32(5.0)  # row 0, col 1  (inside slice)
+    t[4] = Float32(9.0)  # row 0, col 4  (OUTSIDE slice — the trap)
+    t[10] = Float32(7.0)  # row 1, col 2  (inside slice)
+    var view = t.slice(0, 4, axis=1)
+    assert_false(view.is_contiguous(), "fixture must be non-contiguous")
+    return view^
+
+
+def test_argmax_axis_noncontiguous() raises:
+    """Axis argmax reads the view's real rows, not flat offsets."""
+    var view = _make_strided_2x4()
+    var pred = argmax(view, axis=1)
+    assert_equal_int(pred.shape()[0], 2)
+    # Row 0 max is 5.0 at col 1; row 1 max is 7.0 at col 2.
+    assert_equal_int(Int(pred.load[DType.int64](0)), 1)
+    assert_equal_int(Int(pred.load[DType.int64](1)), 2)
+
+
+def test_argmax_flat_noncontiguous() raises:
+    """Flat argmax over a strided view scans only the view's real elements.
+
+    The flat view [0, 5, 0, 0, 0, 0, 7, 0] (logical order) has its max 7.0 at
+    logical index 6 — NOT the 9.0 at raw offset 4 that lives outside the slice.
+    """
+    var view = _make_strided_2x4()
+    var idx = argmax(view)
+    assert_equal_int(idx, 6)
+
+
+def test_top_k_indices_noncontiguous() raises:
+    """Top-k indices are the logical indices of the true top values."""
+    var view = _make_strided_2x4()
+    # Logical flat order: [0,5,0,0, 0,0,7,0]; top-2 are 7.0 (idx 6), 5.0 (idx 1).
+    var idx = top_k_indices(view, 2)
+    assert_equal_int(len(idx), 2)
+    assert_equal_int(idx[0], 6)
+    assert_equal_int(idx[1], 1)
+
+
+def test_top_k_values_noncontiguous() raises:
+    """Top-k values are the true top values (read from the contiguous view)."""
+    var view = _make_strided_2x4()
+    var result = top_k(view, 2)
+    var values = result[0]
+    assert_almost_equal(
+        Float32(values.load[DType.float32](0)), Float32(7.0), tolerance=1e-4
+    )
+    assert_almost_equal(
+        Float32(values.load[DType.float32](1)), Float32(5.0), tolerance=1e-4
+    )
+
+
+def test_argsort_noncontiguous() raises:
+    """Argsort orders the view's real elements, not raw-buffer garbage."""
+    var view = _make_strided_2x4()
+    # Logical: [0,5,0,0, 0,0,7,0]. Descending order by value -> idx 6 (7.0),
+    # then idx 1 (5.0), then the zeros in ascending-index order.
+    var idx = argsort(view, descending=True)
+    assert_equal_int(len(idx), 8)
+    assert_equal_int(idx[0], 6)
+    assert_equal_int(idx[1], 1)
+
+
+def test_contiguous_baseline_unchanged() raises:
+    """Contiguous inputs still behave correctly (guard is a no-op for them)."""
+    var t = zeros([2, 4], DType.float32)
+    t[1] = Float32(5.0)  # row 0, col 1
+    t[6] = Float32(7.0)  # row 1, col 2
+    assert_true(t.is_contiguous(), "baseline fixture must be contiguous")
+    var pred = argmax(t, axis=1)
+    assert_equal_int(Int(pred.load[DType.int64](0)), 1)
+    assert_equal_int(Int(pred.load[DType.int64](1)), 2)
+
+
+def main() raises:
+    print("test_argmax_axis_noncontiguous...", end="")
+    test_argmax_axis_noncontiguous()
+    print(" PASS")
+    print("test_argmax_flat_noncontiguous...", end="")
+    test_argmax_flat_noncontiguous()
+    print(" PASS")
+    print("test_top_k_indices_noncontiguous...", end="")
+    test_top_k_indices_noncontiguous()
+    print(" PASS")
+    print("test_top_k_values_noncontiguous...", end="")
+    test_top_k_values_noncontiguous()
+    print(" PASS")
+    print("test_argsort_noncontiguous...", end="")
+    test_argsort_noncontiguous()
+    print(" PASS")
+    print("test_contiguous_baseline_unchanged...", end="")
+    test_contiguous_baseline_unchanged()
+    print(" PASS")
+    print("ALL test_utils_noncontiguous TESTS PASSED")


### PR DESCRIPTION
## Bug

`core.utils.argmax` (both overloads), `top_k_indices`, `top_k`, and `argsort` read the raw buffer via `_get_float64` using strides **synthesized from `shape()`** under a row-major-contiguous assumption — they ignore a view's actual strides. Given a non-contiguous view (e.g. `AnyTensor.slice(..., axis=1)`), they **silently return wrong indices with no error**.

For a `(N, 10)` view sliced from a `(N, 784)` buffer, row `r` is read at flat offsets `r*10..` instead of `r*784..`, so every row past 0 reads garbage from row 0's tail. (`training/metrics/accuracy.mojo`'s local `argmax` had the same flat-offset bug.)

The reductions in `core/reduction.mojo` already guard against exactly this via `as_contiguous` — the `core/utils.mojo` ops had no equivalent guard or coverage.

## Fix

Materialize a contiguous copy when the input is strided, mirroring `core/reduction.mojo`'s `_dispatch_reduce_*` (`t = tensor if tensor.is_contiguous() else as_contiguous(tensor)`). Added a shared `_as_contiguous_view` helper applied to all four ops; returned indices are into the contiguous logical order (the intended semantics). Also fixed `accuracy.mojo`'s local `argmax`.

## Test

`tests/projectodyssey/core/test_utils_noncontiguous.mojo` reproduces the issue's exact fixture — a `(2, 8)` buffer sliced to `[:, 0:4]` with a `9.0` **trap** at the out-of-slice offset 4 — and asserts correct results for all four ops plus a contiguous baseline. It's auto-picked-up by the CI `core` test-group (`test_utils*.mojo` glob, comprehensive-tests.yml:372/395).

## Verification (reproduce-before-fix)

- All 6 new tests pass in-container.
- **Proven non-vacuous:** with the guard disabled, `test_argmax_axis_noncontiguous` **fails** `Expected 0 == 2` — the buggy read returns the out-of-slice `9.0`'s column instead of the true max. Re-enabling the guard makes it pass.
- No regression in the existing `test_utils.mojo`.

Closes #5572

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Strict-review follow-up (addressed)

- **Sibling bug fixed:** `accuracy.get_topk_indices`/`topk_accuracy` had the identical unguarded flat-offset bug — now guarded too.
- **accuracy.argmax now tested:** added `test_metrics_argmax_noncontiguous` (the fix previously shipped untested), plus `test_argsort_ascending_noncontiguous` for the ascending path.
- **Fixture hardened:** switched `t[i] = Float32(...)` → `t.set(i, ...)` (the sanctioned write idiom).

Now 8 tests, all passing in-container.