### PR TITLE
feat(layers): add Transformer FeedForward (FFN) block (arXiv:1706.03762)

### DIFF
--- a/src/odyssey/core/layers/__init__.mojo
+++ b/src/odyssey/core/layers/__init__.mojo
@@ -9,6 +9,7 @@ Components:
     - Conv2D: 2D convolutional layers
     - ReLU: Rectified Linear Unit activation
     - RNNCell: Vanilla (Elman) recurrent cell (tanh)
+    - FeedForward: Transformer position-wise feed-forward (Linear->act->Linear)
     - Sigmoid: Sigmoid activation function
     - Tanh: Hyperbolic tangent activation
     - BatchNorm: Batch normalization
@@ -42,6 +43,7 @@ from odyssey.core.layers.rnn import RNNCell
 from odyssey.core.layers.lstm import LSTMCell
 from odyssey.core.layers.layernorm import LayerNorm
 from odyssey.core.layers.gru import GRUCell
+from odyssey.core.layers.feedforward import FeedForward
 
 # from .activation import ReLU, Sigmoid, Tanh
 # from .pooling import MaxPool2D, AvgPool2D

--- a/src/odyssey/core/layers/feedforward.mojo
+++ b/src/odyssey/core/layers/feedforward.mojo
@@ -8,8 +8,10 @@ non-linearity in between, applied identically to every position.
 
 with an inner (hidden) dimension `d_ff` that is conventionally larger than the
 model dimension `d_model` (the paper uses d_ff = 4 * d_model). The default
-activation is GELU (as used by BERT/GPT); ReLU (the original Transformer choice)
-is available via `use_gelu=False`.
+activation is exact (erf-based) GELU; ReLU (the original Transformer choice) is
+available via `use_gelu=False`. Note BERT/GPT-2 use the *approximate* (tanh) GELU
+form — that variant is not exposed here yet (would be an additive
+`gelu_approximate` flag forwarding to `gelu(..., approximate=True)`).
 
 This is a thin composition of two `Linear` layers and an activation, so it
 inherits their initialization and matmul/bias-broadcast behavior; it exists as a
@@ -60,7 +62,7 @@ struct FeedForward[dtype: DType = DType.float32](Copyable, Module, Movable):
             d_model: Model (input and output) dimension.
             d_ff: Inner hidden dimension. If <= 0, defaults to 4 * d_model
                 (the ratio used in the original Transformer).
