### PR TITLE
feat(layers): add LSTM cell (Hochreiter & Schmidhuber 1997)

### DIFF
--- a/src/odyssey/core/layers/__init__.mojo
+++ b/src/odyssey/core/layers/__init__.mojo
@@ -39,6 +39,7 @@ from odyssey.core.layers.batchnorm import BatchNorm2dLayer
 from odyssey.core.layers.relu import ReLULayer
 from odyssey.core.layers.dropout import DropoutLayer
 from odyssey.core.layers.rnn import RNNCell
+from odyssey.core.layers.lstm import LSTMCell
 
 # from .activation import ReLU, Sigmoid, Tanh
 # from .pooling import MaxPool2D, AvgPool2D

--- a/src/odyssey/core/layers/lstm.mojo
+++ b/src/odyssey/core/layers/lstm.mojo
@@ -21,7 +21,7 @@ Reference:
 """
 
 from odyssey.tensor.any_tensor import AnyTensor
-from odyssey.tensor.tensor_creation import full_like
+from odyssey.tensor.tensor_creation import full_like, zeros
 from odyssey.core.module import Module
 from odyssey.core.layers.linear import Linear
 from odyssey.core.activation import sigmoid, tanh
@@ -89,8 +89,12 @@ struct LSTMCell[dtype: DType = DType.float32](Copyable, Module, Movable):
     def forward(mut self, input: AnyTensor) raises -> AnyTensor:
         """Module `forward` from a zero initial hidden and cell state.
 
-        Use `step(input, hidden, cell)` to thread real recurrent state. Returns
-        only the new hidden state (the cell state is discarded).
+        Runs a single `step` from all-zero hidden and cell states, so this is
+        exactly the hidden output of `step(input, zeros, zeros)` — the
+        hidden-to-hidden projections still contribute their biases (a zero hidden
+        zeros only the weight terms, not `b_hi`/`b_hf`/`b_hg`/`b_ho`). Returns only
+        the new hidden state (the new cell state is discarded). Use
+        `step(input, hidden, cell)` to thread real recurrent state.
 
         Args:
             input: Input tensor of shape (batch, input_size).
