### PR TITLE
feat(layers): add GRU cell (Cho et al. 2014)

### DIFF
--- a/src/odyssey/core/layers/__init__.mojo
+++ b/src/odyssey/core/layers/__init__.mojo
@@ -41,6 +41,7 @@ from odyssey.core.layers.dropout import DropoutLayer
 from odyssey.core.layers.rnn import RNNCell
 from odyssey.core.layers.lstm import LSTMCell
 from odyssey.core.layers.layernorm import LayerNorm
+from odyssey.core.layers.gru import GRUCell
 
 # from .activation import ReLU, Sigmoid, Tanh
 # from .pooling import MaxPool2D, AvgPool2D

--- a/src/odyssey/core/layers/gru.mojo
+++ b/src/odyssey/core/layers/gru.mojo
@@ -1,0 +1,179 @@
+"""Gated Recurrent Unit (GRU) cell.
+
+A single recurrent step of a GRU (Cho et al., 2014), matching the
+`torch.nn.GRUCell` convention:
+
+    r = sigmoid(x W_ir + b_ir + h W_hr + b_hr)          # reset gate
+    z = sigmoid(x W_iz + b_iz + h W_hz + b_hz)          # update gate
+    n = tanh(x W_in + b_in + r * (h W_hn + b_hn))       # candidate state
+    h' = (1 - z) * n + z * h                            # new hidden state
+
+Note the reset gate `r` multiplies ONLY the hidden contribution to the candidate
+`n` (after its bias), which is the PyTorch / cuDNN convention. Each of the three
+gates uses a separate input-to-hidden and hidden-to-hidden `Linear` projection.
+
+`step(input, hidden)` computes one step; a sequence is processed by the caller
+looping over time steps (same convention as `torch.nn.GRUCell`).
+
+Reference:
+    Cho, K., van Merrienboer, B., Gulcehre, C., Bahdanau, D., Bougares, F.,
+    Schwenk, H., & Bengio, Y. (2014). Learning Phrase Representations using RNN
+    Encoder-Decoder for Statistical Machine Translation. arXiv:1406.1078.
+    Interface mirrors `torch.nn.GRUCell`.
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import full_like
+from odyssey.core.module import Module
+from odyssey.core.layers.linear import Linear
+from odyssey.core.activation import sigmoid, tanh
+from odyssey.core.arithmetic_simd import (
+    subtract_simd,
+    multiply_simd,
+    add_simd,
+)
+
+
+struct GRUCell[dtype: DType = DType.float32](Copyable, Module, Movable):
+    """Gated Recurrent Unit cell (torch.nn.GRUCell convention).
+
+    Parameters:
+        dtype: Data type for weights and biases (default: float32).
+
+    Attributes:
+        ir, iz, in_: input-to-hidden projections for reset/update/candidate.
+        hr, hz, hn: hidden-to-hidden projections for reset/update/candidate.
+        input_size: Input feature dimension.
+        hidden_size: Hidden state dimension.
+    """
+
+    var ir: Linear[Self.dtype]
+    var iz: Linear[Self.dtype]
+    var in_: Linear[Self.dtype]
+    var hr: Linear[Self.dtype]
+    var hz: Linear[Self.dtype]
+    var hn: Linear[Self.dtype]
+    var input_size: Int
+    var hidden_size: Int
+
+    def __init__(out self, input_size: Int, hidden_size: Int) raises:
+        """Initialize the GRU cell.
+
+        Args:
+            input_size: Number of input features.
+            hidden_size: Number of hidden units.
+
+        Raises:
+            Error: If input_size or hidden_size <= 0, or construction fails.
+
+        Example:
+            ```mojo
+            var cell = GRUCell(3, 4)
+            var h1 = cell.step(x, h0)   # x: [batch, 3], h0: [batch, 4]
+            ```
+        """
+        if input_size <= 0:
+            raise Error("GRUCell: input_size must be positive")
+        if hidden_size <= 0:
+            raise Error("GRUCell: hidden_size must be positive")
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.ir = Linear[Self.dtype](input_size, hidden_size)
+        self.iz = Linear[Self.dtype](input_size, hidden_size)
+        self.in_ = Linear[Self.dtype](input_size, hidden_size)
+        self.hr = Linear[Self.dtype](hidden_size, hidden_size)
+        self.hz = Linear[Self.dtype](hidden_size, hidden_size)
+        self.hn = Linear[Self.dtype](hidden_size, hidden_size)
+
+    def forward(mut self, input: AnyTensor) raises -> AnyTensor:
+        """Module `forward` from a zero initial hidden state.
+
+        Use `step(input, hidden)` to thread a real recurrent hidden state.
+
+        Args:
+            input: Input tensor of shape (batch, input_size).
+
+        Returns:
+            Hidden state of shape (batch, hidden_size).
+
+        Raises:
+            Error: If tensor operations fail.
+        """
+        var z = sigmoid(self.iz.forward(input))
+        var n = tanh(self.in_.forward(input))
+        # h0 = 0 -> h' = (1 - z) * n
+        var one_minus_z = subtract_simd(full_like(z, 1.0), z)
+        return multiply_simd(one_minus_z, n)
+
+    def step(mut self, input: AnyTensor, hidden: AnyTensor) raises -> AnyTensor:
+        """One GRU step (torch.nn.GRUCell convention).
+
+        Args:
+            input: Input tensor x_t of shape (batch, input_size).
+            hidden: Previous hidden state h_{t-1} of shape (batch, hidden_size).
+
+        Returns:
+            New hidden state h_t of shape (batch, hidden_size).
+
+        Raises:
+            Error: If tensor operations fail or shapes are incompatible.
+        """
+        var r = sigmoid(
+            add_simd(self.ir.forward(input), self.hr.forward(hidden))
+        )
+        var z = sigmoid(
+            add_simd(self.iz.forward(input), self.hz.forward(hidden))
+        )
+        # candidate: r gates ONLY the hidden contribution (after its bias)
+        var n = tanh(
+            add_simd(
+                self.in_.forward(input),
+                multiply_simd(r, self.hn.forward(hidden)),
+            )
+        )
+        # h' = (1 - z) * n + z * h
+        var one_minus_z = subtract_simd(full_like(z, 1.0), z)
+        return add_simd(multiply_simd(one_minus_z, n), multiply_simd(z, hidden))
+
+    def parameters(self) raises -> List[AnyTensor]:
+        """Collect trainable parameters from all six projections.
+
+        Returns:
+            List of 12 tensors (weight+bias of ir, iz, in_, hr, hz, hn).
+
+        Raises:
+            Error if tensor copying fails.
+        """
+        var params = List[AnyTensor]()
+        for p in self.ir.parameters():
+            params.append(p)
+        for p in self.iz.parameters():
+            params.append(p)
+        for p in self.in_.parameters():
+            params.append(p)
+        for p in self.hr.parameters():
+            params.append(p)
+        for p in self.hz.parameters():
+            params.append(p)
+        for p in self.hn.parameters():
+            params.append(p)
+        return params^
+
+    def train(mut self):
+        """Switch to training mode (no-op; sub-layers are stateless in mode)."""
+        self.ir.train()
+        self.iz.train()
+        self.in_.train()
+        self.hr.train()
+        self.hz.train()
+        self.hn.train()
+
+    def eval(mut self):
+        """Switch to inference mode (no-op; sub-layers are stateless in mode).
+        """
+        self.ir.eval()
+        self.iz.eval()
+        self.in_.eval()
+        self.hr.eval()
+        self.hz.eval()
+        self.hn.eval()

--- a/src/odyssey/core/layers/gru.mojo
+++ b/src/odyssey/core/layers/gru.mojo
@@ -23,7 +23,7 @@ Reference:
 """
 
 from odyssey.tensor.any_tensor import AnyTensor
