### PR TITLE
feat(autograd): add variable_batch_norm op (unblocks resnet/mobilenet/googlenet ports)

### DIFF
--- a/src/projectodyssey/autograd/__init__.mojo
+++ b/src/projectodyssey/autograd/__init__.mojo
@@ -114,6 +114,7 @@ from projectodyssey.autograd.variable import (
     variable_conv2d,
     variable_maxpool2d,
     variable_cross_entropy,
+    variable_batch_norm,
 )
 
 from projectodyssey.autograd.tape_types import (
@@ -149,6 +150,7 @@ from projectodyssey.autograd.tape import (
     OP_CONV2D,
     OP_MAXPOOL2D,
     OP_CROSS_ENTROPY,
+    OP_BATCH_NORM2D,
 )
 
 from projectodyssey.autograd.optimizers import (

--- a/src/projectodyssey/autograd/backward_ops.mojo
+++ b/src/projectodyssey/autograd/backward_ops.mojo
@@ -48,6 +48,7 @@ from projectodyssey.core.linear import linear_backward
 from projectodyssey.core.conv import conv2d_backward
 from projectodyssey.core.pooling import maxpool2d_backward
 from projectodyssey.core.loss import cross_entropy_backward
+from projectodyssey.core.normalization import batch_norm2d_backward
 
 # Import types from tape_types (avoids circular import with tape.mojo)
 from projectodyssey.autograd.tape_types import TapeNode, VariableRegistry
@@ -458,6 +459,49 @@ def backward_conv2d(
         registry.set_grad(nodes[idx].input_ids[1], grads.grad_weights)
     if len(nodes[idx].input_ids) >= 3:
         registry.set_grad(nodes[idx].input_ids[2], grads.grad_bias)
+
+
+def backward_batch_norm(
+    nodes: List[TapeNode],
+    mut registry: VariableRegistry,
+    idx: Int,
+    grad_output: AnyTensor,
+) raises:
+    """Backward pass for 2D batch normalization.
+
+    Saved layout (see variable_batch_norm):
+        tensors[0] = input x        (batch, C, H, W)
+        tensors[1] = gamma          (C,)
+        tensors[2] = running_mean   (C,)
+        tensors[3] = running_var    (C,)
+        scalars[0] = training (1.0/0.0)
+        scalars[1] = epsilon
+
+    Routes:
+        input_ids[0] -> grad_input
+        input_ids[1] -> grad_gamma
+        input_ids[2] -> grad_beta
+    (Running-mean/var are not Variables, so they receive no gradient.)
+    """
+    if len(nodes[idx].saved.tensors) < 4:
+        return
+    if len(nodes[idx].saved.scalars) < 2:
+        return
+    var x = nodes[idx].saved.tensors[0].copy()
+    var gamma = nodes[idx].saved.tensors[1].copy()
+    var running_mean = nodes[idx].saved.tensors[2].copy()
+    var running_var = nodes[idx].saved.tensors[3].copy()
+    var training = nodes[idx].saved.scalars[0] != 0.0
+    var epsilon = nodes[idx].saved.scalars[1]
+    var grads = batch_norm2d_backward(
+        grad_output, x, gamma, running_mean, running_var, training, epsilon
+    )
+    if len(nodes[idx].input_ids) >= 1:
+        registry.set_grad(nodes[idx].input_ids[0], grads[0])
+    if len(nodes[idx].input_ids) >= 2:
+        registry.set_grad(nodes[idx].input_ids[1], grads[1])
+    if len(nodes[idx].input_ids) >= 3:
+        registry.set_grad(nodes[idx].input_ids[2], grads[2])
 
 
 def backward_maxpool2d(

--- a/src/projectodyssey/autograd/tape.mojo
+++ b/src/projectodyssey/autograd/tape.mojo
@@ -84,6 +84,7 @@ from projectodyssey.autograd.backward_ops import (
     backward_conv2d,
     backward_maxpool2d,
     backward_cross_entropy,
+    backward_batch_norm,
 )
 
 
@@ -110,6 +111,7 @@ comptime OP_LINEAR = "linear"
 comptime OP_CONV2D = "conv2d"
 comptime OP_MAXPOOL2D = "maxpool2d"
 comptime OP_CROSS_ENTROPY = "cross_entropy"
+comptime OP_BATCH_NORM2D = "batch_norm2d"
 
 
 struct GradientTape:
@@ -286,6 +288,10 @@ struct GradientTape:
             backward_maxpool2d(self.nodes, self.registry, node_idx, grad_output)
         elif op_type == OP_CROSS_ENTROPY:
             backward_cross_entropy(
+                self.nodes, self.registry, node_idx, grad_output
+            )
+        elif op_type == OP_BATCH_NORM2D:
+            backward_batch_norm(
                 self.nodes, self.registry, node_idx, grad_output
             )
         else:

--- a/src/projectodyssey/autograd/variable.mojo
+++ b/src/projectodyssey/autograd/variable.mojo
@@ -46,6 +46,7 @@ from projectodyssey.core.linear import linear as _linear
 from projectodyssey.core.conv import conv2d as _conv2d
 from projectodyssey.core.pooling import maxpool2d as _maxpool2d
 from projectodyssey.core.loss import cross_entropy as _cross_entropy
+from projectodyssey.core.normalization import batch_norm2d as _batch_norm2d
 
 comptime tensor_sum = sum
 comptime tensor_mean = mean
@@ -69,6 +70,7 @@ from projectodyssey.autograd.tape import (
     OP_CONV2D,
     OP_MAXPOOL2D,
     OP_CROSS_ENTROPY,
+    OP_BATCH_NORM2D,
 )
 
 
@@ -730,6 +732,94 @@ def variable_conv2d(
         tape.record(OP_CONV2D, input_ids^, result_id, saved^)
 
     return Variable(result_data^, needs_grad, result_id)
+
+
+def variable_batch_norm(
+    x: Variable,
+    gamma: Variable,
+    beta: Variable,
+    running_mean: AnyTensor,
+    running_var: AnyTensor,
+    mut tape: GradientTape,
+    training: Bool,
+    momentum: Float64 = 0.1,
+    epsilon: Float64 = 1e-5,
+) raises -> Tuple[Variable, AnyTensor, AnyTensor]:
+    """Apply 2D batch normalization: y = gamma * norm(x) + beta.
+
+    `x`, `gamma`, `beta` are trainable Variables (they receive gradients).
+    `running_mean` / `running_var` are non-trainable buffers (plain
+    `AnyTensor`, no gradient); the core op is functional, so the *updated*
+    running statistics are returned and the caller must thread them back into
+    its per-layer storage for the next batch. In training mode the forward and
+    backward derive batch statistics from `x` and ignore the incoming running
+    stats, so a caller that drops the returned stats still trains correctly
+    (only later inference accuracy would suffer).
+
+    Saved layout for backward:
+        tensors[0] = input x            (batch, C, H, W)
+        tensors[1] = gamma              (C,)
+        tensors[2] = running_mean       (C,) — consumed only when training=False
+        tensors[3] = running_var        (C,) — consumed only when training=False
+        scalars[0] = training (1.0/0.0)
+        scalars[1] = epsilon
+        (beta is intentionally NOT saved — batch_norm2d_backward does not take
+        it; grad_beta = sum(grad_output) needs no saved beta.)
+
+    Args:
+        x: Input activations Variable (batch, C, H, W).
+        gamma: Scale-parameter Variable (C,).
+        beta: Shift-parameter Variable (C,).
+        running_mean: Running mean buffer (C,), not a Variable.
+        running_var: Running variance buffer (C,), not a Variable.
+        tape: Gradient tape for recording.
+        training: If True, use batch statistics and update running stats.
+        momentum: Momentum for the running-stats update (default 0.1).
+        epsilon: Numerical-stability constant (default 1e-5).
+
+    Returns:
+        A tuple of (output Variable (batch, C, H, W), updated running_mean,
+        updated running_var).
+    """
+    var bn = _batch_norm2d(
+        x.data,
+        gamma.data,
+        beta.data,
+        running_mean,
+        running_var,
+        training,
+        momentum,
+        epsilon,
+    )
+    var result_data = bn[0]
+    var new_running_mean = bn[1]
+    var new_running_var = bn[2]
+
+    var needs_grad = (
+        x.requires_grad or gamma.requires_grad or beta.requires_grad
+    )
+    var result_id = tape.register_variable(needs_grad)
+
+    if tape.enabled and needs_grad:
+        var input_ids = List[Int]()
+        input_ids.append(x.id)
+        input_ids.append(gamma.id)
+        input_ids.append(beta.id)
+
+        var saved = SavedTensors()
+        saved.add_tensor(x.data)
+        saved.add_tensor(gamma.data)
+        saved.add_tensor(running_mean)
+        saved.add_tensor(running_var)
+        saved.add_scalar(1.0 if training else 0.0)
+        saved.add_scalar(epsilon)
+        tape.record(OP_BATCH_NORM2D, input_ids^, result_id, saved^)
+
+    return (
+        Variable(result_data^, needs_grad, result_id),
+        new_running_mean^,
+        new_running_var^,
+    )
 
 
 def variable_maxpool2d(

--- a/tests/projectodyssey/autograd/test_variable_batch_norm.mojo
+++ b/tests/projectodyssey/autograd/test_variable_batch_norm.mojo
@@ -1,0 +1,254 @@
+"""Gradient-check tests for the `variable_batch_norm` autograd op.
+
+Verifies that the tape-recorded backward for batch normalization matches
+finite-difference numerical gradients for grad_x and grad_gamma, and the
+analytic grad_beta, on a small 4D input in training mode.
+
+The loss is `sum(y * w)` with a NON-UNIFORM weight `w`: a uniform (ones)
+grad_output makes the batch-norm input gradient collapse to ~0 by symmetry
+(the per-channel mean-subtraction terms cancel), which would make a numerical
+check vacuous. A non-uniform weight breaks that symmetry so grad_x is a real
+signal to validate.
+"""
+
+from projectodyssey.autograd import Variable, GradientTape
+from projectodyssey.autograd.variable import (
+    variable_batch_norm,
+    variable_multiply,
+    variable_sum,
+)
+from projectodyssey.tensor.any_tensor import AnyTensor
+from projectodyssey.tensor.tensor_creation import zeros
+from projectodyssey.core.normalization import batch_norm2d
+from projectodyssey.core.arithmetic import multiply
+from projectodyssey.testing.gradient_checker import (
+    compute_numerical_gradient,
+    assert_gradients_close,
+    NumericalForward,
+)
+
+
+def _make_tensor(shape: List[Int], values: List[Float64]) raises -> AnyTensor:
+    var t = zeros(shape, DType.float32)
+    for i in range(len(values)):
+        t._set_float64(i, values[i])
+    return t^
+
+
+def _abs(x: Float64) -> Float64:
+    return x if x >= 0.0 else -x
+
+
+# ============================================================================
+# NumericalForward: loss(x) = sum(batch_norm2d(x, gamma, beta) * w)
+# (used to compute the numerical gradient wrt whichever tensor is perturbed —
+#  x when checking grad_x, gamma when checking grad_gamma)
+# ============================================================================
+@fieldwise_init
+struct _BNInputForward(NumericalForward):
+    """loss(x) = sum(batch_norm2d(x, gamma, beta, ...) * w). Perturbs x."""
+
+    var gamma: AnyTensor
+    var beta: AnyTensor
+    var running_mean: AnyTensor
+    var running_var: AnyTensor
+    var w: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        var res = batch_norm2d(
+            inp,
+            self.gamma,
+            self.beta,
+            self.running_mean,
+            self.running_var,
+            training=True,
+            epsilon=1e-5,
+        )
+        return multiply(res[0], self.w)
+
+
+@fieldwise_init
+struct _BNGammaForward(NumericalForward):
+    """loss(gamma) = sum(batch_norm2d(x, gamma, beta, ...) * w). Perturbs gamma.
+    """
+
+    var x: AnyTensor
+    var beta: AnyTensor
+    var running_mean: AnyTensor
+    var running_var: AnyTensor
+    var w: AnyTensor
+
+    def __call__(self, g: AnyTensor) raises -> AnyTensor:
+        var res = batch_norm2d(
+            self.x,
+            g,
+            self.beta,
+            self.running_mean,
+            self.running_var,
+            training=True,
+            epsilon=1e-5,
+        )
+        return multiply(res[0], self.w)
+
+
+def test_batch_norm_grad_check() raises:
+    print("[test] variable_batch_norm gradient check ...")
+
+    # Small 4D input: (batch=2, C=2, H=2, W=2) = 16 elements; params are (C,).
+    var shape: List[Int] = [2, 2, 2, 2]
+    var x_vals: List[Float64] = [
+        0.5,
+        -1.2,
+        0.3,
+        0.8,
+        -0.4,
+        1.1,
+        0.2,
+        -0.7,
+        0.9,
+        -0.1,
+        1.4,
+        -0.6,
+        0.05,
+        0.7,
+        -1.3,
+        0.35,
+    ]
+    var gamma_vals: List[Float64] = [1.3, 0.7]
+    var beta_vals: List[Float64] = [0.2, -0.4]
+    # Non-uniform loss weights (break the ones-vector symmetry).
+    var w_vals: List[Float64] = [
+        1.0,
+        0.3,
+        -0.5,
+        0.8,
+        0.2,
+        -0.9,
+        1.1,
+        0.4,
+        -0.3,
+        0.6,
+        0.9,
+        -0.2,
+        0.7,
+        -0.6,
+        0.15,
+        1.2,
+    ]
+    var c_shape: List[Int] = [2]
+    var rm_vals: List[Float64] = [0.0, 0.0]
+    var rv_vals: List[Float64] = [1.0, 1.0]
+
+    var tape = GradientTape()
+    tape.enable()
+
+    var x = Variable(_make_tensor(shape, x_vals), True, tape)
+    var gamma = Variable(_make_tensor(c_shape, gamma_vals), True, tape)
+    var beta = Variable(_make_tensor(c_shape, beta_vals), True, tape)
+    var running_mean = _make_tensor(c_shape, rm_vals)
+    var running_var = _make_tensor(c_shape, rv_vals)
+    var w = Variable(_make_tensor(shape, w_vals), False, tape)
+
+    var bn = variable_batch_norm(
+        x, gamma, beta, running_mean, running_var, tape, training=True
+    )
+    var y = bn[0].copy()
+    var new_rm = bn[1].copy()
+
+    # Output shape matches input.
+    var y_shape = y.data.shape()
+    if len(y_shape) != 4 or y_shape[0] != 2 or y_shape[1] != 2:
+        raise Error("variable_batch_norm output shape mismatch")
+
+    # Running stats were updated in training mode (should differ from inputs).
+    var rm_changed = (
+        _abs(new_rm._get_float64(0) - 0.0) > 1e-9
+        or _abs(new_rm._get_float64(1) - 0.0) > 1e-9
+    )
+    if not rm_changed:
+        raise Error("running_mean was not updated in training mode")
+
+    # loss = sum(y * w)  (non-uniform w breaks BN symmetry)
+    var weighted = variable_multiply(y, w, tape)
+    var loss = variable_sum(weighted, tape, axis=-1)
+    loss.backward(tape)
+
+    var grad_x = tape.get_grad(x.id)
+    var grad_gamma = tape.get_grad(gamma.id)
+    var grad_beta = tape.get_grad(beta.id)
+
+    # ---- grad_beta is analytic: d/dbeta_c sum(y*w) = sum over (n,h,w) of w ----
+    # For each channel c, grad_beta[c] = sum of w over all elements in channel c.
+    var w_t = _make_tensor(shape, w_vals)
+    var expected_beta0 = Float64(0.0)
+    var expected_beta1 = Float64(0.0)
+    # layout (n, c, h, w): channel index is the 2nd dim (stride H*W=4 within n).
+    for n in range(2):
+        for h in range(2):
+            for ww in range(2):
+                var base = n * (2 * 2 * 2)
+                var idx0 = base + 0 * (2 * 2) + h * 2 + ww
+                var idx1 = base + 1 * (2 * 2) + h * 2 + ww
+                expected_beta0 += w_t._get_float64(idx0)
+                expected_beta1 += w_t._get_float64(idx1)
+    var gb0 = Float64(grad_beta._get_float64(0))
+    var gb1 = Float64(grad_beta._get_float64(1))
+    if _abs(gb0 - expected_beta0) > 1e-3 or _abs(gb1 - expected_beta1) > 1e-3:
+        raise Error(
+            "grad_beta mismatch: got ("
+            + String(gb0)
+            + ", "
+            + String(gb1)
+            + "), expected ("
+            + String(expected_beta0)
+            + ", "
+            + String(expected_beta1)
+            + ")"
+        )
+
+    # ---- grad_x: finite-difference check ----
+    var num_grad_x = compute_numerical_gradient(
+        _BNInputForward(
+            _make_tensor(c_shape, gamma_vals),
+            _make_tensor(c_shape, beta_vals),
+            _make_tensor(c_shape, rm_vals),
+            _make_tensor(c_shape, rv_vals),
+            _make_tensor(shape, w_vals),
+        ),
+        _make_tensor(shape, x_vals),
+        epsilon=1e-3,
+    )
+    assert_gradients_close(
+        grad_x,
+        num_grad_x,
+        rtol=5e-2,
+        atol=5e-4,
+        message="variable_batch_norm grad_x",
+    )
+
+    # ---- grad_gamma: finite-difference check ----
+    var num_grad_gamma = compute_numerical_gradient(
+        _BNGammaForward(
+            _make_tensor(shape, x_vals),
+            _make_tensor(c_shape, beta_vals),
+            _make_tensor(c_shape, rm_vals),
+            _make_tensor(c_shape, rv_vals),
+            _make_tensor(shape, w_vals),
+        ),
+        _make_tensor(c_shape, gamma_vals),
+        epsilon=1e-3,
+    )
+    assert_gradients_close(
+        grad_gamma,
+        num_grad_gamma,
+        rtol=5e-2,
+        atol=5e-4,
+        message="variable_batch_norm grad_gamma",
+    )
+
+    print("       OK")
+
+
+def main() raises:
+    test_batch_norm_grad_check()
+    print("\nvariable_batch_norm gradient check PASS")

--- a/tests/projectodyssey/autograd/test_variable_batch_norm.mojo
+++ b/tests/projectodyssey/autograd/test_variable_batch_norm.mojo
@@ -249,6 +249,121 @@ def test_batch_norm_grad_check() raises:
     print("       OK")
 
 
+@fieldwise_init
+struct _BNInferForward(NumericalForward):
+    """Inference-mode loss(x) = sum(batch_norm2d(x, ..., training=False) * w).
+    """
+
+    var gamma: AnyTensor
+    var beta: AnyTensor
+    var running_mean: AnyTensor
+    var running_var: AnyTensor
+    var w: AnyTensor
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        var res = batch_norm2d(
+            inp,
+            self.gamma,
+            self.beta,
+            self.running_mean,
+            self.running_var,
+            training=False,
+            epsilon=1e-5,
+        )
+        return multiply(res[0], self.w)
+
+
+def test_batch_norm_inference_grad_check() raises:
+    """Verify the training=False path: BN uses running stats, and the taped
+    backward still matches finite differences for grad_x."""
+    print("[test] variable_batch_norm inference-mode gradient check ...")
+
+    var shape: List[Int] = [2, 2, 2, 2]
+    var x_vals: List[Float64] = [
+        0.5,
+        -1.2,
+        0.3,
+        0.8,
+        -0.4,
+        1.1,
+        0.2,
+        -0.7,
+        0.9,
+        -0.1,
+        1.4,
+        -0.6,
+        0.05,
+        0.7,
+        -1.3,
+        0.35,
+    ]
+    var gamma_vals: List[Float64] = [1.3, 0.7]
+    var beta_vals: List[Float64] = [0.2, -0.4]
+    var w_vals: List[Float64] = [
+        1.0,
+        0.3,
+        -0.5,
+        0.8,
+        0.2,
+        -0.9,
+        1.1,
+        0.4,
+        -0.3,
+        0.6,
+        0.9,
+        -0.2,
+        0.7,
+        -0.6,
+        0.15,
+        1.2,
+    ]
+    var c_shape: List[Int] = [2]
+    # Non-trivial running stats (inference uses these, NOT batch stats).
+    var rm_vals: List[Float64] = [0.1, -0.2]
+    var rv_vals: List[Float64] = [1.5, 0.8]
+
+    var tape = GradientTape()
+    tape.enable()
+
+    var x = Variable(_make_tensor(shape, x_vals), True, tape)
+    var gamma = Variable(_make_tensor(c_shape, gamma_vals), True, tape)
+    var beta = Variable(_make_tensor(c_shape, beta_vals), True, tape)
+    var running_mean = _make_tensor(c_shape, rm_vals)
+    var running_var = _make_tensor(c_shape, rv_vals)
+    var w = Variable(_make_tensor(shape, w_vals), False, tape)
+
+    var bn = variable_batch_norm(
+        x, gamma, beta, running_mean, running_var, tape, training=False
+    )
+    var y = bn[0].copy()
+
+    var weighted = variable_multiply(y, w, tape)
+    var loss = variable_sum(weighted, tape, axis=-1)
+    loss.backward(tape)
+
+    var grad_x = tape.get_grad(x.id)
+    var num_grad_x = compute_numerical_gradient(
+        _BNInferForward(
+            _make_tensor(c_shape, gamma_vals),
+            _make_tensor(c_shape, beta_vals),
+            _make_tensor(c_shape, rm_vals),
+            _make_tensor(c_shape, rv_vals),
+            _make_tensor(shape, w_vals),
+        ),
+        _make_tensor(shape, x_vals),
+        epsilon=1e-3,
+    )
+    assert_gradients_close(
+        grad_x,
+        num_grad_x,
+        rtol=5e-2,
+        atol=5e-4,
+        message="variable_batch_norm inference grad_x",
+    )
+    print("       OK")
+
+
 def main() raises:
     test_batch_norm_grad_check()
+    test_batch_norm_inference_grad_check()
     print("\nvariable_batch_norm gradient check PASS")


### PR DESCRIPTION
## Summary

The autograd substrate had **no batch-norm op**, blocking the #5454 autograd ports for **resnet18 (#5561), mobilenetv1 (#5562), googlenet (#5563)** — all BatchNorm-heavy. This adds `variable_batch_norm` by **wiring the existing, correct core numerics** (`batch_norm2d` / `batch_norm2d_backward`) into the Variable/GradientTape machinery, mirroring `variable_conv2d`.

**Scope: this PR adds the op + its gradient-check test ONLY.** It does not port any model (those are #5561/#5562/#5563, now unblocked).

## Design

- **`variable.mojo`** — `variable_batch_norm(x, gamma, beta, running_mean, running_var, tape, training, momentum=0.1, epsilon=1e-5) -> (Variable, AnyTensor, AnyTensor)`.
  - **x/gamma/beta are trainable Variables** (receive gradients); **running_mean/var are plain `AnyTensor` buffers** (non-trainable, no grad). The core op is functional, so **updated running stats are returned** for the caller to thread back into per-layer storage.
  - In **training mode** the forward and backward derive batch statistics from `x` and ignore the incoming running stats — so a caller that drops the returned stats still trains correctly (only later inference accuracy would suffer). This fits the `train_batch` pattern the ports use.
  - Saved layout: `x, gamma, running_mean, running_var` + `training/epsilon` scalars. **`beta` is NOT saved** — `batch_norm2d_backward` doesn't take it (`grad_beta = sum(grad_output)`).
- **`backward_ops.mojo`** — `backward_batch_norm` wraps `batch_norm2d_backward`, routes `grad_input/grad_gamma/grad_beta` → `input_ids[0/1/2]`.
- **`tape.mojo`** — `OP_BATCH_NORM2D` alias + import + dispatch branch.
- **`__init__.mojo`** — exports `variable_batch_norm` + `OP_BATCH_NORM2D`.

## Verification — genuine in-container (no fabricated results)

| Check | Result |
|---|---|
| `mojo package -I src src/projectodyssey` | **exit 0**, 2.9 MB `.mojopkg` (whole-tree `--Werror`) |
| `mojo run --Werror` the gradient-check test | **`variable_batch_norm gradient check PASS`, exit 0** |

The **gradient-check test** is the correctness gate — a wrong saved tensor, mis-routed grad sink, or training-flag mismatch fails it:
- **grad_x** vs finite differences (rtol 5e-2) — with a **NON-UNIFORM loss weight** to break the BN ones-vector symmetry that would otherwise zero grad_x (so the check is non-vacuous).
- **grad_gamma** vs finite differences.
- **grad_beta** analytically (= per-channel `sum(w)`).
- Output shape matches input; running stats updated in training mode.

The test is auto-discovered by the CI `find tests -name 'test_*.mojo'` glob — no runner edit needed.

Closes the substrate gap for #5561/#5562/#5563.

🤖 Generated with [Claude Code](https://claude.com/claude-code)