### PR TITLE
chore(settings): swap hephaestus plugin → Athena marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,7 +14,37 @@
     ]
   },
   "enabledPlugins": {
-    "hephaestus@ProjectHephaestus": true,
-    "safety-net@cc-marketplace": true
+    "safety-net@cc-marketplace": true,
+    "advise@Athena": true,
+    "brainstorm@Athena": true,
+    "code-review@Athena": true,
+    "create-reusable-utilities@Athena": true,
+    "finish-branch@Athena": true,
+    "git-worktrees@Athena": true,
+    "github-actions-python-cicd@Athena": true,
+    "learn@Athena": true,
+    "myrmidon-swarm@Athena": true,
+    "python-repo-modernization@Athena": true,
+    "repo-analyze@Athena": true,
+    "repo-analyze-full@Athena": true,
+    "repo-analyze-quick@Athena": true,
+    "repo-analyze-quick-full@Athena": true,
+    "repo-analyze-strict@Athena": true,
+    "repo-analyze-strict-full@Athena": true,
+    "review-pr-strict@Athena": true,
+    "skill-advisor@Athena": true,
+    "systematic-debugging@Athena": true,
+    "test-driven-development@Athena": true,
+    "tidy@Athena": true,
+    "verification@Athena": true,
+    "worktree-cleanup@Athena": true
+  },
+  "extraKnownMarketplaces": {
+    "Athena": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/HomericIntelligence/Athena.git"
+      }
+    }
   }
 }


### PR DESCRIPTION
Migrate .claude/settings.json off the stale hephaestus@ProjectHephaestus plugin ref (which no longer resolves) to the Athena marketplace.

- Removed hephaestus@ProjectHephaestus from enabledPlugins
- Added the 23 <skill>@Athena per-skill plugin keys
- Registered the Athena marketplace under extraKnownMarketplaces (git: HomericIntelligence/Athena)
- Preserved safety-net@cc-marketplace and the existing SessionEnd learn-trigger hook

Verified: valid JSON, hephaestus ref absent, 23 @Athena keys present, safety-net preserved, Athena marketplace present.

Closes #5604

🤖 Generated with [Claude Code](https://claude.com/claude-code)