### PR TITLE
feat(utils): add --max-batches and --smoke to TrainingArgs (#5551 phase 1)

### DIFF
--- a/src/projectodyssey/utils/arg_parser.mojo
+++ b/src/projectodyssey/utils/arg_parser.mojo
@@ -457,7 +457,9 @@ def create_training_parser() raises -> ArgumentParser:
     parser.add_argument("seed", "int", "42")
     parser.add_argument("lr-decay-epochs", "int", "0")
     parser.add_argument("lr-decay-factor", "float", "0.1")
+    parser.add_argument("max-batches", "int", "0")
     parser.add_flag("verbose")
+    parser.add_flag("smoke")
 
     # Optimizer selection (sgd, lion, shampoo, adamw, muon, normuon)
     parser.add_argument("optimizer", "string", "sgd")

--- a/src/projectodyssey/utils/training_args.mojo
+++ b/src/projectodyssey/utils/training_args.mojo
@@ -50,6 +50,10 @@ struct TrainingArgs(Copyable, Movable):
         verbose: Whether to print verbose output.
         lr_decay_epochs: Decay LR every N epochs (0 = no decay).
         lr_decay_factor: Multiply LR by this factor when decaying.
+        max_batches: Cap training to this many batches per epoch (0 = unbounded).
+            Used by the per-PR training-smoke gate to bound a run (#5551).
+        smoke: Smoke mode — skip real dataset loading and train on a tiny
+            in-process synthetic batch (mechanism check, not convergence; #5551).
     """
 
     var epochs: Int
@@ -61,6 +65,8 @@ struct TrainingArgs(Copyable, Movable):
     var verbose: Bool
     var lr_decay_epochs: Int
     var lr_decay_factor: Float64
+    var max_batches: Int
+    var smoke: Bool
 
     def __init__(out self):
         """Initialize with default training arguments."""
@@ -73,6 +79,8 @@ struct TrainingArgs(Copyable, Movable):
         self.verbose = False
         self.lr_decay_epochs = 0
         self.lr_decay_factor = 0.1
+        self.max_batches = 0
+        self.smoke = False
 
 
 # ============================================================================
@@ -234,6 +242,10 @@ def resolve_training_args(
         "lr-decay-factor", default_lr_decay_factor
     )
     var verbose = parsed.get_bool("verbose")
+    # Smoke/max-batches for the per-PR training-smoke gate (#5551). max-batches
+    # is unbounded (0) unless the user passes it; smoke is a flag.
+    var max_batches = parsed.resolve_int("max-batches", 0)
+    var smoke = parsed.get_bool("smoke")
 
     # Validate numeric arguments
     validate_positive_int(epochs, "epochs")
@@ -252,6 +264,11 @@ def resolve_training_args(
             "lr-decay-factor must be in (0.0, 1.0], got: "
             + String(lr_decay_factor)
         )
+    if max_batches < 0:
+        raise Error(
+            "max-batches must be non-negative (0 = unbounded), got: "
+            + String(max_batches)
+        )
 
     return TrainingArgs(
         epochs=epochs,
@@ -263,6 +280,8 @@ def resolve_training_args(
         verbose=verbose,
         lr_decay_epochs=lr_decay_epochs,
         lr_decay_factor=lr_decay_factor,
+        max_batches=max_batches,
+        smoke=smoke,
     )
 
 

--- a/src/projectodyssey/utils/training_args.mojo
+++ b/src/projectodyssey/utils/training_args.mojo
@@ -100,7 +100,9 @@ def parse_training_args() raises -> TrainingArgs:
             --weights-dir <str>: Weights directory (default: "weights")
             --lr-decay-epochs <int>: Decay LR every N epochs (default: 0, disabled)
             --lr-decay-factor <float>: LR decay multiplier (default: 0.1)
+            --max-batches <int>: Cap batches/epoch (default: 0 = unbounded; #5551)
             --verbose: Enable verbose output
+            --smoke: Train on tiny in-process synthetic data, no dataset (#5551)
 
     Returns:
             TrainingArgs struct with parsed and validated values.

--- a/tests/projectodyssey/utils/test_arg_parser.mojo
+++ b/tests/projectodyssey/utils/test_arg_parser.mojo
@@ -287,6 +287,20 @@ def test_resolve_max_batches_and_smoke_user_supplied() raises:
     assert_true(args.smoke)
 
 
+def test_resolve_rejects_negative_max_batches() raises:
+    """A negative --max-batches is rejected (0 = unbounded; #5551)."""
+    var parsed = ParsedArgs()
+    parsed.set_user_supplied("max-batches", "-3")
+    var raised = False
+    try:
+        _ = resolve_training_args(parsed)
+    except:
+        raised = True
+    assert_true(
+        raised, "resolve_training_args must reject negative max-batches"
+    )
+
+
 def main() raises:
     """Run all test_arg_parser tests."""
     print("Running test_arg_parser tests...")
@@ -341,7 +355,11 @@ def main() raises:
 
     test_resolve_user_value_overrides_caller_default()
     test_resolve_max_batches_and_smoke_defaults()
+    print("✓ test_resolve_max_batches_and_smoke_defaults")
     test_resolve_max_batches_and_smoke_user_supplied()
+    print("✓ test_resolve_max_batches_and_smoke_user_supplied")
+    test_resolve_rejects_negative_max_batches()
+    print("✓ test_resolve_rejects_negative_max_batches")
     print("✓ test_resolve_user_value_overrides_caller_default")
 
     print("\nAll test_arg_parser tests passed!")

--- a/tests/projectodyssey/utils/test_arg_parser.mojo
+++ b/tests/projectodyssey/utils/test_arg_parser.mojo
@@ -268,6 +268,25 @@ def test_resolve_user_value_overrides_caller_default() raises:
     assert_equal(args.epochs, 7)
 
 
+def test_resolve_max_batches_and_smoke_defaults() raises:
+    """Max-batches defaults to 0 (unbounded) and smoke to False (#5551)."""
+    var parsed = ParsedArgs()
+    var args = resolve_training_args(parsed)
+    assert_equal(args.max_batches, 0)
+    assert_true(not args.smoke)
+
+
+def test_resolve_max_batches_and_smoke_user_supplied() raises:
+    """--max-batches N and --smoke flag are picked up by resolve (#5551)."""
+    var parsed = ParsedArgs()
+    parsed.set_user_supplied("max-batches", "5")
+    parsed.set_user_supplied("smoke", "true")  # flag → has()/get_bool True
+
+    var args = resolve_training_args(parsed)
+    assert_equal(args.max_batches, 5)
+    assert_true(args.smoke)
+
+
 def main() raises:
     """Run all test_arg_parser tests."""
     print("Running test_arg_parser tests...")
@@ -321,6 +340,8 @@ def main() raises:
     print("✓ test_resolve_honors_caller_default_when_absent")
 
     test_resolve_user_value_overrides_caller_default()
+    test_resolve_max_batches_and_smoke_defaults()
+    test_resolve_max_batches_and_smoke_user_supplied()
     print("✓ test_resolve_user_value_overrides_caller_default")
 
     print("\nAll test_arg_parser tests passed!")


### PR DESCRIPTION
## What

Phase 1 of the ADR-014 per-PR training-smoke gate (#5551) — the **shared flag plumbing** only, as a standalone, fully-tested foundation. Later phases (wiring the 10 entrypoints + `--smoke` synthetic-data path + the required `training-smoke` CI workflow) follow in subsequent PRs per the [plan on #5551](https://github.com/HomericIntelligence/Odyssey/issues/5551).

- `TrainingArgs` gains `max_batches: Int` (0 = unbounded) and `smoke: Bool`.
- `create_training_parser` registers `--max-batches` (int, default 0) and the `--smoke` flag.
- `resolve_training_args` reads both (`max_batches` via `resolve_int` so it honors a caller default; `smoke` via `get_bool`) and validates `max_batches >= 0`.

`max_batches` will bound a run to N batches/epoch; `smoke` will select an in-process synthetic-data path (wired in phase 2) so a smoke run needs no dataset download.

## Tests

`test_resolve_max_batches_and_smoke_defaults` (0 / False) and `test_resolve_max_batches_and_smoke_user_supplied` (`--max-batches 5 --smoke` picked up). Verified in-container: all `test_arg_parser` tests pass. Auto-gated by the CI `test_utils*`/`test_arg_parser` core group.

## Scope

Pure additive flag plumbing — no entrypoint or workflow changes. Backward-compatible (both fields default to their no-op values; existing runs unaffected).

Refs #5551

🤖 Generated with [Claude Code](https://claude.com/claude-code)