### PR TITLE
feat(optimizers): add Sophia clipped-preconditioned update step (arXiv:2305.14342; caller-supplied hessian estimates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ bash scripts/run_primitive_test.sh --list     # list known primitives + paths
 | LayerNorm | layer | `bash scripts/run_primitive_test.sh layernorm` |
 | Transformer FeedForward (FFN) | layer | `bash scripts/run_primitive_test.sh ffn` |
 | ADOPT | optimizer | `bash scripts/run_primitive_test.sh adopt` |
-| Sophia | optimizer | `bash scripts/run_primitive_test.sh sophia` |
+| Sophia (clipped update step; caller-supplied Hessian estimates) | optimizer | `bash scripts/run_primitive_test.sh sophia` |
 | Adan | optimizer | `bash scripts/run_primitive_test.sh adan` |
 | Muon-Hyperball | optimizer | `bash scripts/run_primitive_test.sh muon_hyperball` |
 | LionMuon | optimizer | `bash scripts/run_primitive_test.sh lionmuon` |

--- a/src/odyssey/training/optimizers/README.md
+++ b/src/odyssey/training/optimizers/README.md
@@ -17,6 +17,7 @@ This directory contains optimizer implementations for training neural networks i
 | **Lion** | ~1x params (1 buffer) | O(n) | Memory-constrained, transfer learning | Signed momentum; **LR 3-10x SMALLER than AdamW** |
 | **Adan** | ~4x params (exp_avg + exp_avg_diff + exp_avg_sq + prev_grad) | O(n) | General-purpose, fast convergence | Nesterov-style look-ahead + gradient-difference momentum; arXiv:2208.06677 |
 | **Shampoo** | ~3x params (L [m×m] + R [n×n] + momentum [m×n]) | O(n³) + Newton-Schulz | Second-order baseline, matrix weights | Two-sided matrix preconditioner; Newton-Schulz inverse fourth root; **rank-2 params only** |
+| **Sophia** | ~2x params (momentum + hessian_moment) | O(n) + periodic Hessian | LLM pretraining / second-order-lite | Clipped Hessian-preconditioned momentum; arXiv:2305.14342 |
 
 ## Quick Selection Guide
 

--- a/src/odyssey/training/optimizers/README.md
+++ b/src/odyssey/training/optimizers/README.md
@@ -17,7 +17,7 @@ This directory contains optimizer implementations for training neural networks i
 | **Lion** | ~1x params (1 buffer) | O(n) | Memory-constrained, transfer learning | Signed momentum; **LR 3-10x SMALLER than AdamW** |
 | **Adan** | ~4x params (exp_avg + exp_avg_diff + exp_avg_sq + prev_grad) | O(n) | General-purpose, fast convergence | Nesterov-style look-ahead + gradient-difference momentum; arXiv:2208.06677 |
 | **Shampoo** | ~3x params (L [m×m] + R [n×n] + momentum [m×n]) | O(n³) + Newton-Schulz | Second-order baseline, matrix weights | Two-sided matrix preconditioner; Newton-Schulz inverse fourth root; **rank-2 params only** |
-| **Sophia** | ~2x params (momentum + hessian_moment) | O(n) + periodic Hessian | LLM pretraining / second-order-lite | Clipped Hessian-preconditioned momentum; arXiv:2305.14342 |
+| **Sophia** (update step only) | ~2x params (momentum + hessian_moment) | O(n) | LLM pretraining / second-order-lite | Sophia-style clipped preconditioned update step, `clip(m / max(γ·h, ε), ±ρ)`; Hessian-diagonal estimates are CALLER-SUPPLIED (Sophia-H/G estimators need HVPs — not yet in Odyssey autograd, see `src/odyssey/autograd/TODO.md`); arXiv:2305.14342 |
 
 ## Quick Selection Guide
 

--- a/src/odyssey/training/optimizers/__init__.mojo
+++ b/src/odyssey/training/optimizers/__init__.mojo
@@ -14,6 +14,7 @@ Includes:
 - Lion (EvoLved Sign Momentum — Chen et al. 2023)
 - ADOPT (Modified Adam, optimal convergence for any beta2 — Taniguchi et al. 2024)
 - Adan (Adaptive Nesterov Momentum — Xie et al. 2022)
+- Sophia (Second-order Clipped Stochastic Optimization — Liu et al. 2023)
 - Shampoo (two-sided matrix preconditioner via Newton-Schulz inverse fourth root — Anil et al. 2020)
 
 All optimizers follow pure functional design - caller manages state
@@ -84,6 +85,12 @@ from odyssey.training.optimizers.lion import lion_step, lion_step_simple
 
 # ADOPT optimizer (modified Adam with the optimal convergence rate for any beta2)
 from odyssey.training.optimizers.adopt import adopt_step, adopt_step_simple
+# Sophia optimizer (second-order clipped stochastic optimization — Liu et al. 2023)
+from odyssey.training.optimizers.sophia import (
+    sophia_step,
+    sophia_step_simple,
+    sophia_update_hessian_moment,
+)
 
 # Adan optimizer (adaptive Nesterov momentum — Xie et al. 2022)
 from odyssey.training.optimizers.adan import adan_step, adan_step_simple

--- a/src/odyssey/training/optimizers/__init__.mojo
+++ b/src/odyssey/training/optimizers/__init__.mojo
@@ -85,6 +85,7 @@ from odyssey.training.optimizers.lion import lion_step, lion_step_simple
 
 # ADOPT optimizer (modified Adam with the optimal convergence rate for any beta2)
 from odyssey.training.optimizers.adopt import adopt_step, adopt_step_simple
+
 # Sophia optimizer (second-order clipped stochastic optimization — Liu et al. 2023)
 from odyssey.training.optimizers.sophia import (
     sophia_step,

--- a/src/odyssey/training/optimizers/__init__.mojo
+++ b/src/odyssey/training/optimizers/__init__.mojo
@@ -14,7 +14,8 @@ Includes:
 - Lion (EvoLved Sign Momentum — Chen et al. 2023)
 - ADOPT (Modified Adam, optimal convergence for any beta2 — Taniguchi et al. 2024)
 - Adan (Adaptive Nesterov Momentum — Xie et al. 2022)
-- Sophia (Second-order Clipped Stochastic Optimization — Liu et al. 2023)
+- Sophia update step (clipped preconditioned step only, caller-supplied
+  Hessian-diagonal estimates; Sophia-H/G estimators not included — Liu et al. 2023)
 - Shampoo (two-sided matrix preconditioner via Newton-Schulz inverse fourth root — Anil et al. 2020)
 
 All optimizers follow pure functional design - caller manages state
@@ -86,7 +87,8 @@ from odyssey.training.optimizers.lion import lion_step, lion_step_simple
 # ADOPT optimizer (modified Adam with the optimal convergence rate for any beta2)
 from odyssey.training.optimizers.adopt import adopt_step, adopt_step_simple
 
-# Sophia optimizer (second-order clipped stochastic optimization — Liu et al. 2023)
+# Sophia clipped-preconditioned update step (caller-supplied Hessian estimates
+# — Liu et al. 2023)
 from odyssey.training.optimizers.sophia import (
     sophia_step,
     sophia_step_simple,

--- a/src/odyssey/training/optimizers/sophia.mojo
+++ b/src/odyssey/training/optimizers/sophia.mojo
@@ -53,6 +53,10 @@ def sophia_step(
     gradients: AnyTensor,
     momentum: AnyTensor,
     hessian_moment: AnyTensor,
+    # `hessian` and `beta2` are consumed by the companion
+    # `sophia_update_hessian_moment` (which owns the Hessian-EMA refresh), not by
+    # the step body itself; they are accepted here for signature symmetry so the
+    # two functions share one call shape.
     hessian: AnyTensor,
     learning_rate: Float64,
     beta1: Float64 = 0.96,

--- a/src/odyssey/training/optimizers/sophia.mojo
+++ b/src/odyssey/training/optimizers/sophia.mojo
@@ -1,0 +1,202 @@
+"""Sophia optimizer (Second-order Clipped Stochastic Optimization).
+
+Sophia is a light-weight second-order optimizer that uses a cheap, infrequent
+diagonal Hessian estimate to precondition an EMA of gradients, then CLIPS the
+per-coordinate update. The clipping bounds the influence of coordinates with a
+small or mis-estimated Hessian, giving second-order-like convergence at close to
+first-order cost.
+
+This module implements the per-step update as a pure function; the caller
+supplies the diagonal Hessian estimate `hessian` (from either the Hutchinson
+estimator, Sophia-H, or the Gauss-Newton-Bartlett estimator, Sophia-G). The
+Hessian is expensive to compute, so in practice it is refreshed only every
+`update_period` steps; between refreshes the caller passes the same stale
+Hessian (its EMA `hessian_moment` simply re-averages the same value), which is
+exactly what the reference implementations do.
+
+Sophia update rule (per step):
+    momentum       = beta1 * momentum + (1 - beta1) * gradients
+    hessian_moment = beta2 * hessian_moment + (1 - beta2) * hessian
+    update         = clip(momentum / max(hessian_moment, eps), -rho, +rho)
+    params         = params - learning_rate * update
+
+with optional decoupled (AdamW-style) weight decay applied after the step.
+
+Key characteristics:
+    - Memory: first-moment `momentum` + diagonal-Hessian EMA `hessian_moment`
+      (same footprint as Adam's two buffers).
+    - The clip threshold `rho` (paper default 0.01-0.05) is the fraction of
+      coordinates left un-clipped; it is the single most important hyperparameter.
+    - The denominator is clamped below by `eps` (not `+ eps`), so a zero/negative
+      Hessian estimate degrades gracefully to a large-but-clipped update.
+
+Reference:
+    Liu, H., Li, Z., Hall, D., Liang, P., & Ma, T. (2023).
+    Sophia: A Scalable Stochastic Second-order Optimizer for Language Model
+    Pre-training. arXiv preprint arXiv:2305.14342.
+    https://github.com/Liuhong99/Sophia
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import full_like
+from odyssey.core.arithmetic_simd import (
+    subtract_simd,
+    multiply_simd,
+    add_simd,
+    divide_simd,
+)
+from odyssey.core.elementwise import clip
+
+
+def sophia_step(
+    params: AnyTensor,
+    gradients: AnyTensor,
+    momentum: AnyTensor,
+    hessian_moment: AnyTensor,
+    hessian: AnyTensor,
+    learning_rate: Float64,
+    beta1: Float64 = 0.96,
+    beta2: Float64 = 0.99,
+    rho: Float64 = 0.04,
+    epsilon: Float64 = 1e-12,
+    weight_decay: Float64 = 0.0,
+) raises -> Tuple[AnyTensor, AnyTensor]:
+    """Perform a single Sophia optimization step - pure functional.
+
+    Returns new parameters and the new first-moment (momentum) buffer. The
+    second buffer, `hessian_moment`, is updated IN THE CALLER using
+    `sophia_update_hessian_moment` on the steps where a fresh `hessian` estimate
+    is available (typically every `update_period` steps). This split keeps the
+    signature honest: `sophia_step` reads the current `hessian_moment` but does
+    not decide the Hessian refresh schedule, which the caller owns.
+
+    Args:
+        params: Model parameters to update.
+        gradients: Gradients of loss with respect to params.
+        momentum: First-moment buffer m (EMA of gradients).
+        hessian_moment: EMA of the diagonal Hessian estimate (current value).
+        hessian: The diagonal Hessian estimate for this step. On steps where no
+            fresh estimate is computed, pass the previous `hessian_moment` (or a
+            zero tensor) — the update simply uses the standing `hessian_moment`.
+        learning_rate: Step size for parameter updates.
+        beta1: EMA decay for the first moment (default: 0.96).
+        beta2: EMA decay for the Hessian moment (default: 0.99).
+        rho: Symmetric clip bound on the per-coordinate update (default: 0.04).
+        epsilon: Lower clamp bound on `hessian_moment` in the denominator,
+            i.e. denom = max(hessian_moment, epsilon) (default: 1e-12).
+        weight_decay: Decoupled (AdamW-style) weight decay factor (default: 0.0).
+
+    Returns:
+        Tuple of (new_params, new_momentum).
+
+    Raises:
+        Error: If tensor shapes or dtypes don't match.
+    """
+    if params.shape() != gradients.shape():
+        raise Error(
+            "sophia_step: params and gradients must have the same shape"
+        )
+    if params.shape() != momentum.shape():
+        raise Error("sophia_step: params and momentum must have the same shape")
+    if params.shape() != hessian_moment.shape():
+        raise Error(
+            "sophia_step: params and hessian_moment must have the same shape"
+        )
+    if params.dtype() != gradients.dtype():
+        raise Error(
+            "sophia_step: params and gradients must have the same dtype"
+        )
+
+    # First moment: m = beta1 * m + (1 - beta1) * gradients
+    var beta1_tensor = full_like(momentum, beta1)
+    var one_minus_beta1 = full_like(momentum, 1.0 - beta1)
+    var new_momentum = multiply_simd(beta1_tensor, momentum)
+    var grad_contrib = multiply_simd(one_minus_beta1, gradients)
+    new_momentum = add_simd(new_momentum, grad_contrib)
+
+    # Preconditioned, clipped update:
+    #   update = clip(m / max(hessian_moment, eps), -rho, +rho)
+    var denom = clip(hessian_moment, epsilon, 1.0e30)
+    var raw_update = divide_simd(new_momentum, denom)
+    var update = clip(raw_update, -rho, rho)
+
+    # Parameter update: params = params - learning_rate * update
+    var lr_tensor = full_like(update, learning_rate)
+    var lr_update = multiply_simd(lr_tensor, update)
+    var new_params = subtract_simd(params, lr_update)
+
+    # Decoupled weight decay (AdamW-style), applied after the gradient step.
+    if weight_decay != 0.0:
+        var wd_coeff_tensor = full_like(params, weight_decay * learning_rate)
+        var wd_term = multiply_simd(wd_coeff_tensor, params)
+        new_params = subtract_simd(new_params, wd_term)
+
+    return (new_params, new_momentum)
+
+
+def sophia_update_hessian_moment(
+    hessian_moment: AnyTensor,
+    hessian: AnyTensor,
+    beta2: Float64 = 0.99,
+) raises -> AnyTensor:
+    """Update the diagonal-Hessian EMA with a fresh estimate.
+
+    Call this only on the steps where a fresh Hessian estimate is available
+    (every `update_period` steps in the reference implementation):
+
+        hessian_moment = beta2 * hessian_moment + (1 - beta2) * hessian
+
+    Args:
+        hessian_moment: Current Hessian EMA buffer.
+        hessian: Fresh diagonal Hessian estimate.
+        beta2: EMA decay for the Hessian moment (default: 0.99).
+
+    Returns:
+        The updated hessian_moment buffer.
+
+    Raises:
+        Error: If shapes don't match.
+    """
+    if hessian_moment.shape() != hessian.shape():
+        raise Error(
+            "sophia_update_hessian_moment: hessian_moment and hessian must have"
+            " the same shape"
+        )
+    var beta2_tensor = full_like(hessian_moment, beta2)
+    var one_minus_beta2 = full_like(hessian_moment, 1.0 - beta2)
+    var new_hm = multiply_simd(beta2_tensor, hessian_moment)
+    var h_contrib = multiply_simd(one_minus_beta2, hessian)
+    return add_simd(new_hm, h_contrib)
+
+
+def sophia_step_simple(
+    params: AnyTensor,
+    gradients: AnyTensor,
+    momentum: AnyTensor,
+    hessian_moment: AnyTensor,
+    hessian: AnyTensor,
+    learning_rate: Float64,
+) raises -> Tuple[AnyTensor, AnyTensor]:
+    """Simplified Sophia step with default hyperparameters (Liu et al. 2023).
+
+    Convenience wrapper around `sophia_step` with the paper defaults
+    (betas (0.96, 0.99), rho 0.04, eps 1e-12, no weight decay). Caller manages
+    the momentum and hessian_moment buffers (see `sophia_update_hessian_moment`).
+
+    Args:
+        params: Model parameters to update.
+        gradients: Gradients of loss with respect to params.
+        momentum: First-moment buffer m. Initialize to zeros_like(params).
+        hessian_moment: Diagonal-Hessian EMA buffer.
+        hessian: Diagonal Hessian estimate for this step.
+        learning_rate: Step size for parameter updates.
+
+    Returns:
+        Tuple of (new_params, new_momentum).
+
+    Raises:
+        Error: If tensor shapes or dtypes don't match.
+    """
+    return sophia_step(
+        params, gradients, momentum, hessian_moment, hessian, learning_rate
+    )

--- a/src/odyssey/training/optimizers/sophia.mojo
+++ b/src/odyssey/training/optimizers/sophia.mojo
@@ -1,34 +1,50 @@
-"""Sophia optimizer (Second-order Clipped Stochastic Optimization).
+"""Sophia clipped preconditioned update step (arXiv:2305.14342).
 
-Sophia is a light-weight second-order optimizer that uses a cheap, infrequent
-diagonal Hessian estimate to precondition an EMA of gradients, then CLIPS the
-per-coordinate update. The clipping bounds the influence of coordinates with a
-small or mis-estimated Hessian, giving second-order-like convergence at close to
+SCOPE: this module implements the Sophia-style CLIPPED PRECONDITIONED UPDATE
+STEP only, operating on a CALLER-SUPPLIED diagonal-Hessian estimate. The
+estimators that produce that estimate in the paper — Sophia-H (Hutchinson) and
+Sophia-G (Gauss-Newton-Bartlett) — both require Hessian-vector products /
+higher-order autodiff, which Odyssey's autograd does not provide yet (tracked
+in `src/odyssey/autograd/TODO.md`, Phase 3 "Higher-order gradients" / "Hessian
+computation"). Until then,
+callers must obtain the diagonal Hessian estimate elsewhere and pass it in.
+
+Sophia (Liu et al. 2023) preconditions an EMA of gradients with a cheap,
+infrequently refreshed diagonal-Hessian EMA, then CLIPS the per-coordinate
+update. The clipping bounds the influence of coordinates with a small or
+mis-estimated Hessian, giving second-order-like convergence at close to
 first-order cost.
 
-This module implements the per-step update as a pure function; the caller
-supplies the diagonal Hessian estimate `hessian` (from either the Hutchinson
-estimator, Sophia-H, or the Gauss-Newton-Bartlett estimator, Sophia-G). The
-Hessian is expensive to compute, so in practice it is refreshed only every
-`update_period` steps; between refreshes the caller passes the same stale
-Hessian (its EMA `hessian_moment` simply re-averages the same value), which is
-exactly what the reference implementations do.
-
-Sophia update rule (per step):
+Update rule implemented here (per step):
     momentum       = beta1 * momentum + (1 - beta1) * gradients
-    hessian_moment = beta2 * hessian_moment + (1 - beta2) * hessian
-    update         = clip(momentum / max(hessian_moment, eps), -rho, +rho)
+    update         = clip(momentum / max(gamma * hessian_moment, eps), -rho, +rho)
     params         = params - learning_rate * update
 
-with optional decoupled (AdamW-style) weight decay applied after the step.
+and, on the steps where the caller has a fresh Hessian estimate (every
+`update_period` steps in the reference implementations):
+    hessian_moment = beta2 * hessian_moment + (1 - beta2) * hessian
+via `sophia_update_hessian_moment`.
+
+On the gamma / rho parametrization: the paper's Algorithm 3 writes the update
+as clip(m_t / max(gamma * h_t, eps), 1), and the official implementation
+(github.com/Liuhong99/Sophia, sophia.py) computes
+`ratio = (exp_avg.abs() / (rho * bs * hess + 1e-15)).clamp(None, 1)` — i.e.
+gamma = rho * bs (bs = batch size), so gamma has NO batch-size-free universal
+default. This module therefore exposes gamma explicitly with default 1.0,
+which is exactly the SophiaH parametrization used by pytorch_optimizer
+(kozistr/pytorch_optimizer): the +-rho clip carries the threshold and callers
+fold any gamma = rho * bs scale into the Hessian estimate they supply. To
+reproduce the paper's Algorithm 3 form verbatim, pass gamma explicitly and set
+rho = 1.
 
 Key characteristics:
     - Memory: first-moment `momentum` + diagonal-Hessian EMA `hessian_moment`
       (same footprint as Adam's two buffers).
-    - The clip threshold `rho` (paper default 0.01-0.05) is the fraction of
-      coordinates left un-clipped; it is the single most important hyperparameter.
-    - The denominator is clamped below by `eps` (not `+ eps`), so a zero/negative
-      Hessian estimate degrades gracefully to a large-but-clipped update.
+    - The clip threshold `rho` (paper default 0.01-0.05) bounds every
+      per-coordinate update; it is the single most important hyperparameter.
+    - The denominator is clamped below by `eps` (not `+ eps`), so a
+      zero/negative Hessian estimate degrades gracefully to a
+      large-but-clipped update.
 
 Reference:
     Liu, H., Li, Z., Hall, D., Liang, P., & Ma, T. (2023).
@@ -53,41 +69,43 @@ def sophia_step(
     gradients: AnyTensor,
     momentum: AnyTensor,
     hessian_moment: AnyTensor,
-    # `hessian` and `beta2` are consumed by the companion
-    # `sophia_update_hessian_moment` (which owns the Hessian-EMA refresh), not by
-    # the step body itself; they are accepted here for signature symmetry so the
-    # two functions share one call shape.
-    hessian: AnyTensor,
     learning_rate: Float64,
     beta1: Float64 = 0.96,
-    beta2: Float64 = 0.99,
+    gamma: Float64 = 1.0,
     rho: Float64 = 0.04,
     epsilon: Float64 = 1e-12,
     weight_decay: Float64 = 0.0,
 ) raises -> Tuple[AnyTensor, AnyTensor]:
-    """Perform a single Sophia optimization step - pure functional.
+    """Perform a single Sophia clipped-preconditioned update step.
 
-    Returns new parameters and the new first-moment (momentum) buffer. The
-    second buffer, `hessian_moment`, is updated IN THE CALLER using
-    `sophia_update_hessian_moment` on the steps where a fresh `hessian` estimate
-    is available (typically every `update_period` steps). This split keeps the
-    signature honest: `sophia_step` reads the current `hessian_moment` but does
-    not decide the Hessian refresh schedule, which the caller owns.
+    Pure functional. Returns new parameters and the new first-moment
+    (momentum) buffer. The preconditioner `hessian_moment` is consumed as-is;
+    it is refreshed IN THE CALLER via `sophia_update_hessian_moment` on the
+    steps where a fresh caller-supplied diagonal-Hessian estimate is available
+    (typically every `update_period` steps). This split keeps the signature
+    honest: every parameter of this function participates in the update, and
+    the Hessian refresh schedule — like the Hessian estimator itself (Sophia-H
+    / Sophia-G, not implemented in Odyssey; see module docstring) — is owned
+    by the caller.
 
     Args:
         params: Model parameters to update.
         gradients: Gradients of loss with respect to params.
         momentum: First-moment buffer m (EMA of gradients).
-        hessian_moment: EMA of the diagonal Hessian estimate (current value).
-        hessian: The diagonal Hessian estimate for this step. On steps where no
-            fresh estimate is computed, pass the previous `hessian_moment` (or a
-            zero tensor) — the update simply uses the standing `hessian_moment`.
+        hessian_moment: Diagonal-Hessian EMA used as the preconditioner,
+            maintained by the caller via `sophia_update_hessian_moment`.
         learning_rate: Step size for parameter updates.
         beta1: EMA decay for the first moment (default: 0.96).
-        beta2: EMA decay for the Hessian moment (default: 0.99).
-        rho: Symmetric clip bound on the per-coordinate update (default: 0.04).
-        epsilon: Lower clamp bound on `hessian_moment` in the denominator,
-            i.e. denom = max(hessian_moment, epsilon) (default: 1e-12).
+        gamma: Scale on the preconditioner in the denominator,
+            denom = max(gamma * hessian_moment, epsilon). The official Liu et
+            al. code uses gamma = rho * bs (batch-size coupled, no universal
+            default); the default 1.0 is the SophiaH/pytorch_optimizer
+            parametrization where callers fold that scale into the Hessian
+            estimate they supply. See module docstring.
+        rho: Symmetric clip bound on the per-coordinate update (default: 0.04,
+            the official SophiaG default).
+        epsilon: Lower clamp bound on the scaled denominator,
+            i.e. denom = max(gamma * hessian_moment, epsilon) (default: 1e-12).
         weight_decay: Decoupled (AdamW-style) weight decay factor (default: 0.0).
 
     Returns:
@@ -119,8 +137,10 @@ def sophia_step(
     new_momentum = add_simd(new_momentum, grad_contrib)
 
     # Preconditioned, clipped update:
-    #   update = clip(m / max(hessian_moment, eps), -rho, +rho)
-    var denom = clip(hessian_moment, epsilon, 1.0e30)
+    #   update = clip(m / max(gamma * hessian_moment, eps), -rho, +rho)
+    var gamma_tensor = full_like(hessian_moment, gamma)
+    var scaled_hm = multiply_simd(gamma_tensor, hessian_moment)
+    var denom = clip(scaled_hm, epsilon, 1.0e30)
     var raw_update = divide_simd(new_momentum, denom)
     var update = clip(raw_update, -rho, rho)
 
@@ -143,16 +163,21 @@ def sophia_update_hessian_moment(
     hessian: AnyTensor,
     beta2: Float64 = 0.99,
 ) raises -> AnyTensor:
-    """Update the diagonal-Hessian EMA with a fresh estimate.
+    """Update the diagonal-Hessian EMA with a fresh caller-supplied estimate.
 
-    Call this only on the steps where a fresh Hessian estimate is available
-    (every `update_period` steps in the reference implementation):
+    Call this only on the steps where a fresh diagonal-Hessian estimate is
+    available (every `update_period` steps in the reference implementations):
 
         hessian_moment = beta2 * hessian_moment + (1 - beta2) * hessian
 
+    Note that Odyssey does not implement the Sophia-H (Hutchinson) or Sophia-G
+    (Gauss-Newton-Bartlett) estimators that produce `hessian` in the paper —
+    they need higher-order autodiff, tracked in `src/odyssey/autograd/TODO.md`
+    (Phase 3, "Higher-order gradients"). The estimate is the caller's to supply.
+
     Args:
         hessian_moment: Current Hessian EMA buffer.
-        hessian: Fresh diagonal Hessian estimate.
+        hessian: Fresh caller-supplied diagonal Hessian estimate.
         beta2: EMA decay for the Hessian moment (default: 0.99).
 
     Returns:
@@ -178,21 +203,21 @@ def sophia_step_simple(
     gradients: AnyTensor,
     momentum: AnyTensor,
     hessian_moment: AnyTensor,
-    hessian: AnyTensor,
     learning_rate: Float64,
 ) raises -> Tuple[AnyTensor, AnyTensor]:
-    """Simplified Sophia step with default hyperparameters (Liu et al. 2023).
+    """Simplified Sophia update step with default hyperparameters.
 
-    Convenience wrapper around `sophia_step` with the paper defaults
-    (betas (0.96, 0.99), rho 0.04, eps 1e-12, no weight decay). Caller manages
-    the momentum and hessian_moment buffers (see `sophia_update_hessian_moment`).
+    Convenience wrapper around `sophia_step` with the defaults documented
+    there (beta1 0.96, gamma 1.0, rho 0.04, eps 1e-12, no weight decay).
+    Caller manages the momentum and hessian_moment buffers (see
+    `sophia_update_hessian_moment`) and supplies its own diagonal-Hessian
+    estimates — the Sophia-H/G estimators are not part of this module.
 
     Args:
         params: Model parameters to update.
         gradients: Gradients of loss with respect to params.
         momentum: First-moment buffer m. Initialize to zeros_like(params).
-        hessian_moment: Diagonal-Hessian EMA buffer.
-        hessian: Diagonal Hessian estimate for this step.
+        hessian_moment: Diagonal-Hessian EMA buffer (the preconditioner).
         learning_rate: Step size for parameter updates.
 
     Returns:
@@ -202,5 +227,5 @@ def sophia_step_simple(
         Error: If tensor shapes or dtypes don't match.
     """
     return sophia_step(
-        params, gradients, momentum, hessian_moment, hessian, learning_rate
+        params, gradients, momentum, hessian_moment, learning_rate
     )

--- a/tests/odyssey/training/optimizers/parity_refs/sophia_parity_reference.py
+++ b/tests/odyssey/training/optimizers/parity_refs/sophia_parity_reference.py
@@ -1,0 +1,65 @@
+"""Sophia (SophiaH) parity reference.
+
+Computes ONE SophiaH step for a fixed (params, grad, momentum, hessian_moment,
+hessian) and prints the resulting params + momentum + hessian_moment, so the
+Mojo `sophia_step` (+ `sophia_update_hessian_moment`) can be compared on
+identical inputs.
+
+Why not drive `pytorch_optimizer.SophiaH` directly: that class only creates its
+`momentum` / `hessian_moment` state inside the Hessian-refresh branch, so a
+single hand-seeded step raises `KeyError('momentum')` in the installed version.
+Instead we transcribe SophiaH's exact per-parameter update math verbatim from
+its source (`optimizer/sophia.py`), which is:
+
+    momentum       = beta1 * momentum + (1 - beta1) * grad
+    hessian_moment = beta2 * hessian_moment + (1 - beta2) * hessian   (on refresh)
+    update         = clamp(momentum / clip(hessian_moment, min=eps), -rho, rho)
+    params         = params - lr * update
+
+so the numbers below are exactly what SophiaH computes. NumPy is used purely as
+a calculator for that published algorithm.
+"""
+
+import json
+
+import numpy as np
+
+N = 5
+LR, B1, B2, RHO, EPS = 0.06, 0.96, 0.99, 0.04, 1e-12
+
+params = np.array([0.1, -0.2, 0.3, -0.4, 0.5])
+grad = np.array([0.05, 0.15, -0.25, 0.35, -0.45])
+m = np.array([0.01, -0.02, 0.03, -0.04, 0.05])
+hm = np.array([0.2, 0.25, 0.3, 0.35, 0.4])
+hess = np.array([0.5, 0.6, 0.7, 0.8, 0.9])
+
+# SophiaH per-parameter update (source-verbatim math).
+m2 = B1 * m + (1.0 - B1) * grad
+hm2 = B2 * hm + (1.0 - B2) * hess  # Hessian refresh on this step
+update = np.clip(m2 / np.clip(hm2, EPS, None), -RHO, RHO)
+params2 = params - LR * update
+
+print(
+    json.dumps(
+        {
+            "inputs": {
+                "params": params.tolist(),
+                "grad": grad.tolist(),
+                "m": m.tolist(),
+                "hm": hm.tolist(),
+                "hessian": hess.tolist(),
+                "lr": LR,
+                "beta1": B1,
+                "beta2": B2,
+                "rho": RHO,
+                "eps": EPS,
+            },
+            "reference_out": {
+                "params": params2.tolist(),
+                "m": m2.tolist(),
+                "hm": hm2.tolist(),
+            },
+        },
+        indent=2,
+    )
+)

--- a/tests/odyssey/training/optimizers/parity_refs/sophia_parity_reference.py
+++ b/tests/odyssey/training/optimizers/parity_refs/sophia_parity_reference.py
@@ -1,43 +1,59 @@
-"""Sophia (SophiaH) parity reference.
+"""Sophia clipped-preconditioned-update parity reference.
 
-Computes ONE SophiaH step for a fixed (params, grad, momentum, hessian_moment,
-hessian) and prints the resulting params + momentum + hessian_moment, so the
-Mojo `sophia_step` (+ `sophia_update_hessian_moment`) can be compared on
-identical inputs.
+Computes ONE Sophia update step for a fixed (params, grad, momentum,
+hessian_moment, hessian) and prints the resulting params + momentum +
+hessian_moment, so the Mojo `sophia_step` (+ `sophia_update_hessian_moment`)
+can be compared on identical inputs.
 
-Why not drive `pytorch_optimizer.SophiaH` directly: that class only creates its
-`momentum` / `hessian_moment` state inside the Hessian-refresh branch, so a
-single hand-seeded step raises `KeyError('momentum')` in the installed version.
-Instead we transcribe SophiaH's exact per-parameter update math verbatim from
-its source (`optimizer/sophia.py`), which is:
+The modeled update is the form implemented in sophia.mojo:
 
     momentum       = beta1 * momentum + (1 - beta1) * grad
-    hessian_moment = beta2 * hessian_moment + (1 - beta2) * hessian   (on refresh)
-    update         = clamp(momentum / clip(hessian_moment, min=eps), -rho, rho)
+    hessian_moment = beta2 * hessian_moment + (1 - beta2) * hessian  (on refresh)
+    update         = clamp(momentum / clip(gamma * hessian_moment, min=eps),
+                           -rho, rho)
     params         = params - lr * update
 
-so the numbers below are exactly what SophiaH computes. NumPy is used purely as
-a calculator for that published algorithm.
+which is the paper's clip(m / max(gamma * h, eps), .) update (Liu et al. 2023,
+arXiv:2305.14342, Algorithm 3; official code github.com/Liuhong99/Sophia uses
+gamma = rho * bs with the clamp at 1) expressed in the SophiaH-style
+parametrization with an explicit +-rho clip (kozistr/pytorch_optimizer
+SophiaH). gamma is set to a non-trivial 0.8 here so the parity test actually
+asserts the gamma scaling.
+
+Why not drive `pytorch_optimizer.SophiaH` directly: that class only creates
+its `momentum` / `hessian_moment` state inside the Hessian-refresh branch, so
+a single hand-seeded step raises `KeyError('momentum')` in the installed
+version (and it has no gamma). NumPy is used purely as a calculator for the
+published algorithm.
+
+Vector regime: the inputs are chosen so that coordinates 0-4 land in the
+UNCLIPPED regime (|m / (gamma * h)| < rho, so the preconditioned division is
+what the parity assert exercises) while coordinate 5 saturates the +-rho clip.
+The script prints per-coordinate raw updates and the clipped/unclipped split
+so the regime is auditable.
 """
 
 import json
 
 import numpy as np
 
-N = 5
-LR, B1, B2, RHO, EPS = 0.06, 0.96, 0.99, 0.04, 1e-12
+N = 6
+LR, B1, B2, GAMMA, RHO, EPS = 0.06, 0.96, 0.99, 0.8, 0.04, 1e-12
 
-params = np.array([0.1, -0.2, 0.3, -0.4, 0.5])
-grad = np.array([0.05, 0.15, -0.25, 0.35, -0.45])
-m = np.array([0.01, -0.02, 0.03, -0.04, 0.05])
-hm = np.array([0.2, 0.25, 0.3, 0.35, 0.4])
-hess = np.array([0.5, 0.6, 0.7, 0.8, 0.9])
+params = np.array([0.1, -0.2, 0.3, -0.4, 0.5, -0.6])
+grad = np.array([0.02, -0.03, 0.015, 0.025, -0.01, 0.5])
+m = np.array([0.005, -0.004, 0.003, -0.002, 0.001, 0.05])
+hm = np.array([1.0, 1.2, 0.9, 1.1, 0.8, 0.05])
+hess = np.array([1.1, 1.0, 0.95, 1.05, 0.85, 0.04])
 
-# SophiaH per-parameter update (source-verbatim math).
+# Sophia per-parameter update (see module docstring for provenance).
 m2 = B1 * m + (1.0 - B1) * grad
 hm2 = B2 * hm + (1.0 - B2) * hess  # Hessian refresh on this step
-update = np.clip(m2 / np.clip(hm2, EPS, None), -RHO, RHO)
+raw = m2 / np.clip(GAMMA * hm2, EPS, None)
+update = np.clip(raw, -RHO, RHO)
 params2 = params - LR * update
+
+clipped = np.abs(raw) >= RHO
 
 print(
     json.dumps(
@@ -51,8 +67,15 @@ print(
                 "lr": LR,
                 "beta1": B1,
                 "beta2": B2,
+                "gamma": GAMMA,
                 "rho": RHO,
                 "eps": EPS,
+            },
+            "regime": {
+                "raw_update": raw.tolist(),
+                "clipped_mask": clipped.tolist(),
+                "n_clipped": int(clipped.sum()),
+                "n_unclipped": int((~clipped).sum()),
             },
             "reference_out": {
                 "params": params2.tolist(),

--- a/tests/odyssey/training/optimizers/test_sophia.mojo
+++ b/tests/odyssey/training/optimizers/test_sophia.mojo
@@ -1,0 +1,217 @@
+"""Unit tests for the Sophia optimizer (arXiv:2305.14342).
+
+Tests cover:
+- Shape/dtype guards on sophia_step
+- Numerical parity with the SophiaH reference algorithm (1e-9) on a fixed vector
+- The clip bound (rho) on the per-coordinate update
+- sophia_update_hessian_moment EMA behavior
+- sophia_step_simple delegating to sophia_step with defaults
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros, full
+from odyssey.training.optimizers.sophia import (
+    sophia_step,
+    sophia_step_simple,
+    sophia_update_hessian_moment,
+)
+
+
+def _abs_diff(a: Float64, b: Float64) -> Float64:
+    var d = a - b
+    if d < 0:
+        d = -d
+    return d
+
+
+def test_reject_shape_mismatch() raises:
+    """sophia_step rejects a params/gradients shape mismatch."""
+    print("Running test_reject_shape_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([5], DType.float32)
+    var m = zeros([4], DType.float32)
+    var hm = zeros([4], DType.float32)
+    var h = zeros([4], DType.float32)
+    try:
+        var _ = sophia_step(p, g, m, hm, h, 0.06)
+        raise Error("Should have rejected shape mismatch")
+    except e:
+        print("  ok rejected shape mismatch")
+    print("test_reject_shape_mismatch PASSED")
+
+
+def test_reject_dtype_mismatch() raises:
+    """sophia_step rejects a params/gradients dtype mismatch."""
+    print("Running test_reject_dtype_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float16)
+    var m = zeros([4], DType.float32)
+    var hm = zeros([4], DType.float32)
+    var h = zeros([4], DType.float32)
+    try:
+        var _ = sophia_step(p, g, m, hm, h, 0.06)
+        raise Error("Should have rejected dtype mismatch")
+    except e:
+        print("  ok rejected dtype mismatch")
+    print("test_reject_dtype_mismatch PASSED")
+
+
+def test_parity_with_reference() raises:
+    """One Sophia step must match the SophiaH reference algorithm to 1e-9.
+
+    Fixed inputs and reference outputs transcribed from
+    parity_refs/sophia_parity_reference.py (SophiaH source-verbatim math,
+    lr=0.06, betas=(0.96,0.99), rho=0.04, eps=1e-12, no weight decay). The
+    Hessian moment is refreshed with the fresh hessian BEFORE the step uses it.
+    """
+    print("Running test_parity_with_reference...")
+
+    var rp = List[Float64]()
+    rp.append(0.0976)
+    rp.append(-0.1976)
+    rp.append(0.2976)
+    rp.append(-0.3976)
+    rp.append(0.4976)
+    var rm = List[Float64]()
+    rm.append(0.0116)
+    rm.append(-0.0132)
+    rm.append(0.0188)
+    rm.append(-0.0244)
+    rm.append(0.03)
+    var rhm = List[Float64]()
+    rhm.append(0.203)
+    rhm.append(0.2535)
+    rhm.append(0.304)
+    rhm.append(0.3545)
+    rhm.append(0.405)
+
+    var n = 5
+    var p = zeros([n], DType.float64)
+    var g = zeros([n], DType.float64)
+    var m = zeros([n], DType.float64)
+    var hm = zeros([n], DType.float64)
+    var h = zeros([n], DType.float64)
+    p.store[DType.float64](0, 0.1)
+    p.store[DType.float64](1, -0.2)
+    p.store[DType.float64](2, 0.3)
+    p.store[DType.float64](3, -0.4)
+    p.store[DType.float64](4, 0.5)
+    g.store[DType.float64](0, 0.05)
+    g.store[DType.float64](1, 0.15)
+    g.store[DType.float64](2, -0.25)
+    g.store[DType.float64](3, 0.35)
+    g.store[DType.float64](4, -0.45)
+    m.store[DType.float64](0, 0.01)
+    m.store[DType.float64](1, -0.02)
+    m.store[DType.float64](2, 0.03)
+    m.store[DType.float64](3, -0.04)
+    m.store[DType.float64](4, 0.05)
+    hm.store[DType.float64](0, 0.2)
+    hm.store[DType.float64](1, 0.25)
+    hm.store[DType.float64](2, 0.3)
+    hm.store[DType.float64](3, 0.35)
+    hm.store[DType.float64](4, 0.4)
+    h.store[DType.float64](0, 0.5)
+    h.store[DType.float64](1, 0.6)
+    h.store[DType.float64](2, 0.7)
+    h.store[DType.float64](3, 0.8)
+    h.store[DType.float64](4, 0.9)
+
+    var hm2 = sophia_update_hessian_moment(hm, h, 0.99)
+    var res = sophia_step(p, g, m, hm2, h, 0.06, 0.96, 0.99, 0.04, 1e-12, 0.0)
+    var np = res[0]
+    var nm = res[1]
+
+    for i in range(n):
+        if _abs_diff(np.load[DType.float64](i), rp[i]) > 1e-9:
+            raise Error("param parity mismatch at " + String(i))
+        if _abs_diff(nm.load[DType.float64](i), rm[i]) > 1e-9:
+            raise Error("momentum parity mismatch at " + String(i))
+        if _abs_diff(hm2.load[DType.float64](i), rhm[i]) > 1e-9:
+            raise Error("hessian-moment parity mismatch at " + String(i))
+    print("  ok matches SophiaH reference to 1e-9")
+    print("test_parity_with_reference PASSED")
+
+
+def test_clip_bounds_update() raises:
+    """rho must bound the per-coordinate update magnitude.
+
+    With a small Hessian moment, m / hm is large; the update should saturate to
+    +-rho, so the param step magnitude is exactly lr * rho.
+    """
+    print("Running test_clip_bounds_update...")
+    var n = 3
+    var lr = 0.1
+    var rho = 0.05
+    var p = zeros([n], DType.float64)
+    var g = full([n], 1.0, DType.float64)  # positive grad -> positive momentum
+    var m = zeros([n], DType.float64)
+    # tiny hessian_moment so m/hm blows up and clips to +rho
+    var hm = full([n], 1e-6, DType.float64)
+    var h = full([n], 1e-6, DType.float64)
+
+    var res = sophia_step(p, g, m, hm, h, lr, 0.96, 0.99, rho, 1e-12, 0.0)
+    var np = res[0]
+    var expected = -lr * rho  # p starts at 0, moves by -lr*rho
+    for i in range(n):
+        if _abs_diff(np.load[DType.float64](i), expected) > 1e-9:
+            raise Error("update should clip to rho -> step = -lr*rho")
+    print("  ok update clipped to rho")
+    print("test_clip_bounds_update PASSED")
+
+
+def test_hessian_moment_ema() raises:
+    """sophia_update_hessian_moment does the beta2 EMA correctly."""
+    print("Running test_hessian_moment_ema...")
+    var n = 2
+    var hm = full([n], 0.0, DType.float64)
+    var h = full([n], 4.0, DType.float64)
+    var beta2 = 0.99
+    var new_hm = sophia_update_hessian_moment(hm, h, beta2)
+    var expected = (1.0 - beta2) * 4.0
+    for i in range(n):
+        if _abs_diff(new_hm.load[DType.float64](i), expected) > 1e-9:
+            raise Error("hessian moment EMA incorrect")
+    print("  ok hessian moment EMA = (1-beta2)*h from zero")
+    print("test_hessian_moment_ema PASSED")
+
+
+def test_simple_matches_full_defaults() raises:
+    """sophia_step_simple equals sophia_step with default hyperparameters."""
+    print("Running test_simple_matches_full_defaults...")
+    var n = 4
+    var p = full([n], 0.2, DType.float64)
+    var g = full([n], -0.3, DType.float64)
+    var m = zeros([n], DType.float64)
+    var hm = full([n], 0.5, DType.float64)
+    var h = full([n], 0.5, DType.float64)
+
+    var full_res = sophia_step(p, g, m, hm, h, 0.06)
+    var simple_res = sophia_step_simple(p, g, m, hm, h, 0.06)
+    for i in range(n):
+        if (
+            _abs_diff(
+                full_res[0].load[DType.float64](i),
+                simple_res[0].load[DType.float64](i),
+            )
+            > 1e-12
+        ):
+            raise Error("sophia_step_simple params differ from sophia_step")
+    print("  ok sophia_step_simple == sophia_step with defaults")
+    print("test_simple_matches_full_defaults PASSED")
+
+
+def main() raises:
+    """Run all Sophia tests."""
+    print("=" * 60)
+    print("Sophia Optimizer Test Suite")
+    print("=" * 60)
+    test_reject_shape_mismatch()
+    test_reject_dtype_mismatch()
+    test_parity_with_reference()
+    test_clip_bounds_update()
+    test_hessian_moment_ema()
+    test_simple_matches_full_defaults()
+    print("=" * 60)
+    print("All Sophia tests PASSED")
+    print("=" * 60)

--- a/tests/odyssey/training/optimizers/test_sophia.mojo
+++ b/tests/odyssey/training/optimizers/test_sophia.mojo
@@ -1,8 +1,15 @@
-"""Unit tests for the Sophia optimizer (arXiv:2305.14342).
+"""Unit tests for the Sophia clipped-preconditioned update step (arXiv:2305.14342).
+
+Odyssey implements the Sophia update step with CALLER-SUPPLIED diagonal-Hessian
+estimates (the Sophia-H/G estimators need HVP support, tracked in the autograd
+TODO), so these tests seed the Hessian buffers directly.
 
 Tests cover:
 - Shape/dtype guards on sophia_step
-- Numerical parity with the SophiaH reference algorithm (1e-9) on a fixed vector
+- Numerical parity with the reference algorithm (1e-9) on a fixed vector where
+  5 of 6 coordinates are UNCLIPPED (the m / max(gamma*h, eps) arithmetic is
+  asserted, gamma = 0.8) and 1 coordinate saturates the +-rho clip
+- gamma scaling the denominator (gamma=2 halves an unclipped update)
 - The clip bound (rho) on the per-coordinate update
 - Decoupled (AdamW-style) weight_decay != 0 branch
 - sophia_update_hessian_moment EMA behavior
@@ -32,9 +39,8 @@ def test_reject_shape_mismatch() raises:
     var g = zeros([5], DType.float32)
     var m = zeros([4], DType.float32)
     var hm = zeros([4], DType.float32)
-    var h = zeros([4], DType.float32)
     try:
-        var _ = sophia_step(p, g, m, hm, h, 0.06)
+        var _ = sophia_step(p, g, m, hm, 0.06)
         raise Error("Should have rejected shape mismatch")
     except e:
         print("  ok rejected shape mismatch")
@@ -48,9 +54,8 @@ def test_reject_dtype_mismatch() raises:
     var g = zeros([4], DType.float16)
     var m = zeros([4], DType.float32)
     var hm = zeros([4], DType.float32)
-    var h = zeros([4], DType.float32)
     try:
-        var _ = sophia_step(p, g, m, hm, h, 0.06)
+        var _ = sophia_step(p, g, m, hm, 0.06)
         raise Error("Should have rejected dtype mismatch")
     except e:
         print("  ok rejected dtype mismatch")
@@ -58,35 +63,44 @@ def test_reject_dtype_mismatch() raises:
 
 
 def test_parity_with_reference() raises:
-    """One Sophia step must match the SophiaH reference algorithm to 1e-9.
+    """One Sophia step must match the reference algorithm to 1e-9.
 
     Fixed inputs and reference outputs transcribed from
-    parity_refs/sophia_parity_reference.py (SophiaH source-verbatim math,
-    lr=0.06, betas=(0.96,0.99), rho=0.04, eps=1e-12, no weight decay). The
-    Hessian moment is refreshed with the fresh hessian BEFORE the step uses it.
+    parity_refs/sophia_parity_reference.py (lr=0.06, betas=(0.96,0.99),
+    gamma=0.8, rho=0.04, eps=1e-12, no weight decay). The Hessian moment is
+    refreshed with the fresh hessian BEFORE the step uses it.
+
+    Regime split (from the reference script's printed clipped_mask):
+    coordinates 0-4 are UNCLIPPED (|m/(gamma*hm)| < rho), so the
+    preconditioned-division arithmetic — including the gamma scaling — is what
+    is asserted; coordinate 5 saturates the clip (raw update 1.7034 >> rho),
+    asserting the +-rho bound.
     """
     print("Running test_parity_with_reference...")
 
     var rp = List[Float64]()
-    rp.append(0.0976)
-    rp.append(-0.1976)
-    rp.append(0.2976)
-    rp.append(-0.3976)
-    rp.append(0.4976)
+    rp.append(0.09958041958041959)
+    rp.append(-0.19968447412353924)
+    rp.append(0.2997101610216546)
+    rp.append(-0.39993724420190996)
+    rp.append(0.499947532792005)
+    rp.append(-0.6023999999999999)
     var rm = List[Float64]()
-    rm.append(0.0116)
-    rm.append(-0.0132)
-    rm.append(0.0188)
-    rm.append(-0.0244)
-    rm.append(0.03)
+    rm.append(0.0056)
+    rm.append(-0.005040000000000001)
+    rm.append(0.0034800000000000005)
+    rm.append(-0.0009199999999999992)
+    rm.append(0.0005599999999999997)
+    rm.append(0.06800000000000002)
     var rhm = List[Float64]()
-    rhm.append(0.203)
-    rhm.append(0.2535)
-    rhm.append(0.304)
-    rhm.append(0.3545)
-    rhm.append(0.405)
+    rhm.append(1.0010000000000001)
+    rhm.append(1.198)
+    rhm.append(0.9005000000000001)
+    rhm.append(1.0995)
+    rhm.append(0.8005)
+    rhm.append(0.0499)
 
-    var n = 5
+    var n = 6
     var p = zeros([n], DType.float64)
     var g = zeros([n], DType.float64)
     var m = zeros([n], DType.float64)
@@ -97,29 +111,34 @@ def test_parity_with_reference() raises:
     p.store[DType.float64](2, 0.3)
     p.store[DType.float64](3, -0.4)
     p.store[DType.float64](4, 0.5)
-    g.store[DType.float64](0, 0.05)
-    g.store[DType.float64](1, 0.15)
-    g.store[DType.float64](2, -0.25)
-    g.store[DType.float64](3, 0.35)
-    g.store[DType.float64](4, -0.45)
-    m.store[DType.float64](0, 0.01)
-    m.store[DType.float64](1, -0.02)
-    m.store[DType.float64](2, 0.03)
-    m.store[DType.float64](3, -0.04)
-    m.store[DType.float64](4, 0.05)
-    hm.store[DType.float64](0, 0.2)
-    hm.store[DType.float64](1, 0.25)
-    hm.store[DType.float64](2, 0.3)
-    hm.store[DType.float64](3, 0.35)
-    hm.store[DType.float64](4, 0.4)
-    h.store[DType.float64](0, 0.5)
-    h.store[DType.float64](1, 0.6)
-    h.store[DType.float64](2, 0.7)
-    h.store[DType.float64](3, 0.8)
-    h.store[DType.float64](4, 0.9)
+    p.store[DType.float64](5, -0.6)
+    g.store[DType.float64](0, 0.02)
+    g.store[DType.float64](1, -0.03)
+    g.store[DType.float64](2, 0.015)
+    g.store[DType.float64](3, 0.025)
+    g.store[DType.float64](4, -0.01)
+    g.store[DType.float64](5, 0.5)
+    m.store[DType.float64](0, 0.005)
+    m.store[DType.float64](1, -0.004)
+    m.store[DType.float64](2, 0.003)
+    m.store[DType.float64](3, -0.002)
+    m.store[DType.float64](4, 0.001)
+    m.store[DType.float64](5, 0.05)
+    hm.store[DType.float64](0, 1.0)
+    hm.store[DType.float64](1, 1.2)
+    hm.store[DType.float64](2, 0.9)
+    hm.store[DType.float64](3, 1.1)
+    hm.store[DType.float64](4, 0.8)
+    hm.store[DType.float64](5, 0.05)
+    h.store[DType.float64](0, 1.1)
+    h.store[DType.float64](1, 1.0)
+    h.store[DType.float64](2, 0.95)
+    h.store[DType.float64](3, 1.05)
+    h.store[DType.float64](4, 0.85)
+    h.store[DType.float64](5, 0.04)
 
     var hm2 = sophia_update_hessian_moment(hm, h, 0.99)
-    var res = sophia_step(p, g, m, hm2, h, 0.06, 0.96, 0.99, 0.04, 1e-12, 0.0)
+    var res = sophia_step(p, g, m, hm2, 0.06, 0.96, 0.8, 0.04, 1e-12, 0.0)
     var np = res[0]
     var nm = res[1]
 
@@ -130,15 +149,46 @@ def test_parity_with_reference() raises:
             raise Error("momentum parity mismatch at " + String(i))
         if _abs_diff(hm2.load[DType.float64](i), rhm[i]) > 1e-9:
             raise Error("hessian-moment parity mismatch at " + String(i))
-    print("  ok matches SophiaH reference to 1e-9")
+    print("  ok matches reference to 1e-9 (5 unclipped coords + 1 clipped)")
     print("test_parity_with_reference PASSED")
+
+
+def test_gamma_scales_denominator() raises:
+    """gamma scales the preconditioner: doubling gamma halves an unclipped update.
+
+    With zero seed momentum, m2 = (1-beta1)*g; pick hm large enough that the
+    update is unclipped for both gamma=1 and gamma=2. Then
+    step(gamma=1) = lr * m2 / hm and step(gamma=2) = lr * m2 / (2*hm).
+    """
+    print("Running test_gamma_scales_denominator...")
+    var n = 3
+    var lr = 0.1
+    var p = zeros([n], DType.float64)
+    var g = full([n], 0.5, DType.float64)  # m2 = 0.04*0.5 = 0.02
+    var m = zeros([n], DType.float64)
+    var hm = full([n], 2.0, DType.float64)  # raw(gamma=1) = 0.01 < rho
+
+    var res_g1 = sophia_step(p, g, m, hm, lr, 0.96, 1.0, 0.04, 1e-12, 0.0)
+    var res_g2 = sophia_step(p, g, m, hm, lr, 0.96, 2.0, 0.04, 1e-12, 0.0)
+    var step_g1 = res_g1[0]
+    var step_g2 = res_g2[0]
+
+    for i in range(n):
+        var s1 = step_g1.load[DType.float64](i)  # -lr * 0.02 / 2.0
+        var s2 = step_g2.load[DType.float64](i)  # -lr * 0.02 / 4.0
+        if _abs_diff(s1, -lr * 0.02 / 2.0) > 1e-12:
+            raise Error("gamma=1 step wrong at " + String(i))
+        if _abs_diff(s2, s1 / 2.0) > 1e-12:
+            raise Error("gamma=2 step should be half of gamma=1 step")
+    print("  ok gamma=2 halves the unclipped update vs gamma=1")
+    print("test_gamma_scales_denominator PASSED")
 
 
 def test_clip_bounds_update() raises:
     """rho must bound the per-coordinate update magnitude.
 
-    With a small Hessian moment, m / hm is large; the update should saturate to
-    +-rho, so the param step magnitude is exactly lr * rho.
+    With a small Hessian moment, m / (gamma*hm) is large; the update should
+    saturate to +-rho, so the param step magnitude is exactly lr * rho.
     """
     print("Running test_clip_bounds_update...")
     var n = 3
@@ -147,11 +197,10 @@ def test_clip_bounds_update() raises:
     var p = zeros([n], DType.float64)
     var g = full([n], 1.0, DType.float64)  # positive grad -> positive momentum
     var m = zeros([n], DType.float64)
-    # tiny hessian_moment so m/hm blows up and clips to +rho
+    # tiny hessian_moment so m/(gamma*hm) blows up and clips to +rho
     var hm = full([n], 1e-6, DType.float64)
-    var h = full([n], 1e-6, DType.float64)
 
-    var res = sophia_step(p, g, m, hm, h, lr, 0.96, 0.99, rho, 1e-12, 0.0)
+    var res = sophia_step(p, g, m, hm, lr, 0.96, 1.0, rho, 1e-12, 0.0)
     var np = res[0]
     var expected = -lr * rho  # p starts at 0, moves by -lr*rho
     for i in range(n):
@@ -167,7 +216,8 @@ def test_weight_decay_decoupled() raises:
     Sophia's decoupled decay (like AdamW) is applied AFTER the gradient step and
     scales the ORIGINAL params: new_params -= weight_decay * lr * params. So the
     wd!=0 result must differ from the wd=0 result by exactly wd*lr*params[i] per
-    coordinate. All other inputs (grad, momentum, hessian) are held identical.
+    coordinate. All other inputs (grad, momentum, hessian moment) are held
+    identical.
     """
     print("Running test_weight_decay_decoupled...")
     var n = 4
@@ -182,13 +232,10 @@ def test_weight_decay_decoupled() raises:
     var g = full([n], 0.1, DType.float64)
     var m = zeros([n], DType.float64)
     var hm = full([n], 0.5, DType.float64)
-    var h = full([n], 0.5, DType.float64)
 
     # Same step, once without decay and once with decay.
-    var res_no_wd = sophia_step(
-        p, g, m, hm, h, lr, 0.96, 0.99, 0.04, 1e-12, 0.0
-    )
-    var res_wd = sophia_step(p, g, m, hm, h, lr, 0.96, 0.99, 0.04, 1e-12, wd)
+    var res_no_wd = sophia_step(p, g, m, hm, lr, 0.96, 1.0, 0.04, 1e-12, 0.0)
+    var res_wd = sophia_step(p, g, m, hm, lr, 0.96, 1.0, 0.04, 1e-12, wd)
     var np_no_wd = res_no_wd[0]
     var np_wd = res_wd[0]
 
@@ -234,10 +281,9 @@ def test_simple_matches_full_defaults() raises:
     var g = full([n], -0.3, DType.float64)
     var m = zeros([n], DType.float64)
     var hm = full([n], 0.5, DType.float64)
-    var h = full([n], 0.5, DType.float64)
 
-    var full_res = sophia_step(p, g, m, hm, h, 0.06)
-    var simple_res = sophia_step_simple(p, g, m, hm, h, 0.06)
+    var full_res = sophia_step(p, g, m, hm, 0.06)
+    var simple_res = sophia_step_simple(p, g, m, hm, 0.06)
     for i in range(n):
         if (
             _abs_diff(
@@ -254,11 +300,12 @@ def test_simple_matches_full_defaults() raises:
 def main() raises:
     """Run all Sophia tests."""
     print("=" * 60)
-    print("Sophia Optimizer Test Suite")
+    print("Sophia Clipped-Preconditioned Update Step Test Suite")
     print("=" * 60)
     test_reject_shape_mismatch()
     test_reject_dtype_mismatch()
     test_parity_with_reference()
+    test_gamma_scales_denominator()
     test_clip_bounds_update()
     test_weight_decay_decoupled()
     test_hessian_moment_ema()

--- a/tests/odyssey/training/optimizers/test_sophia.mojo
+++ b/tests/odyssey/training/optimizers/test_sophia.mojo
@@ -4,6 +4,7 @@ Tests cover:
 - Shape/dtype guards on sophia_step
 - Numerical parity with the SophiaH reference algorithm (1e-9) on a fixed vector
 - The clip bound (rho) on the per-coordinate update
+- Decoupled (AdamW-style) weight_decay != 0 branch
 - sophia_update_hessian_moment EMA behavior
 - sophia_step_simple delegating to sophia_step with defaults
 """
@@ -160,6 +161,55 @@ def test_clip_bounds_update() raises:
     print("test_clip_bounds_update PASSED")
 
 
+def test_weight_decay_decoupled() raises:
+    """weight_decay != 0 subtracts the decoupled AdamW term wd*lr*params_orig.
+
+    Sophia's decoupled decay (like AdamW) is applied AFTER the gradient step and
+    scales the ORIGINAL params: new_params -= weight_decay * lr * params. So the
+    wd!=0 result must differ from the wd=0 result by exactly wd*lr*params[i] per
+    coordinate. All other inputs (grad, momentum, hessian) are held identical.
+    """
+    print("Running test_weight_decay_decoupled...")
+    var n = 4
+    var lr = 0.1
+    var wd = 0.05
+    # Non-zero params so the decoupled term is non-trivial per coordinate.
+    var p = zeros([n], DType.float64)
+    p.store[DType.float64](0, 0.2)
+    p.store[DType.float64](1, -0.4)
+    p.store[DType.float64](2, 0.6)
+    p.store[DType.float64](3, -0.8)
+    var g = full([n], 0.1, DType.float64)
+    var m = zeros([n], DType.float64)
+    var hm = full([n], 0.5, DType.float64)
+    var h = full([n], 0.5, DType.float64)
+
+    # Same step, once without decay and once with decay.
+    var res_no_wd = sophia_step(
+        p, g, m, hm, h, lr, 0.96, 0.99, 0.04, 1e-12, 0.0
+    )
+    var res_wd = sophia_step(p, g, m, hm, h, lr, 0.96, 0.99, 0.04, 1e-12, wd)
+    var np_no_wd = res_no_wd[0]
+    var np_wd = res_wd[0]
+
+    for i in range(n):
+        var diff = np_no_wd.load[DType.float64](i) - np_wd.load[DType.float64](
+            i
+        )
+        var expected = wd * lr * p.load[DType.float64](i)
+        if _abs_diff(diff, expected) > 1e-12:
+            raise Error(
+                "decoupled weight decay wrong at "
+                + String(i)
+                + ": got "
+                + String(diff)
+                + " expected "
+                + String(expected)
+            )
+    print("  ok wd!=0 differs from wd=0 by wd*lr*params (decoupled)")
+    print("test_weight_decay_decoupled PASSED")
+
+
 def test_hessian_moment_ema() raises:
     """sophia_update_hessian_moment does the beta2 EMA correctly."""
     print("Running test_hessian_moment_ema...")
@@ -210,6 +260,7 @@ def main() raises:
     test_reject_dtype_mismatch()
     test_parity_with_reference()
     test_clip_bounds_update()
+    test_weight_decay_decoupled()
     test_hessian_moment_ema()
     test_simple_matches_full_defaults()
     print("=" * 60)


### PR DESCRIPTION
## Summary

Adds the **Sophia clipped preconditioned update step** (Liu et al., *Sophia: A Scalable Stochastic Second-order Optimizer for Language Model Pre-training*, 2023, [arXiv:2305.14342](https://arxiv.org/abs/2305.14342)).

**Scope (honest):** this is the Sophia-style **update step only**, operating on **caller-supplied diagonal-Hessian estimates**. The estimators that produce those estimates in the paper — Sophia-H (Hutchinson) and Sophia-G (Gauss–Newton–Bartlett) — require Hessian-vector products / higher-order autodiff, which Odyssey's autograd does not provide yet (tracked in `src/odyssey/autograd/TODO.md`, Phase 3 "Higher-order gradients"). Exported symbols keep their `sophia_*` names because the update rule is Sophia's; every docstring and README row carries the caveat.

## What it does

```
momentum       = beta1 * momentum + (1 - beta1) * grad
hessian_moment = beta2 * hessian_moment + (1 - beta2) * hessian   # on caller's refresh
update         = clip(momentum / max(gamma * hessian_moment, eps), -rho, +rho)
params         = params - lr * update
```

**gamma restored per the paper:** Algorithm 3 writes `clip(m / max(gamma*h, eps), 1)`, and the official implementation ([Liuhong99/Sophia `sophia.py`](https://github.com/Liuhong99/Sophia)) computes `ratio = (exp_avg.abs()/(rho * bs * hess + 1e-15)).clamp(None, 1)` — i.e. `gamma = rho * bs`, batch-size coupled, so gamma has **no batch-size-free universal default**. We expose `gamma` explicitly with default **1.0**, which is exactly the SophiaH parametrization of `pytorch_optimizer` (the ±rho clip carries the threshold; callers fold any `rho*bs` scale into the Hessian estimate they supply). This choice is documented with citations in the module docstring; passing `gamma` explicitly with `rho=1` reproduces the paper's form verbatim.

Pure-functional, caller-managed state (matching `lion`/`adam`): `sophia_step` + `sophia_update_hessian_moment` (the β₂ Hessian EMA, on the caller's refresh schedule) + `sophia_step_simple`. **Honest signatures:** `sophia_step` accepts only parameters it uses — the previously-ignored `hessian`/`beta2` were removed; the Hessian EMA refresh belongs solely to `sophia_update_hessian_moment`.

## Correctness — parity in the meaningful regime

Reference at `tests/odyssey/training/optimizers/parity_refs/sophia_parity_reference.py` (NumPy transcription of the published update, now modeling gamma; prints the per-coordinate raw updates and the clipped/unclipped split). The parity vector has **5 of 6 coordinates UNCLIPPED** — so the `m / max(gamma*hm, eps)` arithmetic (gamma = 0.8) is actually asserted — and **1 coordinate saturating the ±rho clip** (raw update 1.7034 vs rho = 0.04). All hardcoded refs regenerated from the script's output; parity to 1e-9.

## Tests

`tests/odyssey/training/optimizers/test_sophia.mojo`: shape/dtype guards, the regime-split parity vector (1e-9), **gamma scaling** (gamma=2 halves an unclipped update vs gamma=1), the **rho clip bound**, decoupled weight decay, the Hessian-moment EMA, and `sophia_step_simple` == `sophia_step` with defaults. Registered in `optimizers/__init__.mojo`; covered by the CI matrix (`scripts/validate_test_coverage.py` exit 0).

## Relationship to tracking issue

**Refs** mvillmow/Random#66 (OPT-02) — upstream Odyssey optimizer the predictive-coding OPT-02 ablation integration will consume; a prerequisite, not the completion. Does not `Closes` it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
