### PR TITLE
feat(autograd): add variable_depthwise_conv2d + variable_concat ops (unblocks #5562 / #5563)

### DIFF
--- a/src/projectodyssey/autograd/__init__.mojo
+++ b/src/projectodyssey/autograd/__init__.mojo
@@ -59,6 +59,7 @@ Available Variable Operations:
 - variable_sum, variable_mean
 - variable_relu, variable_sigmoid, variable_tanh
 - variable_neg
+- variable_conv2d, variable_depthwise_conv2d, variable_concat (convnet primitives)
 
 Available Loss+Grad Helpers:
 - mse_loss_and_grad: Mean squared error (regression)
@@ -112,6 +113,8 @@ from projectodyssey.autograd.variable import (
     variable_flatten,
     variable_linear,
     variable_conv2d,
+    variable_depthwise_conv2d,
+    variable_concat,
     variable_maxpool2d,
     variable_cross_entropy,
     variable_batch_norm,
@@ -151,6 +154,8 @@ from projectodyssey.autograd.tape import (
     OP_MAXPOOL2D,
     OP_CROSS_ENTROPY,
     OP_BATCH_NORM2D,
+    OP_DEPTHWISE_CONV2D,
+    OP_CONCAT,
 )
 
 from projectodyssey.autograd.optimizers import (

--- a/src/projectodyssey/autograd/backward_ops.mojo
+++ b/src/projectodyssey/autograd/backward_ops.mojo
@@ -45,7 +45,8 @@ from projectodyssey.core.activation import (
     tanh_backward,
 )
 from projectodyssey.core.linear import linear_backward
-from projectodyssey.core.conv import conv2d_backward
+from projectodyssey.core.conv import conv2d_backward, depthwise_conv2d_backward
+from projectodyssey.core.shape import as_contiguous
 from projectodyssey.core.pooling import maxpool2d_backward
 from projectodyssey.core.loss import cross_entropy_backward
 from projectodyssey.core.normalization import batch_norm2d_backward
@@ -554,3 +555,92 @@ def backward_cross_entropy(
     var grad_logits = cross_entropy_backward(grad_output, logits, targets)
     if len(nodes[idx].input_ids) >= 1:
         registry.set_grad(nodes[idx].input_ids[0], grad_logits)
+
+
+def backward_depthwise_conv2d(
+    nodes: List[TapeNode],
+    mut registry: VariableRegistry,
+    idx: Int,
+    grad_output: AnyTensor,
+) raises:
+    """Backward pass for depthwise 2D convolution.
+
+    Saved layout (see variable_depthwise_conv2d):
+        tensors[0] = input x   (batch, C, H, W)
+        tensors[1] = kernel    (C, 1, kH, kW)
+        scalars[0] = stride  (Float64-cast Int)
+        scalars[1] = padding (Float64-cast Int)
+
+    Routes (same as conv2d):
+        input_ids[0] -> grad_input
+        input_ids[1] -> grad_weights
+        input_ids[2] -> grad_bias (if 3 input_ids)
+    """
+    if len(nodes[idx].saved.tensors) < 2:
+        return
+    if len(nodes[idx].saved.scalars) < 2:
+        return
+    var x = nodes[idx].saved.tensors[0].copy()
+    var kernel = nodes[idx].saved.tensors[1].copy()
+    var stride = Int(nodes[idx].saved.scalars[0])
+    var padding = Int(nodes[idx].saved.scalars[1])
+    var grads = depthwise_conv2d_backward(
+        grad_output, x, kernel, stride, padding
+    )
+    if len(nodes[idx].input_ids) >= 1:
+        registry.set_grad(nodes[idx].input_ids[0], grads.grad_input)
+    if len(nodes[idx].input_ids) >= 2:
+        registry.set_grad(nodes[idx].input_ids[1], grads.grad_weights)
+    if len(nodes[idx].input_ids) >= 3:
+        registry.set_grad(nodes[idx].input_ids[2], grads.grad_bias)
+
+
+def backward_concat(
+    nodes: List[TapeNode],
+    mut registry: VariableRegistry,
+    idx: Int,
+    grad_output: AnyTensor,
+) raises:
+    """Backward pass for concatenation along an axis.
+
+    Concat is a pure data-routing op: the gradient wrt each input is simply the
+    slice of `grad_output` that that input contributed. We split `grad_output`
+    along the concat axis at the saved per-input boundaries and route each slice
+    to its input variable.
+
+    Saved layout (see variable_concat):
+        scalars[0]      = axis
+        scalars[1]      = num_inputs (N)
+        scalars[2..2+N] = size of each input along the concat axis (in order)
+
+    Routes:
+        input_ids[i] -> slice(grad_output, offset_i, offset_i + size_i, axis)
+    """
+    if len(nodes[idx].saved.scalars) < 2:
+        return
+    var axis = Int(nodes[idx].saved.scalars[0])
+    var num_inputs = Int(nodes[idx].saved.scalars[1])
+    if len(nodes[idx].saved.scalars) < 2 + num_inputs:
+        return
+    # grad_output must be contiguous so the flat-index slice offsets are valid,
+    # and each slice must be materialized contiguous before routing: `slice`
+    # returns a (possibly strided) view, but VariableRegistry.set_grad reads
+    # gradients by FLAT index (contiguity-assuming), so a strided channel-axis
+    # view would be read incorrectly.
+    var grad_cont = (
+        grad_output if grad_output.is_contiguous() else as_contiguous(
+            grad_output
+        )
+    )
+    var offset = 0
+    for i in range(num_inputs):
+        var size = Int(nodes[idx].saved.scalars[2 + i])
+        var grad_slice = grad_cont.slice(offset, offset + size, axis=axis)
+        var grad_slice_cont = (
+            grad_slice if grad_slice.is_contiguous() else as_contiguous(
+                grad_slice
+            )
+        )
+        if i < len(nodes[idx].input_ids):
+            registry.set_grad(nodes[idx].input_ids[i], grad_slice_cont)
+        offset += size

--- a/src/projectodyssey/autograd/tape.mojo
+++ b/src/projectodyssey/autograd/tape.mojo
@@ -85,6 +85,8 @@ from projectodyssey.autograd.backward_ops import (
     backward_maxpool2d,
     backward_cross_entropy,
     backward_batch_norm,
+    backward_depthwise_conv2d,
+    backward_concat,
 )
 
 
@@ -112,6 +114,8 @@ comptime OP_CONV2D = "conv2d"
 comptime OP_MAXPOOL2D = "maxpool2d"
 comptime OP_CROSS_ENTROPY = "cross_entropy"
 comptime OP_BATCH_NORM2D = "batch_norm2d"
+comptime OP_DEPTHWISE_CONV2D = "depthwise_conv2d"
+comptime OP_CONCAT = "concat"
 
 
 struct GradientTape:
@@ -294,6 +298,12 @@ struct GradientTape:
             backward_batch_norm(
                 self.nodes, self.registry, node_idx, grad_output
             )
+        elif op_type == OP_DEPTHWISE_CONV2D:
+            backward_depthwise_conv2d(
+                self.nodes, self.registry, node_idx, grad_output
+            )
+        elif op_type == OP_CONCAT:
+            backward_concat(self.nodes, self.registry, node_idx, grad_output)
         else:
             raise Error(
                 "Unsupported operation type for backward pass: " + op_type

--- a/src/projectodyssey/autograd/variable.mojo
+++ b/src/projectodyssey/autograd/variable.mojo
@@ -44,6 +44,8 @@ from projectodyssey.core.reduction import sum, mean
 from projectodyssey.core.matrix import matmul
 from projectodyssey.core.linear import linear as _linear
 from projectodyssey.core.conv import conv2d as _conv2d
+from projectodyssey.core.conv import depthwise_conv2d as _depthwise_conv2d
+from projectodyssey.core.shape import concatenate as _concatenate
 from projectodyssey.core.pooling import maxpool2d as _maxpool2d
 from projectodyssey.core.loss import cross_entropy as _cross_entropy
 from projectodyssey.core.normalization import batch_norm2d as _batch_norm2d
@@ -71,6 +73,8 @@ from projectodyssey.autograd.tape import (
     OP_MAXPOOL2D,
     OP_CROSS_ENTROPY,
     OP_BATCH_NORM2D,
+    OP_DEPTHWISE_CONV2D,
+    OP_CONCAT,
 )
 
 
@@ -730,6 +734,117 @@ def variable_conv2d(
         saved.add_scalar(Float64(stride))
         saved.add_scalar(Float64(padding))
         tape.record(OP_CONV2D, input_ids^, result_id, saved^)
+
+    return Variable(result_data^, needs_grad, result_id)
+
+
+def variable_depthwise_conv2d(
+    x: Variable,
+    weights: Variable,
+    bias: Variable,
+    mut tape: GradientTape,
+    stride: Int = 1,
+    padding: Int = 0,
+) raises -> Variable:
+    """Apply depthwise 2D convolution with bias: one filter per input channel.
+
+    Unlike `variable_conv2d` (which mixes all input channels), depthwise conv
+    convolves each input channel with its own filter — the building block of
+    MobileNet / EfficientNet depthwise-separable blocks. Wraps the core
+    `depthwise_conv2d` / `depthwise_conv2d_backward`.
+
+    Saved layout for backward (mirrors OP_CONV2D):
+        tensors[0] = input x      (batch, C, H, W)
+        tensors[1] = weights      (C, 1, kH, kW)
+        scalars[0] = stride
+        scalars[1] = padding
+
+    Args:
+        x: Input activations Variable (batch, C, H, W).
+        weights: Depthwise kernel Variable (C, 1, kH, kW) — one filter per channel.
+        bias: Bias Variable (C,).
+        tape: Gradient tape for recording.
+        stride: Convolution stride (default 1).
+        padding: Zero-padding (default 0).
+
+    Returns:
+        Output Variable of shape (batch, C, out_H, out_W).
+    """
+    var result_data = _depthwise_conv2d(
+        x.data, weights.data, bias.data, stride, padding
+    )
+    var needs_grad = (
+        x.requires_grad or weights.requires_grad or bias.requires_grad
+    )
+    var result_id = tape.register_variable(needs_grad)
+
+    if tape.enabled and needs_grad:
+        var input_ids = List[Int]()
+        input_ids.append(x.id)
+        input_ids.append(weights.id)
+        input_ids.append(bias.id)
+
+        var saved = SavedTensors()
+        saved.add_tensor(x.data)
+        saved.add_tensor(weights.data)
+        saved.add_scalar(Float64(stride))
+        saved.add_scalar(Float64(padding))
+        tape.record(OP_DEPTHWISE_CONV2D, input_ids^, result_id, saved^)
+
+    return Variable(result_data^, needs_grad, result_id)
+
+
+def variable_concat(
+    inputs: List[Variable],
+    mut tape: GradientTape,
+    axis: Int,
+) raises -> Variable:
+    """Concatenate Variables along an existing axis (e.g. channel-axis for
+    Inception depth-concat).
+
+    Concat is a pure data-routing op: forward stacks the inputs along `axis`;
+    backward slices the output gradient back into each input's contiguous range.
+    Wraps the core `concatenate`. Result requires grad if ANY input does.
+
+    Saved layout for backward:
+        scalars[0]      = axis
+        scalars[1]      = num_inputs (N)
+        scalars[2..2+N] = each input's size along `axis`, in order (for the split)
+
+    Args:
+        inputs: Variables to concatenate (all matching except along `axis`).
+        tape: Gradient tape for recording.
+        axis: Axis along which to concatenate (channel axis is 1 for NCHW).
+
+    Returns:
+        Concatenated Variable.
+    """
+    if len(inputs) == 0:
+        raise Error("variable_concat: need at least one input")
+
+    var data_list = List[AnyTensor]()
+    var needs_grad = False
+    for i in range(len(inputs)):
+        data_list.append(inputs[i].data)
+        if inputs[i].requires_grad:
+            needs_grad = True
+
+    var result_data = _concatenate(data_list, axis)
+    var result_id = tape.register_variable(needs_grad)
+
+    if tape.enabled and needs_grad:
+        var input_ids = List[Int]()
+        var saved = SavedTensors()
+        # Resolve a negative axis against the (shared) input rank so the saved
+        # split sizes AND the backward slice use the same positive axis.
+        var rank = len(inputs[0].data.shape())
+        var actual_axis = axis if axis >= 0 else rank + axis
+        saved.add_scalar(Float64(actual_axis))
+        saved.add_scalar(Float64(len(inputs)))
+        for i in range(len(inputs)):
+            input_ids.append(inputs[i].id)
+            saved.add_scalar(Float64(inputs[i].data.shape()[actual_axis]))
+        tape.record(OP_CONCAT, input_ids^, result_id, saved^)
 
     return Variable(result_data^, needs_grad, result_id)
 

--- a/tests/projectodyssey/autograd/test_variable_concat.mojo
+++ b/tests/projectodyssey/autograd/test_variable_concat.mojo
@@ -1,0 +1,151 @@
+"""Gradient-check tests for the `variable_concat` autograd op.
+
+Concat is a pure data-routing op: forward stacks inputs along an axis, backward
+slices the output gradient back into each input's contiguous range. For a loss
+`sum(concat(a, b, ...) * w)`, the gradient wrt each input is EXACTLY the slice of
+`w` covering that input's range — so the check is analytic and exact (no
+finite-difference tolerance needed).
+
+The critical case is the CHANNEL axis (axis=1) of an NCHW tensor: a channel-range
+slice of grad_output is a strided (non-contiguous) view, and the gradient
+registry reads grads by flat index, so `backward_concat` must materialize each
+slice contiguous. This test concatenates two tensors with DIFFERENT channel
+counts along axis=1 to exercise that path.
+"""
+
+from projectodyssey.autograd import Variable, GradientTape
+from projectodyssey.autograd.variable import (
+    variable_concat,
+    variable_multiply,
+    variable_sum,
+)
+from projectodyssey.tensor.any_tensor import AnyTensor
+from projectodyssey.tensor.tensor_creation import zeros
+
+
+def _make_tensor(shape: List[Int], values: List[Float64]) raises -> AnyTensor:
+    var t = zeros(shape, DType.float32)
+    for i in range(len(values)):
+        t._set_float64(i, values[i])
+    return t^
+
+
+def _abs(x: Float64) -> Float64:
+    return x if x >= 0.0 else -x
+
+
+def _nchw_index(n: Int, c: Int, h: Int, w: Int, C: Int, H: Int, W: Int) -> Int:
+    return ((n * C + c) * H + h) * W + w
+
+
+def test_concat_channel_axis_grad_check() raises:
+    print("[test] variable_concat channel-axis gradient check ...")
+
+    # a: (batch=2, Ca=2, H=2, W=2); b: (batch=2, Cb=3, H=2, W=2)
+    # concat along axis=1 -> (2, 5, 2, 2). Exercises unequal channel counts and
+    # the strided channel-slice backward path.
+    var H = 2
+    var W = 2
+    var N = 2
+    var Ca = 2
+    var Cb = 3
+    var Cout = Ca + Cb
+
+    var a_shape: List[Int] = [N, Ca, H, W]
+    var b_shape: List[Int] = [N, Cb, H, W]
+    var out_shape: List[Int] = [N, Cout, H, W]
+
+    # Distinct, non-uniform values so a mis-routed slice would be detected.
+    var a_vals = List[Float64]()
+    for i in range(N * Ca * H * W):
+        a_vals.append(Float64(i) * 0.1 - 0.5)
+    var b_vals = List[Float64]()
+    for i in range(N * Cb * H * W):
+        b_vals.append(Float64(i) * -0.07 + 0.3)
+    # Non-uniform loss weights over the concatenated output.
+    var w_vals = List[Float64]()
+    for i in range(N * Cout * H * W):
+        w_vals.append(Float64((i * 7) % 11) * 0.13 - 0.4)
+
+    var tape = GradientTape()
+    tape.enable()
+
+    var a = Variable(_make_tensor(a_shape, a_vals), True, tape)
+    var b = Variable(_make_tensor(b_shape, b_vals), True, tape)
+    var w = Variable(_make_tensor(out_shape, w_vals), False, tape)
+
+    # Variable is not implicitly copyable; concat callers build the input list
+    # with explicit .copy() (the Variable's tape id is preserved, so gradients
+    # still route to the originals a/b).
+    var inputs = List[Variable]()
+    inputs.append(a.copy())
+    inputs.append(b.copy())
+    var y = variable_concat(inputs, tape, axis=1)
+
+    # Output shape sanity: (2, 5, 2, 2).
+    var ys = y.data.shape()
+    if len(ys) != 4 or ys[0] != N or ys[1] != Cout or ys[2] != H or ys[3] != W:
+        raise Error("variable_concat output shape mismatch")
+
+    # loss = sum(concat(a, b) * w)
+    var weighted = variable_multiply(y, w, tape)
+    var loss = variable_sum(weighted, tape, axis=-1)
+    loss.backward(tape)
+
+    var grad_a = tape.get_grad(a.id)
+    var grad_b = tape.get_grad(b.id)
+
+    # Analytic: grad_a[n,c,h,w] == w[n, c,        h, w]  for c in [0, Ca)
+    #           grad_b[n,c,h,w] == w[n, Ca + c,   h, w]  for c in [0, Cb)
+    var w_t = _make_tensor(out_shape, w_vals)
+
+    for n in range(N):
+        for c in range(Ca):
+            for h in range(H):
+                for ww in range(W):
+                    var ga = grad_a._get_float64(
+                        _nchw_index(n, c, h, ww, Ca, H, W)
+                    )
+                    var expected = w_t._get_float64(
+                        _nchw_index(n, c, h, ww, Cout, H, W)
+                    )
+                    if _abs(ga - expected) > 1e-5:
+                        raise Error(
+                            "grad_a mismatch at ("
+                            + String(n)
+                            + ","
+                            + String(c)
+                            + "): got "
+                            + String(ga)
+                            + " expected "
+                            + String(expected)
+                        )
+
+    for n in range(N):
+        for c in range(Cb):
+            for h in range(H):
+                for ww in range(W):
+                    var gb = grad_b._get_float64(
+                        _nchw_index(n, c, h, ww, Cb, H, W)
+                    )
+                    var expected = w_t._get_float64(
+                        _nchw_index(n, Ca + c, h, ww, Cout, H, W)
+                    )
+                    if _abs(gb - expected) > 1e-5:
+                        raise Error(
+                            "grad_b mismatch at ("
+                            + String(n)
+                            + ","
+                            + String(c)
+                            + "): got "
+                            + String(gb)
+                            + " expected "
+                            + String(expected)
+                        )
+
+    print("       OK")
+
+
+def main() raises:
+    test_concat_channel_axis_grad_check()
+    print("\nvariable_concat gradient check PASS")

--- a/tests/projectodyssey/autograd/test_variable_depthwise_conv2d.mojo
+++ b/tests/projectodyssey/autograd/test_variable_depthwise_conv2d.mojo
@@ -1,0 +1,216 @@
+"""Gradient-check tests for the `variable_depthwise_conv2d` autograd op.
+
+Verifies that the tape-recorded backward for depthwise convolution matches
+finite-difference numerical gradients for grad_x and grad_weights, and the
+analytic grad_bias, on a small multi-channel 4D input.
+
+Depthwise conv applies one filter per input channel (no cross-channel mixing),
+so a correct backward must keep each channel's gradient independent. The loss
+is `sum(y * w)` with a NON-UNIFORM weight `w` so the numerical check exercises a
+real (non-degenerate) gradient signal.
+"""
+
+from projectodyssey.autograd import Variable, GradientTape
+from projectodyssey.autograd.variable import (
+    variable_depthwise_conv2d,
+    variable_multiply,
+    variable_sum,
+)
+from projectodyssey.tensor.any_tensor import AnyTensor
+from projectodyssey.tensor.tensor_creation import zeros
+from projectodyssey.core.conv import depthwise_conv2d
+from projectodyssey.core.arithmetic import multiply
+from projectodyssey.testing.gradient_checker import (
+    compute_numerical_gradient,
+    assert_gradients_close,
+    NumericalForward,
+)
+
+
+def _make_tensor(shape: List[Int], values: List[Float64]) raises -> AnyTensor:
+    var t = zeros(shape, DType.float32)
+    for i in range(len(values)):
+        t._set_float64(i, values[i])
+    return t^
+
+
+def _abs(x: Float64) -> Float64:
+    return x if x >= 0.0 else -x
+
+
+# ============================================================================
+# NumericalForward closures: loss(perturbed) = sum(depthwise_conv2d(...) * w)
+# ============================================================================
+@fieldwise_init
+struct _DWInputForward(NumericalForward):
+    """loss(x) = sum(depthwise_conv2d(x, kernel, bias) * w). Perturbs x."""
+
+    var kernel: AnyTensor
+    var bias: AnyTensor
+    var w: AnyTensor
+    var stride: Int
+    var padding: Int
+
+    def __call__(self, inp: AnyTensor) raises -> AnyTensor:
+        var y = depthwise_conv2d(
+            inp, self.kernel, self.bias, self.stride, self.padding
+        )
+        return multiply(y, self.w)
+
+
+@fieldwise_init
+struct _DWKernelForward(NumericalForward):
+    """loss(kernel) = sum(depthwise_conv2d(x, kernel, bias) * w). Perturbs kernel.
+    """
+
+    var x: AnyTensor
+    var bias: AnyTensor
+    var w: AnyTensor
+    var stride: Int
+    var padding: Int
+
+    def __call__(self, k: AnyTensor) raises -> AnyTensor:
+        var y = depthwise_conv2d(
+            self.x, k, self.bias, self.stride, self.padding
+        )
+        return multiply(y, self.w)
+
+
+def test_depthwise_conv2d_grad_check() raises:
+    print("[test] variable_depthwise_conv2d gradient check ...")
+
+    # Small input: (batch=1, C=2, H=3, W=3); kernel (C=2, 1, 2, 2); stride 1 pad 0
+    # => output (1, 2, 2, 2) = 8 elements.
+    var x_shape: List[Int] = [1, 2, 3, 3]
+    var k_shape: List[Int] = [2, 1, 2, 2]
+    var b_shape: List[Int] = [2]
+    var y_shape: List[Int] = [1, 2, 2, 2]
+    var stride = 1
+    var padding = 0
+
+    var x_vals: List[Float64] = [
+        0.5,
+        -1.2,
+        0.3,
+        0.8,
+        -0.4,
+        1.1,
+        0.2,
+        -0.7,
+        0.9,  # channel 0 (3x3)
+        -0.1,
+        1.4,
+        -0.6,
+        0.05,
+        0.7,
+        -1.3,
+        0.35,
+        0.6,
+        -0.2,  # channel 1 (3x3)
+    ]
+    var k_vals: List[Float64] = [
+        0.4,
+        -0.3,
+        0.7,
+        0.1,  # channel-0 filter (2x2)
+        -0.5,
+        0.9,
+        0.2,
+        -0.8,  # channel-1 filter (2x2)
+    ]
+    var b_vals: List[Float64] = [0.15, -0.25]
+    # Non-uniform loss weights over the 8-element output.
+    var w_vals: List[Float64] = [1.0, 0.3, -0.5, 0.8, 0.2, -0.9, 1.1, 0.4]
+
+    var tape = GradientTape()
+    tape.enable()
+
+    var x = Variable(_make_tensor(x_shape, x_vals), True, tape)
+    var kernel = Variable(_make_tensor(k_shape, k_vals), True, tape)
+    var bias = Variable(_make_tensor(b_shape, b_vals), True, tape)
+    var w = Variable(_make_tensor(y_shape, w_vals), False, tape)
+
+    var y = variable_depthwise_conv2d(x, kernel, bias, tape, stride, padding)
+
+    # Output shape sanity.
+    var ys = y.data.shape()
+    if len(ys) != 4 or ys[0] != 1 or ys[1] != 2 or ys[2] != 2 or ys[3] != 2:
+        raise Error("variable_depthwise_conv2d output shape mismatch")
+
+    var weighted = variable_multiply(y, w, tape)
+    var loss = variable_sum(weighted, tape, axis=-1)
+    loss.backward(tape)
+
+    var grad_x = tape.get_grad(x.id)
+    var grad_k = tape.get_grad(kernel.id)
+    var grad_b = tape.get_grad(bias.id)
+
+    # ---- grad_bias is analytic: d/dbias_c sum(y*w) = sum of w over channel c ----
+    # Output layout (n=1, c, h, w): channel c occupies elements [c*4 .. c*4+4).
+    var w_t = _make_tensor(y_shape, w_vals)
+    var expected_b0 = Float64(0.0)
+    var expected_b1 = Float64(0.0)
+    for i in range(4):
+        expected_b0 += w_t._get_float64(0 * 4 + i)
+        expected_b1 += w_t._get_float64(1 * 4 + i)
+    var gb0 = Float64(grad_b._get_float64(0))
+    var gb1 = Float64(grad_b._get_float64(1))
+    if _abs(gb0 - expected_b0) > 1e-3 or _abs(gb1 - expected_b1) > 1e-3:
+        raise Error(
+            "grad_bias mismatch: got ("
+            + String(gb0)
+            + ", "
+            + String(gb1)
+            + "), expected ("
+            + String(expected_b0)
+            + ", "
+            + String(expected_b1)
+            + ")"
+        )
+
+    # ---- grad_x: finite-difference check ----
+    var num_grad_x = compute_numerical_gradient(
+        _DWInputForward(
+            _make_tensor(k_shape, k_vals),
+            _make_tensor(b_shape, b_vals),
+            _make_tensor(y_shape, w_vals),
+            stride,
+            padding,
+        ),
+        _make_tensor(x_shape, x_vals),
+        epsilon=1e-3,
+    )
+    assert_gradients_close(
+        grad_x,
+        num_grad_x,
+        rtol=5e-2,
+        atol=5e-4,
+        message="variable_depthwise_conv2d grad_x",
+    )
+
+    # ---- grad_weights: finite-difference check ----
+    var num_grad_k = compute_numerical_gradient(
+        _DWKernelForward(
+            _make_tensor(x_shape, x_vals),
+            _make_tensor(b_shape, b_vals),
+            _make_tensor(y_shape, w_vals),
+            stride,
+            padding,
+        ),
+        _make_tensor(k_shape, k_vals),
+        epsilon=1e-3,
+    )
+    assert_gradients_close(
+        grad_k,
+        num_grad_k,
+        rtol=5e-2,
+        atol=5e-4,
+        message="variable_depthwise_conv2d grad_weights",
+    )
+
+    print("       OK")
+
+
+def main() raises:
+    test_depthwise_conv2d_grad_check()
+    print("\nvariable_depthwise_conv2d gradient check PASS")


### PR DESCRIPTION
## Summary

Adds the two remaining autograd substrate ops that block the last two `#5454` example ports, following the exact wiring pattern of `variable_batch_norm` (PR #5590):

- **`variable_depthwise_conv2d`** — depthwise (per-channel, no cross-channel mixing) conv wrapping core `depthwise_conv2d` / `depthwise_conv2d_backward`. New opcode `OP_DEPTHWISE_CONV2D`. **Unblocks #5562** (MobileNetV1 depthwise-separable blocks).
- **`variable_concat(List[Variable], axis)`** — channel-axis (or any-axis) concat wrapping core `concatenate`; backward splits `grad_output` along the concat axis and routes each slice to its input. New opcode `OP_CONCAT`. **Unblocks #5563** (GoogLeNet Inception depth-concat).

Wiring per op: forward + `record` in `variable.mojo`, opcode + dispatch in `tape.mojo`, backward in `backward_ops.mojo`, exports in `autograd/__init__.mojo`.

Closes the substrate side of #5562 and #5563 (the example-port PRs are separate follow-ups).

## Correctness note (concat backward)

`AnyTensor.slice` returns a possibly-**strided view**, but `VariableRegistry.set_grad` reads gradients by **flat index** (contiguity-assuming). A channel-axis slice of an NCHW tensor is non-contiguous, so `backward_concat` materializes `grad_output` and each slice contiguous via `as_contiguous` before routing — otherwise channel-axis grads would be read from the wrong memory. The concat test below specifically exercises this path.

## Verification (real local output)

Ran each test via `pixi run mojo run -I src <test>` (memory-bounded, `CMAKE_BUILD_PARALLEL_LEVEL=2`):

- `test_variable_depthwise_conv2d` — grad_x + grad_weights vs finite differences, grad_bias analytic → **PASS**
- `test_variable_concat` — channel-axis (axis=1) concat of two **unequal-channel** tensors; grads checked exactly against the loss-weight slices → **PASS**
- Regression: `test_variable_batch_norm` and `test_variable_layers` → **PASS** (no regression from the tape-dispatch/import edits)

```
variable_depthwise_conv2d gradient check PASS
variable_concat gradient check PASS
variable_batch_norm gradient check PASS
All Phase 2 substrate gradient checks PASS
```

## Test plan
- [x] New gradient-check tests pass locally
- [x] Existing autograd tests pass locally (no regression)
- [ ] CI green (Comprehensive Mojo Tests / build validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)