-            use_gelu: Use GELU (default, BERT/GPT style) when True; ReLU (the
+            use_gelu: Use exact (erf) GELU (default) when True; ReLU (the
                 original Transformer activation) when False.
 
         Raises:

--- a/src/odyssey/core/layers/feedforward.mojo
+++ b/src/odyssey/core/layers/feedforward.mojo
@@ -1,0 +1,125 @@
+"""Transformer feed-forward network (FFN / MLP) block.
+
+The position-wise feed-forward sub-layer of a Transformer block (Vaswani et al.,
+"Attention Is All You Need", 2017, §3.3): two linear projections with a
+non-linearity in between, applied identically to every position.
+
+    FFN(x) = activation(x W1 + b1) W2 + b2
+
+with an inner (hidden) dimension `d_ff` that is conventionally larger than the
+model dimension `d_model` (the paper uses d_ff = 4 * d_model). The default
+activation is GELU (as used by BERT/GPT); ReLU (the original Transformer choice)
+is available via `use_gelu=False`.
+
+This is a thin composition of two `Linear` layers and an activation, so it
+inherits their initialization and matmul/bias-broadcast behavior; it exists as a
+first-class `Module` so a Transformer block can hold it directly and so its
+parameters are collected uniformly by optimizers.
+
+Reference:
+    Vaswani, A., Shazeer, N., Parmar, N., Uszkoreit, J., Jones, L., Gomez, A. N.,
+    Kaiser, L., & Polosukhin, I. (2017). Attention Is All You Need. NeurIPS 2017.
+    arXiv:1706.03762, §3.3 "Position-wise Feed-Forward Networks".
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.core.module import Module
+from odyssey.core.layers.linear import Linear
+from odyssey.core.activation import gelu, relu
+
+
+struct FeedForward[dtype: DType = DType.float32](Copyable, Module, Movable):
+    """Transformer position-wise feed-forward block: Linear -> act -> Linear.
+
+    Parameters:
+        dtype: Data type for weights and biases (default: float32).
+
+    Attributes:
+        fc1: First linear projection (d_model -> d_ff).
+        fc2: Second linear projection (d_ff -> d_model).
+        d_model: Input/output feature dimension.
+        d_ff: Inner (hidden) feature dimension.
+        use_gelu: If True use GELU activation, else ReLU.
+    """
+
+    var fc1: Linear[Self.dtype]
+    var fc2: Linear[Self.dtype]
+    var d_model: Int
+    var d_ff: Int
+    var use_gelu: Bool
+
+    def __init__(
+        out self,
+        d_model: Int,
+        d_ff: Int = -1,
+        use_gelu: Bool = True,
+    ) raises:
+        """Initialize the feed-forward block.
+
+        Args:
+            d_model: Model (input and output) dimension.
+            d_ff: Inner hidden dimension. If <= 0, defaults to 4 * d_model
+                (the ratio used in the original Transformer).
+            use_gelu: Use GELU (default, BERT/GPT style) when True; ReLU (the
+                original Transformer activation) when False.
+
+        Raises:
+            Error: If d_model <= 0, or if layer construction fails.
+
+        Example:
+            ```mojo
+            var ffn = FeedForward(512)          # d_ff defaults to 2048
+            var out = ffn.forward(x)            # x: [batch, 512] -> [batch, 512]
+            ```
+        """
+        if d_model <= 0:
+            raise Error("FeedForward: d_model must be positive")
+        var inner = d_ff if d_ff > 0 else 4 * d_model
+        self.d_model = d_model
+        self.d_ff = inner
+        self.use_gelu = use_gelu
+        self.fc1 = Linear[Self.dtype](d_model, inner)
+        self.fc2 = Linear[Self.dtype](inner, d_model)
+
+    def forward(mut self, input: AnyTensor) raises -> AnyTensor:
+        """Forward pass: FFN(x) = activation(x W1 + b1) W2 + b2.
+
+        Args:
+            input: Input tensor of shape (..., d_model).
+
+        Returns:
+            Output tensor of shape (..., d_model) (same shape as input).
+
+        Raises:
+            Error: If tensor operations fail or the last dim != d_model.
+        """
+        var hidden = self.fc1.forward(input)
+        var activated = gelu(hidden) if self.use_gelu else relu(hidden)
+        return self.fc2.forward(activated)
+
+    def parameters(self) raises -> List[AnyTensor]:
+        """Collect trainable parameters from both linear sub-layers.
+
+        Returns:
+            List of [fc1.weight, fc1.bias, fc2.weight, fc2.bias].
+
+        Raises:
+            Error if tensor copying fails.
+        """
+        var params = List[AnyTensor]()
+        for p in self.fc1.parameters():
+            params.append(p)
+        for p in self.fc2.parameters():
+            params.append(p)
+        return params^
+
+    def train(mut self):
+        """Switch to training mode (no-op; sub-layers are stateless in mode)."""
+        self.fc1.train()
+        self.fc2.train()
+
+    def eval(mut self):
+        """Switch to inference mode (no-op; sub-layers are stateless in mode).
+        """
+        self.fc1.eval()
+        self.fc2.eval()

--- a/tests/odyssey/core/layers/parity_refs/feedforward_parity_reference.py
+++ b/tests/odyssey/core/layers/parity_refs/feedforward_parity_reference.py
@@ -1,0 +1,57 @@
+"""FeedForward (Transformer FFN) parity reference.
+
+Computes the forward pass of a Transformer position-wise FFN
+(Linear -> GELU(exact) -> Linear) in PyTorch with FIXED weights and a FIXED
+input, and prints the flattened output so the Mojo FeedForward test can set the
+same weights and assert equality.
+
+Odyssey `Linear` uses y = x @ W + b with W of shape (in, out).
+torch.nn.Linear uses y = x @ W_t^T + b with W_t of shape (out, in), so we set
+torch's weight to the TRANSPOSE of the Odyssey weight to make the two identical.
+
+Config: d_model=4, d_ff=8, batch=2, exact GELU (matches torch.nn.GELU()).
+Weights are simple deterministic ramps so they transcribe cleanly into Mojo.
+"""
+
+import json
+
+import torch
+import torch.nn as nn
+
+torch.manual_seed(0)
+D_MODEL, D_FF, B = 4, 8, 2
+
+# Deterministic ramp weights/inputs (Odyssey layout: W1 (d_model,d_ff), W2 (d_ff,d_model))
+W1 = torch.arange(D_MODEL * D_FF, dtype=torch.float64).reshape(D_MODEL, D_FF) * 0.01 - 0.15
+b1 = torch.arange(D_FF, dtype=torch.float64) * 0.02 - 0.08
+W2 = torch.arange(D_FF * D_MODEL, dtype=torch.float64).reshape(D_FF, D_MODEL) * 0.005 - 0.08
+b2 = torch.arange(D_MODEL, dtype=torch.float64) * 0.03 - 0.05
+X = torch.arange(B * D_MODEL, dtype=torch.float64).reshape(B, D_MODEL) * 0.1 - 0.3
+
+fc1 = nn.Linear(D_MODEL, D_FF).double()
+fc2 = nn.Linear(D_FF, D_MODEL).double()
+with torch.no_grad():
+    fc1.weight.copy_(W1.T)  # torch stores (out, in) => transpose of Odyssey (in, out)
+    fc1.bias.copy_(b1)
+    fc2.weight.copy_(W2.T)
+    fc2.bias.copy_(b2)
+
+with torch.no_grad():
+    hidden = fc1(X)
+    activated = torch.nn.functional.gelu(hidden, approximate="none")  # exact GELU
+    out = fc2(activated)
+
+print(
+    json.dumps(
+        {
+            "config": {"d_model": D_MODEL, "d_ff": D_FF, "batch": B},
+            "W1": W1.flatten().tolist(),
+            "b1": b1.tolist(),
+            "W2": W2.flatten().tolist(),
+            "b2": b2.tolist(),
+            "X": X.flatten().tolist(),
+            "out": out.flatten().tolist(),
+        },
+        indent=2,
+    )
+)

--- a/tests/odyssey/core/layers/test_feedforward.mojo
+++ b/tests/odyssey/core/layers/test_feedforward.mojo
@@ -1,0 +1,133 @@
+"""Unit tests for the Transformer FeedForward (FFN) block.
+
+Tests cover:
+- Construction + shape preservation (input (..., d_model) -> (..., d_model))
+- Default inner dimension (d_ff defaults to 4 * d_model)
+- Parameter collection (4 tensors: fc1.weight/bias, fc2.weight/bias)
+- d_model validation (rejects non-positive d_model)
+- Numerical parity with a PyTorch reference (Linear -> exact GELU -> Linear)
+  on fixed ramp weights + input (tolerance 1e-5)
+- ReLU variant (use_gelu=False) runs
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros
+from odyssey.core.layers.feedforward import FeedForward
+
+
+def test_shape_preserved() raises:
+    """FFN maps (batch, d_model) -> (batch, d_model)."""
+    print("Running test_shape_preserved...")
+    var ffn = FeedForward[DType.float32](8, 32)
+    var x = zeros([2, 8], DType.float32)
+    var y = ffn.forward(x)
+    if y.shape()[0] != 2 or y.shape()[1] != 8:
+        raise Error("FFN must preserve (batch, d_model) shape")
+    print("  ok shape preserved (2, 8)")
+    print("test_shape_preserved PASSED")
+
+
+def test_default_inner_dim() raises:
+    """d_ff defaults to 4 * d_model when not given."""
+    print("Running test_default_inner_dim...")
+    var ffn = FeedForward[DType.float32](16)
+    if ffn.d_ff != 64:
+        raise Error("default d_ff should be 4 * d_model")
+    print("  ok default d_ff = 4 * d_model = 64")
+    print("test_default_inner_dim PASSED")
+
+
+def test_parameter_count() raises:
+    """parameters() returns 4 tensors (two Linear layers)."""
+    print("Running test_parameter_count...")
+    var ffn = FeedForward[DType.float32](8, 16)
+    var params = ffn.parameters()
+    if len(params) != 4:
+        raise Error("FFN should expose 4 parameter tensors")
+    print("  ok 4 parameter tensors")
+    print("test_parameter_count PASSED")
+
+
+def test_reject_bad_d_model() raises:
+    """Non-positive d_model must raise."""
+    print("Running test_reject_bad_d_model...")
+    try:
+        var _ = FeedForward[DType.float32](0)
+        raise Error("Should have rejected d_model = 0")
+    except e:
+        print("  ok rejected d_model = 0")
+    print("test_reject_bad_d_model PASSED")
+
+
+def test_parity_with_pytorch() raises:
+    """Forward must match a PyTorch Linear->GELU(exact)->Linear reference.
+
+    Fixed ramp weights/input and the reference output are transcribed from
+    parity_refs/feedforward_parity_reference.py (torch, float64, d_model=4,
+    d_ff=8, batch=2, exact GELU). Odyssey Linear uses W of shape (in, out); the
+    reference sets torch's (out, in) weight to the transpose so the two match.
+    """
+    print("Running test_parity_with_pytorch...")
+
+    # Build the reference output list first, before any tensor stores.
+    var ref = List[Float64]()
+    ref.append(-0.045003)
+    ref.append(-0.014435)
+    ref.append(0.016133)
+    ref.append(0.046701)
+    ref.append(-0.038288)
+    ref.append(-0.007493)
+    ref.append(0.023302)
+    ref.append(0.054096)
+
+    var ffn = FeedForward[DType.float64](4, 8)
+    for i in range(32):
+        ffn.fc1.weight.store[DType.float64](i, Float64(i) * 0.01 - 0.15)
+    for i in range(8):
+        ffn.fc1.bias.store[DType.float64](i, Float64(i) * 0.02 - 0.08)
+    for i in range(32):
+        ffn.fc2.weight.store[DType.float64](i, Float64(i) * 0.005 - 0.08)
+    for i in range(4):
+        ffn.fc2.bias.store[DType.float64](i, Float64(i) * 0.03 - 0.05)
+
+    var x = zeros([2, 4], DType.float64)
+    for i in range(8):
+        x.store[DType.float64](i, Float64(i) * 0.1 - 0.3)
+
+    var y = ffn.forward(x)
+    for i in range(8):
+        var d = y.load[DType.float64](i) - ref[i]
+        if d < 0:
+            d = -d
+        if d > 1e-5:
+            raise Error("FFN parity mismatch at index " + String(i))
+    print("  ok matches PyTorch Linear->GELU->Linear to 1e-5")
+    print("test_parity_with_pytorch PASSED")
+
+
+def test_relu_variant_runs() raises:
+    """use_gelu=False (ReLU activation) runs and preserves shape."""
+    print("Running test_relu_variant_runs...")
+    var ffn = FeedForward[DType.float32](8, 16, use_gelu=False)
+    var x = zeros([2, 8], DType.float32)
+    var y = ffn.forward(x)
+    if y.shape()[0] != 2 or y.shape()[1] != 8:
+        raise Error("ReLU-variant FFN must preserve shape")
+    print("  ok ReLU variant runs")
+    print("test_relu_variant_runs PASSED")
+
+
+def main() raises:
+    """Run all FeedForward tests."""
+    print("=" * 60)
+    print("FeedForward (Transformer FFN) Test Suite")
+    print("=" * 60)
+    test_shape_preserved()
+    test_default_inner_dim()
+    test_parameter_count()
+    test_reject_bad_d_model()
+    test_parity_with_pytorch()
+    test_relu_variant_runs()
+    print("=" * 60)
+    print("All FeedForward tests PASSED")
+    print("=" * 60)


### PR DESCRIPTION
## Summary

Adds the **Transformer position-wise FeedForward (FFN)** block — the feed-forward sub-layer from Vaswani et al., *Attention Is All You Need* (2017), [arXiv:1706.03762 §3.3](https://arxiv.org/abs/1706.03762):

```
FFN(x) = activation(x W1 + b1) W2 + b2
```

A first-class `Module` (`core/layers/feedforward.mojo`) composing two `Linear` layers with an activation in between. Inner dimension `d_ff` defaults to `4 * d_model` (the paper's ratio). Activation is **GELU** by default (BERT/GPT style, exact erf form) or **ReLU** via `use_gelu=False` (the original Transformer choice).

## Correctness — verified against PyTorch

The forward pass **matches a PyTorch `Linear -> GELU(exact) -> Linear` reference to 1e-5** on fixed ramp weights. Reproducible generator at `tests/odyssey/core/layers/parity_refs/feedforward_parity_reference.py`.

> Note: Odyssey `Linear` uses `y = x @ W + b` with `W` of shape `(in, out)`; the reference sets torch's `(out, in)` weight to the **transpose** so the two are identical.

## Tests

`tests/odyssey/core/layers/test_feedforward.mojo`:
- shape preservation (`(batch, d_model) -> (batch, d_model)`)
- default `d_ff = 4 * d_model`
- parameter count (4 tensors: two Linear layers)
- `d_model` validation (rejects non-positive)
- **PyTorch parity vector** (1e-5)
- ReLU variant runs

Registered in `core/layers/__init__.mojo`; CHANGELOG updated.

## Relationship to tracking issue

**Refs** mvillmow/Random#53 (ARCH-03). This is the **upstream Odyssey layer** that the predictive-coding ARCH-03 ablation integration will consume — a *prerequisite*, not the completion of ARCH-03. Does not `Closes` it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)