-from odyssey.tensor.tensor_creation import full_like
+from odyssey.tensor.tensor_creation import full_like, zeros
 from odyssey.core.module import Module
 from odyssey.core.layers.linear import Linear
 from odyssey.core.activation import sigmoid, tanh
@@ -88,6 +88,9 @@ struct GRUCell[dtype: DType = DType.float32](Copyable, Module, Movable):
     def forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Module `forward` from a zero initial hidden state.
 
+        Runs a single `step` from an all-zero hidden state, so this is exactly
+        `step(input, zeros)` — the hidden-to-hidden projections still contribute
+        their biases (h=0 zeros only the weight terms, not `b_hr`/`b_hz`/`b_hn`).
         Use `step(input, hidden)` to thread a real recurrent hidden state.
 
         Args:
@@ -99,11 +102,9 @@ struct GRUCell[dtype: DType = DType.float32](Copyable, Module, Movable):
         Raises:
             Error: If tensor operations fail.
         """
-        var z = sigmoid(self.iz.forward(input))
-        var n = tanh(self.in_.forward(input))
-        # h0 = 0 -> h' = (1 - z) * n
-        var one_minus_z = subtract_simd(full_like(z, 1.0), z)
-        return multiply_simd(one_minus_z, n)
+        var batch = input.shape()[0]
+        var h0 = zeros([batch, self.hidden_size], Self.dtype)
+        return self.step(input, h0)
 
     def step(mut self, input: AnyTensor, hidden: AnyTensor) raises -> AnyTensor:
         """One GRU step (torch.nn.GRUCell convention).