@@ -101,13 +105,11 @@ struct LSTMCell[dtype: DType = DType.float32](Copyable, Module, Movable):
         Raises:
             Error: If tensor operations fail.
         """
-        # h0 = c0 = 0 -> i = sigmoid(x W_ii + b_ii), g = tanh(x W_ig + b_ig),
-        # o = sigmoid(x W_io + b_io); c' = i * g; h' = o * tanh(c').
-        var i = sigmoid(self.ii.forward(input))
-        var g = tanh(self.ig.forward(input))
-        var o = sigmoid(self.io.forward(input))
-        var c_new = multiply_simd(i, g)
-        return multiply_simd(o, tanh(c_new))
+        var batch = input.shape()[0]
+        var h0 = zeros([batch, self.hidden_size], Self.dtype)
+        var c0 = zeros([batch, self.hidden_size], Self.dtype)
+        var hc = self.step(input, h0, c0)
+        return hc[0]
 
     def step(
         mut self, input: AnyTensor, hidden: AnyTensor, cell: AnyTensor

--- a/src/odyssey/core/layers/lstm.mojo
+++ b/src/odyssey/core/layers/lstm.mojo
@@ -1,0 +1,194 @@
+"""Long Short-Term Memory (LSTM) cell.
+
+A single recurrent step of an LSTM (Hochreiter & Schmidhuber, 1997), matching the
+`torch.nn.LSTMCell` convention:
+
+    i = sigmoid(x W_ii + b_ii + h W_hi + b_hi)     # input gate
+    f = sigmoid(x W_if + b_if + h W_hf + b_hf)     # forget gate
+    g = tanh(x W_ig + b_ig + h W_hg + b_hg)        # candidate cell
+    o = sigmoid(x W_io + b_io + h W_ho + b_ho)     # output gate
+    c' = f * c + i * g                             # new cell state
+    h' = o * tanh(c')                              # new hidden state
+
+Each of the four gates uses a separate input-to-hidden and hidden-to-hidden `Linear`
+projection (eight projections total). `step(input, hidden, cell)` computes one step
+and returns the new `(hidden, cell)` pair; a sequence is processed by the caller
+looping over time steps (same convention as `torch.nn.LSTMCell`).
+
+Reference:
+    Hochreiter, S., & Schmidhuber, J. (1997). Long Short-Term Memory. Neural
+    Computation, 9(8), 1735-1780. Interface mirrors `torch.nn.LSTMCell`.
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import full_like
+from odyssey.core.module import Module
+from odyssey.core.layers.linear import Linear
+from odyssey.core.activation import sigmoid, tanh
+from odyssey.core.arithmetic_simd import (
+    multiply_simd,
+    add_simd,
+)
+
+
+struct LSTMCell[dtype: DType = DType.float32](Copyable, Module, Movable):
+    """Long Short-Term Memory cell (torch.nn.LSTMCell convention).
+
+    Parameters:
+        dtype: Data type for weights and biases (default: float32).
+
+    Attributes:
+        ii, if_, ig, io: input-to-hidden projections for input/forget/candidate/output.
+        hi, hf, hg, ho: hidden-to-hidden projections for input/forget/candidate/output.
+        input_size: Input feature dimension.
+        hidden_size: Hidden state dimension.
+    """
+
+    var ii: Linear[Self.dtype]
+    var if_: Linear[Self.dtype]
+    var ig: Linear[Self.dtype]
+    var io: Linear[Self.dtype]
+    var hi: Linear[Self.dtype]
+    var hf: Linear[Self.dtype]
+    var hg: Linear[Self.dtype]
+    var ho: Linear[Self.dtype]
+    var input_size: Int
+    var hidden_size: Int
+
+    def __init__(out self, input_size: Int, hidden_size: Int) raises:
+        """Initialize the LSTM cell.
+
+        Args:
+            input_size: Number of input features.
+            hidden_size: Number of hidden units.
+
+        Raises:
+            Error: If input_size or hidden_size <= 0, or construction fails.
+
+        Example:
+            ```mojo
+            var cell = LSTMCell(3, 4)
+            var hc = cell.step(x, h0, c0)   # x: [B, 3]; h0, c0: [B, 4]
+            ```
+        """
+        if input_size <= 0:
+            raise Error("LSTMCell: input_size must be positive")
+        if hidden_size <= 0:
+            raise Error("LSTMCell: hidden_size must be positive")
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.ii = Linear[Self.dtype](input_size, hidden_size)
+        self.if_ = Linear[Self.dtype](input_size, hidden_size)
+        self.ig = Linear[Self.dtype](input_size, hidden_size)
+        self.io = Linear[Self.dtype](input_size, hidden_size)
+        self.hi = Linear[Self.dtype](hidden_size, hidden_size)
+        self.hf = Linear[Self.dtype](hidden_size, hidden_size)
+        self.hg = Linear[Self.dtype](hidden_size, hidden_size)
+        self.ho = Linear[Self.dtype](hidden_size, hidden_size)
+
+    def forward(mut self, input: AnyTensor) raises -> AnyTensor:
+        """Module `forward` from a zero initial hidden and cell state.
+
+        Use `step(input, hidden, cell)` to thread real recurrent state. Returns
+        only the new hidden state (the cell state is discarded).
+
+        Args:
+            input: Input tensor of shape (batch, input_size).
+
+        Returns:
+            Hidden state of shape (batch, hidden_size).
+
+        Raises:
+            Error: If tensor operations fail.
+        """
+        # h0 = c0 = 0 -> i = sigmoid(x W_ii + b_ii), g = tanh(x W_ig + b_ig),
+        # o = sigmoid(x W_io + b_io); c' = i * g; h' = o * tanh(c').
+        var i = sigmoid(self.ii.forward(input))
+        var g = tanh(self.ig.forward(input))
+        var o = sigmoid(self.io.forward(input))
+        var c_new = multiply_simd(i, g)
+        return multiply_simd(o, tanh(c_new))
+
+    def step(
+        mut self, input: AnyTensor, hidden: AnyTensor, cell: AnyTensor
+    ) raises -> Tuple[AnyTensor, AnyTensor]:
+        """One LSTM step (torch.nn.LSTMCell convention).
+
+        Args:
+            input: Input tensor x_t of shape (batch, input_size).
+            hidden: Previous hidden state h_{t-1} of shape (batch, hidden_size).
+            cell: Previous cell state c_{t-1} of shape (batch, hidden_size).
+
+        Returns:
+            Tuple (h_t, c_t): new hidden state and new cell state, each of shape
+            (batch, hidden_size).
+
+        Raises:
+            Error: If tensor operations fail or shapes are incompatible.
+        """
+        var i = sigmoid(
+            add_simd(self.ii.forward(input), self.hi.forward(hidden))
+        )
+        var f = sigmoid(
+            add_simd(self.if_.forward(input), self.hf.forward(hidden))
+        )
+        var g = tanh(add_simd(self.ig.forward(input), self.hg.forward(hidden)))
+        var o = sigmoid(
+            add_simd(self.io.forward(input), self.ho.forward(hidden))
+        )
+        # c' = f * c + i * g
+        var c_new = add_simd(multiply_simd(f, cell), multiply_simd(i, g))
+        # h' = o * tanh(c')
+        var h_new = multiply_simd(o, tanh(c_new))
+        return (h_new, c_new)
+
+    def parameters(self) raises -> List[AnyTensor]:
+        """Collect trainable parameters from all eight projections.
+
+        Returns:
+            List of 16 tensors (weight+bias of ii, if_, ig, io, hi, hf, hg, ho).
+
+        Raises:
+            Error if tensor copying fails.
+        """
+        var params = List[AnyTensor]()
+        for p in self.ii.parameters():
+            params.append(p)
+        for p in self.if_.parameters():
+            params.append(p)
+        for p in self.ig.parameters():
+            params.append(p)
+        for p in self.io.parameters():
+            params.append(p)
+        for p in self.hi.parameters():
+            params.append(p)
+        for p in self.hf.parameters():
+            params.append(p)
+        for p in self.hg.parameters():
+            params.append(p)
+        for p in self.ho.parameters():
+            params.append(p)
+        return params^
+
+    def train(mut self):
+        """Switch to training mode (no-op; sub-layers are stateless in mode)."""
+        self.ii.train()
+        self.if_.train()
+        self.ig.train()
+        self.io.train()
+        self.hi.train()
+        self.hf.train()
+        self.hg.train()
+        self.ho.train()
+
+    def eval(mut self):
+        """Switch to inference mode (no-op; sub-layers are stateless in mode).
+        """
+        self.ii.eval()
+        self.if_.eval()
+        self.ig.eval()
+        self.io.eval()
+        self.hi.eval()
+        self.hf.eval()
+        self.hg.eval()
+        self.ho.eval()

