### PR TITLE
refactor(tensor): add AnyTensor shared-data constructor, drop allocate-then-free conversion (#5566)

### DIFF
--- a/src/projectodyssey/tensor/any_tensor.mojo
+++ b/src/projectodyssey/tensor/any_tensor.mojo
@@ -409,6 +409,62 @@ struct AnyTensor(
         for i in range(len(data)):
             self._set_float64(i, Float64(data[i]))
 
+    def __init__(
+        out self,
+        *,
+        shared_data: UnsafePointer[UInt8, origin=MutAnyOrigin],
+        base_data: UnsafePointer[UInt8, origin=MutAnyOrigin],
+        shape: List[Int],
+        strides: List[Int],
+        dtype: DType,
+        numel: Int,
+        is_view: Bool,
+        refcount: UnsafePointer[Int, origin=MutAnyOrigin],
+        original_numel_quantized: Int,
+        allocated_size: Int,
+    ):
+        """Internal constructor for zero-copy conversion (NOT public API).
+
+        Creates an AnyTensor sharing ownership of an existing byte buffer via a
+        shared refcount pointer — no allocation or copy occurs. Increments the
+        shared refcount to establish shared ownership (B4 critical — prevents a
+        dangling pointer from ASAP destruction of the source). The buffer is
+        freed exactly once, when the last reference (source or this AnyTensor)
+        is destroyed.
+
+        This mirrors `Tensor.__init__`'s internal raw-field constructor and is
+        the target of `Tensor.as_any()`'s zero-copy conversion (#5566),
+        replacing the previous allocate-then-free + field-surgery approach.
+
+        Args:
+            shared_data: Byte-level pointer to the existing element storage.
+                For non-offset buffers this equals `base_data`.
+            base_data: The original `pooled_alloc` pointer to free at refcount 0.
+            shape: Shape dimensions (copied into a fresh List).
+            strides: Row-major strides in elements (copied into a fresh List).
+            dtype: The element data type.
+            numel: Total number of elements.
+            is_view: Whether this tensor shares data with another.
+            refcount: Shared refcount pointer (same pointer, not a copy).
+            original_numel_quantized: Original element count before quantization.
+            allocated_size: Allocated size in bytes.
+        """
+        self._data = shared_data
+        self._base_data = base_data
+        self._shape = List[Int]()
+        for i in range(len(shape)):
+            self._shape.append(shape[i])
+        self._strides = List[Int]()
+        for i in range(len(strides)):
+            self._strides.append(strides[i])
+        self._dtype = dtype
+        self._numel = numel
+        self._is_view = is_view
+        self._refcount = refcount
+        self._refcount[] += 1  # CRITICAL: shared ownership (B4)
+        self._original_numel_quantized = original_numel_quantized
+        self._allocated_size = allocated_size
+
     def __init__(out self, *, copy: Self):
         """Copy constructor - creates a shared-ownership copy with reference counting.
 

--- a/src/projectodyssey/tensor/tensor.mojo
+++ b/src/projectodyssey/tensor/tensor.mojo
@@ -465,14 +465,16 @@ struct Tensor[dtype: DType = DType.float32](
         so ASAP destruction of either only decrements (not frees) the count
         until the last reference goes away (B4).
 
-        Safety: This method performs manual field replacement on an AnyTensor
-        because AnyTensor lacks an internal constructor accepting raw pointers.
-        The temporary AnyTensor's independent allocation is fully torn down
-        (data freed, refcount freed) before fields are replaced with shared
-        pointers from this Tensor.
+        Safety: This uses AnyTensor's internal shared-data constructor, which
+        adopts this Tensor's existing byte buffer + refcount pointer directly
+        (no allocation, no copy). The constructor increments the shared refcount
+        so both `self` and the returned AnyTensor own the buffer; it is freed
+        exactly once, when the last reference is destroyed (B4). Since a Tensor
+        never offsets its `_data`, the AnyTensor's `_base_data` equals `_data`.
 
-        TODO(#5566): Replace with AnyTensor internal constructor once available,
-        eliminating the allocate-then-free overhead and fragile field surgery.
+        Fixed in #5566: previously this allocated a temporary AnyTensor, tore
+        down its independent allocation (freeing data + refcount), then replaced
+        its fields with shared pointers — wasteful and fragile "field surgery".
 
         Returns:
             An AnyTensor sharing the same data and refcount.
@@ -480,44 +482,24 @@ struct Tensor[dtype: DType = DType.float32](
         Raises:
             Error: If AnyTensor construction fails.
         """
-        # Create an AnyTensor with same shape/dtype — this allocates its own
-        # independent data buffer and refcount pointer.
-        var shape_copy = List[Int]()
-        for i in range(len(self._shape)):
-            shape_copy.append(self._shape[i])
-        var result = AnyTensor(shape_copy, Self.dtype)
-
-        # --- Tear down the temporary AnyTensor's independent allocation ---
-        # Free the independently allocated data buffer (safe: result is the
-        # sole owner at this point, refcount == 1).
-        var tmp_data = result._data
-        var tmp_alloc_size = result._allocated_size
-        var tmp_refcount = result._refcount
-        pooled_free(tmp_data, tmp_alloc_size)
-        # Free the independent refcount pointer (was allocated with alloc[Int](1))
-        tmp_refcount.free()
-
-        # --- Replace fields with shared pointers from this Tensor ---
-        # Share our data pointer (bitcast typed -> UInt8 for AnyTensor)
-        result._data = self._data.bitcast[UInt8]()
-        # `_base_data` must also point at the shared allocation, NOT the freed
-        # temp buffer the AnyTensor constructor set it to. The Tensor never
-        # offsets its `_data`, so the base equals `_data` here. `AnyTensor.__del__`
-        # frees `_base_data` at refcount 0.
-        result._base_data = self._data.bitcast[UInt8]()
-        result._allocated_size = self._allocated_size
-        result._shape = self._shape.copy()
-        result._strides = self._strides.copy()
-        result._numel = self._numel
-        result._is_view = self._is_view
-        result._original_numel_quantized = self._original_numel_quantized
-
-        # Share our refcount and increment for shared ownership (B4 critical).
-        # After this, both `self` and `result` point to the same refcount.
-        result._refcount = self._refcount
-        result._refcount[] += 1
-
-        return result^
+        # Share this Tensor's existing byte buffer and refcount directly — no
+        # temporary allocation. Bitcast the typed pointer to UInt8 for the
+        # type-erased AnyTensor; `base_data == shared_data` because a Tensor
+        # never offsets its `_data`. The constructor increments the shared
+        # refcount for shared ownership (B4 critical).
+        var byte_ptr = self._data.bitcast[UInt8]()
+        return AnyTensor(
+            shared_data=byte_ptr,
+            base_data=byte_ptr,
+            shape=self._shape,
+            strides=self._strides,
+            dtype=Self.dtype,
+            numel=self._numel,
+            is_view=self._is_view,
+            refcount=self._refcount,
+            original_numel_quantized=self._original_numel_quantized,
+            allocated_size=self._allocated_size,
+        )
 
     # ------------------------------------------------------------------
     # String representation (H4 fix: typed access, no _get_float64)


### PR DESCRIPTION
## Summary

`Tensor[dtype].as_any()` previously converted to `AnyTensor` by **allocating a temporary AnyTensor** (its own data buffer + refcount), then **tearing that allocation down** (`pooled_free` of the data, `.free()` of the refcount) and overwriting every field with shared pointers from the source `Tensor`. This allocate-then-free plus manual "field surgery" was wasteful (an alloc/free round-trip per conversion) and fragile (any new `AnyTensor` field silently broke the hand-copied field list).

## Changes Made

- **New internal `AnyTensor` constructor** (`any_tensor.mojo`): a keyword-only ctor (`shared_data=`, `base_data=`, `shape=`, `strides=`, `dtype=`, `numel=`, `is_view=`, `refcount=`, `original_numel_quantized=`, `allocated_size=`) that adopts an already-allocated byte buffer + refcount **directly — no allocation, no copy**. It mirrors the existing internal `Tensor` raw-field constructor and does `self._refcount[] += 1` to establish shared ownership (B4). Both the source `Tensor` and the returned `AnyTensor` reference the same buffer; the destructor frees it **exactly once**, when the last reference (owner or view) is destroyed.
- **`as_any()` rewritten** (`tensor.mojo:459`): bitcasts the typed pointer to `UInt8` once and calls the new constructor (`base_data == shared_data`, since a `Tensor` never offsets `_data`), removing the temp allocation, the `pooled_free`/`free` teardown, and the field surgery.
- **TODO updated**: the `TODO(#5005)`/`TODO(#5566)` marker is replaced with a note that the optimization is now done.

## Files Modified

- `src/projectodyssey/tensor/any_tensor.mojo` (+56)
- `src/projectodyssey/tensor/tensor.mojo` (+38 / −45)

## Verification (mojo native, glibc 2.39)

```text
tests/.../test_tensor_any_conversion.mojo:  8/8 PASS
tests/.../test_tensor_refcount.mojo:        6/6 PASS
```

- `test_tensor_refcount.mojo` includes `test_refcount_survives_tensor_destruction` — source `Tensor` destroyed via ASAP, `AnyTensor` still valid: proves the shared refcount keeps the buffer alive with **no double-free / use-after-free**.
- 2000-iteration conversion loop (incl. survive-source-destruction path): **no crash, data consistent**.
- `mojo build --Werror` on the conversion test: **exit 0, no warnings** (new ctor compiles clean).
- `python3 scripts/validate_test_coverage.py`: **rc 0**.
- `mojo format` on changed files: **no changes**.

## Refcount / ownership contract

The zero-copy share is safe: `as_any()` passes `self._refcount` (the same pointer, not a copy) and the ctor increments it, so the count reflects both references. Whichever reference is destroyed last frees `_base_data` (== the source's buffer) via `pooled_free` and frees the refcount cell — identical semantics to the previous field-surgery path, just without the intermediate alloc/free.

Closes #5566

🤖 Generated with [Claude Code](https://claude.com/claude-code)