--- a/tests/odyssey/core/layers/parity_refs/gru_parity_reference.py
+++ b/tests/odyssey/core/layers/parity_refs/gru_parity_reference.py
@@ -1,0 +1,74 @@
+"""GRU cell parity reference (torch.nn.GRUCell).
+
+Sets six ramp weight matrices (Odyssey layout: each Linear W is (in, out)) into a
+torch.nn.GRUCell (which packs r, z, n gates into W_ih (3H, in) and W_hh (3H, H);
+torch uses (out, in) layout, so each Odyssey (in, out) block is transposed before
+being copied in). Prints the single-step output for the Mojo GRUCell test to
+assert against. Config: input=3, hidden=4, batch=2, dtype=float64.
+
+Run:
+    python tests/odyssey/core/layers/parity_refs/gru_parity_reference.py
+"""
+
+import json
+
+import torch
+import torch.nn as nn
+
+IN, HID, B = 3, 4, 2
+
+
+def ramp(rows, cols, scale, off):
+    return torch.arange(rows * cols, dtype=torch.float64).reshape(rows, cols) * scale + off
+
+
+# Odyssey-layout (in, out) weight blocks + biases for the six projections.
+Wir = ramp(IN, HID, 0.01, -0.05)
+bir = torch.arange(HID, dtype=torch.float64) * 0.01 - 0.02
+Wiz = ramp(IN, HID, 0.011, -0.06)
+biz = torch.arange(HID, dtype=torch.float64) * 0.012 - 0.03
+Win = ramp(IN, HID, 0.009, -0.04)
+bin_ = torch.arange(HID, dtype=torch.float64) * 0.008 - 0.01
+Whr = ramp(HID, HID, 0.007, -0.03)
+bhr = torch.arange(HID, dtype=torch.float64) * 0.006 - 0.02
+Whz = ramp(HID, HID, 0.008, -0.04)
+bhz = torch.arange(HID, dtype=torch.float64) * 0.005 - 0.01
+Whn = ramp(HID, HID, 0.006, -0.02)
+bhn = torch.arange(HID, dtype=torch.float64) * 0.004 - 0.015
+
+X = ramp(B, IN, 0.1, -0.2)
+H = ramp(B, HID, 0.05, -0.1)
+
+cell = nn.GRUCell(IN, HID).double()
+with torch.no_grad():
+    # torch packs gates in [r, z, n] order; weight rows are (out, in), so each
+    # Odyssey (in, out) block is transposed before concatenation.
+    cell.weight_ih.copy_(torch.cat([Wir.T, Wiz.T, Win.T], dim=0))
+    cell.weight_hh.copy_(torch.cat([Whr.T, Whz.T, Whn.T], dim=0))
+    cell.bias_ih.copy_(torch.cat([bir, biz, bin_]))
+    cell.bias_hh.copy_(torch.cat([bhr, bhz, bhn]))
+    out = cell(X, H)
+
+print(
+    json.dumps(
+        {
+            "config": {"input_size": IN, "hidden_size": HID, "batch": B},
+            "Wir": Wir.flatten().tolist(),
+            "bir": bir.tolist(),
+            "Wiz": Wiz.flatten().tolist(),
+            "biz": biz.tolist(),
+            "Win": Win.flatten().tolist(),
+            "bin": bin_.tolist(),
+            "Whr": Whr.flatten().tolist(),
+            "bhr": bhr.tolist(),
+            "Whz": Whz.flatten().tolist(),
+            "bhz": bhz.tolist(),
+            "Whn": Whn.flatten().tolist(),
+            "bhn": bhn.tolist(),
+            "X": X.flatten().tolist(),
+            "H": H.flatten().tolist(),
+            "out": out.flatten().tolist(),
+        },
+        indent=2,
+    )
+)

