### PR TITLE
ci(training-smoke): add ADR-014 training-mechanism gate (#5551 Phase B)

### DIFF
--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -179,6 +179,44 @@ jobs:
         run: just test-example-backward
 
   # ============================================================================
+  # Training Smoke (ADR-014, #5551) - assert each training entrypoint's MECHANISM
+  # works: runs a few bounded batches on synthetic data (--smoke, no dataset
+  # download) to exit 0 and emit >=2 finite parseable full-precision loss lines.
+  # NOT a convergence check. One job per model via a matrix so wall-clock stays
+  # low (each entry AOT-compiles + runs independently, in parallel).
+  # ============================================================================
+  training-smoke:
+    needs: [mojo-compilation]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    name: "Training Smoke (${{ matrix.example }}/${{ matrix.entry }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { example: resnet18_cifar10,   entry: train.mojo }
+          - { example: googlenet_cifar10,  entry: train.mojo }
+          - { example: vgg16_cifar10,      entry: train.mojo }
+          - { example: mobilenetv1_cifar10, entry: train.mojo }
+          - { example: alexnet_cifar10,    entry: run_train.mojo }
+          - { example: mnist,              entry: train.mojo }
+          - { example: lenet_emnist,       entry: train.mojo }
+          - { example: lenet_emnist,       entry: run_train.mojo }
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Set up container
+        uses: ./.github/actions/setup-container
+
+      - name: Install Just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
+
+      - name: Run training smoke (synthetic, bounded)
+        run: just training-smoke-one ${{ matrix.example }} ${{ matrix.entry }}
+
+  # ============================================================================
   # Test Coverage Validation - Ensure all tests are discovered
   # ============================================================================
   validate-test-coverage:

--- a/justfile
+++ b/justfile
@@ -1346,3 +1346,72 @@ _test-example-backward-inner:
         fi
     done
     exit $fail
+
+# Run ONE model's training ENTRYPOINT for a few smoke batches on synthetic data
+# (--smoke, no dataset download) and assert the training MECHANISM works
+# (ADR-014, #5551): the entrypoint runs to exit 0 and emits >=2 finite,
+# parseable, full-precision loss lines. NOT a convergence check. The GHA
+# `training-smoke` job runs this per-model via a matrix so wall-clock stays low.
+# Usage: just training-smoke-one resnet18_cifar10 train.mojo
+training-smoke-one example entry:
+    @just _run "just _training-smoke-one-inner '{{example}}' '{{entry}}'"
+
+[private]
+_training-smoke-one-inner example entry:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    REPO_ROOT="$(pwd)"
+    ex="{{example}}"
+    f="examples/$ex/{{entry}}"
+    if [ ! -f "$f" ]; then echo "MISSING (expected): $f"; exit 1; fi
+    echo "=================================================="
+    echo "Training smoke: $f"
+    echo "=================================================="
+    # --epochs 1 is REQUIRED: some models loop `for epoch in range(epochs)`
+    # (default up to 200); --max-batches only caps batches PER epoch. The
+    # {{MOJO_TARGET_CPU}} strip is the #6413 AVX-512 workaround (see justfile:40).
+    out=$(pixi run mojo run --Werror {{MOJO_TARGET_CPU}} \
+            -I "$REPO_ROOT/src" -I "$REPO_ROOT" \
+            -I "$REPO_ROOT/examples/$ex" -Xlinker -lm "$f" \
+            --smoke --max-batches 3 --batch-size 4 --epochs 1 2>&1)
+    rc=$?
+    echo "$out" | grep -iE "Loss:" | head -5
+    if [ $rc -ne 0 ]; then
+        echo "FAILED (exit $rc): $f"
+        echo "$out" | tail -15
+        exit 1
+    fi
+    # Assert >=2 loss lines, each parseable as a finite float.
+    losses=$(echo "$out" | grep -oiE "Loss:[[:space:]]*[-0-9.eE]+" \
+             | grep -oE "[-0-9.eE]+$")
+    n=$(printf '%s\n' "$losses" | grep -c .)
+    if [ "$n" -lt 2 ]; then
+        echo "FAILED: expected >=2 loss lines, got $n: $f"
+        exit 1
+    fi
+    if printf '%s\n' "$losses" | grep -qiE "nan|inf"; then
+        echo "FAILED: non-finite loss value: $f"
+        exit 1
+    fi
+    echo "OK: $f ($n finite loss lines)"
+
+# Run the training-smoke check for ALL 8 primary entrypoints locally (serial).
+# CI runs them in parallel via a matrix; use this for a full local check.
+training-smoke-all:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    fail=0
+    ENTRIES=(
+        "resnet18_cifar10 train.mojo"
+        "googlenet_cifar10 train.mojo"
+        "vgg16_cifar10 train.mojo"
+        "mobilenetv1_cifar10 train.mojo"
+        "alexnet_cifar10 run_train.mojo"
+        "mnist train.mojo"
+        "lenet_emnist train.mojo"
+        "lenet_emnist run_train.mojo"
+    )
+    for e in "${ENTRIES[@]}"; do
+        just training-smoke-one $e || fail=1
+    done
+    exit $fail

--- a/justfile
+++ b/justfile
@@ -1369,7 +1369,7 @@ _training-smoke-one-inner example entry:
     echo "=================================================="
     # --epochs 1 is REQUIRED: some models loop `for epoch in range(epochs)`
     # (default up to 200); --max-batches only caps batches PER epoch. The
-    # {{MOJO_TARGET_CPU}} strip is the #6413 AVX-512 workaround (see justfile:40).
+    # {{MOJO_TARGET_CPU}} strip is the #6413 AVX-512 workaround (see MOJO_TARGET_CPU def).
     out=$(pixi run mojo run --Werror {{MOJO_TARGET_CPU}} \
             -I "$REPO_ROOT/src" -I "$REPO_ROOT" \
             -I "$REPO_ROOT/examples/$ex" -Xlinker -lm "$f" \
@@ -1381,16 +1381,24 @@ _training-smoke-one-inner example entry:
         echo "$out" | tail -15
         exit 1
     fi
-    # Assert >=2 loss lines, each parseable as a finite float.
-    losses=$(echo "$out" | grep -oiE "Loss:[[:space:]]*[-0-9.eE]+" \
-             | grep -oE "[-0-9.eE]+$")
-    n=$(printf '%s\n' "$losses" | grep -c .)
-    if [ "$n" -lt 2 ]; then
-        echo "FAILED: expected >=2 loss lines, got $n: $f"
+    # Reject non-finite losses. This MUST run against the RAW "Loss:" lines,
+    # BEFORE numeric extraction: the value regex below (`[-0-9.eE]+`) contains
+    # none of n/a/i/f, so it silently strips "nan"/"inf" to "" or a bare "-".
+    # Checking the stripped values would make this guard dead code and let a
+    # diverged run (e.g. "Loss: -inf") pass green — exactly the mechanism
+    # failure ADR-014 is meant to catch.
+    loss_lines=$(echo "$out" | grep -iE "Loss:[[:space:]]*[-+]?(nan|inf|[0-9.])")
+    if echo "$loss_lines" | grep -qiE "Loss:[[:space:]]*[-+]?(nan|inf)([^a-z0-9]|$)"; then
+        echo "FAILED: non-finite loss value: $f"
+        echo "$loss_lines" | grep -iE "nan|inf"
         exit 1
     fi
-    if printf '%s\n' "$losses" | grep -qiE "nan|inf"; then
-        echo "FAILED: non-finite loss value: $f"
+    # Assert >=2 loss lines, each parseable as a finite float.
+    losses=$(echo "$loss_lines" | grep -oiE "Loss:[[:space:]]*[-+]?[0-9.eE]+" \
+             | grep -oE "[-+]?[0-9.eE]+$")
+    n=$(printf '%s\n' "$losses" | grep -c .)
+    if [ "$n" -lt 2 ]; then
+        echo "FAILED: expected >=2 finite loss lines, got $n: $f"
         exit 1
     fi
     echo "OK: $f ($n finite loss lines)"


### PR DESCRIPTION
## Summary

Phase B of #5551 (ADR-014 training-smoke CI gate). Stacked on #5582 (Phase 2, the `--smoke`/`--max-batches` entrypoint wiring).

Adds a **training-smoke** CI gate that runs each of the 8 primary training entrypoints for a few bounded batches on **synthetic data** (`--smoke`, no dataset download) and asserts the training **MECHANISM** works:

> the entrypoint runs to **exit 0** and emits **≥2 finite, parseable, full-precision loss lines**.

This is a *mechanism* check per ADR-014, **not a convergence check** — loss on 3 tiny synthetic batches from random init is noisy, so there is deliberately **no monotonic-decrease assertion**.

## Changes

**`justfile`**
- `training-smoke-one <example> <entry>` — per-model recipe (used by the CI matrix).
- `training-smoke-all` — serial full run for local use.
- Each runs `mojo run --Werror {{MOJO_TARGET_CPU}} … --smoke --max-batches 3 --batch-size 4 --epochs 1` and asserts ≥2 finite loss lines + exit 0.
  - `{{MOJO_TARGET_CPU}}` is the #6413 AVX-512 JIT-SIGILL strip.
  - `--epochs 1` is **required**: several models loop `for epoch in range(epochs)` (default up to 200); `--max-batches` only caps batches *per epoch*.

**`.github/workflows/comprehensive-tests.yml`**
- New `training-smoke` job, `needs: [mojo-compilation]`, mirroring `example-backward-tests` (setup-container + setup-just).
- **8-way `include` matrix, `fail-fast: false`** — each model AOT-compiles + runs in parallel, so wall-clock ≈ one model (~3–6 min) instead of 8× serial. This is why I chose a matrix over a single serial job (the issue's "<5 min" target does not hold for 8 models compiling serially).

Matrix entries: resnet18, googlenet, vgg16, mobilenetv1 (`train.mojo`); alexnet, lenet_emnist (`run_train.mojo`); mnist, lenet_emnist (`train.mojo`).

## Verification

- `just training-smoke-one resnet18_cifar10 train.mojo` in-container → **5 finite loss lines, exit 0, `OK`** (recipe assertion logic validated against real output).
- Workflow YAML parses (`yaml.safe_load`): job present, 8 matrix entries, `fail-fast: false`, `needs: [mojo-compilation]`.
- justfile parses (`just --list`).
- All 8 entrypoints were verified end-to-end in-container in #5582.

## Notes / review points

- **Human-review-gated** (workflow file, per AGENTS.md).
- Merge order: #5581 → #5582 → **this**.
- Loss values here are noisy-by-design (random init, 3 synthetic batches); the gate intentionally checks *mechanism*, not *quality* — consistent with ADR-014.

🤖 Generated with [Claude Code](https://claude.com/claude-code)