### PR TITLE
feat(optimizers): add ADOPT optimizer (arXiv:2411.02853)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ADOPT optimizer** ([arXiv:2411.02853](https://arxiv.org/abs/2411.02853),
+  Taniguchi et al., NeurIPS 2024) — a modified Adam that achieves the optimal
+  `O(1/sqrt(T))` convergence rate for any `beta2 in [0, 1)`. Pure-functional
+  `adopt_step` / `adopt_step_simple` in `training/optimizers/adopt.mojo`,
+  numerically verified against the public `pytorch_optimizer.ADOPT` reference
+  to 1e-9.
+
 ## [0.2.0] - 2026-07-09
 
 ### Added

--- a/src/odyssey/training/optimizers/README.md
+++ b/src/odyssey/training/optimizers/README.md
@@ -9,6 +9,7 @@ This directory contains optimizer implementations for training neural networks i
 | **SGD** | ~1x params | O(n) | Small batch, fast convergence | With momentum (default 0.9) |
 | **Adam** | ~2x params (m + v) | O(n) | General-purpose, adaptive LR | Coupled weight decay |
 | **AdamW** | ~2x params (m + v) | O(n) | General-purpose default | Decoupled weight decay (default 0.01) |
+| **ADOPT** | ~2x params (m + v) | O(n) | General-purpose adaptive | Clamp-min denom (not sqrt(v)+eps); normalizes by previous v; arXiv:2411.02853 |
 | **RMSprop** | ~1x params (v only) | O(n) | RNNs, non-convex problems | Adaptive learning rates |
 | **LARS** | ~1x params | O(n) | Large-batch distributed training | Layer-wise adaptive rate scaling |
 | **Muon** | ~1x params (matrix-only) | O(n) + Newton-Schulz | **Matrix-shaped weights only** | Newton-Schulz orthogonalization; Jordan et al. 2024 |

--- a/src/odyssey/training/optimizers/__init__.mojo
+++ b/src/odyssey/training/optimizers/__init__.mojo
@@ -76,7 +76,7 @@ from odyssey.training.optimizers.normuon import (
 from odyssey.training.optimizers.lion import lion_step, lion_step_simple
 
 # ADOPT optimizer (modified Adam with the optimal convergence rate for any beta2)
-from odyssey.training.optimizers.adopt import adopt_step
+from odyssey.training.optimizers.adopt import adopt_step, adopt_step_simple
 
 # Shampoo optimizer (two-sided matrix preconditioner via Newton-Schulz inverse fourth root)
 from odyssey.training.optimizers.shampoo import (

--- a/src/odyssey/training/optimizers/__init__.mojo
+++ b/src/odyssey/training/optimizers/__init__.mojo
@@ -12,6 +12,7 @@ Includes:
 - Muon (Newton-Schulz Orthogonalized Momentum — Jordan et al. 2024)
 - NorMuon (Muon with per-parameter normalization)
 - Lion (EvoLved Sign Momentum — Chen et al. 2023)
+- ADOPT (Modified Adam, optimal convergence for any beta2 — Taniguchi et al. 2024)
 - Shampoo (two-sided matrix preconditioner via Newton-Schulz inverse fourth root — Anil et al. 2020)
 
 All optimizers follow pure functional design - caller manages state
@@ -73,6 +74,9 @@ from odyssey.training.optimizers.normuon import (
 
 # Lion optimizer (EvoLved Sign Momentum — Chen et al. 2023)
 from odyssey.training.optimizers.lion import lion_step, lion_step_simple
+
+# ADOPT optimizer (modified Adam with the optimal convergence rate for any beta2)
+from odyssey.training.optimizers.adopt import adopt_step
 
 # Shampoo optimizer (two-sided matrix preconditioner via Newton-Schulz inverse fourth root)
 from odyssey.training.optimizers.shampoo import (

--- a/src/odyssey/training/optimizers/adopt.mojo
+++ b/src/odyssey/training/optimizers/adopt.mojo
@@ -157,3 +157,37 @@ def adopt_step(
     new_second_moment = add_simd(new_second_moment, v_contrib)
 
     return (new_params, new_momentum, new_second_moment)
+
+
+def adopt_step_simple(
+    params: AnyTensor,
+    gradients: AnyTensor,
+    momentum: AnyTensor,
+    second_moment: AnyTensor,
+    learning_rate: Float64,
+) raises -> Tuple[AnyTensor, AnyTensor, AnyTensor]:
+    """Simplified ADOPT step with default hyperparameters (Taniguchi et al. 2024).
+
+    Convenience wrapper around `adopt_step` for the common case: default betas
+    (0.9, 0.9999), epsilon 1e-6, clipping disabled, and no weight decay. Caller
+    still manages the momentum and second-moment buffers.
+
+    On the first step, initialize `second_moment` to the first squared gradient
+    (v_0 = g_0^2) as recommended by the paper (see `adopt_step`).
+
+    Args:
+        params: Model parameters to update.
+        gradients: Gradients of loss with respect to params.
+        momentum: First-moment buffer m. Initialize to zeros_like(params).
+        second_moment: Second-moment buffer v from the previous step.
+        learning_rate: Step size for parameter updates.
+
+    Returns:
+        Tuple of (new_params, new_momentum, new_second_moment).
+
+    Raises:
+        Error: If tensor shapes or dtypes don't match.
+    """
+    return adopt_step(
+        params, gradients, momentum, second_moment, learning_rate
+    )

--- a/src/odyssey/training/optimizers/adopt.mojo
+++ b/src/odyssey/training/optimizers/adopt.mojo
@@ -142,9 +142,7 @@ def adopt_step(
 
     # Decoupled weight decay (AdamW-style), applied after the gradient step.
     if weight_decay != 0.0:
-        var wd_coeff_tensor = full_like(
-            params, weight_decay * learning_rate
-        )
+        var wd_coeff_tensor = full_like(params, weight_decay * learning_rate)
         var wd_term = multiply_simd(wd_coeff_tensor, params)
         new_params = subtract_simd(new_params, wd_term)
 
@@ -188,6 +186,4 @@ def adopt_step_simple(
     Raises:
         Error: If tensor shapes or dtypes don't match.
     """
-    return adopt_step(
-        params, gradients, momentum, second_moment, learning_rate
-    )
+    return adopt_step(params, gradients, momentum, second_moment, learning_rate)

--- a/src/odyssey/training/optimizers/adopt.mojo
+++ b/src/odyssey/training/optimizers/adopt.mojo
@@ -1,0 +1,159 @@
+"""ADOPT optimizer (Adaptive gradient method with the Optimal convergence rate).
+
+This module provides the ADOPT optimizer for updating model parameters during
+training. ADOPT is a modified Adam that achieves the optimal O(1/sqrt(T))
+convergence rate for smooth non-convex objectives with any beta2 in [0, 1),
+removing Adam's dependence on a problem-specific beta2 bound.
+
+ADOPT makes two changes to Adam:
+    1. It removes the current gradient from the second-moment normalization by
+       normalizing with the SECOND MOMENT (v is updated AFTER the normalization
+       uses it), decorrelating the numerator and denominator.
+    2. It applies element-wise clipping to the normalized gradient, which
+       stabilizes early-iteration updates when the second-moment estimate is
+       still poorly conditioned.
+
+ADOPT update rule (per step t, 1-indexed):
+    normalized = clip(gradients / max(sqrt(v), eps), -clip_value, +clip_value)
+    m = beta1 * m + (1 - beta1) * normalized
+    params = params - learning_rate * m
+    v = beta2 * v + (1 - beta2) * gradients^2   (second moment updated LAST)
+
+The second-moment buffer `v` is updated with the current squared gradient only
+AFTER it has been used (via its previous value) to normalize the gradient. This
+is the key difference from Adam, where the same-step second moment is used.
+
+Weight decay, when nonzero, is decoupled (AdamW-style):
+    params = params - learning_rate * weight_decay * params
+
+Key characteristics:
+    - Memory: same as Adam (first moment `m` + second moment `v`).
+    - Convergence: optimal rate for any beta2 in [0, 1); robust to beta2 choice.
+    - Clipping: the clip_value schedule in the paper grows with t; this
+      pure-functional step takes a fixed clip_value per call, so the caller may
+      pass a step-dependent value (e.g. clip_value = t**0.25) to reproduce the
+      paper's schedule, or a large constant to disable clipping.
+
+Reference:
+    Taniguchi, S., Harada, K., Minegishi, G., Oshima, Y., Jeong, S. C.,
+    Nagahara, G., Iiyama, T., Suzuki, M., Iwasawa, Y., & Matsuo, Y. (2024).
+    ADOPT: Modified Adam Can Converge with Any beta2 with the Optimal Rate.
+    Advances in Neural Information Processing Systems (NeurIPS) 2024.
+    arXiv preprint arXiv:2411.02853
+    https://github.com/iShohei220/adopt
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import full_like
+from odyssey.core.arithmetic_simd import (
+    subtract_simd,
+    multiply_simd,
+    add_simd,
+    divide_simd,
+)
+from odyssey.core.elementwise import sqrt, clip
+
+
+def adopt_step(
+    params: AnyTensor,
+    gradients: AnyTensor,
+    momentum: AnyTensor,
+    second_moment: AnyTensor,
+    learning_rate: Float64,
+    beta1: Float64 = 0.9,
+    beta2: Float64 = 0.9999,
+    epsilon: Float64 = 1e-6,
+    clip_value: Float64 = 1.0e30,
+    weight_decay: Float64 = 0.0,
+) raises -> Tuple[AnyTensor, AnyTensor, AnyTensor]:
+    """Perform a single ADOPT optimization step - pure functional.
+
+    Returns new parameters, new first-moment (momentum) buffer, and new
+    second-moment buffer. Caller manages all state.
+
+    IMPORTANT: the second-moment buffer passed in must be the value from the
+    PREVIOUS step (or a small positive initialization such as gradients^2 on
+    step 1 to avoid a zero denominator). ADOPT normalizes the current gradient
+    by this previous second moment, then updates the second moment with the
+    current squared gradient. On the very first step, initialize `second_moment`
+    to the first squared gradient (v_0 = g_0^2) as recommended by the paper so
+    that the normalized gradient is well-scaled; passing all-zeros makes the
+    step-1 denominator equal to `epsilon` for every coordinate.
+
+    Args:
+        params: Model parameters to update.
+        gradients: Gradients of loss with respect to params.
+        momentum: First-moment buffer m (EMA of normalized gradients).
+        second_moment: Second-moment buffer v (EMA of squared gradients) from
+            the previous step.
+        learning_rate: Step size for parameter updates.
+        beta1: Exponential decay rate for the first moment (default: 0.9).
+        beta2: Exponential decay rate for the second moment (default: 0.9999).
+            ADOPT converges at the optimal rate for ANY beta2 in [0, 1).
+        epsilon: Numerical-stability term used as the lower clamp bound on
+            sqrt(v) in the denominator, i.e. denom = max(sqrt(v), epsilon)
+            (default: 1e-6).
+        clip_value: Symmetric element-wise clip bound applied to the normalized
+            gradient; values are clamped to [-clip_value, +clip_value]. Pass a
+            step-dependent value (e.g. t**0.25) to reproduce the paper's growing
+            clip schedule, or leave at the large default to disable clipping.
+        weight_decay: Decoupled (AdamW-style) weight decay factor (default: 0.0).
+
+    Returns:
+        Tuple of (new_params, new_momentum, new_second_moment).
+
+    Raises:
+        Error: If tensor shapes or dtypes don't match.
+    """
+    if params.shape() != gradients.shape():
+        raise Error("adopt_step: params and gradients must have the same shape")
+    if params.shape() != momentum.shape():
+        raise Error("adopt_step: params and momentum must have the same shape")
+    if params.shape() != second_moment.shape():
+        raise Error(
+            "adopt_step: params and second_moment must have the same shape"
+        )
+    if params.dtype() != gradients.dtype():
+        raise Error("adopt_step: params and gradients must have the same dtype")
+
+    # Denominator uses the PREVIOUS second moment, clamped below by epsilon:
+    #   denom = max(sqrt(v), epsilon)
+    # This matches the reference ADOPT (`exp_avg_sq.sqrt().clamp_(min=eps)`),
+    # NOT the Adam-style `sqrt(v) + eps`. `clip(x, epsilon, +inf)` is the
+    # element-wise clamp-min since Odyssey has no dedicated maximum() op.
+    var sqrt_v = sqrt(second_moment)
+    var denom = clip(sqrt_v, epsilon, 1.0e30)
+
+    # Normalize the gradient by the previous second moment, then clip.
+    var normalized = divide_simd(gradients, denom)
+    normalized = clip(normalized, -clip_value, clip_value)
+
+    # First moment: m = beta1 * m + (1 - beta1) * normalized
+    var beta1_tensor = full_like(momentum, beta1)
+    var one_minus_beta1 = full_like(momentum, 1.0 - beta1)
+    var new_momentum = multiply_simd(beta1_tensor, momentum)
+    var norm_contrib = multiply_simd(one_minus_beta1, normalized)
+    new_momentum = add_simd(new_momentum, norm_contrib)
+
+    # Parameter update: params = params - learning_rate * m
+    var lr_tensor = full_like(new_momentum, learning_rate)
+    var lr_step = multiply_simd(lr_tensor, new_momentum)
+    var new_params = subtract_simd(params, lr_step)
+
+    # Decoupled weight decay (AdamW-style), applied after the gradient step.
+    if weight_decay != 0.0:
+        var wd_coeff_tensor = full_like(
+            params, weight_decay * learning_rate
+        )
+        var wd_term = multiply_simd(wd_coeff_tensor, params)
+        new_params = subtract_simd(new_params, wd_term)
+
+    # Second moment updated LAST: v = beta2 * v + (1 - beta2) * gradients^2
+    var beta2_tensor = full_like(second_moment, beta2)
+    var one_minus_beta2 = full_like(second_moment, 1.0 - beta2)
+    var grad_sq = multiply_simd(gradients, gradients)
+    var new_second_moment = multiply_simd(beta2_tensor, second_moment)
+    var v_contrib = multiply_simd(one_minus_beta2, grad_sq)
+    new_second_moment = add_simd(new_second_moment, v_contrib)
+
+    return (new_params, new_momentum, new_second_moment)

--- a/tests/odyssey/training/optimizers/parity_refs/adopt_parity_reference.py
+++ b/tests/odyssey/training/optimizers/parity_refs/adopt_parity_reference.py
@@ -10,47 +10,54 @@ sets exp_avg_sq = grad^2 and returns without updating params on step 1). To
 compare a *general* step we run TWO steps: step 1 seeds the state, step 2 is the
 one we compare (both optimizers start step 2 from the same seeded state).
 """
-import torch, json, sys
+
+import torch
+import json
 from pytorch_optimizer import ADOPT
 
 torch.manual_seed(0)
 N = 6
 # fixed inputs (deterministic, no randomness) so Mojo can replay them exactly
 params0 = torch.tensor([0.10, -0.20, 0.30, -0.40, 0.50, -0.60], dtype=torch.float64)
-grad_a  = torch.tensor([0.05, 0.15, -0.25, 0.35, -0.45, 0.55], dtype=torch.float64)  # step-1 grad
-grad_b  = torch.tensor([-0.02, 0.08, 0.12, -0.18, 0.22, -0.28], dtype=torch.float64)  # step-2 grad
+grad_a = torch.tensor([0.05, 0.15, -0.25, 0.35, -0.45, 0.55], dtype=torch.float64)  # step-1 grad
+grad_b = torch.tensor([-0.02, 0.08, 0.12, -0.18, 0.22, -0.28], dtype=torch.float64)  # step-2 grad
 
 LR, B1, B2, EPS = 0.01, 0.9, 0.9999, 1e-6
-NO_CLIP = lambda step: 1.0e30  # effectively disable clipping
+
+
+def NO_CLIP(step):  # noqa: N802 — clip_lambda schedule; huge => clipping disabled
+    return 1.0e30
+
 
 p = params0.clone().requires_grad_(True)
-opt = ADOPT([p], lr=LR, betas=(B1, B2), eps=EPS, weight_decay=0.0,
-            clip_lambda=NO_CLIP)
+opt = ADOPT([p], lr=LR, betas=(B1, B2), eps=EPS, weight_decay=0.0, clip_lambda=NO_CLIP)
 
 # --- step 1: seeds exp_avg_sq = grad_a^2, exp_avg stays 0, params unchanged ---
 p.grad = grad_a.clone()
 opt.step()
 st = opt.state[p]
-after1 = dict(params=p.detach().tolist(),
-             m=st['exp_avg'].tolist(),
-             v=st['exp_avg_sq'].tolist())
+after1 = dict(params=p.detach().tolist(), m=st["exp_avg"].tolist(), v=st["exp_avg_sq"].tolist())
 
 # --- step 2: the step we compare. State entering step 2 = after1's m,v ---
-m_in = st['exp_avg'].clone().tolist()
-v_in = st['exp_avg_sq'].clone().tolist()
+m_in = st["exp_avg"].clone().tolist()
+v_in = st["exp_avg_sq"].clone().tolist()
 p.grad = grad_b.clone()
 opt.step()
 st2 = opt.state[p]
-after2 = dict(params=p.detach().tolist(),
-             m=st2['exp_avg'].tolist(),
-             v=st2['exp_avg_sq'].tolist())
+after2 = dict(params=p.detach().tolist(), m=st2["exp_avg"].tolist(), v=st2["exp_avg_sq"].tolist())
 
 out = dict(
     inputs_step2=dict(
-        params=after1['params'],   # params entering step 2 (= after step 1)
+        params=after1["params"],  # params entering step 2 (= after step 1)
         grad=grad_b.tolist(),
-        m=m_in, v=v_in,
-        lr=LR, beta1=B1, beta2=B2, eps=EPS, clip=1.0e30, wd=0.0,
+        m=m_in,
+        v=v_in,
+        lr=LR,
+        beta1=B1,
+        beta2=B2,
+        eps=EPS,
+        clip=1.0e30,
+        wd=0.0,
     ),
     reference_step2_out=after2,
 )

--- a/tests/odyssey/training/optimizers/parity_refs/adopt_parity_reference.py
+++ b/tests/odyssey/training/optimizers/parity_refs/adopt_parity_reference.py
@@ -1,0 +1,57 @@
+"""ADOPT parity reference: run a fixed (params, grad, state) through the public
+pytorch_optimizer.ADOPT for ONE step, print the resulting params + state so the
+Mojo adopt_step can be compared against identical inputs.
+
+We disable the clip (clip_lambda -> huge) and weight_decay to isolate the core
+update, and set betas/eps to the Mojo defaults. Second moment is initialized to
+grad^2 (v_0 = g_0^2) to match the well-scaled-first-step recommendation, which
+is exactly what pytorch_optimizer.ADOPT does internally on the first step (it
+sets exp_avg_sq = grad^2 and returns without updating params on step 1). To
+compare a *general* step we run TWO steps: step 1 seeds the state, step 2 is the
+one we compare (both optimizers start step 2 from the same seeded state).
+"""
+import torch, json, sys
+from pytorch_optimizer import ADOPT
+
+torch.manual_seed(0)
+N = 6
+# fixed inputs (deterministic, no randomness) so Mojo can replay them exactly
+params0 = torch.tensor([0.10, -0.20, 0.30, -0.40, 0.50, -0.60], dtype=torch.float64)
+grad_a  = torch.tensor([0.05, 0.15, -0.25, 0.35, -0.45, 0.55], dtype=torch.float64)  # step-1 grad
+grad_b  = torch.tensor([-0.02, 0.08, 0.12, -0.18, 0.22, -0.28], dtype=torch.float64)  # step-2 grad
+
+LR, B1, B2, EPS = 0.01, 0.9, 0.9999, 1e-6
+NO_CLIP = lambda step: 1.0e30  # effectively disable clipping
+
+p = params0.clone().requires_grad_(True)
+opt = ADOPT([p], lr=LR, betas=(B1, B2), eps=EPS, weight_decay=0.0,
+            clip_lambda=NO_CLIP)
+
+# --- step 1: seeds exp_avg_sq = grad_a^2, exp_avg stays 0, params unchanged ---
+p.grad = grad_a.clone()
+opt.step()
+st = opt.state[p]
+after1 = dict(params=p.detach().tolist(),
+             m=st['exp_avg'].tolist(),
+             v=st['exp_avg_sq'].tolist())
+
+# --- step 2: the step we compare. State entering step 2 = after1's m,v ---
+m_in = st['exp_avg'].clone().tolist()
+v_in = st['exp_avg_sq'].clone().tolist()
+p.grad = grad_b.clone()
+opt.step()
+st2 = opt.state[p]
+after2 = dict(params=p.detach().tolist(),
+             m=st2['exp_avg'].tolist(),
+             v=st2['exp_avg_sq'].tolist())
+
+out = dict(
+    inputs_step2=dict(
+        params=after1['params'],   # params entering step 2 (= after step 1)
+        grad=grad_b.tolist(),
+        m=m_in, v=v_in,
+        lr=LR, beta1=B1, beta2=B2, eps=EPS, clip=1.0e30, wd=0.0,
+    ),
+    reference_step2_out=after2,
+)
+print(json.dumps(out, indent=2))

--- a/tests/odyssey/training/optimizers/test_adopt.mojo
+++ b/tests/odyssey/training/optimizers/test_adopt.mojo
@@ -3,6 +3,7 @@
 Tests cover:
 - Shape validation (params/gradients/momentum/second_moment must match)
 - Dtype validation (params/gradients must share a dtype)
+- Decoupled weight decay (nonzero wd shifts params by lr*wd*params vs wd=0)
 - Numerical parity with the public `pytorch_optimizer.ADOPT` reference on a
   fixed (params, grad, m, v) vector for one step (tolerance 1e-9)
 - Descent behavior (a nonzero gradient moves params against the gradient)
@@ -69,6 +70,64 @@ def test_reject_second_moment_shape() raises:
     except e:
         print("  ✓ Correctly rejected second_moment shape mismatch")
     print("test_reject_second_moment_shape PASSED")
+
+
+def test_reject_momentum_shape() raises:
+    """ADOPT must reject a momentum whose shape differs from params."""
+    print("Running test_reject_momentum_shape...")
+    var params = zeros([4], DType.float32)
+    var grad = zeros([4], DType.float32)
+    var m = zeros([3], DType.float32)
+    var v = zeros([4], DType.float32)
+    try:
+        var _ = adopt_step(params, grad, m, v, 0.01)
+        raise Error("Should have rejected momentum shape mismatch")
+    except e:
+        print("  ✓ Correctly rejected momentum shape mismatch")
+    print("test_reject_momentum_shape PASSED")
+
+
+def test_weight_decay_differs_from_zero() raises:
+    """Nonzero decoupled weight decay must shift params vs the wd=0 result.
+
+    With AdamW-style decoupled decay applied after the gradient step, a positive
+    weight_decay subtracts `lr * wd * params` from each coordinate. For a
+    positive param this makes the decayed result strictly smaller than the wd=0
+    result; the exact gap must equal `lr * wd * params` (the gradient step is
+    identical between the two calls since it does not depend on weight_decay).
+    """
+    print("Running test_weight_decay_differs_from_zero...")
+    alias N = 4
+    var lr = 0.1
+    var wd = 0.5
+    var p_val = 2.0
+
+    var p0 = full([N], p_val, DType.float64)
+    var g = full([N], 0.5, DType.float64)
+    var m0 = zeros([N], DType.float64)
+    var v0 = full([N], 0.25, DType.float64)  # v_prev = g^2
+
+    # wd = 0 baseline.
+    var p_wd0 = full([N], p_val, DType.float64)
+    var res0 = adopt_step(p_wd0, g, m0, v0, lr, 0.9, 0.9999, 1e-6, 1.0e30, 0.0)
+    var np0 = res0[0]
+
+    # wd = 0.5.
+    var res_wd = adopt_step(p0, g, m0, v0, lr, 0.9, 0.9999, 1e-6, 1.0e30, wd)
+    var np_wd = res_wd[0]
+
+    var expected_gap = lr * wd * p_val  # 0.1 * 0.5 * 2.0 = 0.1
+    for i in range(N):
+        var a = np0.load[DType.float64](i)
+        var b = np_wd.load[DType.float64](i)
+        # Decayed param is strictly smaller for a positive param.
+        if not (b < a):
+            raise Error("weight decay should reduce a positive param")
+        # Gap equals lr * wd * params exactly.
+        if _abs_diff(a - b, expected_gap) > 1e-9:
+            raise Error("weight-decay gap != lr * wd * params")
+    print("  ✓ nonzero weight decay shifts params by lr*wd*params")
+    print("test_weight_decay_differs_from_zero PASSED")
 
 
 def test_parity_with_reference() raises:
@@ -279,6 +338,8 @@ def main() raises:
     test_reject_shape_mismatch()
     test_reject_dtype_mismatch()
     test_reject_second_moment_shape()
+    test_reject_momentum_shape()
+    test_weight_decay_differs_from_zero()
     test_parity_with_reference()
     test_descent_direction()
     test_second_moment_updates_last()

--- a/tests/odyssey/training/optimizers/test_adopt.mojo
+++ b/tests/odyssey/training/optimizers/test_adopt.mojo
@@ -88,26 +88,47 @@ def test_parity_with_reference() raises:
     var v = zeros([N], DType.float64)
 
     var pv = List[Float64]()
-    pv.append(0.1); pv.append(-0.2); pv.append(0.3)
-    pv.append(-0.4); pv.append(0.5); pv.append(-0.6)
+    pv.append(0.1)
+    pv.append(-0.2)
+    pv.append(0.3)
+    pv.append(-0.4)
+    pv.append(0.5)
+    pv.append(-0.6)
     var gv = List[Float64]()
-    gv.append(-0.02); gv.append(0.08); gv.append(0.12)
-    gv.append(-0.18); gv.append(0.22); gv.append(-0.28)
+    gv.append(-0.02)
+    gv.append(0.08)
+    gv.append(0.12)
+    gv.append(-0.18)
+    gv.append(0.22)
+    gv.append(-0.28)
     var vv = List[Float64]()
-    vv.append(0.0025000000000000005); vv.append(0.0225); vv.append(0.0625)
-    vv.append(0.12249999999999998); vv.append(0.2025); vv.append(0.30250000000000005)
+    vv.append(0.0025000000000000005)
+    vv.append(0.0225)
+    vv.append(0.0625)
+    vv.append(0.12249999999999998)
+    vv.append(0.2025)
+    vv.append(0.30250000000000005)
 
     var rp = List[Float64]()
-    rp.append(0.1004); rp.append(-0.20053333333333334); rp.append(0.29952)
-    rp.append(-0.39948571428571433); rp.append(0.49951111111111113)
+    rp.append(0.1004)
+    rp.append(-0.20053333333333334)
+    rp.append(0.29952)
+    rp.append(-0.39948571428571433)
+    rp.append(0.49951111111111113)
     rp.append(-0.5994909090909091)
     var rm = List[Float64]()
-    rm.append(-0.03999999999999999); rm.append(0.05333333333333332)
-    rm.append(0.04799999999999999); rm.append(-0.05142857142857142)
-    rm.append(0.04888888888888888); rm.append(-0.050909090909090904)
+    rm.append(-0.03999999999999999)
+    rm.append(0.05333333333333332)
+    rm.append(0.04799999999999999)
+    rm.append(-0.05142857142857142)
+    rm.append(0.04888888888888888)
+    rm.append(-0.050909090909090904)
     var rv = List[Float64]()
-    rv.append(0.002499790000000001); rv.append(0.02249839); rv.append(0.06249519)
-    rv.append(0.12249098999999998); rv.append(0.20248459000000002)
+    rv.append(0.002499790000000001)
+    rv.append(0.02249839)
+    rv.append(0.06249519)
+    rv.append(0.12249098999999998)
+    rv.append(0.20248459000000002)
     rv.append(0.30247759)
 
     for i in range(N):
@@ -193,7 +214,9 @@ def test_clip_bounds_normalized_gradient() raises:
     var g = full([N], 0.5, DType.float64)
     var m0 = zeros([N], DType.float64)
     var v0 = full([N], 0.25, DType.float64)  # v_prev = g^2
-    var res_un = adopt_step(p_un, g, m0, v0, lr, beta1, 0.9999, 1e-6, 1.0e30, 0.0)
+    var res_un = adopt_step(
+        p_un, g, m0, v0, lr, beta1, 0.9999, 1e-6, 1.0e30, 0.0
+    )
     var m_un = res_un[1]
 
     # Clipped step with clip_value = 0.25 (< 1). normalized ~= +1 -> clipped to 0.25.
@@ -228,15 +251,21 @@ def test_simple_matches_full_defaults() raises:
     var full_res = adopt_step(p, g, m, v, 0.01)
     var simple_res = adopt_step_simple(p, g, m, v, 0.01)
     for i in range(N):
-        if _abs_diff(
-            full_res[0].load[DType.float64](i),
-            simple_res[0].load[DType.float64](i),
-        ) > 1e-12:
+        if (
+            _abs_diff(
+                full_res[0].load[DType.float64](i),
+                simple_res[0].load[DType.float64](i),
+            )
+            > 1e-12
+        ):
             raise Error("adopt_step_simple params differ from adopt_step")
-        if _abs_diff(
-            full_res[2].load[DType.float64](i),
-            simple_res[2].load[DType.float64](i),
-        ) > 1e-12:
+        if (
+            _abs_diff(
+                full_res[2].load[DType.float64](i),
+                simple_res[2].load[DType.float64](i),
+            )
+            > 1e-12
+        ):
             raise Error("adopt_step_simple second moment differs")
     print("  ✓ adopt_step_simple == adopt_step with defaults")
     print("test_simple_matches_full_defaults PASSED")

--- a/tests/odyssey/training/optimizers/test_adopt.mojo
+++ b/tests/odyssey/training/optimizers/test_adopt.mojo
@@ -8,13 +8,14 @@ Tests cover:
 - Descent behavior (a nonzero gradient moves params against the gradient)
 - Clipping (a tight clip_value bounds the normalized-gradient contribution)
 - Second-moment update ordering (v is updated with grad^2 AFTER being used)
+- adopt_step_simple delegates to adopt_step with the default hyperparameters
 """
 from odyssey.tensor.any_tensor import (
     AnyTensor,
     zeros,
     full,
 )
-from odyssey.training.optimizers.adopt import adopt_step
+from odyssey.training.optimizers.adopt import adopt_step, adopt_step_simple
 from std.math import abs as math_abs
 
 
@@ -76,7 +77,8 @@ def test_parity_with_reference() raises:
     Fixed inputs (params entering step 2, grad, m=0, v=grad_prev^2) and the
     reference outputs are transcribed from a one-step run of the public
     pytorch_optimizer.ADOPT (lr=0.01, betas=(0.9,0.9999), eps=1e-6, no clip,
-    no weight decay). See tools/adopt_parity_reference.py in the PR description.
+    no weight decay). See parity_refs/adopt_parity_reference.py alongside this
+    test for the reproducible reference generator.
     """
     print("Running test_parity_with_reference...")
     alias N = 6
@@ -173,6 +175,73 @@ def test_second_moment_updates_last() raises:
     print("test_second_moment_updates_last PASSED")
 
 
+def test_clip_bounds_normalized_gradient() raises:
+    """A tight clip_value must bound the first-moment (and hence the step).
+
+    With m=0 and v_prev=g^2, the un-clipped normalized gradient is
+    grad / max(sqrt(g^2), eps) = sign(grad) ~= +-1. A clip_value below 1 must
+    reduce |m| = (1-beta1)*|clip(normalized)| below (1-beta1)*1, and shrink the
+    param step proportionally versus the un-clipped case.
+    """
+    print("Running test_clip_bounds_normalized_gradient...")
+    alias N = 4
+    var beta1 = 0.9
+    var lr = 0.1
+
+    # Un-clipped reference step (huge clip => no clipping).
+    var p_un = full([N], 0.0, DType.float64)
+    var g = full([N], 0.5, DType.float64)
+    var m0 = zeros([N], DType.float64)
+    var v0 = full([N], 0.25, DType.float64)  # v_prev = g^2
+    var res_un = adopt_step(p_un, g, m0, v0, lr, beta1, 0.9999, 1e-6, 1.0e30, 0.0)
+    var m_un = res_un[1]
+
+    # Clipped step with clip_value = 0.25 (< 1). normalized ~= +1 -> clipped to 0.25.
+    var p_cl = full([N], 0.0, DType.float64)
+    var res_cl = adopt_step(p_cl, g, m0, v0, lr, beta1, 0.9999, 1e-6, 0.25, 0.0)
+    var m_cl = res_cl[1]
+
+    var expected_un = (1.0 - beta1) * 1.0  # normalized ~= +1
+    var expected_cl = (1.0 - beta1) * 0.25  # clipped to 0.25
+    for i in range(N):
+        var mu = m_un.load[DType.float64](i)
+        var mc = m_cl.load[DType.float64](i)
+        if _abs_diff(mu, expected_un) > 1e-6:
+            raise Error("un-clipped momentum should be (1-beta1)*1")
+        if _abs_diff(mc, expected_cl) > 1e-6:
+            raise Error("clipped momentum should be (1-beta1)*clip_value")
+        if not (mc < mu):
+            raise Error("clipping should reduce the momentum magnitude")
+    print("  ✓ clip_value bounds the normalized-gradient contribution")
+    print("test_clip_bounds_normalized_gradient PASSED")
+
+
+def test_simple_matches_full_defaults() raises:
+    """adopt_step_simple must equal adopt_step with default hyperparameters."""
+    print("Running test_simple_matches_full_defaults...")
+    alias N = 5
+    var p = full([N], 0.2, DType.float64)
+    var g = full([N], -0.3, DType.float64)
+    var m = zeros([N], DType.float64)
+    var v = full([N], 0.09, DType.float64)
+
+    var full_res = adopt_step(p, g, m, v, 0.01)
+    var simple_res = adopt_step_simple(p, g, m, v, 0.01)
+    for i in range(N):
+        if _abs_diff(
+            full_res[0].load[DType.float64](i),
+            simple_res[0].load[DType.float64](i),
+        ) > 1e-12:
+            raise Error("adopt_step_simple params differ from adopt_step")
+        if _abs_diff(
+            full_res[2].load[DType.float64](i),
+            simple_res[2].load[DType.float64](i),
+        ) > 1e-12:
+            raise Error("adopt_step_simple second moment differs")
+    print("  ✓ adopt_step_simple == adopt_step with defaults")
+    print("test_simple_matches_full_defaults PASSED")
+
+
 def main() raises:
     """Run all ADOPT tests (local `mojo run`; CI uses `mojo test` discovery)."""
     print("=" * 60)
@@ -184,6 +253,8 @@ def main() raises:
     test_parity_with_reference()
     test_descent_direction()
     test_second_moment_updates_last()
+    test_clip_bounds_normalized_gradient()
+    test_simple_matches_full_defaults()
     print("=" * 60)
     print("All ADOPT tests PASSED")
     print("=" * 60)

--- a/tests/odyssey/training/optimizers/test_adopt.mojo
+++ b/tests/odyssey/training/optimizers/test_adopt.mojo
@@ -1,0 +1,189 @@
+"""Unit tests for the ADOPT optimizer (arXiv:2411.02853).
+
+Tests cover:
+- Shape validation (params/gradients/momentum/second_moment must match)
+- Dtype validation (params/gradients must share a dtype)
+- Numerical parity with the public `pytorch_optimizer.ADOPT` reference on a
+  fixed (params, grad, m, v) vector for one step (tolerance 1e-9)
+- Descent behavior (a nonzero gradient moves params against the gradient)
+- Clipping (a tight clip_value bounds the normalized-gradient contribution)
+- Second-moment update ordering (v is updated with grad^2 AFTER being used)
+"""
+from odyssey.tensor.any_tensor import (
+    AnyTensor,
+    zeros,
+    full,
+)
+from odyssey.training.optimizers.adopt import adopt_step
+from std.math import abs as math_abs
+
+
+def _abs_diff(a: Float64, b: Float64) -> Float64:
+    var d = a - b
+    if d < 0:
+        d = -d
+    return d
+
+
+def test_reject_shape_mismatch() raises:
+    """ADOPT must reject params/gradients shape mismatches."""
+    print("Running test_reject_shape_mismatch...")
+    var params = zeros([4], DType.float32)
+    var grad = zeros([5], DType.float32)
+    var m = zeros([4], DType.float32)
+    var v = zeros([4], DType.float32)
+    try:
+        var _ = adopt_step(params, grad, m, v, 0.01)
+        raise Error("Should have rejected shape mismatch")
+    except e:
+        print("  ✓ Correctly rejected shape mismatch: " + String(e))
+    print("test_reject_shape_mismatch PASSED")
+
+
+def test_reject_dtype_mismatch() raises:
+    """ADOPT must reject params/gradients dtype mismatches."""
+    print("Running test_reject_dtype_mismatch...")
+    var params = zeros([4], DType.float32)
+    var grad = zeros([4], DType.float16)
+    var m = zeros([4], DType.float32)
+    var v = zeros([4], DType.float32)
+    try:
+        var _ = adopt_step(params, grad, m, v, 0.01)
+        raise Error("Should have rejected dtype mismatch")
+    except e:
+        print("  ✓ Correctly rejected dtype mismatch: " + String(e))
+    print("test_reject_dtype_mismatch PASSED")
+
+
+def test_reject_second_moment_shape() raises:
+    """ADOPT must reject a second_moment whose shape differs from params."""
+    print("Running test_reject_second_moment_shape...")
+    var params = zeros([4], DType.float32)
+    var grad = zeros([4], DType.float32)
+    var m = zeros([4], DType.float32)
+    var v = zeros([3], DType.float32)
+    try:
+        var _ = adopt_step(params, grad, m, v, 0.01)
+        raise Error("Should have rejected second_moment shape mismatch")
+    except e:
+        print("  ✓ Correctly rejected second_moment shape mismatch")
+    print("test_reject_second_moment_shape PASSED")
+
+
+def test_parity_with_reference() raises:
+    """One ADOPT step must match `pytorch_optimizer.ADOPT` to 1e-9.
+
+    Fixed inputs (params entering step 2, grad, m=0, v=grad_prev^2) and the
+    reference outputs are transcribed from a one-step run of the public
+    pytorch_optimizer.ADOPT (lr=0.01, betas=(0.9,0.9999), eps=1e-6, no clip,
+    no weight decay). See tools/adopt_parity_reference.py in the PR description.
+    """
+    print("Running test_parity_with_reference...")
+    alias N = 6
+    var p = zeros([N], DType.float64)
+    var g = zeros([N], DType.float64)
+    var m = zeros([N], DType.float64)
+    var v = zeros([N], DType.float64)
+
+    var pv = List[Float64]()
+    pv.append(0.1); pv.append(-0.2); pv.append(0.3)
+    pv.append(-0.4); pv.append(0.5); pv.append(-0.6)
+    var gv = List[Float64]()
+    gv.append(-0.02); gv.append(0.08); gv.append(0.12)
+    gv.append(-0.18); gv.append(0.22); gv.append(-0.28)
+    var vv = List[Float64]()
+    vv.append(0.0025000000000000005); vv.append(0.0225); vv.append(0.0625)
+    vv.append(0.12249999999999998); vv.append(0.2025); vv.append(0.30250000000000005)
+
+    var rp = List[Float64]()
+    rp.append(0.1004); rp.append(-0.20053333333333334); rp.append(0.29952)
+    rp.append(-0.39948571428571433); rp.append(0.49951111111111113)
+    rp.append(-0.5994909090909091)
+    var rm = List[Float64]()
+    rm.append(-0.03999999999999999); rm.append(0.05333333333333332)
+    rm.append(0.04799999999999999); rm.append(-0.05142857142857142)
+    rm.append(0.04888888888888888); rm.append(-0.050909090909090904)
+    var rv = List[Float64]()
+    rv.append(0.002499790000000001); rv.append(0.02249839); rv.append(0.06249519)
+    rv.append(0.12249098999999998); rv.append(0.20248459000000002)
+    rv.append(0.30247759)
+
+    for i in range(N):
+        p.store[DType.float64](i, pv[i])
+        g.store[DType.float64](i, gv[i])
+        v.store[DType.float64](i, vv[i])
+
+    var res = adopt_step(p, g, m, v, 0.01, 0.9, 0.9999, 1e-6, 1.0e30, 0.0)
+    var np = res[0]
+    var nm = res[1]
+    var nv = res[2]
+
+    var tol = 1e-9
+    for i in range(N):
+        if _abs_diff(np.load[DType.float64](i), rp[i]) > tol:
+            raise Error("param parity mismatch at " + String(i))
+        if _abs_diff(nm.load[DType.float64](i), rm[i]) > tol:
+            raise Error("momentum parity mismatch at " + String(i))
+        if _abs_diff(nv.load[DType.float64](i), rv[i]) > tol:
+            raise Error("second-moment parity mismatch at " + String(i))
+    print("  ✓ Matches pytorch_optimizer.ADOPT to 1e-9")
+    print("test_parity_with_reference PASSED")
+
+
+def test_descent_direction() raises:
+    """A positive gradient must decrease the parameter (and vice versa)."""
+    print("Running test_descent_direction...")
+    alias N = 3
+    var p = full([N], 1.0, DType.float32)
+    var g = full([N], 0.5, DType.float32)  # positive grad
+    var m = zeros([N], DType.float32)
+    var v = full([N], 0.25, DType.float32)  # v_prev = g^2
+
+    var res = adopt_step(p, g, m, v, 0.1)
+    var np = res[0]
+    for i in range(N):
+        if not (np.load[DType.float32](i) < 1.0):
+            raise Error("positive gradient should decrease param")
+    print("  ✓ Positive gradient decreased params")
+    print("test_descent_direction PASSED")
+
+
+def test_second_moment_updates_last() raises:
+    """Second moment must be updated with grad^2 using the (1-beta2) weight after use.
+
+    With v_prev = 0 (all zeros), one step should leave
+    new_v = (1 - beta2) * grad^2 (the beta2 * 0 term vanishes).
+    """
+    print("Running test_second_moment_updates_last...")
+    alias N = 2
+    var p = zeros([N], DType.float32)
+    var g = full([N], 2.0, DType.float32)  # grad^2 = 4
+    var m = zeros([N], DType.float32)
+    var v = zeros([N], DType.float32)  # v_prev = 0
+
+    var beta2 = 0.9999
+    var res = adopt_step(p, g, m, v, 0.01, 0.9, beta2)
+    var nv = res[2]
+    var expected = (1.0 - beta2) * 4.0
+    for i in range(N):
+        var got = Float64(nv.load[DType.float32](i))
+        if _abs_diff(got, expected) > 1e-6:
+            raise Error("second moment not updated as (1-beta2)*grad^2")
+    print("  ✓ v updated as (1-beta2)*grad^2 from zero state")
+    print("test_second_moment_updates_last PASSED")
+
+
+def main() raises:
+    """Run all ADOPT tests (local `mojo run`; CI uses `mojo test` discovery)."""
+    print("=" * 60)
+    print("ADOPT Optimizer Test Suite")
+    print("=" * 60)
+    test_reject_shape_mismatch()
+    test_reject_dtype_mismatch()
+    test_reject_second_moment_shape()
+    test_parity_with_reference()
+    test_descent_direction()
+    test_second_moment_updates_last()
+    print("=" * 60)
+    print("All ADOPT tests PASSED")
+    print("=" * 60)


### PR DESCRIPTION
## Summary

Adds the **ADOPT** optimizer (Taniguchi et al., *ADOPT: Modified Adam Can Converge with Any β₂ with the Optimal Rate*, NeurIPS 2024, [arXiv:2411.02853](https://arxiv.org/abs/2411.02853)).

ADOPT is a modified Adam that achieves the optimal `O(1/√T)` convergence rate for smooth non-convex objectives with **any** `β₂ ∈ [0, 1)`, removing Adam's dependence on a problem-specific `β₂` bound.

## What it does

Two changes vs Adam:
1. **Decorrelated normalization** — the gradient is normalized by the **previous** second moment; `v` is updated with `grad²` only *after* being used.
2. **Clipping** — element-wise clip of the normalized gradient (caller passes a possibly step-dependent `clip_value` to reproduce the paper's growing schedule).

Update rule:
```
normalized = clip(grad / max(sqrt(v), eps), -clip_value, +clip_value)
m          = beta1 * m + (1 - beta1) * normalized
params     = params - lr * m
v          = beta2 * v + (1 - beta2) * grad^2      # updated LAST
```

Follows the existing pure-functional optimizer convention (caller manages state), matching `lion_step` / `muon_step`. Ships `adopt_step` + `adopt_step_simple`; registered in `optimizers/__init__.mojo`; CHANGELOG updated.

## Correctness — verified against a public PyTorch implementation

One `adopt_step` **matches `pytorch_optimizer.ADOPT` to 1e-9** on a fixed input vector. The reproducible reference harness is included at `tests/odyssey/training/optimizers/parity_refs/adopt_parity_reference.py`.

> During development the parity check caught a real bug: the denominator must be `max(sqrt(v), eps)` (clamp-min), **not** the Adam-style `sqrt(v) + eps`. Fixed and re-verified.

## Tests

`tests/odyssey/training/optimizers/test_adopt.mojo`:
- params/gradients/momentum/second_moment shape guards
- params/gradients dtype guard
- **reference-parity vector** (1e-9)
- descent direction
- second-moment update ordering (`v ← (1-β₂)·grad²` from a zero state)
- **clip bound** on the normalized gradient
- `adopt_step_simple` == `adopt_step` with defaults

## Relationship to tracking issue

**Refs** mvillmow/Random#65 (OPT-01). This PR is the **upstream Odyssey optimizer** that the predictive-coding OPT-01 ablation integration will consume — it is a *prerequisite* for OPT-01, **not** its completion. OPT-01's own acceptance criteria (flag-gated PC + BP integration in `predictive-coding-mojo/src`, mutual-exclusion guard, `tests/pc/` coverage, ablation-matrix results) remain open and will land as a separate consumer PR. Deliberately does **not** `Closes` #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)