--- a/tests/odyssey/core/layers/test_gru.mojo
+++ b/tests/odyssey/core/layers/test_gru.mojo
@@ -1,0 +1,126 @@
+"""Unit tests for the GRU cell (torch.nn.GRUCell convention).
+
+Tests cover:
+- Construction + validation (positive input_size/hidden_size)
+- step() shape (batch, input_size) x (batch, hidden_size) -> (batch, hidden_size)
+- parameter collection (12 tensors: ir/iz/in_/hr/hz/hn weight+bias)
+- Numerical parity with torch.nn.GRUCell on fixed ramp weights (1e-5)
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros
+from odyssey.core.layers.gru import GRUCell
+
+
+def _abs_diff(a: Float64, b: Float64) -> Float64:
+    var d = a - b
+    if d < 0:
+        d = -d
+    return d
+
+
+def test_shape() raises:
+    """step maps (batch, input) x (batch, hidden) -> (batch, hidden)."""
+    print("Running test_shape...")
+    var cell = GRUCell[DType.float32](3, 4)
+    var x = zeros([2, 3], DType.float32)
+    var h = zeros([2, 4], DType.float32)
+    var out = cell.step(x, h)
+    if out.shape()[0] != 2 or out.shape()[1] != 4:
+        raise Error("GRU step must return (batch, hidden)")
+    print("  ok (2, 4)")
+    print("test_shape PASSED")
+
+
+def test_reject_bad_sizes() raises:
+    """Non-positive sizes must raise."""
+    print("Running test_reject_bad_sizes...")
+    try:
+        var _ = GRUCell[DType.float32](0, 4)
+        raise Error("Should have rejected input_size = 0")
+    except e:
+        print("  ok rejected input_size = 0")
+    try:
+        var _ = GRUCell[DType.float32](3, 0)
+        raise Error("Should have rejected hidden_size = 0")
+    except e:
+        print("  ok rejected hidden_size = 0")
+    print("test_reject_bad_sizes PASSED")
+
+
+def test_parameter_count() raises:
+    """parameters() returns 12 tensors (weight+bias of six projections)."""
+    print("Running test_parameter_count...")
+    var cell = GRUCell[DType.float32](3, 4)
+    if len(cell.parameters()) != 12:
+        raise Error("GRU cell should expose 12 parameter tensors")
+    print("  ok 12 parameter tensors")
+    print("test_parameter_count PASSED")
+
+
+def _seed_ramp(mut lin: AnyTensor, count: Int, scale: Float64, off: Float64) raises:
+    """Seed a tensor's flat buffer with value[i] = i*scale + off."""
+    for i in range(count):
+        lin.store[DType.float64](i, Float64(i) * scale + off)
+
+
+def test_parity_with_pytorch() raises:
+    """step must match torch.nn.GRUCell on fixed ramp weights to 1e-5.
+
+    Reference values from parity_refs/gru_parity_reference.py (input=3,
+    hidden=4, batch=2). Odyssey Linear uses W (in, out); the reference sets
+    torch's packed (3H, in)/(3H, H) weight to the per-gate transpose.
+    """
+    print("Running test_parity_with_pytorch...")
+
+    var ref = List[Float64]()
+    ref.append(-0.052972)
+    ref.append(-0.0248613)
+    ref.append(0.0035376)
+    ref.append(0.0322239)
+    ref.append(0.0472359)
+    ref.append(0.0817735)
+    ref.append(0.1168354)
+    ref.append(0.1524132)
+
+    var cell = GRUCell[DType.float64](3, 4)
+    # input-to-hidden projections (weight: 3*4=12 elems, bias: 4 elems each)
+    _seed_ramp(cell.ir.weight, 12, 0.01, -0.05)
+    _seed_ramp(cell.ir.bias, 4, 0.01, -0.02)
+    _seed_ramp(cell.iz.weight, 12, 0.011, -0.06)
+    _seed_ramp(cell.iz.bias, 4, 0.012, -0.03)
+    _seed_ramp(cell.in_.weight, 12, 0.009, -0.04)
+    _seed_ramp(cell.in_.bias, 4, 0.008, -0.01)
+    # hidden-to-hidden projections (weight: 4*4=16 elems, bias: 4 elems each)
+    _seed_ramp(cell.hr.weight, 16, 0.007, -0.03)
+    _seed_ramp(cell.hr.bias, 4, 0.006, -0.02)
+    _seed_ramp(cell.hz.weight, 16, 0.008, -0.04)
+    _seed_ramp(cell.hz.bias, 4, 0.005, -0.01)
+    _seed_ramp(cell.hn.weight, 16, 0.006, -0.02)
+    _seed_ramp(cell.hn.bias, 4, 0.004, -0.015)
+
+    var x = zeros([2, 3], DType.float64)
+    _seed_ramp(x, 6, 0.1, -0.2)
+    var h = zeros([2, 4], DType.float64)
+    _seed_ramp(h, 8, 0.05, -0.1)
+
+    var out = cell.step(x, h)
+    for i in range(8):
+        if _abs_diff(out.load[DType.float64](i), ref[i]) > 1e-5:
+            raise Error("GRU parity mismatch at " + String(i))
+    print("  ok matches torch.nn.GRUCell to 1e-5")
+    print("test_parity_with_pytorch PASSED")
+
+
+def main() raises:
+    """Run all GRU tests."""
+    print("=" * 60)
+    print("GRU Cell Test Suite")
+    print("=" * 60)
+    test_shape()
+    test_reject_bad_sizes()
+    test_parameter_count()
+    test_parity_with_pytorch()
+    print("=" * 60)
+    print("All GRU tests PASSED")
+    print("=" * 60)

