### PR TITLE
fix(ci): bump Dockerfile PIXI_VERSION 0.65.0 -> 0.70.2 to read v7 lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,8 +82,12 @@ ENV PIXI_HOME=/home/${USER_NAME}/.pixi
 ENV PIXI_CACHE_DIR=/home/${USER_NAME}/.cache/pixi
 RUN mkdir -p $PIXI_HOME $PIXI_CACHE_DIR $HOME/.cache/rattler
 
-# Install Pixi as dev user (pinned version for reproducible builds)
-ENV PIXI_VERSION=0.65.0
+# Install Pixi as dev user (pinned version for reproducible builds).
+# Must be >= the pixi that writes pixi.lock locally (0.70.x -> lockfile v7).
+# Older pixi (<=0.67) cannot read a v7 lock and fails with a misleading
+# "missing `version` field in lock file" error (#5589 bumped Dockerfile.ci,
+# setup-pixi, and _required.yml to 0.70.2 but missed this Dockerfile).
+ENV PIXI_VERSION=0.70.2
 RUN curl -fsSL https://pixi.sh/install.sh | PIXI_VERSION=${PIXI_VERSION} bash
 
 # Copy dependency manifests first for layer caching.


### PR DESCRIPTION
## Summary

`main` is red: the "Comprehensive Tests" workflow's job **"Comprehensive Mojo Tests (autograd-tensor-base)"** fails at the "Set up container" step with:

```
Error:   × Failed to load lock file from `/workspace/pixi.lock`
  ╰─▶ missing `version` field in lock file
Error: executing docker-compose exec -T odyssey-dev pixi run mojo --version: exit status 1
```

Reproduced live on current `origin/main` (147b1517, run 29225888173, job 86741817873).

## Root cause

`pixi.lock` is **not** malformed — it has a valid `version: 7` top-level field (confirmed
locally with `pixi install --locked`, exit 0, using pixi 0.70.2).

The real bug: `Dockerfile` (the `development`/`odyssey-dev` target driven by
`docker-compose.yml`, which is what "Set up container" runs) was still pinned to
`ENV PIXI_VERSION=0.65.0`. Pixi 0.68.0 bumped the lock-file schema to `version: 7`; pixi
0.65.0 predates that and can't parse a v7 lock, misreporting it as "missing `version` field".

Commit ef16785d (#5589) re-locked `pixi.lock` in v7 format and correctly bumped pixi to
0.70.2 in `Dockerfile.ci`, `.github/actions/setup-pixi/action.yml`, and
`.github/workflows/_required.yml` — but missed this `Dockerfile`, so `odyssey-dev` (used by
the "Comprehensive Mojo Tests" matrix jobs) kept installing the old, incompatible pixi.

## Fix

Bump `Dockerfile`'s `PIXI_VERSION` from `0.65.0` to `0.70.2`, matching every other pixi pin
in the repo. No dependency/lock changes — `pixi.lock` is untouched.

## Verification

- `pixi install --locked` against the unchanged, committed `pixi.lock` succeeds (exit 0)
  with pixi 0.70.2 (memory-bounded via `ulimit -v` per repo host-safety guidance).
- Confirmed all other pixi version pins in the repo (`Dockerfile.ci`, `setup-pixi/action.yml`,
  `_required.yml`) already point at 0.70.2 — this change makes `Dockerfile` consistent with
  them.

## Files changed

- `Dockerfile` — `PIXI_VERSION=0.65.0` → `0.70.2` (+ comment explaining the v7 lock
  constraint, mirroring the existing comment in `setup-pixi/action.yml`)

Opened as draft; auto-merge intentionally not armed pending review.