--- a/tests/odyssey/core/layers/parity_refs/lstm_parity_reference.py
+++ b/tests/odyssey/core/layers/parity_refs/lstm_parity_reference.py
@@ -1,0 +1,85 @@
+"""LSTM cell parity reference (torch.nn.LSTMCell).
+
+Sets eight ramp weight matrices (Odyssey layout: each Linear W is (in, out)) into a
+torch.nn.LSTMCell (which packs i, f, g, o gates into W_ih (4H, in) and W_hh (4H, H);
+torch uses (out, in) layout, so each Odyssey (in, out) block is transposed before
+being copied in). Prints the single-step (h', c') outputs for the Mojo LSTMCell test
+to assert against. Config: input=3, hidden=4, batch=2, dtype=float64.
+
+Run:
+    python tests/odyssey/core/layers/parity_refs/lstm_parity_reference.py
+"""
+
+import json
+
+import torch
+import torch.nn as nn
+
+IN, HID, B = 3, 4, 2
+
+
+def ramp(rows, cols, scale, off):
+    return torch.arange(rows * cols, dtype=torch.float64).reshape(rows, cols) * scale + off
+
+
+# Odyssey-layout (in, out) weight blocks + biases for the eight projections.
+Wii = ramp(IN, HID, 0.01, -0.05)
+bii = torch.arange(HID, dtype=torch.float64) * 0.01 - 0.02
+Wif = ramp(IN, HID, 0.011, -0.06)
+bif = torch.arange(HID, dtype=torch.float64) * 0.012 - 0.03
+Wig = ramp(IN, HID, 0.009, -0.04)
+big = torch.arange(HID, dtype=torch.float64) * 0.008 - 0.01
+Wio = ramp(IN, HID, 0.012, -0.055)
+bio = torch.arange(HID, dtype=torch.float64) * 0.009 - 0.025
+Whi = ramp(HID, HID, 0.007, -0.03)
+bhi = torch.arange(HID, dtype=torch.float64) * 0.006 - 0.02
+Whf = ramp(HID, HID, 0.008, -0.04)
+bhf = torch.arange(HID, dtype=torch.float64) * 0.005 - 0.01
+Whg = ramp(HID, HID, 0.006, -0.02)
+bhg = torch.arange(HID, dtype=torch.float64) * 0.004 - 0.015
+Who = ramp(HID, HID, 0.0075, -0.035)
+bho = torch.arange(HID, dtype=torch.float64) * 0.0045 - 0.012
+
+X = ramp(B, IN, 0.1, -0.2)
+H = ramp(B, HID, 0.05, -0.1)
+C = ramp(B, HID, 0.03, -0.06)
+
+cell = nn.LSTMCell(IN, HID).double()
+with torch.no_grad():
+    # torch packs gates in [i, f, g, o] order; weight rows are (out, in), so each
+    # Odyssey (in, out) block is transposed before concatenation.
+    cell.weight_ih.copy_(torch.cat([Wii.T, Wif.T, Wig.T, Wio.T], dim=0))
+    cell.weight_hh.copy_(torch.cat([Whi.T, Whf.T, Whg.T, Who.T], dim=0))
+    cell.bias_ih.copy_(torch.cat([bii, bif, big, bio]))
+    cell.bias_hh.copy_(torch.cat([bhi, bhf, bhg, bho]))
+    h_out, c_out = cell(X, (H, C))
+
+print(
+    json.dumps(
+        {
+            "config": {"input_size": IN, "hidden_size": HID, "batch": B},
+            "Wii": Wii.flatten().tolist(),
+            "bii": bii.tolist(),
+            "Wif": Wif.flatten().tolist(),
+            "bif": bif.tolist(),
+            "Wig": Wig.flatten().tolist(),
+            "big": big.tolist(),
+            "Wio": Wio.flatten().tolist(),
+            "bio": bio.tolist(),
+            "Whi": Whi.flatten().tolist(),
+            "bhi": bhi.tolist(),
+            "Whf": Whf.flatten().tolist(),
+            "bhf": bhf.tolist(),
+            "Whg": Whg.flatten().tolist(),
+            "bhg": bhg.tolist(),
+            "Who": Who.flatten().tolist(),
+            "bho": bho.tolist(),
+            "X": X.flatten().tolist(),
+            "H": H.flatten().tolist(),
+            "C": C.flatten().tolist(),
+            "h_out": h_out.flatten().tolist(),
+            "c_out": c_out.flatten().tolist(),
+        },
+        indent=2,
+    )
+)

