### PR TITLE
fix(googlenet): persist BatchNorm running stats in training forward (#5575)

### DIFF
--- a/examples/googlenet_cifar10/model.mojo
+++ b/examples/googlenet_cifar10/model.mojo
@@ -217,7 +217,7 @@ struct InceptionModule:
         var b1 = conv2d(
             x, self.conv1x1_1_weights, self.conv1x1_1_bias, stride=1, padding=0
         )
-        b1, _, _ = batch_norm2d(
+        var b1_bn_result = batch_norm2d(
             b1,
             self.bn1x1_1_gamma,
             self.bn1x1_1_beta,
@@ -225,13 +225,16 @@ struct InceptionModule:
             self.bn1x1_1_running_var,
             training,
         )
+        b1 = b1_bn_result[0]
+        self.bn1x1_1_running_mean = b1_bn_result[1]
+        self.bn1x1_1_running_var = b1_bn_result[2]
         b1 = relu(b1)
 
         # Branch 2: 1×1 reduce → 3×3 conv
         var b2 = conv2d(
             x, self.conv1x1_2_weights, self.conv1x1_2_bias, stride=1, padding=0
         )
-        b2, _, _ = batch_norm2d(
+        var b2_bn1_result = batch_norm2d(
             b2,
             self.bn1x1_2_gamma,
             self.bn1x1_2_beta,
@@ -239,11 +242,14 @@ struct InceptionModule:
             self.bn1x1_2_running_var,
             training,
         )
+        b2 = b2_bn1_result[0]
+        self.bn1x1_2_running_mean = b2_bn1_result[1]
+        self.bn1x1_2_running_var = b2_bn1_result[2]
         b2 = relu(b2)
         b2 = conv2d(
             b2, self.conv3x3_weights, self.conv3x3_bias, stride=1, padding=1
         )
-        b2, _, _ = batch_norm2d(
+        var b2_bn2_result = batch_norm2d(
             b2,
             self.bn3x3_gamma,
             self.bn3x3_beta,
@@ -251,13 +257,16 @@ struct InceptionModule:
             self.bn3x3_running_var,
             training,
         )
+        b2 = b2_bn2_result[0]
+        self.bn3x3_running_mean = b2_bn2_result[1]
+        self.bn3x3_running_var = b2_bn2_result[2]
         b2 = relu(b2)
 
         # Branch 3: 1×1 reduce → 5×5 conv
         var b3 = conv2d(
             x, self.conv1x1_3_weights, self.conv1x1_3_bias, stride=1, padding=0
         )
-        b3, _, _ = batch_norm2d(
+        var b3_bn1_result = batch_norm2d(
             b3,
             self.bn1x1_3_gamma,
             self.bn1x1_3_beta,
@@ -265,11 +274,14 @@ struct InceptionModule:
             self.bn1x1_3_running_var,
             training,
         )
+        b3 = b3_bn1_result[0]
+        self.bn1x1_3_running_mean = b3_bn1_result[1]
+        self.bn1x1_3_running_var = b3_bn1_result[2]
         b3 = relu(b3)
         b3 = conv2d(
             b3, self.conv5x5_weights, self.conv5x5_bias, stride=1, padding=2
         )
-        b3, _, _ = batch_norm2d(
+        var b3_bn2_result = batch_norm2d(
             b3,
             self.bn5x5_gamma,
             self.bn5x5_beta,
@@ -277,6 +289,9 @@ struct InceptionModule:
             self.bn5x5_running_var,
             training,
         )
+        b3 = b3_bn2_result[0]
+        self.bn5x5_running_mean = b3_bn2_result[1]
+        self.bn5x5_running_var = b3_bn2_result[2]
         b3 = relu(b3)
 
         # Branch 4: 3×3 max pool → 1×1 projection
@@ -284,7 +299,7 @@ struct InceptionModule:
         b4 = conv2d(
             b4, self.conv1x1_4_weights, self.conv1x1_4_bias, stride=1, padding=0
         )
-        b4, _, _ = batch_norm2d(
+        var b4_bn_result = batch_norm2d(
             b4,
             self.bn1x1_4_gamma,
             self.bn1x1_4_beta,
@@ -292,6 +307,9 @@ struct InceptionModule:
             self.bn1x1_4_running_var,
             training,
         )
+        b4 = b4_bn_result[0]
+        self.bn1x1_4_running_mean = b4_bn_result[1]
+        self.bn1x1_4_running_var = b4_bn_result[2]
         b4 = relu(b4)
 
         # Concatenate all branches depth-wise
@@ -763,12 +781,15 @@ struct InceptionGradients(Movable):
 
 
 def inception_forward_cached(
-    module: InceptionModule, x: AnyTensor
+    mut module: InceptionModule, x: AnyTensor
 ) raises -> Tuple[AnyTensor, InceptionCache]:
     """Forward pass through one Inception module, caching every activation.
 
-    Training-mode BatchNorm (write-backs of running stats are handled by the
-    caller / eval path; here we only need the forward output + cache).
+    Runs BatchNorm in training mode and writes the EMA-updated running_mean /
+    running_var back onto ``module`` at every BN site, so that post-training
+    inference (``training=False``) uses the accumulated statistics rather than
+    the init values (mean=0, var=1). Taking ``module`` mutably is what makes the
+    write-back possible (fixes #5575).
 
     Returns:
         (output, cache) where output is the depth-wise concatenation of the
@@ -778,7 +799,7 @@ def inception_forward_cached(
     var b1_conv = conv2d(
         x, module.conv1x1_1_weights, module.conv1x1_1_bias, stride=1, padding=0
     )
-    var b1_bn, _, _ = batch_norm2d(
+    var b1_bn_result = batch_norm2d(
         b1_conv,
         module.bn1x1_1_gamma,
         module.bn1x1_1_beta,
@@ -786,13 +807,16 @@ def inception_forward_cached(
         module.bn1x1_1_running_var,
         True,
     )
+    var b1_bn = b1_bn_result[0]
+    module.bn1x1_1_running_mean = b1_bn_result[1]
+    module.bn1x1_1_running_var = b1_bn_result[2]
     var b1 = relu(b1_bn)
 
     # Branch 2: conv1x1_2 -> BN -> ReLU -> conv3x3 -> BN -> ReLU
     var b2_conv1 = conv2d(
         x, module.conv1x1_2_weights, module.conv1x1_2_bias, stride=1, padding=0
     )
-    var b2_bn1, _, _ = batch_norm2d(
+    var b2_bn1_result = batch_norm2d(
         b2_conv1,
         module.bn1x1_2_gamma,
         module.bn1x1_2_beta,
@@ -800,6 +824,9 @@ def inception_forward_cached(
         module.bn1x1_2_running_var,
         True,
     )
+    var b2_bn1 = b2_bn1_result[0]
+    module.bn1x1_2_running_mean = b2_bn1_result[1]
+    module.bn1x1_2_running_var = b2_bn1_result[2]
     var b2_relu1 = relu(b2_bn1)
     var b2_conv2 = conv2d(
         b2_relu1,
@@ -808,7 +835,7 @@ def inception_forward_cached(
         stride=1,
         padding=1,
     )
-    var b2_bn2, _, _ = batch_norm2d(
+    var b2_bn2_result = batch_norm2d(
         b2_conv2,
         module.bn3x3_gamma,
         module.bn3x3_beta,
@@ -816,13 +843,16 @@ def inception_forward_cached(
         module.bn3x3_running_var,
         True,
     )
+    var b2_bn2 = b2_bn2_result[0]
+    module.bn3x3_running_mean = b2_bn2_result[1]
+    module.bn3x3_running_var = b2_bn2_result[2]
     var b2 = relu(b2_bn2)
 
     # Branch 3: conv1x1_3 -> BN -> ReLU -> conv5x5 -> BN -> ReLU
     var b3_conv1 = conv2d(
         x, module.conv1x1_3_weights, module.conv1x1_3_bias, stride=1, padding=0
     )
-    var b3_bn1, _, _ = batch_norm2d(
+    var b3_bn1_result = batch_norm2d(
         b3_conv1,
         module.bn1x1_3_gamma,
         module.bn1x1_3_beta,
@@ -830,6 +860,9 @@ def inception_forward_cached(
         module.bn1x1_3_running_var,
         True,
     )
+    var b3_bn1 = b3_bn1_result[0]
+    module.bn1x1_3_running_mean = b3_bn1_result[1]
+    module.bn1x1_3_running_var = b3_bn1_result[2]
     var b3_relu1 = relu(b3_bn1)
     var b3_conv2 = conv2d(
         b3_relu1,
@@ -838,7 +871,7 @@ def inception_forward_cached(
         stride=1,
         padding=2,
     )
-    var b3_bn2, _, _ = batch_norm2d(
+    var b3_bn2_result = batch_norm2d(
         b3_conv2,
         module.bn5x5_gamma,
         module.bn5x5_beta,
@@ -846,6 +879,9 @@ def inception_forward_cached(
         module.bn5x5_running_var,
         True,
     )
+    var b3_bn2 = b3_bn2_result[0]
+    module.bn5x5_running_mean = b3_bn2_result[1]
+    module.bn5x5_running_var = b3_bn2_result[2]
     var b3 = relu(b3_bn2)
 
     # Branch 4: maxpool -> conv1x1_4 -> BN -> ReLU
@@ -857,7 +893,7 @@ def inception_forward_cached(
         stride=1,
         padding=0,
     )
-    var b4_bn, _, _ = batch_norm2d(
+    var b4_bn_result = batch_norm2d(
         b4_conv,
         module.bn1x1_4_gamma,
         module.bn1x1_4_beta,
@@ -865,6 +901,9 @@ def inception_forward_cached(
         module.bn1x1_4_running_var,
         True,
     )
+    var b4_bn = b4_bn_result[0]
+    module.bn1x1_4_running_mean = b4_bn_result[1]
+    module.bn1x1_4_running_var = b4_bn_result[2]
     var b4 = relu(b4_bn)
 
     var c1 = b1.shape()[1]
@@ -1241,7 +1280,7 @@ struct GoogLeNet:
             stride=1,
             padding=1,
         )
-        out, _, _ = batch_norm2d(
+        var initial_bn_result = batch_norm2d(
             out,
             self.initial_bn_gamma,
             self.initial_bn_beta,
@@ -1249,6 +1288,9 @@ struct GoogLeNet:
             self.initial_bn_running_var,
             training,
         )
+        out = initial_bn_result[0]
+        self.initial_bn_running_mean = initial_bn_result[1]
+        self.initial_bn_running_var = initial_bn_result[2]
         out = relu(out)
         # Shape: (batch, 64, 32, 32)
 

--- a/examples/googlenet_cifar10/test_bn_persistence.mojo
+++ b/examples/googlenet_cifar10/test_bn_persistence.mojo
@@ -1,0 +1,143 @@
+"""BatchNorm running-stat persistence regression test for GoogLeNet (#5575).
+
+A training forward (`training=True`) must write the EMA-updated running_mean /
+running_var back onto the model, so a subsequent inference forward
+(`training=False`) uses the accumulated statistics rather than the init values
+(mean=0, var=1). Before the fix, both `GoogLeNet.forward`'s stem BN and every
+BN inside `InceptionModule.forward` / `inception_forward_cached` discarded
+batch_norm2d's updated stats via `out, _, _ = batch_norm2d(...)`, so inference
+silently used stale init values and produced wrong results.
+
+Same class of bug (and fix) as MobileNetV1 #5537.
+"""
+
+from model import GoogLeNet
+from projectodyssey.tensor.any_tensor import AnyTensor
+from projectodyssey.tensor.tensor_creation import zeros
+
+
+def assert_true(cond: Bool, msg: String) raises:
+    if not cond:
+        raise Error("assertion failed: " + msg)
+
+
+def _running_var_sig(t: AnyTensor) raises -> Float32:
+    """Sum of running_var — a scalar signature that is num_channels at init.
+
+    running_var is initialized to all-ones, so its sum equals the channel
+    count. A training forward pushes it toward the batch variance, changing the
+    sum; this gives a single value to compare before/after.
+    """
+    var d = t._data.bitcast[Float32]()
+    var s = Float32(0.0)
+    for i in range(t._numel):
+        s += d[i]
+    return s
+
+
+def _running_mean_sig(t: AnyTensor) raises -> Float32:
+    """Sum of running_mean — 0 at init (all-zeros), nonzero after training."""
+    var d = t._data.bitcast[Float32]()
+    var s = Float32(0.0)
+    for i in range(t._numel):
+        s += d[i]
+    return s
+
+
+def test_bn_running_stats_persist_after_training() raises:
+    """A training forward updates the model's persistent BN running stats."""
+    var model = GoogLeNet(num_classes=10)
+
+    # Non-trivial, non-uniform input so batch statistics differ from init.
+    var x = zeros([2, 3, 32, 32], DType.float32)
+    var xd = x._data.bitcast[Float32]()
+    for i in range(2 * 3 * 32 * 32):
+        xd[i] = Float32(i % 7) * 0.1 - 0.3
+
+    # Snapshot the initial (stem) BN stats (init: mean sum = 0, var sum = C).
+    var mean_before = _running_mean_sig(model.initial_bn_running_mean)
+    var var_before = _running_var_sig(model.initial_bn_running_var)
+
+    _ = model.forward(x, training=True)
+
+    var mean_after = _running_mean_sig(model.initial_bn_running_mean)
+    var var_after = _running_var_sig(model.initial_bn_running_var)
+
+    # Init running_mean is all-zeros; a training forward must move it.
+    assert_true(
+        mean_before == Float32(0.0),
+        "precondition: initial running_mean must start at 0, got "
+        + String(mean_before),
+    )
+    assert_true(
+        mean_after != mean_before,
+        "initial_bn_running_mean was NOT updated by training forward (still "
+        + String(mean_after)
+        + ") — stats discarded (#5575)",
+    )
+    assert_true(
+        var_after != var_before,
+        "initial_bn_running_var was NOT updated by training forward (still "
+        + String(var_after)
+        + ") — stats discarded (#5575)",
+    )
+
+
+def test_bn_stats_persist_in_inception_modules() raises:
+    """The Inception modules also persist their BN running stats.
+
+    Checks the FIRST (inception_3a) AND LAST (inception_5b) module, so this
+    proves the shared InceptionModule.forward path persists for every module,
+    not just one.
+    """
+    var model = GoogLeNet(num_classes=10)
+    var x = zeros([2, 3, 32, 32], DType.float32)
+    var xd = x._data.bitcast[Float32]()
+    for i in range(2 * 3 * 32 * 32):
+        xd[i] = Float32(i % 5) * 0.2 - 0.4
+
+    var i3a_before = _running_mean_sig(model.inception_3a.bn1x1_1_running_mean)
+    var i5b_before = _running_mean_sig(model.inception_5b.bn1x1_1_running_mean)
+
+    _ = model.forward(x, training=True)
+
+    assert_true(
+        _running_mean_sig(model.inception_3a.bn1x1_1_running_mean)
+        != i3a_before,
+        "inception_3a (first) BN running_mean not persisted (#5575)",
+    )
+    assert_true(
+        _running_mean_sig(model.inception_5b.bn1x1_1_running_mean)
+        != i5b_before,
+        "inception_5b (last) BN running_mean not persisted (#5575)",
+    )
+
+
+def test_inference_forward_leaves_stats_unchanged() raises:
+    """A training=False forward must NOT change running stats (inference-safe).
+    """
+    var model = GoogLeNet(num_classes=10)
+    var x = zeros([2, 3, 32, 32], DType.float32)
+    var xd = x._data.bitcast[Float32]()
+    for i in range(2 * 3 * 32 * 32):
+        xd[i] = Float32(i % 3) * 0.3
+
+    var mean_before = _running_mean_sig(model.initial_bn_running_mean)
+    _ = model.forward(x, training=False)
+    assert_true(
+        _running_mean_sig(model.initial_bn_running_mean) == mean_before,
+        "inference forward must not mutate BN running stats",
+    )
+
+
+def main() raises:
+    print("test_bn_running_stats_persist_after_training...", end="")
+    test_bn_running_stats_persist_after_training()
+    print(" PASS")
+    print("test_bn_stats_persist_in_inception_modules...", end="")
+    test_bn_stats_persist_in_inception_modules()
+    print(" PASS")
+    print("test_inference_forward_leaves_stats_unchanged...", end="")
+    test_inference_forward_leaves_stats_unchanged()
+    print(" PASS")
+    print("ALL GoogLeNet BN-persistence TESTS PASSED")

--- a/examples/googlenet_cifar10/train.mojo
+++ b/examples/googlenet_cifar10/train.mojo
@@ -435,7 +435,7 @@ def compute_gradients(
         stride=1,
         padding=1,
     )
-    var init_bn, _, _ = batch_norm2d(
+    var init_bn_result = batch_norm2d(
         init_conv,
         model.initial_bn_gamma,
         model.initial_bn_beta,
@@ -443,6 +443,9 @@ def compute_gradients(
         model.initial_bn_running_var,
         True,
     )
+    var init_bn = init_bn_result[0]
+    model.initial_bn_running_mean = init_bn_result[1]
+    model.initial_bn_running_var = init_bn_result[2]
     var init_relu = relu(init_bn)
     var init_pool = maxpool2d(init_relu, kernel_size=3, stride=2, padding=1)
 

--- a/justfile
+++ b/justfile
@@ -1402,6 +1402,7 @@ _test-example-backward-inner:
     # Entries are "<example-dir>/<test-file>".
     EXAMPLE_TESTS=(
         "googlenet_cifar10/test_backward.mojo"
+        "googlenet_cifar10/test_bn_persistence.mojo"
         "resnet18_cifar10/test_backward.mojo"
         "mobilenetv1_cifar10/test_bn_persistence.mojo"
     )

--- a/scripts/validate_test_coverage.py
+++ b/scripts/validate_test_coverage.py
@@ -66,11 +66,13 @@ def find_test_files(root_dir: Path) -> List[Path]:
         # `just test-example-backward` — it uses synthetic interleaved-class
         # data with no dataset download.
         "examples/googlenet_cifar10/test_backward.mojo",
-        # MobileNetV1 BatchNorm running-stat persistence regression (#5537).
-        # Example-dir test (imports `from model`), EXECUTED per-PR by the
-        # "example-backward-tests" job via `just test-example-backward`
-        # (EXAMPLE_TESTS list) with synthetic data — not a src/ unit test.
+        # MobileNetV1 / GoogLeNet BatchNorm running-stat persistence regression
+        # (#5537 / #5575). Example-dir tests (import `from model`), EXECUTED
+        # per-PR by the "example-backward-tests" job via
+        # `just test-example-backward` (EXAMPLE_TESTS list) with synthetic
+        # data — not src/ unit tests.
         "examples/mobilenetv1_cifar10/test_bn_persistence.mojo",
+        "examples/googlenet_cifar10/test_bn_persistence.mojo",
         # Conda recipe smoke test — executed by rattler-build's `tests:`
         # block when the package is built (see conda.recipe/recipe.yaml),
         # not by the per-PR CI test matrix.


### PR DESCRIPTION
## Summary

GoogLeNet's training forward path discarded the EMA-updated BatchNorm `running_mean`/`running_var` via the `x, _, _ = batch_norm2d(...)` form. Post-training inference (`training=False`) therefore used the init values (mean=0, var=1) and produced wrong results. Same class of bug as the MobileNetV1 fix in #5537.

## Changes Made

- **`InceptionModule.forward`** (`mut self`): capture `batch_norm2d`'s returned updated stats at all 6 BN sites and write them back to `self.<bn>_running_mean/_running_var`.
- **`inception_forward_cached`**: signature changed from `module: InceptionModule` to **`mut module: InceptionModule`** (the crux — it previously took the module by borrow and could not persist stats), and write updated running stats back at all 6 BN sites. Callers in `train.mojo` (`compute_gradients`) already hold the model mutably, so `model.inception_Xx` binds mutably with **no ripple into `inception_backward`** (which stays borrow).
- **`GoogLeNet.forward`** (`mut self`): stem BN now writes its updated stats back.
- **`compute_gradients`** (`train.mojo`): stem BN write-back for the training loop.
- **Regression test** `examples/googlenet_cifar10/test_bn_persistence.mojo` (mirrors mobilenet's #5537 test): stem + first (`inception_3a`) + last (`inception_5b`) BN stats change after a training forward; an inference forward leaves them unchanged.
- **CI**: added the test to the `just test-example-backward` `EXAMPLE_TESTS` list (same wiring #5537 used for mobilenet).

## Files Modified

- `examples/googlenet_cifar10/model.mojo`
- `examples/googlenet_cifar10/train.mojo`
- `examples/googlenet_cifar10/test_bn_persistence.mojo` (new)
- `justfile`

## Verification

Build clean under `mojo build` (catches unused-var, `--Werror`-equivalent):

```text
$ ulimit -v 6291456; CMAKE_BUILD_PARALLEL_LEVEL=2 pixi run mojo build -I src \
    examples/googlenet_cifar10/test_bn_persistence.mojo -o /tmp/gnet_bn -Xlinker -lm
EXIT=0
```

`train.mojo` (exercises the `mut module` propagation through `inception_forward_cached` callers) also builds clean: `EXIT=0`. `test_backward`, `test_model`, `inference` all build `EXIT=0`.

Test run (fixed code):

```text
test_bn_running_stats_persist_after_training... PASS
test_bn_stats_persist_in_inception_modules... PASS
test_inference_forward_leaves_stats_unchanged... PASS
ALL GoogLeNet BN-persistence TESTS PASSED
```

Regression guard proven — reverting the stem write-back to the buggy `out, _, _ =` form makes the test fail:

```text
test_bn_running_stats_persist_after_training...Unhandled exception caught during execution:
assertion failed: initial_bn_running_mean was NOT updated by training forward (still 0.0) — stats discarded (#5575)
```

Mirrors the #5537 MobileNetV1 fix and test.

Closes #5575

🤖 Generated with [Claude Code](https://claude.com/claude-code)