### PR TITLE
feat(optimizers): add FTRL-Proximal optimizer (McMahan et al. 2013)

### DIFF
--- a/src/odyssey/training/optimizers/__init__.mojo
+++ b/src/odyssey/training/optimizers/__init__.mojo
@@ -84,6 +84,9 @@ from odyssey.training.optimizers.lion import lion_step, lion_step_simple
 # ADOPT optimizer (modified Adam with the optimal convergence rate for any beta2)
 from odyssey.training.optimizers.adopt import adopt_step, adopt_step_simple
 
+# FTRL-Proximal optimizer (online learning with L1 sparsity — McMahan et al. 2013)
+from odyssey.training.optimizers.ftrl import ftrl_step, ftrl_step_simple
+
 # Shampoo optimizer (two-sided matrix preconditioner via Newton-Schulz inverse fourth root)
 from odyssey.training.optimizers.shampoo import (
     shampoo_step,

--- a/src/odyssey/training/optimizers/ftrl.mojo
+++ b/src/odyssey/training/optimizers/ftrl.mojo
@@ -1,0 +1,192 @@
+"""FTRL-Proximal optimizer (Follow-The-Regularized-Leader).
+
+This module provides the FTRL-Proximal optimizer for updating model parameters
+during training. FTRL-Proximal (McMahan et al. 2013) is the online-learning
+optimizer behind Google's click-through-rate models: it accumulates a
+per-coordinate linearized gradient sum and, at each step, solves a closed-form
+regularized objective that yields SPARSE weights via L1 (lasso) shrinkage.
+
+FTRL-Proximal update rule (per coordinate i, per step; 1-indexed):
+    sigma_i = (sqrt(n_i + g_i^2) - sqrt(n_i)) / alpha       # per-coord learning-rate delta
+    z_i    += g_i - sigma_i * w_i                           # linearized weight-sum
+    n_i    += g_i^2                                         # sum of squared gradients
+    w_i     = 0                                   if |z_i| <= lambda1
+              -(z_i - sign(z_i) * lambda1)
+              / ((beta + sqrt(n_i)) / alpha + lambda2)      otherwise
+
+where `z` (the linearized gradient/weight sum) and `n` (the sum of squared
+gradients) are the two per-parameter state buffers the caller threads across
+steps, and:
+    - alpha    is the per-coordinate learning-rate scale,
+    - beta     smooths the adaptive per-coordinate rate (paper default 1.0),
+    - lambda1  is the L1 (sparsity) regularization strength,
+    - lambda2  is the L2 regularization strength.
+
+The `w_i = 0 if |z_i| <= lambda1` branch is what makes FTRL produce exact zeros
+(sparsity), unlike Adam/SGD. This implementation expresses the whole update
+element-wise with vectorized ops — the soft-threshold magnitude
+`max(|z| - lambda1, 0)` is exactly zero on the `|z| <= lambda1` branch, so the
+piecewise rule collapses to a single closed form with no per-element control
+flow:
+    w = -sign(z) * clip(|z| - lambda1, 0, +inf)
+        / ((beta + sqrt(n)) / alpha + lambda2)
+
+Note the standard `learning_rate` argument multiplies the final weight so the
+optimizer fits the shared `<name>_step(..., learning_rate, ...)` signature;
+setting it to 1.0 recovers textbook FTRL (whose step size lives in `alpha`).
+
+Key characteristics:
+    - Memory: two buffers per parameter (`z` and `n`), same footprint as Adam.
+    - Sparsity: L1 term drives coordinates to EXACT zero (feature selection).
+    - Online: designed for one-pass streaming; robust to non-stationary data.
+
+Reference:
+    McMahan, H. B., Holt, G., Sculley, D., Young, M., Ebner, D., Grady, J.,
+    Nie, L., Phillips, T., Davydov, E., Golovin, D., Chikkerur, S., Liu, D.,
+    Wattenberg, M., Hrafnkelsson, A. M., Boulos, T., & Kubica, J. (2013).
+    Ad Click Prediction: a View from the Trenches. Proceedings of the 19th ACM
+    SIGKDD International Conference on Knowledge Discovery and Data Mining
+    (KDD '13), Algorithm 1 (Per-Coordinate FTRL-Proximal with L1 and L2).
+    https://research.google.com/pubs/archive/41159.pdf
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import full_like
+from odyssey.core.arithmetic_simd import (
+    subtract_simd,
+    multiply_simd,
+    add_simd,
+    divide_simd,
+)
+from odyssey.core.elementwise import sqrt, abs, sign, clip, negate
+
+
+def ftrl_step(
+    params: AnyTensor,
+    gradients: AnyTensor,
+    z: AnyTensor,
+    n: AnyTensor,
+    learning_rate: Float64,
+    alpha: Float64 = 0.1,
+    beta: Float64 = 1.0,
+    lambda1: Float64 = 0.0,
+    lambda2: Float64 = 0.0,
+) raises -> Tuple[AnyTensor, AnyTensor, AnyTensor]:
+    """Perform a single FTRL-Proximal optimization step - pure functional.
+
+    Returns new parameters and the two updated state buffers `(z, n)`. The
+    caller manages all state; initialize both `z` and `n` to zeros on step 1.
+
+    Unlike SGD/Adam, FTRL RECOMPUTES the weight from `z` and `n` each step
+    rather than incrementing it, so the incoming `params` value is not read for
+    the update magnitude — it is only used to validate shape/dtype. Pass the
+    current params for that validation; the returned params are the freshly
+    solved FTRL weights.
+
+    Args:
+        params: Model parameters (used for shape/dtype validation; FTRL solves
+            the new weights from `z`/`n`, it does not read the old magnitude).
+        gradients: Gradients of loss with respect to params.
+        z: Linearized gradient/weight-sum buffer (per-coordinate). Zeros on
+            step 1.
+        n: Sum-of-squared-gradients buffer (per-coordinate). Zeros on step 1.
+        learning_rate: Global step-size multiplier applied to the solved weight
+            (1.0 = textbook FTRL, whose per-coordinate rate lives in `alpha`).
+        alpha: Per-coordinate learning-rate scale (default: 0.1).
+        beta: Smoothing constant for the adaptive per-coordinate rate
+            (default: 1.0, the paper's default).
+        lambda1: L1 (lasso) regularization strength — drives weights to exact
+            zero (default: 0.0).
+        lambda2: L2 regularization strength (default: 0.0).
+
+    Returns:
+        Tuple of (new_params, new_z, new_n).
+
+    Raises:
+        Error: If tensor shapes or dtypes don't match.
+    """
+    if params.shape() != gradients.shape():
+        raise Error("ftrl_step: params and gradients must have the same shape")
+    if params.shape() != z.shape():
+        raise Error("ftrl_step: params and z must have the same shape")
+    if params.shape() != n.shape():
+        raise Error("ftrl_step: params and n must have the same shape")
+    if params.dtype() != gradients.dtype():
+        raise Error("ftrl_step: params and gradients must have the same dtype")
+
+    # --- Update the state buffers ---------------------------------------------
+    # sigma = (sqrt(n + g^2) - sqrt(n)) / alpha
+    var grad_sq = multiply_simd(gradients, gradients)
+    var n_new = add_simd(n, grad_sq)
+    var sqrt_n = sqrt(n)
+    var sqrt_n_new = sqrt(n_new)
+    var alpha_tensor = full_like(n, alpha)
+    var sigma = divide_simd(subtract_simd(sqrt_n_new, sqrt_n), alpha_tensor)
+
+    # z += g - sigma * w   (w = the OLD weights = incoming params)
+    var sigma_w = multiply_simd(sigma, params)
+    var z_new = add_simd(z, subtract_simd(gradients, sigma_w))
+
+    # --- Solve the new weights from (z, n) ------------------------------------
+    # numerator (soft-threshold): -sign(z) * max(|z| - lambda1, 0)
+    #   max(|z| - lambda1, 0) is exactly 0 on the |z| <= lambda1 branch, so the
+    #   piecewise `w = 0 if |z| <= lambda1` rule needs no control flow.
+    var abs_z = abs(z_new)
+    var lambda1_tensor = full_like(z_new, lambda1)
+    var shrunk = clip(subtract_simd(abs_z, lambda1_tensor), 0.0, 1.0e30)
+    var numerator = negate(multiply_simd(sign(z_new), shrunk))
+
+    # denominator: (beta + sqrt(n_new)) / alpha + lambda2   (always > 0)
+    var beta_tensor = full_like(n_new, beta)
+    var denom = divide_simd(add_simd(beta_tensor, sqrt_n_new), alpha_tensor)
+    denom = add_simd(denom, full_like(n_new, lambda2))
+
+    var new_params = divide_simd(numerator, denom)
+
+    # Global learning-rate multiplier (1.0 = textbook FTRL).
+    if learning_rate != 1.0:
+        var lr_tensor = full_like(new_params, learning_rate)
+        new_params = multiply_simd(lr_tensor, new_params)
+
+    return (new_params, z_new, n_new)
+
+
+def ftrl_step_simple(
+    params: AnyTensor,
+    gradients: AnyTensor,
+    z: AnyTensor,
+    n: AnyTensor,
+    learning_rate: Float64,
+) raises -> Tuple[AnyTensor, AnyTensor, AnyTensor]:
+    """Simplified FTRL-Proximal step with default hyperparameters.
+
+    Convenience wrapper around `ftrl_step` for the common case: alpha 0.1,
+    beta 1.0, and NO regularization (lambda1 = lambda2 = 0). With no L1 term the
+    output is dense (no sparsity); pass `ftrl_step` with a nonzero `lambda1` to
+    enable feature-selecting sparsity. Caller still manages the `z` and `n`
+    buffers (both zeros on step 1).
+
+    Args:
+        params: Model parameters (used for shape/dtype validation).
+        gradients: Gradients of loss with respect to params.
+        z: Linearized gradient/weight-sum buffer. Zeros on step 1.
+        n: Sum-of-squared-gradients buffer. Zeros on step 1.
+        learning_rate: Global step-size multiplier on the solved weight.
+
+    Returns:
+        Tuple of (new_params, new_z, new_n).
+
+    Raises:
+        Error: If tensor shapes or dtypes don't match.
+    """
+    return ftrl_step(
+        params,
+        gradients,
+        z,
+        n,
+        learning_rate,
+        alpha=0.1,
+        beta=1.0,
+        lambda1=0.0,
+        lambda2=0.0,
+    )

--- a/tests/odyssey/training/optimizers/parity_refs/ftrl_parity_reference.py
+++ b/tests/odyssey/training/optimizers/parity_refs/ftrl_parity_reference.py
@@ -1,0 +1,66 @@
+"""FTRL-Proximal parity reference: an independent numpy transcription of McMahan
+et al. 2013 Algorithm 1 (Per-Coordinate FTRL-Proximal with L1 and L2), run for
+TWO steps on fixed inputs, printing the resulting weights so the Mojo `ftrl_step`
+can be compared against identical inputs.
+
+FTRL is not in torch.optim, and its update is an exact closed-form algorithm, so
+the numpy transcription of Algorithm 1 IS the authoritative reference (no
+framework dependency). Step 1 seeds the (z, n) state from zero; step 2 is the
+general step. Both steps are compared in the Mojo test.
+
+Run:  python tests/odyssey/training/optimizers/parity_refs/ftrl_parity_reference.py
+"""
+
+import json
+
+import numpy as np
+
+# Fixed deterministic inputs (replayed exactly in the Mojo test).
+N = 6
+params0 = np.array([0.10, -0.20, 0.30, -0.40, 0.50, -0.60], dtype=np.float64)
+grad_a = np.array([0.05, 0.15, -0.25, 0.35, -0.45, 0.55], dtype=np.float64)  # step 1
+grad_b = np.array([-0.02, 0.08, 0.12, -0.18, 0.22, -0.28], dtype=np.float64)  # step 2
+
+ALPHA, BETA, L1, L2, LR = 0.1, 1.0, 0.02, 0.01, 1.0
+
+
+def ftrl_step(w, g, z, n, alpha=ALPHA, beta=BETA, l1=L1, l2=L2, lr=LR):
+    """One per-coordinate FTRL-Proximal step (McMahan 2013, Algorithm 1)."""
+    n_new = n + g * g
+    sigma = (np.sqrt(n_new) - np.sqrt(n)) / alpha
+    z_new = z + g - sigma * w
+    # Closed-form weight solve. max(|z| - l1, 0) is exactly 0 on the
+    # |z| <= l1 branch, so the piecewise "w = 0 if |z| <= l1" rule needs no
+    # control flow (produces exact zeros — the FTRL sparsity property).
+    shrunk = np.maximum(np.abs(z_new) - l1, 0.0)
+    numer = -np.sign(z_new) * shrunk
+    denom = (beta + np.sqrt(n_new)) / alpha + l2
+    w_new = numer / denom
+    if lr != 1.0:
+        w_new = lr * w_new
+    return w_new, z_new, n_new
+
+
+def main():
+    z = np.zeros(N)
+    n = np.zeros(N)
+    w1, z, n = ftrl_step(params0, grad_a, z, n)
+    w2, z2, n2 = ftrl_step(w1, grad_b, z, n)
+    out = {
+        "N": N,
+        "params0": params0.tolist(),
+        "grad_a": grad_a.tolist(),
+        "grad_b": grad_b.tolist(),
+        "alpha": ALPHA,
+        "beta": BETA,
+        "lambda1": L1,
+        "lambda2": L2,
+        "lr": LR,
+        "w_step1": [round(x, 10) for x in w1.tolist()],
+        "w_step2": [round(x, 10) for x in w2.tolist()],
+    }
+    print(json.dumps(out, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/odyssey/training/optimizers/test_ftrl.mojo
+++ b/tests/odyssey/training/optimizers/test_ftrl.mojo
@@ -1,0 +1,188 @@
+"""Unit tests for the FTRL-Proximal optimizer (McMahan et al. 2013).
+
+Tests cover:
+- Shape/dtype validation (rejects mismatched params/gradients/state)
+- Numerical parity with an independent numpy transcription of McMahan Algorithm 1
+  over a 2-step run (step 1 seeds state from zero; step 2 is a general step), 1e-6
+- The L1 sparsity property: a coordinate whose |z| <= lambda1 is driven to EXACTLY
+  zero (the feature that distinguishes FTRL from Adam/SGD)
+- lambda1 = 0 produces a dense (no exact-zero-forcing) update via ftrl_step_simple
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor, zeros
+from odyssey.training.optimizers.ftrl import ftrl_step, ftrl_step_simple
+
+
+def _abs_diff(a: Float64, b: Float64) -> Float64:
+    var d = a - b
+    if d < 0:
+        d = -d
+    return d
+
+
+def _seed(mut t: AnyTensor, vals: List[Float64]) raises:
+    for i in range(len(vals)):
+        t.store[DType.float64](i, vals[i])
+
+
+def _lst(*vals: Float64) -> List[Float64]:
+    """Build a List[Float64] from varargs (the List(a, b, ...) literal form
+    does not parse on this Mojo build; append is the portable idiom)."""
+    var out = List[Float64]()
+    for v in vals:
+        out.append(v)
+    return out^
+
+
+def test_reject_shape_mismatch() raises:
+    """FTRL rejects mismatched params/gradients/state shapes."""
+    print("Running test_reject_shape_mismatch...")
+    var p = zeros([6], DType.float64)
+    var g = zeros([5], DType.float64)
+    var z = zeros([6], DType.float64)
+    var n = zeros([6], DType.float64)
+    try:
+        var (_, _, _) = ftrl_step(p, g, z, n, 1.0)
+        raise Error("should have rejected mismatched grad shape")
+    except e:
+        print("  ok rejected mismatched grad shape")
+    var g2 = zeros([6], DType.float64)
+    var z2 = zeros([5], DType.float64)
+    try:
+        var (_, _, _) = ftrl_step(p, g2, z2, n, 1.0)
+        raise Error("should have rejected mismatched z shape")
+    except e:
+        print("  ok rejected mismatched z shape")
+    print("test_reject_shape_mismatch PASSED")
+
+
+def test_parity_two_step() raises:
+    """Match the numpy transcription (McMahan Alg. 1) over 2 steps to 1e-6.
+
+    Reference values from parity_refs/ftrl_parity_reference.py
+    (N=6, alpha=0.1, beta=1.0, lambda1=0.02, lambda2=0.01, lr=1.0). Step 1 seeds
+    (z, n) from zero; step 2 is a general step. Both are compared.
+    """
+    print("Running test_parity_two_step...")
+
+    var params0 = _lst(0.10, -0.20, 0.30, -0.40, 0.50, -0.60)
+    var grad_a = _lst(0.05, 0.15, -0.25, 0.35, -0.45, 0.55)
+    var grad_b = _lst(-0.02, 0.08, 0.12, -0.18, 0.22, -0.28)
+
+    var ref1 = _lst(
+        -0.0,
+        -0.0373588184,
+        0.0783373301,
+        -0.1280532939,
+        0.1847002068,
+        -0.2469374597,
+    )
+    var ref2 = _lst(
+        0.0,
+        -0.0441905861,
+        0.0689499248,
+        -0.1151461207,
+        0.1700520865,
+        -0.2296339729,
+    )
+
+    var w = zeros([6], DType.float64)
+    _seed(w, params0)
+    var g1 = zeros([6], DType.float64)
+    _seed(g1, grad_a)
+    var g2 = zeros([6], DType.float64)
+    _seed(g2, grad_b)
+    var z = zeros([6], DType.float64)
+    var n = zeros([6], DType.float64)
+
+    # step 1
+    var r1 = ftrl_step(w, g1, z, n, 1.0, 0.1, 1.0, 0.02, 0.01)
+    var w1 = r1[0]
+    z = r1[1]
+    n = r1[2]
+    for i in range(6):
+        if _abs_diff(w1.load[DType.float64](i), ref1[i]) > 1e-6:
+            raise Error("FTRL step-1 mismatch at " + String(i))
+
+    # step 2 (general step, from the seeded state)
+    var r2 = ftrl_step(w1, g2, z, n, 1.0, 0.1, 1.0, 0.02, 0.01)
+    var w2 = r2[0]
+    for i in range(6):
+        if _abs_diff(w2.load[DType.float64](i), ref2[i]) > 1e-6:
+            raise Error("FTRL step-2 mismatch at " + String(i))
+
+    print("  ok matches McMahan Alg.1 reference over 2 steps to 1e-6")
+    print("test_parity_two_step PASSED")
+
+
+def test_l1_sparsity() raises:
+    """A coordinate with |z| <= lambda1 is driven to EXACTLY zero.
+
+    Coordinate 0 (grad 0.05) has |z| below lambda1=0.02 after step 1, so FTRL's
+    L1 shrinkage zeroes it exactly — the sparsity property. Assert it is bit-zero,
+    not merely small.
+    """
+    print("Running test_l1_sparsity...")
+    var params0 = _lst(0.10, -0.20, 0.30, -0.40, 0.50, -0.60)
+    var grad_a = _lst(0.05, 0.15, -0.25, 0.35, -0.45, 0.55)
+
+    var w = zeros([6], DType.float64)
+    _seed(w, params0)
+    var g = zeros([6], DType.float64)
+    _seed(g, grad_a)
+    var z = zeros([6], DType.float64)
+    var n = zeros([6], DType.float64)
+
+    var r = ftrl_step(w, g, z, n, 1.0, 0.1, 1.0, 0.02, 0.01)
+    var w1 = r[0]
+    if w1.load[DType.float64](0) != 0.0:
+        raise Error("coordinate 0 should be exactly zero under L1 shrinkage")
+    # a large-gradient coordinate must be nonzero
+    if w1.load[DType.float64](5) == 0.0:
+        raise Error("coordinate 5 (large grad) should be nonzero")
+    print("  ok L1 drives small-|z| coordinate to exact zero")
+    print("test_l1_sparsity PASSED")
+
+
+def test_simple_no_reg_is_dense() raises:
+    """The ftrl_step_simple (lambda1=0) produces a dense update — no forced zeros.
+
+    With no L1 term the soft-threshold never clips to zero, so every nonzero
+    gradient yields a nonzero weight (the update is dense).
+    """
+    print("Running test_simple_no_reg_is_dense...")
+    var params0 = _lst(0.10, -0.20, 0.30, -0.40, 0.50, -0.60)
+    var grad_a = _lst(0.05, 0.15, -0.25, 0.35, -0.45, 0.55)
+
+    var w = zeros([6], DType.float64)
+    _seed(w, params0)
+    var g = zeros([6], DType.float64)
+    _seed(g, grad_a)
+    var z = zeros([6], DType.float64)
+    var n = zeros([6], DType.float64)
+
+    var r = ftrl_step_simple(w, g, z, n, 1.0)
+    var w1 = r[0]
+    for i in range(6):
+        if w1.load[DType.float64](i) == 0.0:
+            raise Error(
+                "no coordinate should be exactly zero without L1 (at "
+                + String(i)
+                + ")"
+            )
+    print("  ok no-regularization step is dense")
+    print("test_simple_no_reg_is_dense PASSED")
+
+
+def main() raises:
+    """Run all FTRL tests."""
+    print("=" * 60)
+    print("FTRL-Proximal Optimizer Test Suite")
+    print("=" * 60)
+    test_reject_shape_mismatch()
+    test_parity_two_step()
+    test_l1_sparsity()
+    test_simple_no_reg_is_dense()
+    print("=" * 60)
+    print("All FTRL tests PASSED")
+    print("=" * 60)


### PR DESCRIPTION
## Summary

Adds the **FTRL-Proximal** (Follow-The-Regularized-Leader) optimizer — the online-learning method behind Google's CTR models (McMahan et al. 2013). It accumulates per-coordinate linearized-gradient (`z`) and squared-gradient (`n`) sums, and each step solves a closed-form L1/L2-regularized objective yielding **sparse** weights via lasso shrinkage.

- `ftrl_step(params, gradients, z, n, learning_rate, alpha, beta, lambda1, lambda2)` — pure-functional, returns `(new_params, new_z, new_n)`; caller threads the two state buffers (zeros on step 1).
- `ftrl_step_simple(...)` — defaults (alpha 0.1, beta 1.0, no regularization).
- Registered in `optimizers/__init__.mojo`.

The piecewise "w = 0 if |z| ≤ λ1" rule is expressed as a single vectorized soft-threshold — `-sign(z)·clip(|z|−λ1, 0, ∞) / denom` — which is exactly zero on that branch, so there is no per-element control flow.

## Tests
`tests/odyssey/training/optimizers/test_ftrl.mojo`:
- shape/dtype-mismatch rejection
- **2-step numerical parity (1e-6)** vs an independent numpy transcription of McMahan Algorithm 1 (`parity_refs/ftrl_parity_reference.py`)
- the **L1 sparsity property**: a coordinate with |z| ≤ λ1 is driven to *exact* zero
- λ1 = 0 yields a dense update

## Verification
Local `mojo package -I src src/odyssey` builds clean (FTRL compiles + registers). CI validates the Mojo test build (the local pixi patch rejects the `List[Float64]()` test idiom that CI accepts — same idiom as the merged ADOPT/MGUP/SOAP tests).

## Reference
McMahan, H. B. et al. (2013). *Ad Click Prediction: a View from the Trenches.* KDD '13, Algorithm 1 (Per-Coordinate FTRL-Proximal with L1 and L2). https://research.google.com/pubs/archive/41159.pdf

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Relationship to tracking issue
Refs mvillmow/Random#82 (OPT-17). Per the project's two-repo staging, this PR delivers only the Odyssey primitive; the consumer-side sweep/ablation wiring (FTRL as a selectable optimizer arm) lands in predictive-coding-mojo after the repin, so this uses `Refs` not `Closes`.