--- a/tests/odyssey/core/layers/test_lstm.mojo
+++ b/tests/odyssey/core/layers/test_lstm.mojo
@@ -1,0 +1,150 @@
+"""Unit tests for the LSTM cell (torch.nn.LSTMCell convention).
+
+Tests cover:
+- Construction + validation (positive input_size/hidden_size)
+- step() shapes: (batch, input) x (batch, hidden) x (batch, hidden)
+  -> ((batch, hidden), (batch, hidden))
+- parameter collection (16 tensors: ii/if_/ig/io/hi/hf/hg/ho weight+bias)
+- Numerical parity with torch.nn.LSTMCell on fixed ramp weights (1e-5), for
+  both the new hidden state h' and the new cell state c'
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros
+from odyssey.core.layers.lstm import LSTMCell
+
+
+def _abs_diff(a: Float64, b: Float64) -> Float64:
+    var d = a - b
+    if d < 0:
+        d = -d
+    return d
+
+
+def _seed_ramp(mut t: AnyTensor, count: Int, scale: Float64, off: Float64) raises:
+    """Seed a tensor's flat buffer with value[i] = i*scale + off."""
+    for i in range(count):
+        t.store[DType.float64](i, Float64(i) * scale + off)
+
+
+def test_shape() raises:
+    """step maps (batch, in) x (batch, hid) x (batch, hid) -> two (batch, hid)."""
+    print("Running test_shape...")
+    var cell = LSTMCell[DType.float32](3, 4)
+    var x = zeros([2, 3], DType.float32)
+    var h = zeros([2, 4], DType.float32)
+    var c = zeros([2, 4], DType.float32)
+    var hc = cell.step(x, h, c)
+    if hc[0].shape()[0] != 2 or hc[0].shape()[1] != 4:
+        raise Error("LSTM step must return hidden (batch, hidden)")
+    if hc[1].shape()[0] != 2 or hc[1].shape()[1] != 4:
+        raise Error("LSTM step must return cell (batch, hidden)")
+    print("  ok ((2, 4), (2, 4))")
+    print("test_shape PASSED")
+
+
+def test_reject_bad_sizes() raises:
+    """Non-positive sizes must raise."""
+    print("Running test_reject_bad_sizes...")
+    try:
+        var _ = LSTMCell[DType.float32](0, 4)
+        raise Error("Should have rejected input_size = 0")
+    except e:
+        print("  ok rejected input_size = 0")
+    try:
+        var _ = LSTMCell[DType.float32](3, 0)
+        raise Error("Should have rejected hidden_size = 0")
+    except e:
+        print("  ok rejected hidden_size = 0")
+    print("test_reject_bad_sizes PASSED")
+
+
+def test_parameter_count() raises:
+    """parameters() returns 16 tensors (weight+bias of eight projections)."""
+    print("Running test_parameter_count...")
+    var cell = LSTMCell[DType.float32](3, 4)
+    if len(cell.parameters()) != 16:
+        raise Error("LSTM cell should expose 16 parameter tensors")
+    print("  ok 16 parameter tensors")
+    print("test_parameter_count PASSED")
+
+
+def test_parity_with_pytorch() raises:
+    """step must match torch.nn.LSTMCell on fixed ramp weights to 1e-5.
+
+    Reference values from parity_refs/lstm_parity_reference.py (input=3,
+    hidden=4, batch=2). Odyssey Linear uses W (in, out); the reference sets
+    torch's packed (4H, in)/(4H, H) weight to the per-gate transpose. Both the
+    new hidden state h' and the new cell state c' are checked.
+    """
+    print("Running test_parity_with_pytorch...")
+
+    var ref_h = List[Float64]()
+    ref_h.append(-0.017694965)
+    ref_h.append(-0.008305559)
+    ref_h.append(0.00130057)
+    ref_h.append(0.011117769)
+    ref_h.append(0.013930657)
+    ref_h.append(0.027275374)
+    ref_h.append(0.0412858)
+    ref_h.append(0.055944425)
+
+    var ref_c = List[Float64]()
+    ref_c.append(-0.035740954)
+    ref_c.append(-0.016693206)
+    ref_c.append(0.002601797)
+    ref_c.append(0.022143402)
+    ref_c.append(0.028108978)
+    ref_c.append(0.05436392)
+    ref_c.append(0.08133847)
+    ref_c.append(0.109021286)
+
+    var cell = LSTMCell[DType.float64](3, 4)
+    # input-to-hidden projections (weight: 3*4=12 elems, bias: 4 elems each)
+    _seed_ramp(cell.ii.weight, 12, 0.01, -0.05)
+    _seed_ramp(cell.ii.bias, 4, 0.01, -0.02)
+    _seed_ramp(cell.if_.weight, 12, 0.011, -0.06)
+    _seed_ramp(cell.if_.bias, 4, 0.012, -0.03)
+    _seed_ramp(cell.ig.weight, 12, 0.009, -0.04)
+    _seed_ramp(cell.ig.bias, 4, 0.008, -0.01)
+    _seed_ramp(cell.io.weight, 12, 0.012, -0.055)
+    _seed_ramp(cell.io.bias, 4, 0.009, -0.025)
+    # hidden-to-hidden projections (weight: 4*4=16 elems, bias: 4 elems each)
+    _seed_ramp(cell.hi.weight, 16, 0.007, -0.03)
+    _seed_ramp(cell.hi.bias, 4, 0.006, -0.02)
+    _seed_ramp(cell.hf.weight, 16, 0.008, -0.04)
+    _seed_ramp(cell.hf.bias, 4, 0.005, -0.01)
+    _seed_ramp(cell.hg.weight, 16, 0.006, -0.02)
+    _seed_ramp(cell.hg.bias, 4, 0.004, -0.015)
+    _seed_ramp(cell.ho.weight, 16, 0.0075, -0.035)
+    _seed_ramp(cell.ho.bias, 4, 0.0045, -0.012)
+
+    var x = zeros([2, 3], DType.float64)
+    _seed_ramp(x, 6, 0.1, -0.2)
+    var h = zeros([2, 4], DType.float64)
+    _seed_ramp(h, 8, 0.05, -0.1)
+    var c = zeros([2, 4], DType.float64)
+    _seed_ramp(c, 8, 0.03, -0.06)
+
+    var hc = cell.step(x, h, c)
+    for i in range(8):
+        if _abs_diff(hc[0].load[DType.float64](i), ref_h[i]) > 1e-5:
+            raise Error("LSTM hidden parity mismatch at " + String(i))
+        if _abs_diff(hc[1].load[DType.float64](i), ref_c[i]) > 1e-5:
+            raise Error("LSTM cell parity mismatch at " + String(i))
+    print("  ok matches torch.nn.LSTMCell (h and c) to 1e-5")
+    print("test_parity_with_pytorch PASSED")
+
+
+def main() raises:
+    """Run all LSTM tests."""
+    print("=" * 60)
+    print("LSTM Cell Test Suite")
+    print("=" * 60)
+    test_shape()
+    test_reject_bad_sizes()
+    test_parameter_count()
+    test_parity_with_pytorch()
+    print("=" * 60)
+    print("All LSTM tests PASSED")
+    print("=" * 60)

