### PR TITLE
feat(layers): add vanilla RNN cell (Elman 1990)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Vanilla RNN cell** (Elman 1990) — `RNNCell` in `core/layers/rnn.mojo`,
+  h_t = tanh(x W_ih + b_ih + h W_hh + b_hh), verified against `torch.nn.RNNCell` to 1e-5.
+
 - **Full manual backward passes + real CIFAR-10 training** for three CNN examples,
   each with genuine measured epoch validation (no synthetic placeholders):
   - MobileNetV1 ([#3187](https://github.com/HomericIntelligence/Odyssey/issues/3187)):

--- a/src/odyssey/core/layers/__init__.mojo
+++ b/src/odyssey/core/layers/__init__.mojo
@@ -8,6 +8,7 @@ Components:
     - Linear: Fully connected (dense) layers
     - Conv2D: 2D convolutional layers
     - ReLU: Rectified Linear Unit activation
+    - RNNCell: Vanilla (Elman) recurrent cell (tanh)
     - Sigmoid: Sigmoid activation function
     - Tanh: Hyperbolic tangent activation
     - BatchNorm: Batch normalization
@@ -37,6 +38,7 @@ from odyssey.core.layers.conv2d import Conv2dLayer
 from odyssey.core.layers.batchnorm import BatchNorm2dLayer
 from odyssey.core.layers.relu import ReLULayer
 from odyssey.core.layers.dropout import DropoutLayer
+from odyssey.core.layers.rnn import RNNCell
 
 # from .activation import ReLU, Sigmoid, Tanh
 # from .pooling import MaxPool2D, AvgPool2D

--- a/src/odyssey/core/layers/rnn.mojo
+++ b/src/odyssey/core/layers/rnn.mojo
@@ -1,0 +1,127 @@
+"""Vanilla (Elman) RNN cell.
+
+A single recurrent step of a vanilla Elman RNN (Elman, 1990):
+
+    h_t = tanh(x_t @ W_ih + b_ih + h_{t-1} @ W_hh + b_hh)
+
+The cell holds the input-to-hidden and hidden-to-hidden projections as two
+`Linear` layers and applies a tanh nonlinearity to their sum. `forward` computes
+one step given the current input `x_t` and previous hidden state `h_{t-1}`; a
+sequence is processed by the caller looping `forward` over time steps (the same
+convention as PyTorch's `nn.RNNCell`).
+
+Reference:
+    Elman, J. L. (1990). Finding Structure in Time. Cognitive Science, 14(2),
+    179-211. (Vanilla / Elman RNN.)
+    Interface mirrors `torch.nn.RNNCell` (nonlinearity='tanh').
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.core.module import Module
+from odyssey.core.layers.linear import Linear
+from odyssey.core.activation import tanh
+
+
+struct RNNCell[dtype: DType = DType.float32](Copyable, Module, Movable):
+    """Vanilla Elman RNN cell: h_t = tanh(x_t W_ih + b_ih + h_{t-1} W_hh + b_hh).
+
+    Parameters:
+        dtype: Data type for weights and biases (default: float32).
+
+    Attributes:
+        ih: Input-to-hidden projection (input_size -> hidden_size).
+        hh: Hidden-to-hidden projection (hidden_size -> hidden_size).
+        input_size: Input feature dimension.
+        hidden_size: Hidden state dimension.
+    """
+
+    var ih: Linear[Self.dtype]
+    var hh: Linear[Self.dtype]
+    var input_size: Int
+    var hidden_size: Int
+
+    def __init__(out self, input_size: Int, hidden_size: Int) raises:
+        """Initialize the RNN cell.
+
+        Args:
+            input_size: Number of input features.
+            hidden_size: Number of hidden units.
+
+        Raises:
+            Error: If input_size or hidden_size <= 0, or layer construction fails.
+
+        Example:
+            ```mojo
+            var cell = RNNCell(3, 4)
+            var h1 = cell.forward(x, h0)   # x: [batch, 3], h0: [batch, 4]
+            ```
+        """
+        if input_size <= 0:
+            raise Error("RNNCell: input_size must be positive")
+        if hidden_size <= 0:
+            raise Error("RNNCell: hidden_size must be positive")
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.ih = Linear[Self.dtype](input_size, hidden_size)
+        self.hh = Linear[Self.dtype](hidden_size, hidden_size)
+
+    def forward(mut self, input: AnyTensor) raises -> AnyTensor:
+        """Module `forward` for a zero initial hidden state.
+
+        Computes one step from a zero hidden state:
+        `h = tanh(input @ W_ih + b_ih)`. Use `step(input, hidden)` to thread a
+        real recurrent hidden state across time.
+
+        Args:
+            input: Input tensor of shape (batch, input_size).
+
+        Returns:
+            Hidden state of shape (batch, hidden_size).
+
+        Raises:
+            Error: If tensor operations fail.
+        """
+        return tanh(self.ih.forward(input))
+
+    def step(mut self, input: AnyTensor, hidden: AnyTensor) raises -> AnyTensor:
+        """One recurrent step: h_t = tanh(x_t W_ih + b_ih + h_{t-1} W_hh + b_hh).
+
+        Args:
+            input: Input tensor x_t of shape (batch, input_size).
+            hidden: Previous hidden state h_{t-1} of shape (batch, hidden_size).
+
+        Returns:
+            New hidden state h_t of shape (batch, hidden_size).
+
+        Raises:
+            Error: If tensor operations fail or shapes are incompatible.
+        """
+        var pre = self.ih.forward(input) + self.hh.forward(hidden)
+        return tanh(pre)
+
+    def parameters(self) raises -> List[AnyTensor]:
+        """Collect trainable parameters from both projections.
+
+        Returns:
+            List of [ih.weight, ih.bias, hh.weight, hh.bias].
+
+        Raises:
+            Error if tensor copying fails.
+        """
+        var params = List[AnyTensor]()
+        for p in self.ih.parameters():
+            params.append(p)
+        for p in self.hh.parameters():
+            params.append(p)
+        return params^
+
+    def train(mut self):
+        """Switch to training mode (no-op; sub-layers are stateless in mode)."""
+        self.ih.train()
+        self.hh.train()
+
+    def eval(mut self):
+        """Switch to inference mode (no-op; sub-layers are stateless in mode).
+        """
+        self.ih.eval()
+        self.hh.eval()

--- a/src/odyssey/core/layers/rnn.mojo
+++ b/src/odyssey/core/layers/rnn.mojo
@@ -17,6 +17,7 @@ Reference:
 """
 
 from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros
 from odyssey.core.module import Module
 from odyssey.core.layers.linear import Linear
 from odyssey.core.activation import tanh
@@ -81,7 +82,11 @@ struct RNNCell[dtype: DType = DType.float32](Copyable, Module, Movable):
         Raises:
             Error: If tensor operations fail.
         """
-        return tanh(self.ih.forward(input))
+        # A zero hidden zeros only the hidden-to-hidden WEIGHT term, not its bias
+        # b_hh — so delegate to step(input, zeros) rather than dropping b_hh.
+        var batch = input.shape()[0]
+        var h0 = zeros([batch, self.hidden_size], Self.dtype)
+        return self.step(input, h0)
 
     def step(mut self, input: AnyTensor, hidden: AnyTensor) raises -> AnyTensor:
         """One recurrent step: h_t = tanh(x_t W_ih + b_ih + h_{t-1} W_hh + b_hh).

--- a/tests/odyssey/core/layers/parity_refs/rnn_parity_reference.py
+++ b/tests/odyssey/core/layers/parity_refs/rnn_parity_reference.py
@@ -1,0 +1,51 @@
+"""Vanilla RNN cell parity reference.
+
+Computes h_t = tanh(x @ W_ih + b_ih + h @ W_hh + b_hh) in PyTorch with FIXED
+ramp weights + input + hidden, and prints the flattened output so the Mojo
+RNNCell test can set the same weights (Odyssey Linear layout (in, out); torch
+nn.RNNCell uses (out, in), so torch weights are the transpose) and assert.
+
+Config: input_size=3, hidden_size=4, batch=2.
+"""
+
+import json
+
+import torch
+import torch.nn as nn
+
+torch.manual_seed(0)
+IN, HID, B = 3, 4, 2
+
+# Odyssey layout: W_ih (in, hid), W_hh (hid, hid); ramp values
+W_ih = torch.arange(IN * HID, dtype=torch.float64).reshape(IN, HID) * 0.02 - 0.1
+b_ih = torch.arange(HID, dtype=torch.float64) * 0.03 - 0.05
+W_hh = torch.arange(HID * HID, dtype=torch.float64).reshape(HID, HID) * 0.01 - 0.06
+b_hh = torch.arange(HID, dtype=torch.float64) * 0.02 - 0.03
+X = torch.arange(B * IN, dtype=torch.float64).reshape(B, IN) * 0.1 - 0.2
+H = torch.arange(B * HID, dtype=torch.float64).reshape(B, HID) * 0.05 - 0.1
+
+cell = nn.RNNCell(IN, HID, nonlinearity="tanh").double()
+with torch.no_grad():
+    cell.weight_ih.copy_(W_ih.T)  # torch (out, in) = transpose of Odyssey (in, out)
+    cell.bias_ih.copy_(b_ih)
+    cell.weight_hh.copy_(W_hh.T)
+    cell.bias_hh.copy_(b_hh)
+
+with torch.no_grad():
+    out = cell(X, H)
+
+print(
+    json.dumps(
+        {
+            "config": {"input_size": IN, "hidden_size": HID, "batch": B},
+            "W_ih": W_ih.flatten().tolist(),
+            "b_ih": b_ih.tolist(),
+            "W_hh": W_hh.flatten().tolist(),
+            "b_hh": b_hh.tolist(),
+            "X": X.flatten().tolist(),
+            "H": H.flatten().tolist(),
+            "out": out.flatten().tolist(),
+        },
+        indent=2,
+    )
+)

--- a/tests/odyssey/core/layers/test_rnn.mojo
+++ b/tests/odyssey/core/layers/test_rnn.mojo
@@ -101,6 +101,54 @@ def test_parity_with_pytorch() raises:
     print("test_parity_with_pytorch PASSED")
 
 
+def test_forward_equals_zero_state_step() raises:
+    """forward(x) must equal step(x, zeros) even with a nonzero b_hh.
+
+    A zero initial hidden zeros only the hidden-to-hidden WEIGHT term, not its
+    bias b_hh. This asserts forward() includes b_hh (regression guard: an earlier
+    shortcut computed tanh(ih.forward(x)) and dropped b_hh, so forward diverged
+    from step once b_hh was trained nonzero).
+    """
+    print("Running test_forward_equals_zero_state_step...")
+    var cell = RNNCell[DType.float64](3, 4)
+    for i in range(4):
+        cell.hh.bias.store[DType.float64](i, Float64(i) * 0.02 + 0.05)
+    var x = zeros([2, 3], DType.float64)
+    for i in range(6):
+        x.store[DType.float64](i, Float64(i) * 0.1 - 0.2)
+    var h0 = zeros([2, 4], DType.float64)
+
+    var f = cell.forward(x)
+    var s = cell.step(x, h0)
+    for i in range(8):
+        if _abs_diff(f.load[DType.float64](i), s.load[DType.float64](i)) > 1e-12:
+            raise Error("forward != step(x, zeros) at " + String(i))
+    print("  ok forward(x) == step(x, zeros) with nonzero b_hh")
+    print("test_forward_equals_zero_state_step PASSED")
+
+
+def test_parameter_order() raises:
+    """parameters() must return [ih.weight, ih.bias, hh.weight, hh.bias] in order.
+
+    A consumer that threads per-parameter state (e.g. the PC error chain) relies
+    on this positional contract, so assert identity by numel, not just count.
+    """
+    print("Running test_parameter_order...")
+    var cell = RNNCell[DType.float64](3, 4)
+    var params = cell.parameters()
+    # ih.weight: 3x4=12, ih.bias: 4, hh.weight: 4x4=16, hh.bias: 4.
+    if params[0].numel() != 12:
+        raise Error("params[0] should be ih.weight (12)")
+    if params[1].numel() != 4:
+        raise Error("params[1] should be ih.bias (4)")
+    if params[2].numel() != 16:
+        raise Error("params[2] should be hh.weight (16)")
+    if params[3].numel() != 4:
+        raise Error("params[3] should be hh.bias (4)")
+    print("  ok parameter order ih.weight/ih.bias/hh.weight/hh.bias")
+    print("test_parameter_order PASSED")
+
+
 def main() raises:
     """Run all RNN tests."""
     print("=" * 60)
@@ -110,6 +158,8 @@ def main() raises:
     test_reject_bad_sizes()
     test_parameter_count()
     test_parity_with_pytorch()
+    test_forward_equals_zero_state_step()
+    test_parameter_order()
     print("=" * 60)
     print("All RNN tests PASSED")
     print("=" * 60)

--- a/tests/odyssey/core/layers/test_rnn.mojo
+++ b/tests/odyssey/core/layers/test_rnn.mojo
@@ -1,0 +1,115 @@
+"""Unit tests for the vanilla (Elman) RNN cell.
+
+Tests cover:
+- Construction + validation (positive input_size/hidden_size)
+- step() shape (batch, input_size) x (batch, hidden_size) -> (batch, hidden_size)
+- parameter collection (4 tensors: ih.weight/bias, hh.weight/bias)
+- Numerical parity with torch.nn.RNNCell (tanh) on fixed ramp weights (1e-5)
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros
+from odyssey.core.layers.rnn import RNNCell
+
+
+def _abs_diff(a: Float64, b: Float64) -> Float64:
+    var d = a - b
+    if d < 0:
+        d = -d
+    return d
+
+
+def test_shape() raises:
+    """step maps (batch, input) x (batch, hidden) -> (batch, hidden)."""
+    print("Running test_shape...")
+    var cell = RNNCell[DType.float32](3, 4)
+    var x = zeros([2, 3], DType.float32)
+    var h = zeros([2, 4], DType.float32)
+    var out = cell.step(x, h)
+    if out.shape()[0] != 2 or out.shape()[1] != 4:
+        raise Error("RNN step must return (batch, hidden)")
+    print("  ok (2, 4)")
+    print("test_shape PASSED")
+
+
+def test_reject_bad_sizes() raises:
+    """Non-positive sizes must raise."""
+    print("Running test_reject_bad_sizes...")
+    try:
+        var _ = RNNCell[DType.float32](0, 4)
+        raise Error("Should have rejected input_size = 0")
+    except e:
+        print("  ok rejected input_size = 0")
+    try:
+        var _ = RNNCell[DType.float32](3, 0)
+        raise Error("Should have rejected hidden_size = 0")
+    except e:
+        print("  ok rejected hidden_size = 0")
+    print("test_reject_bad_sizes PASSED")
+
+
+def test_parameter_count() raises:
+    """parameters() returns 4 tensors."""
+    print("Running test_parameter_count...")
+    var cell = RNNCell[DType.float32](3, 4)
+    if len(cell.parameters()) != 4:
+        raise Error("RNN cell should expose 4 parameter tensors")
+    print("  ok 4 parameter tensors")
+    print("test_parameter_count PASSED")
+
+
+def test_parity_with_pytorch() raises:
+    """step must match torch.nn.RNNCell(tanh) on fixed ramp weights to 1e-5.
+
+    Reference values from parity_refs/rnn_parity_reference.py (input=3,
+    hidden=4, batch=2). Odyssey Linear uses W (in, out); the reference sets
+    torch's (out, in) weight to the transpose.
+    """
+    print("Running test_parity_with_pytorch...")
+
+    var ref = List[Float64]()
+    ref.append(-0.0479632)
+    ref.append(-0.005)
+    ref.append(0.0379817)
+    ref.append(0.0808233)
+    ref.append(-0.0659043)
+    ref.append(0.003)
+    ref.append(0.0718758)
+    ref.append(0.140073)
+
+    var cell = RNNCell[DType.float64](3, 4)
+    for i in range(12):
+        cell.ih.weight.store[DType.float64](i, Float64(i) * 0.02 - 0.1)
+    for i in range(4):
+        cell.ih.bias.store[DType.float64](i, Float64(i) * 0.03 - 0.05)
+    for i in range(16):
+        cell.hh.weight.store[DType.float64](i, Float64(i) * 0.01 - 0.06)
+    for i in range(4):
+        cell.hh.bias.store[DType.float64](i, Float64(i) * 0.02 - 0.03)
+    var x = zeros([2, 3], DType.float64)
+    for i in range(6):
+        x.store[DType.float64](i, Float64(i) * 0.1 - 0.2)
+    var h = zeros([2, 4], DType.float64)
+    for i in range(8):
+        h.store[DType.float64](i, Float64(i) * 0.05 - 0.1)
+
+    var out = cell.step(x, h)
+    for i in range(8):
+        if _abs_diff(out.load[DType.float64](i), ref[i]) > 1e-5:
+            raise Error("RNN parity mismatch at " + String(i))
+    print("  ok matches torch.nn.RNNCell to 1e-5")
+    print("test_parity_with_pytorch PASSED")
+
+
+def main() raises:
+    """Run all RNN tests."""
+    print("=" * 60)
+    print("Vanilla RNN Cell Test Suite")
+    print("=" * 60)
+    test_shape()
+    test_reject_bad_sizes()
+    test_parameter_count()
+    test_parity_with_pytorch()
+    print("=" * 60)
+    print("All RNN tests PASSED")
+    print("=" * 60)


### PR DESCRIPTION
## Summary

Adds a vanilla (Elman) **RNN cell** as a first-class `Module`:
```
h_t = tanh(x_t W_ih + b_ih + h_{t-1} W_hh + b_hh)
```
Composes input-to-hidden + hidden-to-hidden `Linear` projections with tanh. `step(input, hidden)` does one recurrent step; the caller loops it over a sequence (mirrors `torch.nn.RNNCell`, nonlinearity='tanh').

## Correctness

`step` **matches `torch.nn.RNNCell` to 1e-5** on fixed ramp weights. Reference at `tests/odyssey/core/layers/parity_refs/rnn_parity_reference.py` (Odyssey Linear uses W (in, out); torch (out, in) is set to the transpose).

## Tests
Shape, size validation, parameter count (4 tensors), and the PyTorch parity vector. Registered in `core/layers/__init__.mojo`; CHANGELOG updated.

**Refs** mvillmow/Random#55 (ARCH-05) — upstream prerequisite; does not `Closes` it. Establishes the recurrent-cell pattern for the GRU/LSTM follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)