### PR TITLE
fix(mobilenetv1): persist BatchNorm running stats during training (#5537)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ examples/*/inference
 test_*
 !tests/**
 !conda.recipe/test_*
+# `test_*` above targets compiled Mojo test BINARIES, but also matches `.mojo`
+# sources; rescue example test sources so they can be tracked + run in CI
+# (e.g. examples/*/test_backward.mojo, test_bn_persistence.mojo).
+!examples/**/test_*.mojo
 .worktrees/
 .claude/worktrees/
 .claude/scheduled_tasks.lock

--- a/examples/mobilenetv1_cifar10/model.mojo
+++ b/examples/mobilenetv1_cifar10/model.mojo
@@ -215,7 +215,11 @@ struct DepthwiseSeparableBlock:
         var out = depthwise_conv2d(
             x, self.dw_weights, self.dw_bias, stride=stride, padding=1
         )
-        out, _, _ = batch_norm2d(
+        # Persist the updated running stats back onto the block (#5537): under
+        # training=True batch_norm2d returns EMA-updated running_mean/var; if
+        # discarded, forward(training=False) inference uses the stale init
+        # (0, 1) values and produces wrong results.
+        var dw_bn = batch_norm2d(
             out,
             self.dw_bn_gamma,
             self.dw_bn_beta,
@@ -223,11 +227,14 @@ struct DepthwiseSeparableBlock:
             self.dw_bn_running_var,
             training,
         )
+        out = dw_bn[0]
+        self.dw_bn_running_mean = dw_bn[1]
+        self.dw_bn_running_var = dw_bn[2]
         out = relu(out)
 
         # Pointwise convolution (channel mixing, 1×1)
         out = conv2d(out, self.pw_weights, self.pw_bias, stride=1, padding=0)
-        out, _, _ = batch_norm2d(
+        var pw_bn = batch_norm2d(
             out,
             self.pw_bn_gamma,
             self.pw_bn_beta,
@@ -235,6 +242,9 @@ struct DepthwiseSeparableBlock:
             self.pw_bn_running_var,
             training,
         )
+        out = pw_bn[0]
+        self.pw_bn_running_mean = pw_bn[1]
+        self.pw_bn_running_var = pw_bn[2]
         out = relu(out)
 
         return out
@@ -347,7 +357,8 @@ struct MobileNetV1:
             stride=2,
             padding=1,
         )
-        out, _, _ = batch_norm2d(
+        # Persist EMA-updated running stats (#5537) — see block forward above.
+        var initial_bn = batch_norm2d(
             out,
             self.initial_bn_gamma,
             self.initial_bn_beta,
@@ -355,6 +366,9 @@ struct MobileNetV1:
             self.initial_bn_running_var,
             training,
         )
+        out = initial_bn[0]
+        self.initial_bn_running_mean = initial_bn[1]
+        self.initial_bn_running_var = initial_bn[2]
         out = relu(out)
         # Shape: (batch, 32, 16, 16)
 

--- a/examples/mobilenetv1_cifar10/test_bn_persistence.mojo
+++ b/examples/mobilenetv1_cifar10/test_bn_persistence.mojo
@@ -88,18 +88,25 @@ def test_bn_stats_persist_in_depthwise_blocks() raises:
     for i in range(2 * 3 * 32 * 32):
         xd[i] = Float32(i % 5) * 0.2 - 0.4
 
-    var dw_before = _running_mean_sig(model.ds_block_1.dw_bn_running_mean)
-    var pw_before = _running_mean_sig(model.ds_block_1.pw_bn_running_mean)
+    var dw1_before = _running_mean_sig(model.ds_block_1.dw_bn_running_mean)
+    var pw1_before = _running_mean_sig(model.ds_block_1.pw_bn_running_mean)
+    # Also check the LAST block, so this proves the shared block forward path
+    # persists for every block, not just the first.
+    var dw13_before = _running_mean_sig(model.ds_block_13.dw_bn_running_mean)
 
     _ = model.forward(x, training=True)
 
     assert_true(
-        _running_mean_sig(model.ds_block_1.dw_bn_running_mean) != dw_before,
+        _running_mean_sig(model.ds_block_1.dw_bn_running_mean) != dw1_before,
         "ds_block_1 depthwise BN running_mean not persisted (#5537)",
     )
     assert_true(
-        _running_mean_sig(model.ds_block_1.pw_bn_running_mean) != pw_before,
+        _running_mean_sig(model.ds_block_1.pw_bn_running_mean) != pw1_before,
         "ds_block_1 pointwise BN running_mean not persisted (#5537)",
+    )
+    assert_true(
+        _running_mean_sig(model.ds_block_13.dw_bn_running_mean) != dw13_before,
+        "ds_block_13 (last) depthwise BN running_mean not persisted (#5537)",
     )
 
 

--- a/examples/mobilenetv1_cifar10/test_bn_persistence.mojo
+++ b/examples/mobilenetv1_cifar10/test_bn_persistence.mojo
@@ -1,0 +1,133 @@
+"""BatchNorm running-stat persistence regression test for MobileNetV1 (#5537).
+
+A training forward (`training=True`) must write the EMA-updated running_mean /
+running_var back onto the model, so a subsequent inference forward
+(`training=False`) uses the accumulated statistics rather than the init values
+(mean=0, var=1). Before the fix, `forward` discarded batch_norm2d's updated
+stats via `out, _, _ = batch_norm2d(...)`, so inference silently used stale
+init values and produced wrong results.
+"""
+
+from model import MobileNetV1
+from projectodyssey.tensor.any_tensor import AnyTensor
+from projectodyssey.tensor.tensor_creation import zeros
+
+
+def assert_true(cond: Bool, msg: String) raises:
+    if not cond:
+        raise Error("assertion failed: " + msg)
+
+
+def _running_var_sig(t: AnyTensor) raises -> Float32:
+    """Sum of running_var — a scalar signature that is num_channels at init.
+
+    running_var is initialized to all-ones, so its sum equals the channel
+    count. A training forward pushes it toward the batch variance, changing the
+    sum; this gives a single value to compare before/after.
+    """
+    var d = t._data.bitcast[Float32]()
+    var s = Float32(0.0)
+    for i in range(t._numel):
+        s += d[i]
+    return s
+
+
+def _running_mean_sig(t: AnyTensor) raises -> Float32:
+    """Sum of running_mean — 0 at init (all-zeros), nonzero after training."""
+    var d = t._data.bitcast[Float32]()
+    var s = Float32(0.0)
+    for i in range(t._numel):
+        s += d[i]
+    return s
+
+
+def test_bn_running_stats_persist_after_training() raises:
+    """A training forward updates the model's persistent BN running stats."""
+    var model = MobileNetV1(num_classes=10)
+
+    # Non-trivial, non-uniform input so batch statistics differ from init.
+    var x = zeros([2, 3, 32, 32], DType.float32)
+    var xd = x._data.bitcast[Float32]()
+    for i in range(2 * 3 * 32 * 32):
+        xd[i] = Float32(i % 7) * 0.1 - 0.3
+
+    # Snapshot the initial-conv BN stats (init: mean sum = 0, var sum = C).
+    var mean_before = _running_mean_sig(model.initial_bn_running_mean)
+    var var_before = _running_var_sig(model.initial_bn_running_var)
+
+    _ = model.forward(x, training=True)
+
+    var mean_after = _running_mean_sig(model.initial_bn_running_mean)
+    var var_after = _running_var_sig(model.initial_bn_running_var)
+
+    # Init running_mean is all-zeros; a training forward must move it.
+    assert_true(
+        mean_before == Float32(0.0),
+        "precondition: initial running_mean must start at 0, got "
+        + String(mean_before),
+    )
+    assert_true(
+        mean_after != mean_before,
+        "initial_bn_running_mean was NOT updated by training forward (still "
+        + String(mean_after)
+        + ") — stats discarded (#5537)",
+    )
+    assert_true(
+        var_after != var_before,
+        "initial_bn_running_var was NOT updated by training forward (still "
+        + String(var_after)
+        + ") — stats discarded (#5537)",
+    )
+
+
+def test_bn_stats_persist_in_depthwise_blocks() raises:
+    """The depthwise-separable blocks also persist their BN running stats."""
+    var model = MobileNetV1(num_classes=10)
+    var x = zeros([2, 3, 32, 32], DType.float32)
+    var xd = x._data.bitcast[Float32]()
+    for i in range(2 * 3 * 32 * 32):
+        xd[i] = Float32(i % 5) * 0.2 - 0.4
+
+    var dw_before = _running_mean_sig(model.ds_block_1.dw_bn_running_mean)
+    var pw_before = _running_mean_sig(model.ds_block_1.pw_bn_running_mean)
+
+    _ = model.forward(x, training=True)
+
+    assert_true(
+        _running_mean_sig(model.ds_block_1.dw_bn_running_mean) != dw_before,
+        "ds_block_1 depthwise BN running_mean not persisted (#5537)",
+    )
+    assert_true(
+        _running_mean_sig(model.ds_block_1.pw_bn_running_mean) != pw_before,
+        "ds_block_1 pointwise BN running_mean not persisted (#5537)",
+    )
+
+
+def test_inference_forward_leaves_stats_unchanged() raises:
+    """A training=False forward must NOT change running stats (inference-safe).
+    """
+    var model = MobileNetV1(num_classes=10)
+    var x = zeros([2, 3, 32, 32], DType.float32)
+    var xd = x._data.bitcast[Float32]()
+    for i in range(2 * 3 * 32 * 32):
+        xd[i] = Float32(i % 3) * 0.3
+
+    var mean_before = _running_mean_sig(model.initial_bn_running_mean)
+    _ = model.forward(x, training=False)
+    assert_true(
+        _running_mean_sig(model.initial_bn_running_mean) == mean_before,
+        "inference forward must not mutate BN running stats",
+    )
+
+
+def main() raises:
+    print("test_bn_running_stats_persist_after_training...", end="")
+    test_bn_running_stats_persist_after_training()
+    print(" PASS")
+    print("test_bn_stats_persist_in_depthwise_blocks...", end="")
+    test_bn_stats_persist_in_depthwise_blocks()
+    print(" PASS")
+    print("test_inference_forward_leaves_stats_unchanged...", end="")
+    test_inference_forward_leaves_stats_unchanged()
+    print(" PASS")
+    print("ALL MobileNetV1 BN-persistence TESTS PASSED")

--- a/justfile
+++ b/justfile
@@ -1286,12 +1286,13 @@ bump-version new_version:
     echo "All files updated. Verifying sync..."
     python3 scripts/check_version_sync.py
 
-# Run example backward-pass tests (GoogLeNet + ResNet-18) from their example
-# dirs. These live under examples/<model>/ (import `from model`/`from train`),
-# so they cannot run via `test-group` (which targets tests/). They are excluded
-# from the src coverage validator but MUST execute somewhere — this recipe is
-# the per-PR runner wired into comprehensive-tests.yml. Synthetic data only, no
-# dataset download. Fails (non-zero exit) if any test's assertions fail.
+# Run example correctness tests (backward-pass + BN-persistence) from their
+# example dirs. These live under examples/<model>/ (import `from model`/`from
+# train`), so they cannot run via `test-group` (which targets tests/). They are
+# excluded from the src coverage validator but MUST execute somewhere — this
+# recipe is the per-PR runner wired into comprehensive-tests.yml. Synthetic data
+# only, no dataset download. Fails (non-zero exit) if any test's assertions
+# fail. See the EXAMPLE_TESTS list below for the current set.
 test-example-backward:
     @just _run "just _test-example-backward-inner"
 
@@ -1301,18 +1302,25 @@ _test-example-backward-inner:
     set -euo pipefail
     REPO_ROOT="$(pwd)"
     fail=0
-    # Expected backward tests — each MUST exist and run. A missing file is a
+    # Expected example tests — each MUST exist and run. A missing file is a
     # hard failure (regression signal), not a silent skip: if a test is
     # renamed or deleted, this job must go red rather than pass green.
-    for ex in googlenet_cifar10 resnet18_cifar10; do
-        f="examples/$ex/test_backward.mojo"
+    # Entries are "<example-dir>/<test-file>".
+    EXAMPLE_TESTS=(
+        "googlenet_cifar10/test_backward.mojo"
+        "resnet18_cifar10/test_backward.mojo"
+        "mobilenetv1_cifar10/test_bn_persistence.mojo"
+    )
+    for entry in "${EXAMPLE_TESTS[@]}"; do
+        ex="${entry%%/*}"
+        f="examples/$entry"
         if [ ! -f "$f" ]; then
             echo "MISSING (expected): $f"
             fail=1
             continue
         fi
         echo "=================================================="
-        echo "Running example backward test: $f"
+        echo "Running example test: $f"
         echo "=================================================="
         # Strip AVX-512 from the target (modular/modular#6413). The "Example
         # Backward Tests" job flakes with "execution crashed" inside

--- a/scripts/validate_test_coverage.py
+++ b/scripts/validate_test_coverage.py
@@ -66,6 +66,11 @@ def find_test_files(root_dir: Path) -> List[Path]:
         # `just test-example-backward` — it uses synthetic interleaved-class
         # data with no dataset download.
         "examples/googlenet_cifar10/test_backward.mojo",
+        # MobileNetV1 BatchNorm running-stat persistence regression (#5537).
+        # Example-dir test (imports `from model`), EXECUTED per-PR by the
+        # "example-backward-tests" job via `just test-example-backward`
+        # (EXAMPLE_TESTS list) with synthetic data — not a src/ unit test.
+        "examples/mobilenetv1_cifar10/test_bn_persistence.mojo",
         # Conda recipe smoke test — executed by rattler-build's `tests:`
         # block when the package is built (see conda.recipe/recipe.yaml),
         # not by the per-PR CI test matrix.


### PR DESCRIPTION
## Bug

MobileNetV1's `forward` **discarded** the EMA-updated BatchNorm running statistics: `out, _, _ = batch_norm2d(...)` at the initial-conv BN and in every depthwise-separable block's depthwise+pointwise BN. Under `training=True`, `batch_norm2d` returns `(output, running_mean_new, running_var_new)`, but dropping the stats meant a subsequent `forward(training=False)` inference used the **init values** (mean=0, var=1) instead of the accumulated statistics — **silently wrong inference/validation after training**.

## Fix

Capture the tuple and write the updated stats back onto the `mut self` model/block fields, matching the pattern **ResNet-18 already uses**. Applied at the initial BN and both BNs in `DepthwiseSeparableBlock.forward`.

## Test

`examples/mobilenetv1_cifar10/test_bn_persistence.mojo` asserts:
- (a) a training forward moves initial-conv `running_mean`/`var` off their init values,
- (b) the depthwise-separable blocks persist too,
- (c) an inference (`training=False`) forward leaves stats unchanged.

Wired into the per-PR example-test recipe (`test-example-backward`, now a general `EXAMPLE_TESTS` list, carrying the #6413 AVX-512 strip).

## Verification (reproduce-before-fix)

- All 3 tests pass in-container; the full recipe (GoogLeNet + ResNet-18 backward + this) is green.
- **Proven non-vacuous:** with the write-backs reverted, the test fails `initial_bn_running_mean was NOT updated by training forward (still 0.0) — stats discarded (#5537)`.

## Scope / triage of the sibling issues

- **ResNet-18 (#5532/#5533/#5534): moot** — already persists BN stats at all 40 BN calls (verified). Recommend closing.
- **GoogLeNet: same bug, separate fix** — its training path `inception_forward_cached` is **not** `mut self` and needs a signature refactor; tracked as **#5575**.

## Also

Fixed `.gitignore`: the broad `test_*` rule (intended for compiled test *binaries*) silently ignored example test **sources** — which is why `test_backward.mojo` had to be force-added. Added `!examples/**/test_*.mojo` so example tests are tracked normally.

Closes #5537

🤖 Generated with [Claude Code](https://claude.com/claude-code)