--- a/tests/odyssey/core/layers/test_lstm.mojo
+++ b/tests/odyssey/core/layers/test_lstm.mojo
@@ -139,6 +139,41 @@ def test_parity_with_pytorch() raises:
     print("test_parity_with_pytorch PASSED")
 
 
+def test_forward_equals_zero_state_step() raises:
+    """forward(x) must equal step(x, zeros, zeros)[0] with nonzero h->h biases.
+
+    A zero initial (hidden, cell) zeros only the hidden-to-hidden WEIGHT terms,
+    not the biases b_hi/b_hf/b_hg/b_ho. This asserts forward() includes them
+    (regression guard: an earlier shortcut dropped the h->h biases, so forward
+    diverged from a zero-state step once those biases were trained nonzero).
+    """
+    print("Running test_forward_equals_zero_state_step...")
+    var cell = LSTMCell[DType.float64](3, 4)
+    for i in range(4):
+        cell.hi.bias.store[DType.float64](i, Float64(i) * 0.01 + 0.05)
+        cell.hf.bias.store[DType.float64](i, Float64(i) * 0.02 - 0.03)
+        cell.hg.bias.store[DType.float64](i, Float64(i) * 0.015 + 0.02)
+        cell.ho.bias.store[DType.float64](i, Float64(i) * 0.01 - 0.01)
+    var x = zeros([2, 3], DType.float64)
+    for i in range(6):
+        x.store[DType.float64](i, Float64(i) * 0.1 - 0.2)
+    var h0 = zeros([2, 4], DType.float64)
+    var c0 = zeros([2, 4], DType.float64)
+
+    var f = cell.forward(x)
+    var hc = cell.step(x, h0, c0)
+    for i in range(8):
+        if (
+            _abs_diff(f.load[DType.float64](i), hc[0].load[DType.float64](i))
+            > 1e-12
+        ):
+            raise Error("forward != step(x, zeros, zeros)[0] at " + String(i))
+    print(
+        "  ok forward(x) == step(x, zeros, zeros)[0] with nonzero h->h biases"
+    )
+    print("test_forward_equals_zero_state_step PASSED")
+
+
 def main() raises:
     """Run all LSTM tests."""
     print("=" * 60)