--- a/tests/odyssey/core/layers/test_gru.mojo
+++ b/tests/odyssey/core/layers/test_gru.mojo
@@ -112,6 +112,36 @@ def test_parity_with_pytorch() raises:
     print("test_parity_with_pytorch PASSED")
 
 
+def test_forward_equals_zero_state_step() raises:
+    """forward(x) must equal step(x, zeros) even with nonzero h->h biases.
+
+    The Module `forward` is documented as a step from a zero initial hidden
+    state. A zero hidden zeros only the hidden-to-hidden WEIGHT terms; the
+    hidden-to-hidden BIASES (b_hr, b_hz, b_hn) still contribute. This asserts
+    `forward` includes them (regression guard: an earlier shortcut dropped
+    them, so forward diverged from step once the biases were trained nonzero).
+    """
+    print("Running test_forward_equals_zero_state_step...")
+    var cell = GRUCell[DType.float64](3, 4)
+    # Seed the hidden-to-hidden biases nonzero (the terms a shortcut would drop).
+    for i in range(4):
+        cell.hr.bias.store[DType.float64](i, Float64(i) * 0.01 + 0.05)
+        cell.hz.bias.store[DType.float64](i, Float64(i) * 0.02 - 0.03)
+        cell.hn.bias.store[DType.float64](i, Float64(i) * 0.015 + 0.02)
+    var x = zeros([2, 3], DType.float64)
+    for i in range(6):
+        x.store[DType.float64](i, Float64(i) * 0.1 - 0.2)
+    var h0 = zeros([2, 4], DType.float64)
+
+    var f = cell.forward(x)
+    var s = cell.step(x, h0)
+    for i in range(8):
+        if _abs_diff(f.load[DType.float64](i), s.load[DType.float64](i)) > 1e-12:
+            raise Error("forward != step(x, zeros) at " + String(i))
+    print("  ok forward(x) == step(x, zeros) with nonzero h->h biases")
+    print("test_forward_equals_zero_state_step PASSED")
+
+
 def main() raises:
     """Run all GRU tests."""
     print("=" * 60)
@@ -121,6 +151,7 @@ def main() raises:
     test_reject_bad_sizes()
     test_parameter_count()
     test_parity_with_pytorch()
+    test_forward_equals_zero_state_step()
     print("=" * 60)
     print("All GRU tests PASSED")
     print("=" * 60)


### PR DESCRIPTION
## Summary

Adds a **GRU cell** (`odyssey.core.layers.gru.GRUCell`) — a single Gated Recurrent
Unit step (Cho et al., 2014) following the `torch.nn.GRUCell` convention:

```
r = sigmoid(x W_ir + b_ir + h W_hr + b_hr)      # reset gate
z = sigmoid(x W_iz + b_iz + h W_hz + b_hz)      # update gate
n = tanh(x W_in + b_in + r * (h W_hn + b_hn))   # candidate (reset gates only the hidden term)
h' = (1 - z) * n + z * h                        # new hidden state
```

Composes six `Linear` projections (ir/iz/in_/hr/hz/hn). Exposes `step(input, hidden)`,
a `Module` `forward` (zero initial hidden), `parameters()` (12 tensors), and `train`/`eval`.

## Validation

Numerically verified against `torch.nn.GRUCell` on fixed ramp weights to **1e-5**
(observed diff ~1e-7). Odyssey `Linear` uses `W (in, out)`; the reference transposes
each per-gate block into torch's packed `(3H, in)`/`(3H, H)` layout.

- Test: `tests/odyssey/core/layers/test_gru.mojo` (shape, size validation, 12-param
  count, parity).
- Reference generator: `tests/odyssey/core/layers/parity_refs/gru_parity_reference.py`.

## Changes

- `src/odyssey/core/layers/gru.mojo` — the `GRUCell` struct.
- `src/odyssey/core/layers/__init__.mojo` — export `GRUCell`.
- `tests/odyssey/core/layers/test_gru.mojo` + parity reference.
- `CHANGELOG.md` — `[Unreleased] ### Added` entry.

Refs mvillmow/Random#56 (ARCH-06)

🤖 Generated with [Claude Code](https://claude.com/claude-code)