### PR TITLE
docs(autograd): fix op-catalog drift (15 -> 18 op types) flagged by review of #5594

### DIFF
--- a/src/projectodyssey/autograd/README.md
+++ b/src/projectodyssey/autograd/README.md
@@ -274,7 +274,7 @@ for epoch in range(num_epochs):
 - SGD optimizer
 - Integration points with existing backward passes
 - **Automatic operation recording in Variable**
-- **Backward pass dispatch (15 op types: add/sub/mul/div/matmul/sum/mean/relu/sigmoid/tanh/flatten/linear/conv2d/maxpool2d/cross_entropy)**
+- **Backward pass dispatch (18 op types: add/sub/mul/div/matmul/sum/mean/relu/sigmoid/tanh/flatten/linear/conv2d/depthwise_conv2d/maxpool2d/cross_entropy/batch_norm2d/concat)**
 - **Automatic gradient computation in tape.backward()** — forward execution
   appends nodes in topological order, so reverse iteration is correct
   reverse-topological order (no DAG sort needed)
@@ -283,11 +283,14 @@ for epoch in range(num_epochs):
 
 ### Phase 2 substrate (complete)
 
-`variable_flatten`, `variable_linear`, `variable_conv2d`, `variable_maxpool2d`,
-`variable_cross_entropy` enable end-to-end convnet training (LeNet/AlexNet/VGG
-forward+backward via `loss.backward(tape)`). See
-`tests/projectodyssey/autograd/test_variable_layers.mojo` for FD-validated
-gradient checks.
+`variable_flatten`, `variable_linear`, `variable_conv2d`,
+`variable_depthwise_conv2d`, `variable_maxpool2d`, `variable_cross_entropy`,
+`variable_batch_norm`, and `variable_concat` enable end-to-end convnet training
+(LeNet/AlexNet/VGG/ResNet, plus depthwise-separable MobileNet and Inception
+depth-concat) forward+backward via `loss.backward(tape)`. See
+`tests/projectodyssey/autograd/test_variable_layers.mojo`,
+`test_variable_batch_norm.mojo`, `test_variable_depthwise_conv2d.mojo`, and
+`test_variable_concat.mojo` for FD-validated gradient checks.
 
 Also fixed in Phase 2: `SavedTensors.add_tensor` and `VariableRegistry.set_grad`
 previously hardcoded `bitcast[Float32]`, silently corrupting fp16/bf16/fp64

--- a/src/projectodyssey/autograd/TODO.md
+++ b/src/projectodyssey/autograd/TODO.md
@@ -91,7 +91,8 @@ The autograd module follows **YAGNI** (You Aren't Gonna Need It) and **KISS** (K
 
 ### Potential Future Additions
 
-- [ ] `concat_backward` - Concatenation gradient
+- [x] `concat_backward` - Concatenation gradient (implemented as `backward_concat` /
+      `variable_concat`, OP_CONCAT — channel-axis depth-concat for Inception; #5591)
 - [ ] `stack_backward` - Stack operation gradient
 - [ ] `reshape_backward` - Reshape gradient
 - [ ] `expand_dims_backward` - Dimension expansion gradient
@@ -112,8 +113,9 @@ The autograd module follows **YAGNI** (You Aren't Gonna Need It) and **KISS** (K
 ### Phase 2: Automatic Differentiation (DELIVERED — #5452)
 
 - [x] **Full tape-based autograd** — Variable + GradientTape + automatic
-  backward dispatch for 15 op types (arithmetic, matmul, reductions,
-  activations, flatten, linear, conv2d, maxpool2d, cross_entropy).
+  backward dispatch for 18 op types (arithmetic, matmul, reductions,
+  activations, flatten, linear, conv2d, depthwise_conv2d, maxpool2d,
+  cross_entropy, batch_norm2d, concat).
 - [x] **Variable wrapper** — tape recording, gradient accumulation,
   dtype-agnostic SavedTensors round-trip.
 - [x] Dtype-correct copy/accumulate in `SavedTensors` and `VariableRegistry`


### PR DESCRIPTION
## Summary

Fixes the in-package autograd doc drift surfaced by the strict PR review of #5594 (Dimension 2, Architecture Alignment — MAJOR finding).

The backward-pass dispatch chain grew to **18 op types** (`batch_norm2d` from #5590; `depthwise_conv2d` + `concat` from #5594), but the docs still enumerated 15:

- **README.md** — dispatch list `15 -> 18 op types`, adding `batch_norm2d`, `depthwise_conv2d`, `concat`. Refreshed the "Phase 2 substrate" op list + test-file pointers to include `variable_batch_norm` / `variable_depthwise_conv2d` / `variable_concat`.
- **TODO.md** — marked `concat_backward` as **DELIVERED** (`backward_concat` / `OP_CONCAT`, #5591); bumped the "Phase 2 (DELIVERED)" op count `15 -> 18`.

Verified `grep -rn "15 op" src/projectodyssey/autograd/` returns nothing after the change. Actual dispatch count confirmed at 18 via the `if/elif` branch count in `tape.mojo:_dispatch_backward_op`.

**Doc-only — no code change.** Single-purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)