@@ -148,6 +183,7 @@ def main() raises:
     test_reject_bad_sizes()
     test_parameter_count()
     test_parity_with_pytorch()
+    test_forward_equals_zero_state_step()
     print("=" * 60)
     print("All LSTM tests PASSED")
     print("=" * 60)

--- a/tests/odyssey/core/layers/test_lstm.mojo
+++ b/tests/odyssey/core/layers/test_lstm.mojo
@@ -21,14 +21,17 @@ def _abs_diff(a: Float64, b: Float64) -> Float64:
     return d
 
 
-def _seed_ramp(mut t: AnyTensor, count: Int, scale: Float64, off: Float64) raises:
+def _seed_ramp(
+    mut t: AnyTensor, count: Int, scale: Float64, off: Float64
+) raises:
     """Seed a tensor's flat buffer with value[i] = i*scale + off."""
     for i in range(count):
         t.store[DType.float64](i, Float64(i) * scale + off)
 
 
 def test_shape() raises:
-    """step maps (batch, in) x (batch, hid) x (batch, hid) -> two (batch, hid)."""
+    """step maps (batch, in) x (batch, hid) x (batch, hid) -> two (batch, hid).
+    """
     print("Running test_shape...")
     var cell = LSTMCell[DType.float32](3, 4)
     var x = zeros([2, 3], DType.float32)


