### PR TITLE
[Fix] Repair red main: stale test-count badge + broken --fix path

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -287,7 +287,14 @@ jobs:
           # were resolved by version floors in pixi.toml and are no longer
           # ignored. Drop the remaining entries once upstream lands a fix.
           set -euo pipefail
-          pip install setuptools wheel
+          # --upgrade is required: without it, pip leaves the runner's
+          # pre-installed setuptools in place ("Requirement already
+          # satisfied"), and pip-audit scans the whole environment — a stale
+          # runner setuptools fails the scan on a vuln unrelated to this
+          # project's declared dependencies (e.g. PYSEC-2026-3447 against
+          # setuptools 79.0.1, fixed in 83.0.0). Same rationale as the pip
+          # upgrade in the "Install pip-audit" step above.
+          pip install --upgrade setuptools wheel
           pip install -e . --no-deps
           pip-audit --skip-editable \
             --ignore-vuln CVE-2026-44708 \

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ maximum performance and type safety.
 
 [![Mojo](https://img.shields.io/badge/Mojo-1.0.0b2-orange.svg)](https://mojolang.org/)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-298+-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-332%2B-brightgreen.svg)](tests/)
 [![Coverage](https://img.shields.io/badge/coverage-pending-lightgrey.svg)](#coverage-status)
 [![CI](https://github.com/HomericIntelligence/Odyssey/actions/workflows/comprehensive-tests.yml/badge.svg)](https://github.com/HomericIntelligence/Odyssey/actions/workflows/comprehensive-tests.yml)
 [![Build](https://github.com/HomericIntelligence/Odyssey/actions/workflows/build-validation.yml/badge.svg)](https://github.com/HomericIntelligence/Odyssey/actions/workflows/build-validation.yml)
@@ -29,7 +29,7 @@ research papers with production-quality implementations. It has two goals:
 2. **Provide a reusable shared library** of ML components that paper implementations build on
 
 The project currently has ~198K lines of Mojo code, 7 fully-implemented neural network
-architectures, and 298+ tests across layerwise unit tests and end-to-end integration tests.
+architectures, and 332+ tests across layerwise unit tests and end-to-end integration tests.
 
 > **Note on project identity:** The GitHub repo description says "Training framework written
 > in Mojo." This repo is sometimes described elsewhere as an "experimental agent research

--- a/scripts/check_test_count_badge.py
+++ b/scripts/check_test_count_badge.py
@@ -35,8 +35,10 @@ from common import EXCLUDE_DIRS
 # Matches patterns like: tests-247%2B, tests-122%2B, tests-300
 _BADGE_COUNT_RE = re.compile(r"tests-(\d[\d,]*?)(?:%2B|-brightgreen|\+|\.svg|-[a-z])")
 
-# Pattern that identifies the tests badge line in README.md
-_BADGE_LINE_RE = re.compile(r"(https://img\.shields\.io/badge/tests-)(\d[\d,]*)(%2B-brightgreen\.svg)")
+# Pattern that identifies the tests badge line in README.md.
+# Accepts both URL-encoded (%2B) and literal (+) plus signs so --fix can update
+# either form; the existing encoding is preserved by the capture group.
+_BADGE_LINE_RE = re.compile(r"(https://img\.shields\.io/badge/tests-)(\d[\d,]*)((?:%2B|\+)-brightgreen\.svg)")
 
 # Pattern that identifies prose mentions of test count (e.g., "223+ tests")
 _PROSE_COUNT_RE = re.compile(r"(\d[\d,]*?)\+\s+tests")

--- a/tests/scripts/test_check_test_count_badge.py
+++ b/tests/scripts/test_check_test_count_badge.py
@@ -75,6 +75,7 @@ def test_count_test_files_empty_dir(tmp_path: Path) -> None:
         ("[![Tests](https://img.shields.io/badge/tests-122%2B-brightgreen.svg)](tests/)", 122),
         ("[![Tests](https://img.shields.io/badge/tests-300%2B-brightgreen.svg)](tests/)", 300),
         ("[![Tests](https://img.shields.io/badge/tests-1000%2B-brightgreen.svg)](tests/)", 1000),
+        ("[![Tests](https://img.shields.io/badge/tests-298+-brightgreen.svg)](tests/)", 298),
     ],
 )
 def test_parse_badge_count_various_values(tmp_path: Path, badge_url: str, expected: int) -> None:
@@ -144,6 +145,20 @@ def test_update_badge_rewrites_count(tmp_path: Path) -> None:
     content = readme.read_text()
     assert "tests-300%2B-brightgreen.svg" in content
     assert "tests-122" not in content
+
+
+def test_update_badge_rewrites_literal_plus_form(tmp_path: Path) -> None:
+    """Should update badges that use a literal '+' instead of '%2B'.
+
+    Regression test: main went red because README.md used the literal-'+'
+    badge form, which --fix silently failed to rewrite.
+    """
+    readme = tmp_path / "README.md"
+    readme.write_text("[![Tests](https://img.shields.io/badge/tests-298+-brightgreen.svg)](tests/)\n")
+    update_badge(readme, 332)
+    content = readme.read_text()
+    assert "tests-332+-brightgreen.svg" in content
+    assert "tests-298" not in content
 
 
 def test_update_badge_preserves_rest_of_file(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

main fails `lint` (Required Checks) and `pre-commit` on the `check-test-count-badge` hook: badge=298+, actual=332 (drift 10.2% > 10% tolerance). Because these checks run `pre-commit run --all-files`, every open PR inherits the failure. Additionally, `security/dependency-scan` began failing on all branches when PYSEC-2026-3447 was published, because the job audits the runner's stale pre-installed setuptools.

This PR:

1. Updates the README test badge and prose mention from 298+ to 332+ (badge normalized to the canonical `%2B` form).
2. Fixes `scripts/check_test_count_badge.py --fix`, which could not repair the current README: `_BADGE_LINE_RE` only matched `%2B`-encoded badges while the README used a literal `+`, so `--fix` updated the prose only, exited 0, and left the badge stale. The regex now accepts both forms and preserves the existing encoding.
3. Adds regression tests for the literal-`+` form (parse + update).
4. Fixes `security/dependency-scan`: `pip install setuptools wheel` without `--upgrade` is a no-op ("Requirement already satisfied"), leaving the runner's setuptools 79.0.1 for pip-audit to flag (PYSEC-2026-3447, fixed in 83.0.0). Now upgrades before auditing, mirroring the existing pip upgrade in the same job.

Verified locally: `pre-commit run --all-files` fully green; `pytest tests/scripts/test_check_test_count_badge.py` 25 passed.

Closes #5620

🤖 Generated with [Claude Code](https://claude.com/claude-code)