### PR DESCRIPTION
## Summary

Adds an **LSTM cell** (`odyssey.core.layers.lstm.LSTMCell`) — a single Long
Short-Term Memory step (Hochreiter & Schmidhuber, 1997) following the
`torch.nn.LSTMCell` convention:

```
i = sigmoid(x W_ii + b_ii + h W_hi + b_hi)   # input gate
f = sigmoid(x W_if + b_if + h W_hf + b_hf)   # forget gate
g = tanh(x W_ig + b_ig + h W_hg + b_hg)      # candidate cell
o = sigmoid(x W_io + b_io + h W_ho + b_ho)   # output gate
c' = f * c + i * g                           # new cell state
h' = o * tanh(c')                            # new hidden state
```

Composes eight `Linear` projections (ii/if_/ig/io/hi/hf/hg/ho). `step(input,
hidden, cell)` returns the new `(h', c')` tuple; also exposes a `Module`
`forward` (zero initial state, returns h'), `parameters()` (16 tensors), and
`train`/`eval`.

## Validation

Both the new hidden state **h'** and the new cell state **c'** verified against
`torch.nn.LSTMCell` on fixed ramp weights to **1e-5** (observed diff ~1e-8).
Odyssey `Linear` uses `W (in, out)`; the reference transposes each per-gate block
into torch's packed `(4H, in)`/`(4H, H)` layout.

- Test: `tests/odyssey/core/layers/test_lstm.mojo` (shapes, size validation,
  16-param count, h+c parity).
- Reference generator: `tests/odyssey/core/layers/parity_refs/lstm_parity_reference.py`.

## Changes

- `src/odyssey/core/layers/lstm.mojo` — the `LSTMCell` struct.
- `src/odyssey/core/layers/__init__.mojo` — export `LSTMCell`.
- `tests/odyssey/core/layers/test_lstm.mojo` + parity reference.
- `CHANGELOG.md` — `[Unreleased] ### Added` entry.

Refs mvillmow/Random#57 (ARCH-07)

🤖 Generated with [Claude Code](https://claude.com/claude-code)