### PR TITLE
fix(ci): fail comprehensive-tests on Mojo compile errors + repair swallowed test imports

### DIFF
--- a/examples/mobilenetv1_cifar10/__init__.mojo
+++ b/examples/mobilenetv1_cifar10/__init__.mojo
@@ -1,0 +1,17 @@
+"""MobileNetV1 CIFAR-10 example package.
+
+Makes ``examples/mobilenetv1_cifar10/`` an importable Mojo package so its
+modules can be referenced as package submodules from repo-root include paths
+(e.g. ``from examples.mobilenetv1_cifar10.model import MobileNetV1``), which is
+how the functional smoke test in ``tests/examples/test_mobilenetv1_train_step.mojo``
+imports the real training machinery.
+
+Modules:
+- model.mojo          - MobileNetV1 architecture (depthwise-separable convs)
+- train.mojo          - SGD training entrypoint
+- train_autograd.mojo - Autograd-based training entrypoint
+- inference.mojo      - Inference entrypoint
+
+Run training directly:
+    mojo run -I . -I examples/mobilenetv1_cifar10 examples/mobilenetv1_cifar10/train.mojo
+"""

--- a/examples/mobilenetv1_cifar10/inference.mojo
+++ b/examples/mobilenetv1_cifar10/inference.mojo
@@ -21,7 +21,7 @@ from odyssey.data.batch_utils import (
 from odyssey.data.constants import DatasetInfo
 from odyssey.data.datasets import CIFAR10Dataset, get_cifar10_classes
 from odyssey.training.metrics import evaluate_logits_batch
-from model import MobileNetV1
+from examples.mobilenetv1_cifar10.model import MobileNetV1
 
 
 def evaluate_model(

--- a/examples/mobilenetv1_cifar10/test_bn_persistence.mojo
+++ b/examples/mobilenetv1_cifar10/test_bn_persistence.mojo
@@ -8,7 +8,7 @@ stats via `out, _, _ = batch_norm2d(...)`, so inference silently used stale
 init values and produced wrong results.
 """
 
-from model import MobileNetV1
+from examples.mobilenetv1_cifar10.model import MobileNetV1
 from odyssey.tensor.any_tensor import AnyTensor
 from odyssey.tensor.tensor_creation import zeros
 

--- a/examples/mobilenetv1_cifar10/test_model.mojo
+++ b/examples/mobilenetv1_cifar10/test_model.mojo
@@ -1,6 +1,6 @@
 """Quick integration test for MobileNetV1 model."""
 
-from model import MobileNetV1
+from examples.mobilenetv1_cifar10.model import MobileNetV1
 from odyssey.tensor.any_tensor import AnyTensor
 from odyssey.tensor.tensor_creation import zeros
 

--- a/examples/mobilenetv1_cifar10/train.mojo
+++ b/examples/mobilenetv1_cifar10/train.mojo
@@ -55,7 +55,7 @@ from odyssey.data.datasets import CIFAR10Dataset
 from odyssey.data import one_hot_encode
 from odyssey.training.schedulers import step_lr
 from odyssey.utils.training_args import parse_training_args_with_defaults
-from model import MobileNetV1
+from examples.mobilenetv1_cifar10.model import MobileNetV1
 
 
 def compute_gradients(

--- a/examples/mobilenetv1_cifar10/train_autograd.mojo
+++ b/examples/mobilenetv1_cifar10/train_autograd.mojo
@@ -54,7 +54,7 @@ Requirements:
     - Dataset location: datasets/cifar10/
 """
 
-from model import MobileNetV1
+from examples.mobilenetv1_cifar10.model import MobileNetV1
 from odyssey.data.datasets import CIFAR10Dataset
 from odyssey.data.formats import one_hot_encode
 from odyssey.data.constants import DatasetInfo

--- a/justfile
+++ b/justfile
@@ -996,15 +996,23 @@ _test-group-inner path pattern:
             if ! ulimit -v unlimited 2>/dev/null; then
                 echo "warn: 'ulimit -v unlimited' rejected by environment" >&2
             fi
-            test_exit=0
-            if ! pixi run mojo --Werror -debug-level=line-tables -I "$REPO_ROOT/src" -I "$REPO_ROOT" -I . "$test_file"; then
-                test_exit=$?
-            fi
+            # Capture the real exit code. The previous idiom
+            # (`if ! mojo ...; then test_exit=$?`) read $? AFTER the `!`
+            # negation, so a failing compile/run yielded test_exit=0 and
+            # every failure — including Mojo parse errors — was counted as
+            # a PASS (false-green, see run 29513897485). `set +e` + direct
+            # `$?` capture makes compile failures count as test failures.
+            set +e
+            pixi run mojo --Werror -debug-level=line-tables -I "$REPO_ROOT/src" -I "$REPO_ROOT" -I . "$test_file"
+            test_exit=$?
+            set -e
             if [ "${test_exit}" -eq 0 ]; then
+                echo "✅ PASSED: $test_file"
                 passed_count=$((passed_count + 1))
             else
+                echo "❌ FAILED (exit ${test_exit}): $test_file"
                 failed_count=$((failed_count + 1))
-                failed_tests="$failed_tests\n  - $test_file"
+                failed_tests="$failed_tests\n  - $test_file (exit ${test_exit})"
             fi
         fi
     done
@@ -1021,6 +1029,16 @@ _test-group-inner path pattern:
     if [ $test_count -eq 0 ]; then
         echo ""
         echo "❌ ERROR: No tests were executed"
+        exit 1
+    fi
+
+    # Accounting guard: every attempted file MUST have been recorded as
+    # exactly one of pass/fail. A mismatch means a run produced neither
+    # verdict (control-flow bug in this recipe) — fail loudly, never green.
+    if [ $((passed_count + failed_count)) -ne $test_count ]; then
+        echo ""
+        echo "❌ ERROR: test accounting mismatch: passed ($passed_count) + failed ($failed_count) != total ($test_count)"
+        echo "   A test file was attempted but produced neither a pass nor a fail verdict."
         exit 1
     fi
 

--- a/src/odyssey/training/optimizers/muon.mojo
+++ b/src/odyssey/training/optimizers/muon.mojo
@@ -101,11 +101,16 @@ def is_muon_eligible(params: AnyTensor) -> Bool:
 def newton_schulz_orthogonalize(
     X: AnyTensor, steps: Int = 5
 ) raises -> AnyTensor:
-    """Apply Newton-Schulz iteration to orthogonalize a matrix.
+    """Apply Newton-Schulz iteration to approximately orthogonalize a matrix.
 
-    Newton-Schulz iteration converges to the orthogonal matrix nearest X in the
-    Frobenius norm. It is a fixed-point iteration: at convergence, the result Y
-    satisfies Y @ Y^T ≈ I_rows (if rows <= cols) or Y^T @ Y ≈ I_cols (if rows > cols).
+    Classical Newton-Schulz converges to the orthogonal polar factor of X, but
+    this variant uses Jordan's tuned quintic coefficients, which trade exact
+    convergence for speed: after 5 steps every singular value of Y lands in
+    roughly [0.68, 1.13] and then oscillates in that band (it does NOT
+    converge to 1). The result satisfies Y @ Y^T ~ I_rows (if rows <= cols) or
+    Y^T @ Y ~ I_cols (if rows > cols) only to within that singular-value band
+    — Muon needs only an approximately-orthogonal update direction, so this
+    looseness is deliberate (see the Jordan writeup linked below).
 
     Algorithm (Jordan et al. 2024):
         1. Pre-normalize X by its Frobenius norm (spectral pre-normalization)
@@ -117,13 +122,15 @@ def newton_schulz_orthogonalize(
         4. Transpose back if needed
 
     The coefficients (a, b, c) = (3.4445, -4.7750, 2.0315) are from the published
-    recipe. They are optimized for fast convergence to orthogonality in 5 steps.
+    recipe. They maximize how fast small singular values are pushed up toward 1,
+    at the cost of never converging exactly (singular values end in ~[0.68, 1.13]).
     See: https://github.com/KellerJordan/Muon/blob/main/muon/torch/optim.py
 
     Args:
         X: A rank-2 tensor (matrix) to orthogonalize.
         steps: Number of Newton-Schulz iterations (default: 5).
-               5 iterations typically achieves singular values within 1e-5 of 1.0.
+               5 iterations typically lands singular values in ~[0.68, 1.13];
+               more steps do NOT tighten the band (the iteration oscillates).
 
     Returns:
         Orthogonalized matrix Y with the same shape as X.
@@ -136,8 +143,8 @@ def newton_schulz_orthogonalize(
         var X = zeros([8, 16], DType.float32)  # Tall matrix (8 rows, 16 cols)
         # Fill X with random values...
         var Y = newton_schulz_orthogonalize(X, steps=5)
-        # Y satisfies: Y @ Y^T ≈ I_8 (rows orthonormal)
-        # Frobenius norm of (Y @ Y^T - I) < 1e-5 in fp32
+        # Y satisfies: Y @ Y^T ~ I_8 to within the singular-value band
+        # (all singular values of Y in ~[0.68, 1.13] for well-conditioned X)
         ```
 
     Note:

--- a/tests/examples/test_mobilenetv1_train_step.mojo
+++ b/tests/examples/test_mobilenetv1_train_step.mojo
@@ -12,12 +12,12 @@ the four acceptance criteria from #5525:
 
 Runs as: pixi run mojo -I src -I . ./tests/examples/test_mobilenetv1_train_step.mojo
 
-The example modules are imported as package submodules (examples has an
-__init__.mojo, as does examples/mobilenetv1_cifar10), so the compiler resolves
+The example modules are imported as package submodules (both examples/ and
+examples/mobilenetv1_cifar10/ carry an __init__.mojo), so the compiler resolves
 them via the repository-root include path used by the test group runner.
 """
 
-from math import isnan, isinf
+from std.math import isnan, isinf
 
 from odyssey.tensor.any_tensor import AnyTensor
 from odyssey.tensor.tensor_creation import ones, zeros

--- a/tests/odyssey/conftest.mojo
+++ b/tests/odyssey/conftest.mojo
@@ -411,8 +411,6 @@ def create_simple_dataset(
 
     # Generate samples
     for i in range(n_samples):
-        var item_seed = seed_value + i
-
         # Generate input features
         var input_features = List[Float32]()
         for j in range(input_dim):

--- a/tests/odyssey/core/layers/test_feedforward.mojo
+++ b/tests/odyssey/core/layers/test_feedforward.mojo
@@ -28,7 +28,7 @@ def test_shape_preserved() raises:
 
 
 def test_default_inner_dim() raises:
-    """d_ff defaults to 4 * d_model when not given."""
+    """`d_ff` defaults to 4 * d_model when not given."""
     print("Running test_default_inner_dim...")
     var ffn = FeedForward[DType.float32](16)
     if ffn.d_ff != 64:
@@ -38,7 +38,7 @@ def test_default_inner_dim() raises:
 
 
 def test_parameter_count() raises:
-    """parameters() returns 4 tensors (two Linear layers)."""
+    """`parameters()` returns 4 tensors (two Linear layers)."""
     print("Running test_parameter_count...")
     var ffn = FeedForward[DType.float32](8, 16)
     var params = ffn.parameters()
@@ -54,7 +54,7 @@ def test_reject_bad_d_model() raises:
     try:
         var _ = FeedForward[DType.float32](0)
         raise Error("Should have rejected d_model = 0")
-    except e:
+    except _:
         print("  ok rejected d_model = 0")
     print("test_reject_bad_d_model PASSED")
 
@@ -70,15 +70,15 @@ def test_parity_with_pytorch() raises:
     print("Running test_parity_with_pytorch...")
 
     # Build the reference output list first, before any tensor stores.
-    var ref = List[Float64]()
-    ref.append(-0.045003)
-    ref.append(-0.014435)
-    ref.append(0.016133)
-    ref.append(0.046701)
-    ref.append(-0.038288)
-    ref.append(-0.007493)
-    ref.append(0.023302)
-    ref.append(0.054096)
+    var ref_vals = List[Float64]()
+    ref_vals.append(-0.045003)
+    ref_vals.append(-0.014435)
+    ref_vals.append(0.016133)
+    ref_vals.append(0.046701)
+    ref_vals.append(-0.038288)
+    ref_vals.append(-0.007493)
+    ref_vals.append(0.023302)
+    ref_vals.append(0.054096)
 
     var ffn = FeedForward[DType.float64](4, 8)
     for i in range(32):
@@ -96,7 +96,7 @@ def test_parity_with_pytorch() raises:
 
     var y = ffn.forward(x)
     for i in range(8):
-        var d = y.load[DType.float64](i) - ref[i]
+        var d = y.load[DType.float64](i) - ref_vals[i]
         if d < 0:
             d = -d
         if d > 1e-5:
@@ -106,7 +106,7 @@ def test_parity_with_pytorch() raises:
 
 
 def test_relu_variant_runs() raises:
-    """use_gelu=False (ReLU activation) runs and preserves shape."""
+    """`use_gelu=False` (ReLU activation) runs and preserves shape."""
     print("Running test_relu_variant_runs...")
     var ffn = FeedForward[DType.float32](8, 16, use_gelu=False)
     var x = zeros([2, 8], DType.float32)

--- a/tests/odyssey/core/layers/test_gru.mojo
+++ b/tests/odyssey/core/layers/test_gru.mojo
@@ -20,7 +20,7 @@ def _abs_diff(a: Float64, b: Float64) -> Float64:
 
 
 def test_shape() raises:
-    """step maps (batch, input) x (batch, hidden) -> (batch, hidden)."""
+    """`step` maps (batch, input) x (batch, hidden) -> (batch, hidden)."""
     print("Running test_shape...")
     var cell = GRUCell[DType.float32](3, 4)
     var x = zeros([2, 3], DType.float32)
@@ -38,18 +38,18 @@ def test_reject_bad_sizes() raises:
     try:
         var _ = GRUCell[DType.float32](0, 4)
         raise Error("Should have rejected input_size = 0")
-    except e:
+    except _:
         print("  ok rejected input_size = 0")
     try:
         var _ = GRUCell[DType.float32](3, 0)
         raise Error("Should have rejected hidden_size = 0")
-    except e:
+    except _:
         print("  ok rejected hidden_size = 0")
     print("test_reject_bad_sizes PASSED")
 
 
 def test_parameter_count() raises:
-    """parameters() returns 12 tensors (weight+bias of six projections)."""
+    """`parameters()` returns 12 tensors (weight+bias of six projections)."""
     print("Running test_parameter_count...")
     var cell = GRUCell[DType.float32](3, 4)
     if len(cell.parameters()) != 12:
@@ -58,14 +58,16 @@ def test_parameter_count() raises:
     print("test_parameter_count PASSED")
 
 
-def _seed_ramp(mut lin: AnyTensor, count: Int, scale: Float64, off: Float64) raises:
+def _seed_ramp(
+    mut lin: AnyTensor, count: Int, scale: Float64, off: Float64
+) raises:
     """Seed a tensor's flat buffer with value[i] = i*scale + off."""
     for i in range(count):
         lin.store[DType.float64](i, Float64(i) * scale + off)
 
 
 def test_parity_with_pytorch() raises:
-    """step must match torch.nn.GRUCell on fixed ramp weights to 1e-5.
+    """`step` must match torch.nn.GRUCell on fixed ramp weights to 1e-5.
 
     Reference values from parity_refs/gru_parity_reference.py (input=3,
     hidden=4, batch=2). Odyssey Linear uses W (in, out); the reference sets
@@ -73,15 +75,15 @@ def test_parity_with_pytorch() raises:
     """
     print("Running test_parity_with_pytorch...")
 
-    var ref = List[Float64]()
-    ref.append(-0.052972)
-    ref.append(-0.0248613)
-    ref.append(0.0035376)
-    ref.append(0.0322239)
-    ref.append(0.0472359)
-    ref.append(0.0817735)
-    ref.append(0.1168354)
-    ref.append(0.1524132)
+    var ref_vals = List[Float64]()
+    ref_vals.append(-0.052972)
+    ref_vals.append(-0.0248613)
+    ref_vals.append(0.0035376)
+    ref_vals.append(0.0322239)
+    ref_vals.append(0.0472359)
+    ref_vals.append(0.0817735)
+    ref_vals.append(0.1168354)
+    ref_vals.append(0.1524132)
 
     var cell = GRUCell[DType.float64](3, 4)
     # input-to-hidden projections (weight: 3*4=12 elems, bias: 4 elems each)
@@ -106,14 +108,14 @@ def test_parity_with_pytorch() raises:
 
     var out = cell.step(x, h)
     for i in range(8):
-        if _abs_diff(out.load[DType.float64](i), ref[i]) > 1e-5:
+        if _abs_diff(out.load[DType.float64](i), ref_vals[i]) > 1e-5:
             raise Error("GRU parity mismatch at " + String(i))
     print("  ok matches torch.nn.GRUCell to 1e-5")
     print("test_parity_with_pytorch PASSED")
 
 
 def test_forward_equals_zero_state_step() raises:
-    """forward(x) must equal step(x, zeros) even with nonzero h->h biases.
+    """`forward(x)` must equal step(x, zeros) even with nonzero h->h biases.
 
     The Module `forward` is documented as a step from a zero initial hidden
     state. A zero hidden zeros only the hidden-to-hidden WEIGHT terms; the
@@ -136,7 +138,10 @@ def test_forward_equals_zero_state_step() raises:
     var f = cell.forward(x)
     var s = cell.step(x, h0)
     for i in range(8):
-        if _abs_diff(f.load[DType.float64](i), s.load[DType.float64](i)) > 1e-12:
+        if (
+            _abs_diff(f.load[DType.float64](i), s.load[DType.float64](i))
+            > 1e-12
+        ):
             raise Error("forward != step(x, zeros) at " + String(i))
     print("  ok forward(x) == step(x, zeros) with nonzero h->h biases")
     print("test_forward_equals_zero_state_step PASSED")

--- a/tests/odyssey/core/layers/test_layernorm.mojo
+++ b/tests/odyssey/core/layers/test_layernorm.mojo
@@ -29,7 +29,7 @@ def _seed_ramp(
 
 
 def test_shape() raises:
-    """forward preserves (batch, features)."""
+    """`forward` preserves (batch, features)."""
     print("Running test_shape...")
     var ln = LayerNorm[DType.float32](4)
     var x = zeros([2, 4], DType.float32)
@@ -46,14 +46,13 @@ def test_reject_bad_sizes() raises:
     try:
         var _ = LayerNorm[DType.float32](0)
         raise Error("Should have rejected num_features = 0")
-    except e:
+    except _:
         print("  ok rejected num_features = 0")
     print("test_reject_bad_sizes PASSED")
 
 
 def test_reject_feature_mismatch() raises:
-    """forward() must raise when the input's last dim != num_features.
-
+    """`forward()` must raise when the input's last dim != num_features.
     Guards the docstring's promised feature-dimension check: gamma/beta are
     sized num_features, so a mismatched-width input would misindex the affine
     params. A LayerNorm(4) fed a (2, 5) tensor must raise, not silently misread.
@@ -64,13 +63,13 @@ def test_reject_feature_mismatch() raises:
     try:
         var _ = ln.forward(x)
         raise Error("Should have rejected feature dim 5 != num_features 4")
-    except e:
+    except _:
         print("  ok rejected feature-dim mismatch (5 != 4)")
     print("test_reject_feature_mismatch PASSED")
 
 
 def test_parameter_count() raises:
-    """parameters() returns 2 tensors (gamma, beta)."""
+    """`parameters()` returns 2 tensors (gamma, beta)."""
     print("Running test_parameter_count...")
     var ln = LayerNorm[DType.float32](4)
     if len(ln.parameters()) != 2:
@@ -80,8 +79,7 @@ def test_parameter_count() raises:
 
 
 def test_parity_with_pytorch() raises:
-    """forward must match torch.nn.LayerNorm on a fixed ramp input to 1e-5.
-
+    """`forward` must match torch.nn.LayerNorm on a fixed ramp input to 1e-5.
     Reference values from parity_refs/layernorm_parity_reference.py (batch=2,
     features=4, eps=1e-5). Two cases: default affine (gamma=1, beta=0) and a
     custom affine.

--- a/tests/odyssey/core/layers/test_lstm.mojo
+++ b/tests/odyssey/core/layers/test_lstm.mojo
@@ -30,7 +30,7 @@ def _seed_ramp(
 
 
 def test_shape() raises:
-    """step maps (batch, in) x (batch, hid) x (batch, hid) -> two (batch, hid).
+    """`step` maps (batch, in) x (batch, hid) x (batch, hid) -> two (batch, hid).
     """
     print("Running test_shape...")
     var cell = LSTMCell[DType.float32](3, 4)
@@ -52,18 +52,18 @@ def test_reject_bad_sizes() raises:
     try:
         var _ = LSTMCell[DType.float32](0, 4)
         raise Error("Should have rejected input_size = 0")
-    except e:
+    except _:
         print("  ok rejected input_size = 0")
     try:
         var _ = LSTMCell[DType.float32](3, 0)
         raise Error("Should have rejected hidden_size = 0")
-    except e:
+    except _:
         print("  ok rejected hidden_size = 0")
     print("test_reject_bad_sizes PASSED")
 
 
 def test_parameter_count() raises:
-    """parameters() returns 16 tensors (weight+bias of eight projections)."""
+    """`parameters()` returns 16 tensors (weight+bias of eight projections)."""
     print("Running test_parameter_count...")
     var cell = LSTMCell[DType.float32](3, 4)
     if len(cell.parameters()) != 16:
@@ -73,8 +73,7 @@ def test_parameter_count() raises:
 
 
 def test_parity_with_pytorch() raises:
-    """step must match torch.nn.LSTMCell on fixed ramp weights to 1e-5.
-
+    """`step` must match torch.nn.LSTMCell on fixed ramp weights to 1e-5.
     Reference values from parity_refs/lstm_parity_reference.py (input=3,
     hidden=4, batch=2). Odyssey Linear uses W (in, out); the reference sets
     torch's packed (4H, in)/(4H, H) weight to the per-gate transpose. Both the
@@ -140,8 +139,7 @@ def test_parity_with_pytorch() raises:
 
 
 def test_forward_equals_zero_state_step() raises:
-    """forward(x) must equal step(x, zeros, zeros)[0] with nonzero h->h biases.
-
+    """`forward(x)` must equal `step(x, zeros, zeros)[0]` with nonzero h->h biases.
     A zero initial (hidden, cell) zeros only the hidden-to-hidden WEIGHT terms,
     not the biases b_hi/b_hf/b_hg/b_ho. This asserts forward() includes them
     (regression guard: an earlier shortcut dropped the h->h biases, so forward

--- a/tests/odyssey/core/layers/test_rnn.mojo
+++ b/tests/odyssey/core/layers/test_rnn.mojo
@@ -20,7 +20,7 @@ def _abs_diff(a: Float64, b: Float64) -> Float64:
 
 
 def test_shape() raises:
-    """step maps (batch, input) x (batch, hidden) -> (batch, hidden)."""
+    """`step` maps (batch, input) x (batch, hidden) -> (batch, hidden)."""
     print("Running test_shape...")
     var cell = RNNCell[DType.float32](3, 4)
     var x = zeros([2, 3], DType.float32)
@@ -38,18 +38,18 @@ def test_reject_bad_sizes() raises:
     try:
         var _ = RNNCell[DType.float32](0, 4)
         raise Error("Should have rejected input_size = 0")
-    except e:
+    except _:
         print("  ok rejected input_size = 0")
     try:
         var _ = RNNCell[DType.float32](3, 0)
         raise Error("Should have rejected hidden_size = 0")
-    except e:
+    except _:
         print("  ok rejected hidden_size = 0")
     print("test_reject_bad_sizes PASSED")
 
 
 def test_parameter_count() raises:
-    """parameters() returns 4 tensors."""
+    """`parameters()` returns 4 tensors."""
     print("Running test_parameter_count...")
     var cell = RNNCell[DType.float32](3, 4)
     if len(cell.parameters()) != 4:
@@ -59,7 +59,7 @@ def test_parameter_count() raises:
 
 
 def test_parity_with_pytorch() raises:
-    """step must match torch.nn.RNNCell(tanh) on fixed ramp weights to 1e-5.
+    """`step` must match torch.nn.RNNCell(tanh) on fixed ramp weights to 1e-5.
 
     Reference values from parity_refs/rnn_parity_reference.py (input=3,
     hidden=4, batch=2). Odyssey Linear uses W (in, out); the reference sets
@@ -67,15 +67,15 @@ def test_parity_with_pytorch() raises:
     """
     print("Running test_parity_with_pytorch...")
 
-    var ref = List[Float64]()
-    ref.append(-0.0479632)
-    ref.append(-0.005)
-    ref.append(0.0379817)
-    ref.append(0.0808233)
-    ref.append(-0.0659043)
-    ref.append(0.003)
-    ref.append(0.0718758)
-    ref.append(0.140073)
+    var ref_vals = List[Float64]()
+    ref_vals.append(-0.0479632)
+    ref_vals.append(-0.005)
+    ref_vals.append(0.0379817)
+    ref_vals.append(0.0808233)
+    ref_vals.append(-0.0659043)
+    ref_vals.append(0.003)
+    ref_vals.append(0.0718758)
+    ref_vals.append(0.140073)
 
     var cell = RNNCell[DType.float64](3, 4)
     for i in range(12):
@@ -95,14 +95,14 @@ def test_parity_with_pytorch() raises:
 
     var out = cell.step(x, h)
     for i in range(8):
-        if _abs_diff(out.load[DType.float64](i), ref[i]) > 1e-5:
+        if _abs_diff(out.load[DType.float64](i), ref_vals[i]) > 1e-5:
             raise Error("RNN parity mismatch at " + String(i))
     print("  ok matches torch.nn.RNNCell to 1e-5")
     print("test_parity_with_pytorch PASSED")
 
 
 def test_forward_equals_zero_state_step() raises:
-    """forward(x) must equal step(x, zeros) even with a nonzero b_hh.
+    """`forward(x)` must equal step(x, zeros) even with a nonzero b_hh.
 
     A zero initial hidden zeros only the hidden-to-hidden WEIGHT term, not its
     bias b_hh. This asserts forward() includes b_hh (regression guard: an earlier
@@ -121,14 +121,17 @@ def test_forward_equals_zero_state_step() raises:
     var f = cell.forward(x)
     var s = cell.step(x, h0)
     for i in range(8):
-        if _abs_diff(f.load[DType.float64](i), s.load[DType.float64](i)) > 1e-12:
+        if (
+            _abs_diff(f.load[DType.float64](i), s.load[DType.float64](i))
+            > 1e-12
+        ):
             raise Error("forward != step(x, zeros) at " + String(i))
     print("  ok forward(x) == step(x, zeros) with nonzero b_hh")
     print("test_forward_equals_zero_state_step PASSED")
 
 
 def test_parameter_order() raises:
-    """parameters() must return [ih.weight, ih.bias, hh.weight, hh.bias] in order.
+    """`parameters()` must return [ih.weight, ih.bias, hh.weight, hh.bias] in order.
 
     A consumer that threads per-parameter state (e.g. the PC error chain) relies
     on this positional contract, so assert identity by numel, not just count.

--- a/tests/odyssey/core/test_eigen.mojo
+++ b/tests/odyssey/core/test_eigen.mojo
@@ -9,7 +9,8 @@ Tests cover:
 """
 
 from std.math import sqrt as scalar_sqrt
-from odyssey.tensor.any_tensor import AnyTensor, zeros
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros
 from odyssey.core.eigen import symmetric_eigh
 
 
@@ -27,7 +28,7 @@ def test_reject_non_square() raises:
     try:
         var (_, _) = symmetric_eigh(m)
         raise Error("Should have rejected 2x3")
-    except e:
+    except _:
         print("  ok rejected non-square")
     print("test_reject_non_square PASSED")
 

--- a/tests/odyssey/core/test_gradient_clipping_simd.mojo
+++ b/tests/odyssey/core/test_gradient_clipping_simd.mojo
@@ -6,6 +6,7 @@ from odyssey.core import (
     clip_grad_global_norm_,
 )
 from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros
 from tests.odyssey.conftest import (
     assert_true,
 )
@@ -15,7 +16,11 @@ from std.collections import List
 
 def test_clip_grad_value_f32() raises:
     """Test clip_grad_value_ with float32."""
-    var grad = AnyTensor([1.0, 2.0, 3.0, -4.0], dtype=DType.float32)
+    var grad = zeros([4], DType.float32)
+    grad._set_float64(0, 1.0)
+    grad._set_float64(1, 2.0)
+    grad._set_float64(2, 3.0)
+    grad._set_float64(3, -4.0)
     clip_grad_value_(grad, 2.5)
 
     assert_true(abs(grad._get_float64(0) - 1.0) < 1e-6)
@@ -26,7 +31,11 @@ def test_clip_grad_value_f32() raises:
 
 def test_clip_grad_value_f64() raises:
     """Test clip_grad_value_ with float64."""
-    var grad = AnyTensor([1.0, 2.0, 3.0, -4.0], dtype=DType.float64)
+    var grad = zeros([4], DType.float64)
+    grad._set_float64(0, 1.0)
+    grad._set_float64(1, 2.0)
+    grad._set_float64(2, 3.0)
+    grad._set_float64(3, -4.0)
     clip_grad_value_(grad, 2.5)
 
     assert_true(abs(grad._get_float64(0) - 1.0) < 1e-6)
@@ -37,7 +46,9 @@ def test_clip_grad_value_f64() raises:
 
 def test_clip_grad_norm_f32() raises:
     """Test clip_grad_norm_ with float32."""
-    var grad = AnyTensor([3.0, 4.0], dtype=DType.float32)
+    var grad = zeros([2], DType.float32)
+    grad._set_float64(0, 3.0)
+    grad._set_float64(1, 4.0)
     var norm = clip_grad_norm_(grad, 2.5)
 
     # Original norm: sqrt(9 + 16) = 5.0
@@ -50,7 +61,9 @@ def test_clip_grad_norm_f32() raises:
 
 def test_clip_grad_norm_f64() raises:
     """Test clip_grad_norm_ with float64."""
-    var grad = AnyTensor([3.0, 4.0], dtype=DType.float64)
+    var grad = zeros([2], DType.float64)
+    grad._set_float64(0, 3.0)
+    grad._set_float64(1, 4.0)
     var norm = clip_grad_norm_(grad, 2.5)
 
     # Original norm: sqrt(9 + 16) = 5.0
@@ -63,8 +76,10 @@ def test_clip_grad_norm_f64() raises:
 
 def test_clip_grad_global_norm_f32() raises:
     """Test clip_grad_global_norm_ with float32."""
-    var grad1 = AnyTensor([3.0, 4.0], dtype=DType.float32)
-    var grad2 = AnyTensor([0.0, 0.0], dtype=DType.float32)
+    var grad1 = zeros([2], DType.float32)
+    grad1._set_float64(0, 3.0)
+    grad1._set_float64(1, 4.0)
+    var grad2 = zeros([2], DType.float32)
     var grads = List[AnyTensor](grad1, grad2)
 
     var global_norm = clip_grad_global_norm_(grads, 2.5)
@@ -79,8 +94,10 @@ def test_clip_grad_global_norm_f32() raises:
 
 def test_clip_grad_global_norm_f64() raises:
     """Test clip_grad_global_norm_ with float64."""
-    var grad1 = AnyTensor([3.0, 4.0], dtype=DType.float64)
-    var grad2 = AnyTensor([0.0, 0.0], dtype=DType.float64)
+    var grad1 = zeros([2], DType.float64)
+    grad1._set_float64(0, 3.0)
+    grad1._set_float64(1, 4.0)
+    var grad2 = zeros([2], DType.float64)
     var grads = List[AnyTensor](grad1, grad2)
 
     var global_norm = clip_grad_global_norm_(grads, 2.5)
@@ -95,7 +112,10 @@ def test_clip_grad_global_norm_f64() raises:
 
 def test_clip_grad_value_no_clipping_f32() raises:
     """Test clip_grad_value_ when clipping is not needed (float32)."""
-    var grad = AnyTensor([0.5, 1.0, 1.5], dtype=DType.float32)
+    var grad = zeros([3], DType.float32)
+    grad._set_float64(0, 0.5)
+    grad._set_float64(1, 1.0)
+    grad._set_float64(2, 1.5)
     clip_grad_value_(grad, 2.0)
 
     assert_true(abs(grad._get_float64(0) - 0.5) < 1e-6)
@@ -105,7 +125,9 @@ def test_clip_grad_value_no_clipping_f32() raises:
 
 def test_clip_grad_norm_no_clipping_f32() raises:
     """Test clip_grad_norm_ when clipping is not needed (float32)."""
-    var grad = AnyTensor([1.0, 2.0], dtype=DType.float32)
+    var grad = zeros([2], DType.float32)
+    grad._set_float64(0, 1.0)
+    grad._set_float64(1, 2.0)
     var norm = clip_grad_norm_(grad, 10.0)
 
     # norm = sqrt(1 + 4) = sqrt(5) ≈ 2.236
@@ -119,8 +141,10 @@ def test_clip_grad_norm_no_clipping_f32() raises:
 
 def test_clip_grad_global_norm_no_clipping_f64() raises:
     """Test clip_grad_global_norm_ when clipping is not needed (float64)."""
-    var grad1 = AnyTensor([1.0, 2.0], dtype=DType.float64)
-    var grad2 = AnyTensor([0.0, 0.0], dtype=DType.float64)
+    var grad1 = zeros([2], DType.float64)
+    grad1._set_float64(0, 1.0)
+    grad1._set_float64(1, 2.0)
+    var grad2 = zeros([2], DType.float64)
     var grads = List[AnyTensor](grad1, grad2)
 
     var global_norm = clip_grad_global_norm_(grads, 10.0)

--- a/tests/odyssey/core/test_gradient_clipping_simd.mojo
+++ b/tests/odyssey/core/test_gradient_clipping_simd.mojo
@@ -80,7 +80,9 @@ def test_clip_grad_global_norm_f32() raises:
     grad1._set_float64(0, 3.0)
     grad1._set_float64(1, 4.0)
     var grad2 = zeros([2], DType.float32)
-    var grads = List[AnyTensor](grad1, grad2)
+    var grads: List[AnyTensor] = []
+    grads.append(grad1)
+    grads.append(grad2)
 
     var global_norm = clip_grad_global_norm_(grads, 2.5)
 
@@ -98,7 +100,9 @@ def test_clip_grad_global_norm_f64() raises:
     grad1._set_float64(0, 3.0)
     grad1._set_float64(1, 4.0)
     var grad2 = zeros([2], DType.float64)
-    var grads = List[AnyTensor](grad1, grad2)
+    var grads: List[AnyTensor] = []
+    grads.append(grad1)
+    grads.append(grad2)
 
     var global_norm = clip_grad_global_norm_(grads, 2.5)
 
@@ -145,7 +149,9 @@ def test_clip_grad_global_norm_no_clipping_f64() raises:
     grad1._set_float64(0, 1.0)
     grad1._set_float64(1, 2.0)
     var grad2 = zeros([2], DType.float64)
-    var grads = List[AnyTensor](grad1, grad2)
+    var grads: List[AnyTensor] = []
+    grads.append(grad1)
+    grads.append(grad2)
 
     var global_norm = clip_grad_global_norm_(grads, 10.0)
 

--- a/tests/odyssey/integration/test_packaging.mojo
+++ b/tests/odyssey/integration/test_packaging.mojo
@@ -16,8 +16,8 @@ from odyssey.training import (
     LossTracker,
     MSELoss,
     ModelCheckpoint,
-    SGD,
     StepLR,
+    TrainingLoopSGD as SGD,
 )
 from odyssey.data import (
     AnyTensorDataset,

--- a/tests/odyssey/integration/test_training_workflow.mojo
+++ b/tests/odyssey/integration/test_training_workflow.mojo
@@ -24,7 +24,8 @@ from tests.odyssey.conftest import (
     create_simple_dataset,
     TestFixtures,
 )
-from odyssey.tensor.any_tensor import AnyTensor, zeros, ones
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros, ones
 from odyssey.core.linear import linear_no_bias
 from odyssey.training.optimizers.sgd import sgd_step_simple
 

--- a/tests/odyssey/training/optimizers/test_adan.mojo
+++ b/tests/odyssey/training/optimizers/test_adan.mojo
@@ -24,7 +24,7 @@ def _abs_diff(a: Float64, b: Float64) -> Float64:
 
 
 def test_reject_shape_mismatch() raises:
-    """adan_step rejects a params/gradients shape mismatch."""
+    """`adan_step` rejects a params/gradients shape mismatch."""
     print("Running test_reject_shape_mismatch...")
     var p = zeros([4], DType.float32)
     var g = zeros([5], DType.float32)
@@ -35,13 +35,13 @@ def test_reject_shape_mismatch() raises:
     try:
         var _ = adan_step(p, g, m, dd, v, pg, 1, 0.001)
         raise Error("Should have rejected shape mismatch")
-    except e:
+    except _:
         print("  ok rejected shape mismatch")
     print("test_reject_shape_mismatch PASSED")
 
 
 def test_reject_dtype_mismatch() raises:
-    """adan_step rejects a params/gradients dtype mismatch."""
+    """`adan_step` rejects a params/gradients dtype mismatch."""
     print("Running test_reject_dtype_mismatch...")
     var p = zeros([4], DType.float32)
     var g = zeros([4], DType.float16)
@@ -52,7 +52,7 @@ def test_reject_dtype_mismatch() raises:
     try:
         var _ = adan_step(p, g, m, dd, v, pg, 1, 0.001)
         raise Error("Should have rejected dtype mismatch")
-    except e:
+    except _:
         print("  ok rejected dtype mismatch")
     print("test_reject_dtype_mismatch PASSED")
 
@@ -145,7 +145,7 @@ def test_parity_with_reference() raises:
 
 
 def test_step_simple_matches_defaults() raises:
-    """adan_step_simple must equal adan_step with the default hyperparameters.
+    """`adan_step_simple` must equal `adan_step` with the default hyperparameters.
     """
     print("Running test_step_simple_matches_defaults...")
     var n = 5
@@ -184,7 +184,7 @@ def test_step_simple_matches_defaults() raises:
 
 
 def test_weight_decay() raises:
-    """weight_decay applies the paper's divisive decoupled (proximal) decay.
+    """`weight_decay` applies the paper's divisive decoupled (proximal) decay.
 
     With a zero gradient the gradient step is zero, so the only change is the
     decoupled proximal decay `params /= (1 + lr * weight_decay)` (Algorithm 1
@@ -236,7 +236,7 @@ def test_weight_decay() raises:
 
 
 def test_prev_grad_passthrough() raises:
-    """new_prev_grad must equal the current gradient (for the next step)."""
+    """`new_prev_grad` must equal the current gradient (for the next step)."""
     print("Running test_prev_grad_passthrough...")
     var n = 3
     var p = zeros([n], DType.float64)

--- a/tests/odyssey/training/optimizers/test_adopt.mojo
+++ b/tests/odyssey/training/optimizers/test_adopt.mojo
@@ -11,11 +11,8 @@ Tests cover:
 - Second-moment update ordering (v is updated with grad^2 AFTER being used)
 - adopt_step_simple delegates to adopt_step with the default hyperparameters
 """
-from odyssey.tensor.any_tensor import (
-    AnyTensor,
-    zeros,
-    full,
-)
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros, full
 from odyssey.training.optimizers.adopt import adopt_step, adopt_step_simple
 from std.math import abs as math_abs
 
@@ -67,7 +64,7 @@ def test_reject_second_moment_shape() raises:
     try:
         var _ = adopt_step(params, grad, m, v, 0.01)
         raise Error("Should have rejected second_moment shape mismatch")
-    except e:
+    except _:
         print("  ✓ Correctly rejected second_moment shape mismatch")
     print("test_reject_second_moment_shape PASSED")
 
@@ -82,7 +79,7 @@ def test_reject_momentum_shape() raises:
     try:
         var _ = adopt_step(params, grad, m, v, 0.01)
         raise Error("Should have rejected momentum shape mismatch")
-    except e:
+    except _:
         print("  ✓ Correctly rejected momentum shape mismatch")
     print("test_reject_momentum_shape PASSED")
 
@@ -97,7 +94,7 @@ def test_weight_decay_differs_from_zero() raises:
     identical between the two calls since it does not depend on weight_decay).
     """
     print("Running test_weight_decay_differs_from_zero...")
-    alias N = 4
+    comptime N = 4
     var lr = 0.1
     var wd = 0.5
     var p_val = 2.0
@@ -140,7 +137,7 @@ def test_parity_with_reference() raises:
     test for the reproducible reference generator.
     """
     print("Running test_parity_with_reference...")
-    alias N = 6
+    comptime N = 6
     var p = zeros([N], DType.float64)
     var g = zeros([N], DType.float64)
     var m = zeros([N], DType.float64)
@@ -215,7 +212,7 @@ def test_parity_with_reference() raises:
 def test_descent_direction() raises:
     """A positive gradient must decrease the parameter (and vice versa)."""
     print("Running test_descent_direction...")
-    alias N = 3
+    comptime N = 3
     var p = full([N], 1.0, DType.float32)
     var g = full([N], 0.5, DType.float32)  # positive grad
     var m = zeros([N], DType.float32)
@@ -237,7 +234,7 @@ def test_second_moment_updates_last() raises:
     new_v = (1 - beta2) * grad^2 (the beta2 * 0 term vanishes).
     """
     print("Running test_second_moment_updates_last...")
-    alias N = 2
+    comptime N = 2
     var p = zeros([N], DType.float32)
     var g = full([N], 2.0, DType.float32)  # grad^2 = 4
     var m = zeros([N], DType.float32)
@@ -264,7 +261,7 @@ def test_clip_bounds_normalized_gradient() raises:
     param step proportionally versus the un-clipped case.
     """
     print("Running test_clip_bounds_normalized_gradient...")
-    alias N = 4
+    comptime N = 4
     var beta1 = 0.9
     var lr = 0.1
 
@@ -299,9 +296,9 @@ def test_clip_bounds_normalized_gradient() raises:
 
 
 def test_simple_matches_full_defaults() raises:
-    """adopt_step_simple must equal adopt_step with default hyperparameters."""
+    """`adopt_step_simple` must equal `adopt_step` with default hyperparameters."""
     print("Running test_simple_matches_full_defaults...")
-    alias N = 5
+    comptime N = 5
     var p = full([N], 0.2, DType.float64)
     var g = full([N], -0.3, DType.float64)
     var m = zeros([N], DType.float64)

--- a/tests/odyssey/training/optimizers/test_adopt.mojo
+++ b/tests/odyssey/training/optimizers/test_adopt.mojo
@@ -296,7 +296,8 @@ def test_clip_bounds_normalized_gradient() raises:
 
 
 def test_simple_matches_full_defaults() raises:
-    """`adopt_step_simple` must equal `adopt_step` with default hyperparameters."""
+    """`adopt_step_simple` must equal `adopt_step` with default hyperparameters.
+    """
     print("Running test_simple_matches_full_defaults...")
     comptime N = 5
     var p = full([N], 0.2, DType.float64)

--- a/tests/odyssey/training/optimizers/test_ftrl.mojo
+++ b/tests/odyssey/training/optimizers/test_ftrl.mojo
@@ -148,11 +148,19 @@ def test_l1_sparsity() raises:
 def test_simple_no_reg_is_dense() raises:
     """The ftrl_step_simple (lambda1=0) produces a dense update — no forced zeros.
 
-    With no L1 term the soft-threshold never clips to zero, so every nonzero
-    gradient yields a nonzero weight (the update is dense).
+    With no L1 term the soft-threshold never clips to zero, so every coordinate
+    with a nonzero accumulated z yields a nonzero weight (w = -z / denom).
+
+    Input caveat: "dense" means no THRESHOLD-forced zeros, but z itself can be
+    exactly zero by arithmetic cancellation: on step 1 from zero state,
+    z = g - (|g|/alpha)*w0, which is exactly 0.0 whenever w0 == alpha*sign(g).
+    The shared fixture (w0[0]=0.10 == alpha=0.1, g[0]=0.05 > 0) hits exactly
+    that trap — w[0] = -0/denom = 0 is CORRECT dense behavior, not a bug. So
+    this test uses w0[0]=0.15 to keep every z nonzero (numpy fp64 reference:
+    z = [-0.025, 0.45, -1.0, 1.75, -2.7, 3.85], no zeros).
     """
     print("Running test_simple_no_reg_is_dense...")
-    var params0 = _lst(0.10, -0.20, 0.30, -0.40, 0.50, -0.60)
+    var params0 = _lst(0.15, -0.20, 0.30, -0.40, 0.50, -0.60)
     var grad_a = _lst(0.05, 0.15, -0.25, 0.35, -0.45, 0.55)
 
     var w = zeros([6], DType.float64)

--- a/tests/odyssey/training/optimizers/test_ftrl.mojo
+++ b/tests/odyssey/training/optimizers/test_ftrl.mojo
@@ -9,7 +9,8 @@ Tests cover:
 - lambda1 = 0 produces a dense (no exact-zero-forcing) update via ftrl_step_simple
 """
 
-from odyssey.tensor.any_tensor import AnyTensor, zeros
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros
 from odyssey.training.optimizers.ftrl import ftrl_step, ftrl_step_simple
 
 
@@ -44,14 +45,14 @@ def test_reject_shape_mismatch() raises:
     try:
         var (_, _, _) = ftrl_step(p, g, z, n, 1.0)
         raise Error("should have rejected mismatched grad shape")
-    except e:
+    except _:
         print("  ok rejected mismatched grad shape")
     var g2 = zeros([6], DType.float64)
     var z2 = zeros([5], DType.float64)
     try:
         var (_, _, _) = ftrl_step(p, g2, z2, n, 1.0)
         raise Error("should have rejected mismatched z shape")
-    except e:
+    except _:
         print("  ok rejected mismatched z shape")
     print("test_reject_shape_mismatch PASSED")
 

--- a/tests/odyssey/training/optimizers/test_lionmuon.mojo
+++ b/tests/odyssey/training/optimizers/test_lionmuon.mojo
@@ -20,7 +20,8 @@ output, 12 decimal places); the script threads state sequentially, so
 ref_{n+1} == rule(ref_n) by construction.
 """
 
-from odyssey.tensor.any_tensor import AnyTensor, zeros, zeros_like
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros, zeros_like
 from odyssey.training.optimizers.lionmuon import (
     lionmuon_step,
     lionmuon_step_simple,
@@ -59,7 +60,7 @@ def test_reject_bad_period() raises:
     try:
         var (_, _, _) = lionmuon_step(W, G, LM, MM, 0.1, 0, 0)
         raise Error("Should have rejected period = 0")
-    except e:
+    except _:
         print("  ok rejected period = 0")
     print("test_reject_bad_period PASSED")
 

--- a/tests/odyssey/training/optimizers/test_mgup_muon.mojo
+++ b/tests/odyssey/training/optimizers/test_mgup_muon.mojo
@@ -9,7 +9,8 @@ Tests cover:
   coordinates move further than the un-amplified Muon step)
 """
 
-from odyssey.tensor.any_tensor import AnyTensor, zeros, zeros_like
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros, zeros_like
 from odyssey.training.optimizers.mgup_muon import (
     mgup_muon_step,
     mgup_muon_step_simple,
@@ -38,7 +39,7 @@ def test_reject_non_2d() raises:
     try:
         var (_, _) = mgup_muon_step(p, g, m, learning_rate=0.01)
         raise Error("Should have rejected 1D params")
-    except e:
+    except _:
         print("  ok rejected 1D params")
     print("test_reject_non_2d PASSED")
 
@@ -52,19 +53,19 @@ def test_parity_with_reference() raises:
     """
     print("Running test_parity_with_reference...")
 
-    var ref = List[Float64]()
-    ref.append(-0.4690749)
-    ref.append(-0.3902363)
-    ref.append(-0.2959352)
-    ref.append(-0.201634)
-    ref.append(-0.0788658)
-    ref.append(0.0037723)
-    ref.append(0.0969775)
-    ref.append(0.1901828)
-    ref.append(0.3056717)
-    ref.append(0.397781)
-    ref.append(0.4898903)
-    ref.append(0.5639991)
+    var ref_vals = List[Float64]()
+    ref_vals.append(-0.4690749)
+    ref_vals.append(-0.3902363)
+    ref_vals.append(-0.2959352)
+    ref_vals.append(-0.201634)
+    ref_vals.append(-0.0788658)
+    ref_vals.append(0.0037723)
+    ref_vals.append(0.0969775)
+    ref_vals.append(0.1901828)
+    ref_vals.append(0.3056717)
+    ref_vals.append(0.397781)
+    ref_vals.append(0.4898903)
+    ref_vals.append(0.5639991)
 
     var W = zeros([3, 4], DType.float64)
     _seed_ramp(W, 12, 0.1, -0.5)
@@ -74,14 +75,14 @@ def test_parity_with_reference() raises:
 
     var (new_p, _) = mgup_muon_step(W, G, M, 0.1, 0.25, 2.0)
     for i in range(12):
-        if _abs_diff(new_p.load[DType.float64](i), ref[i]) > 1e-6:
+        if _abs_diff(new_p.load[DType.float64](i), ref_vals[i]) > 1e-6:
             raise Error("MGUP-Muon parity mismatch at " + String(i))
     print("  ok matches reference to 1e-6")
     print("test_parity_with_reference PASSED")
 
 
 def test_reduces_to_muon_when_disabled() raises:
-    """fraction=0 or scale=1 must reproduce a plain Muon step exactly."""
+    """`fraction=0` or `scale=1` must reproduce a plain Muon step exactly."""
     print("Running test_reduces_to_muon_when_disabled...")
     var W = zeros([3, 4], DType.float64)
     _seed_ramp(W, 12, 0.1, -0.5)
@@ -155,19 +156,19 @@ def test_float32_matches_float64() raises:
     print("Running test_float32_matches_float64...")
 
     # float64 reference values (same fixture as test_parity_with_reference).
-    var ref = List[Float64]()
-    ref.append(-0.4690749)
-    ref.append(-0.3902363)
-    ref.append(-0.2959352)
-    ref.append(-0.201634)
-    ref.append(-0.0788658)
-    ref.append(0.0037723)
-    ref.append(0.0969775)
-    ref.append(0.1901828)
-    ref.append(0.3056717)
-    ref.append(0.397781)
-    ref.append(0.4898903)
-    ref.append(0.5639991)
+    var ref_vals = List[Float64]()
+    ref_vals.append(-0.4690749)
+    ref_vals.append(-0.3902363)
+    ref_vals.append(-0.2959352)
+    ref_vals.append(-0.201634)
+    ref_vals.append(-0.0788658)
+    ref_vals.append(0.0037723)
+    ref_vals.append(0.0969775)
+    ref_vals.append(0.1901828)
+    ref_vals.append(0.3056717)
+    ref_vals.append(0.397781)
+    ref_vals.append(0.4898903)
+    ref_vals.append(0.5639991)
 
     var W = zeros([3, 4], DType.float32)
     for i in range(12):
@@ -180,7 +181,7 @@ def test_float32_matches_float64() raises:
     var (new_p, _) = mgup_muon_step(W, G, M, 0.1, 0.25, 2.0)
     for i in range(12):
         var got = Float64(new_p.load[DType.float32](i))
-        if _abs_diff(got, ref[i]) > 1e-5:
+        if _abs_diff(got, ref_vals[i]) > 1e-5:
             raise Error("MGUP float32 mismatch vs float64 at " + String(i))
     print("  ok float32 step matches float64 reference to 1e-5")
     print("test_float32_matches_float64 PASSED")

--- a/tests/odyssey/training/optimizers/test_mgup_muon.mojo
+++ b/tests/odyssey/training/optimizers/test_mgup_muon.mojo
@@ -25,7 +25,9 @@ def _abs_diff(a: Float64, b: Float64) -> Float64:
     return d
 
 
-def _seed_ramp(mut t: AnyTensor, count: Int, scale: Float64, off: Float64) raises:
+def _seed_ramp(
+    mut t: AnyTensor, count: Int, scale: Float64, off: Float64
+) raises:
     for i in range(count):
         t.store[DType.float64](i, Float64(i) * scale + off)
 
@@ -94,9 +96,19 @@ def test_reduces_to_muon_when_disabled() raises:
     var (p_frac0, _) = mgup_muon_step(W, G, M, 0.1, 0.0, 2.0)
     var (p_scale1, _) = mgup_muon_step(W, G, M, 0.1, 0.25, 1.0)
     for i in range(12):
-        if _abs_diff(p_muon.load[DType.float64](i), p_frac0.load[DType.float64](i)) > 1e-12:
+        if (
+            _abs_diff(
+                p_muon.load[DType.float64](i), p_frac0.load[DType.float64](i)
+            )
+            > 1e-12
+        ):
             raise Error("fraction=0 should equal plain Muon at " + String(i))
-        if _abs_diff(p_muon.load[DType.float64](i), p_scale1.load[DType.float64](i)) > 1e-12:
+        if (
+            _abs_diff(
+                p_muon.load[DType.float64](i), p_scale1.load[DType.float64](i)
+            )
+            > 1e-12
+        ):
             raise Error("scale=1 should equal plain Muon at " + String(i))
     print("  ok fraction=0 and scale=1 both reduce to Muon")
     print("test_reduces_to_muon_when_disabled PASSED")
@@ -119,8 +131,12 @@ def test_selected_move_further() raises:
     var (p_mgup, _) = mgup_muon_step(W, G, M, 0.1, 0.25, 2.0)
     var any_larger = False
     for i in range(12):
-        var d_muon = _abs_diff(p_muon.load[DType.float64](i), W.load[DType.float64](i))
-        var d_mgup = _abs_diff(p_mgup.load[DType.float64](i), W.load[DType.float64](i))
+        var d_muon = _abs_diff(
+            p_muon.load[DType.float64](i), W.load[DType.float64](i)
+        )
+        var d_mgup = _abs_diff(
+            p_mgup.load[DType.float64](i), W.load[DType.float64](i)
+        )
         if d_mgup > d_muon + 1e-9:
             any_larger = True
     if not any_larger:

--- a/tests/odyssey/training/optimizers/test_muon_hyperball.mojo
+++ b/tests/odyssey/training/optimizers/test_muon_hyperball.mojo
@@ -27,7 +27,9 @@ def _abs_diff(a: Float64, b: Float64) -> Float64:
     return d
 
 
-def _seed_ramp(mut t: AnyTensor, count: Int, scale: Float64, off: Float64) raises:
+def _seed_ramp(
+    mut t: AnyTensor, count: Int, scale: Float64, off: Float64
+) raises:
     for i in range(count):
         t.store[DType.float64](i, Float64(i) * scale + off)
 
@@ -134,12 +136,17 @@ def test_parity_nonsaturated_weight_ball() raises:
         )
     if _abs_diff(norm, 1.1829041645848064) > 1e-6:
         raise Error("non-saturated result norm drifted: " + String(norm))
-    print("  ok matches non-saturated reference to 1e-6 (||W_new||_F = " + String(norm) + " < 10.0)")
+    print(
+        "  ok matches non-saturated reference to 1e-6 (||W_new||_F = "
+        + String(norm)
+        + " < 10.0)"
+    )
     print("test_parity_nonsaturated_weight_ball PASSED")
 
 
 def test_weight_norm_constraint_active() raises:
-    """||W_new||_F must not exceed weight_norm_max when the update overshoots it."""
+    """||W_new||_F must not exceed weight_norm_max when the update overshoots it.
+    """
     print("Running test_weight_norm_constraint_active...")
     var W = zeros([3, 4], DType.float64)
     _seed_ramp(W, 12, 0.1, -0.5)
@@ -152,14 +159,18 @@ def test_weight_norm_constraint_active() raises:
     var norm = compute_tensor_l2_norm(new_p)
     if norm > radius + 1e-6:
         raise Error(
-            "weight-norm constraint violated: " + String(norm) + " > " + String(radius)
+            "weight-norm constraint violated: "
+            + String(norm)
+            + " > "
+            + String(radius)
         )
     print("  ok ||W_new||_F <= weight_norm_max (" + String(norm) + ")")
     print("test_weight_norm_constraint_active PASSED")
 
 
 def test_update_norm_constraint_active() raises:
-    """||W_new - W||_F must not exceed update_norm_max (weight clamp disabled)."""
+    """||W_new - W||_F must not exceed update_norm_max (weight clamp disabled).
+    """
     print("Running test_update_norm_constraint_active...")
     var W = zeros([3, 4], DType.float64)
     _seed_ramp(W, 12, 0.1, -0.5)

--- a/tests/odyssey/training/optimizers/test_muon_hyperball.mojo
+++ b/tests/odyssey/training/optimizers/test_muon_hyperball.mojo
@@ -11,7 +11,8 @@ Tests cover:
 - Disabling a constraint (radius <= 0) leaves the corresponding norm unclamped
 """
 
-from odyssey.tensor.any_tensor import AnyTensor, zeros, zeros_like
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros, zeros_like
 from odyssey.training.optimizers.muon_hyperball import (
     muon_hyperball_step,
     muon_hyperball_step_simple,
@@ -40,7 +41,7 @@ def test_reject_non_2d() raises:
     try:
         var (_, _) = muon_hyperball_step(p, g, m, learning_rate=0.01)
         raise Error("Should have rejected 1D params")
-    except e:
+    except _:
         print("  ok rejected 1D params")
     print("test_reject_non_2d PASSED")
 
@@ -54,19 +55,19 @@ def test_parity_with_reference() raises:
     """
     print("Running test_parity_with_reference...")
 
-    var ref = List[Float64]()
-    ref.append(-0.4096168)
-    ref.append(-0.3298968)
-    ref.append(-0.2501768)
-    ref.append(-0.1704568)
-    ref.append(-0.0756045)
-    ref.append(0.003189)
-    ref.append(0.0819826)
-    ref.append(0.1607761)
-    ref.append(0.2584078)
-    ref.append(0.3362749)
-    ref.append(0.414142)
-    ref.append(0.4920091)
+    var ref_vals = List[Float64]()
+    ref_vals.append(-0.4096168)
+    ref_vals.append(-0.3298968)
+    ref_vals.append(-0.2501768)
+    ref_vals.append(-0.1704568)
+    ref_vals.append(-0.0756045)
+    ref_vals.append(0.003189)
+    ref_vals.append(0.0819826)
+    ref_vals.append(0.1607761)
+    ref_vals.append(0.2584078)
+    ref_vals.append(0.3362749)
+    ref_vals.append(0.414142)
+    ref_vals.append(0.4920091)
 
     var W = zeros([3, 4], DType.float64)
     _seed_ramp(W, 12, 0.1, -0.5)
@@ -76,7 +77,7 @@ def test_parity_with_reference() raises:
 
     var (new_p, _) = muon_hyperball_step(W, G, M, 0.1, 1.0, 0.1)
     for i in range(12):
-        if _abs_diff(new_p.load[DType.float64](i), ref[i]) > 1e-6:
+        if _abs_diff(new_p.load[DType.float64](i), ref_vals[i]) > 1e-6:
             raise Error("Muon Hyperball parity mismatch at " + String(i))
     print("  ok matches reference to 1e-6")
     print("test_parity_with_reference PASSED")
@@ -93,19 +94,19 @@ def test_parity_nonsaturated_weight_ball() raises:
     """
     print("Running test_parity_nonsaturated_weight_ball...")
 
-    var ref = List[Float64]()
-    ref.append(-0.4845374394768569)
-    ref.append(-0.3902363086961616)
-    ref.append(-0.295935177915466)
-    ref.append(-0.20163404713477076)
-    ref.append(-0.08943287547482938)
-    ref.append(0.0037723344357082148)
-    ref.append(0.09697754434624539)
-    ref.append(0.19018275425678322)
-    ref.append(0.30567168852719817)
-    ref.append(0.39778097756757763)
-    ref.append(0.48989026660795737)
-    ref.append(0.5819995556483368)
+    var ref_vals = List[Float64]()
+    ref_vals.append(-0.4845374394768569)
+    ref_vals.append(-0.3902363086961616)
+    ref_vals.append(-0.295935177915466)
+    ref_vals.append(-0.20163404713477076)
+    ref_vals.append(-0.08943287547482938)
+    ref_vals.append(0.0037723344357082148)
+    ref_vals.append(0.09697754434624539)
+    ref_vals.append(0.19018275425678322)
+    ref_vals.append(0.30567168852719817)
+    ref_vals.append(0.39778097756757763)
+    ref_vals.append(0.48989026660795737)
+    ref_vals.append(0.5819995556483368)
 
     var W = zeros([3, 4], DType.float64)
     _seed_ramp(W, 12, 0.1, -0.5)
@@ -116,7 +117,7 @@ def test_parity_nonsaturated_weight_ball() raises:
     var weight_norm_max = 10.0
     var (new_p, _) = muon_hyperball_step(W, G, M, 0.1, weight_norm_max, 0.1)
     for i in range(12):
-        if _abs_diff(new_p.load[DType.float64](i), ref[i]) > 1e-6:
+        if _abs_diff(new_p.load[DType.float64](i), ref_vals[i]) > 1e-6:
             raise Error(
                 "Muon Hyperball non-saturated parity mismatch at " + String(i)
             )

--- a/tests/odyssey/training/optimizers/test_normuon.mojo
+++ b/tests/odyssey/training/optimizers/test_normuon.mojo
@@ -9,8 +9,8 @@ Tests cover:
 - Gradient checking (numerical vs analytical)
 """
 
-from odyssey.tensor.any_tensor import (
-    AnyTensor,
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import (
     zeros,
     zeros_like,
     randn,

--- a/tests/odyssey/training/optimizers/test_shampoo.mojo
+++ b/tests/odyssey/training/optimizers/test_shampoo.mojo
@@ -12,8 +12,8 @@ Tests cover:
 - Genuine descent on quadratic objectives
 """
 
-from odyssey.tensor.any_tensor import (
-    AnyTensor,
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import (
     zeros,
     zeros_like,
     randn,

--- a/tests/odyssey/training/optimizers/test_shampoo.mojo
+++ b/tests/odyssey/training/optimizers/test_shampoo.mojo
@@ -442,8 +442,12 @@ def test_descent_on_quadratic() raises:
         var grad = multiply_simd(two, W_t)
 
         # Step
+        # max_precond_norm clamps the Gram accumulators before the inverse
+        # fourth-root so the fixed-step Newton-Schulz iteration stays inside its
+        # convergence basin over this multi-step descent (else the internal
+        # _newton_schulz_inv_sqrt correctly raises "failed to converge").
         var (W_new, L_new, R_new, m_new) = shampoo_step(
-            W_t, grad, L_t, R_t, m_t, learning_rate=0.01
+            W_t, grad, L_t, R_t, m_t, learning_rate=0.01, max_precond_norm=1e2
         )
 
         W_t = W_new
@@ -494,8 +498,12 @@ def test_descent_on_non_square() raises:
         var two = full_like(W_t, 2.0)
         var grad = multiply_simd(two, W_t)
 
+        # max_precond_norm clamps the Gram accumulators before the inverse
+        # fourth-root so the fixed-step Newton-Schulz iteration stays inside its
+        # convergence basin over this multi-step descent (else the internal
+        # _newton_schulz_inv_sqrt correctly raises "failed to converge").
         var (W_new, L_new, R_new, m_new) = shampoo_step(
-            W_t, grad, L_t, R_t, m_t, learning_rate=0.01
+            W_t, grad, L_t, R_t, m_t, learning_rate=0.01, max_precond_norm=1e2
         )
 
         W_t = W_new

--- a/tests/odyssey/training/optimizers/test_soap.mojo
+++ b/tests/odyssey/training/optimizers/test_soap.mojo
@@ -8,7 +8,8 @@ Tests cover:
   rotated Adam, project-back, bias correction, weight decay, and state threading
 """
 
-from odyssey.tensor.any_tensor import AnyTensor, zeros
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros
 from odyssey.training.optimizers.soap import soap_step, init_soap_state
 
 
@@ -42,13 +43,13 @@ def test_reject_non_2d() raises:
             p, g, z, z2, z3, z4, z5, z6, 1, 0.1
         )
         raise Error("Should have rejected 1D params")
-    except e:
+    except _:
         print("  ok rejected 1D params")
     print("test_reject_non_2d PASSED")
 
 
 def test_init_state_shapes() raises:
-    """init_soap_state returns 6 zeroed tensors with the right shapes."""
+    """`init_soap_state` returns 6 zeroed tensors with the right shapes."""
     print("Running test_init_state_shapes...")
     var W = zeros([3, 4], DType.float64)
     var st = init_soap_state(W)

--- a/tests/odyssey/training/optimizers/test_sophia.mojo
+++ b/tests/odyssey/training/optimizers/test_sophia.mojo
@@ -16,7 +16,7 @@ Tests cover:
 - sophia_step_simple delegating to sophia_step with defaults
 """
 
-from odyssey.tensor.any_tensor import AnyTensor
+From odyssey.tensor.any_tensor import AnyTensor
 from odyssey.tensor.tensor_creation import zeros, full
 from odyssey.training.optimizers.sophia import (
     sophia_step,
@@ -33,7 +33,7 @@ def _abs_diff(a: Float64, b: Float64) -> Float64:
 
 
 def test_reject_shape_mismatch() raises:
-    """sophia_step rejects a params/gradients shape mismatch."""
+    """`sophia_step` rejects a params/gradients shape mismatch."""
     print("Running test_reject_shape_mismatch...")
     var p = zeros([4], DType.float32)
     var g = zeros([5], DType.float32)
@@ -48,7 +48,7 @@ def test_reject_shape_mismatch() raises:
 
 
 def test_reject_dtype_mismatch() raises:
-    """sophia_step rejects a params/gradients dtype mismatch."""
+    """`sophia_step` rejects a params/gradients dtype mismatch."""
     print("Running test_reject_dtype_mismatch...")
     var p = zeros([4], DType.float32)
     var g = zeros([4], DType.float16)
@@ -76,7 +76,7 @@ def test_parity_with_reference() raises:
     is asserted; coordinate 5 saturates the clip (raw update 1.7034 >> rho),
     asserting the +-rho bound.
     """
-    print("Running test_parity_with_reference...")
+    Print("Running test_parity_with_reference...")
 
     var rp = List[Float64]()
     rp.append(0.09958041958041959)
@@ -154,13 +154,13 @@ def test_parity_with_reference() raises:
 
 
 def test_gamma_scales_denominator() raises:
-    """gamma scales the preconditioner: doubling gamma halves an unclipped update.
+    """`gamma` scales the preconditioner: doubling gamma halves an unclipped update.
 
     With zero seed momentum, m2 = (1-beta1)*g; pick hm large enough that the
     update is unclipped for both gamma=1 and gamma=2. Then
     step(gamma=1) = lr * m2 / hm and step(gamma=2) = lr * m2 / (2*hm).
     """
-    print("Running test_gamma_scales_denominator...")
+    Print("Running test_gamma_scales_denominator...")
     var n = 3
     var lr = 0.1
     var p = zeros([n], DType.float64)
@@ -185,12 +185,12 @@ def test_gamma_scales_denominator() raises:
 
 
 def test_clip_bounds_update() raises:
-    """rho must bound the per-coordinate update magnitude.
+    """`rho` must bound the per-coordinate update magnitude.
 
     With a small Hessian moment, m / (gamma*hm) is large; the update should
     saturate to +-rho, so the param step magnitude is exactly lr * rho.
     """
-    print("Running test_clip_bounds_update...")
+    Print("Running test_clip_bounds_update...")
     var n = 3
     var lr = 0.1
     var rho = 0.05
@@ -211,7 +211,7 @@ def test_clip_bounds_update() raises:
 
 
 def test_weight_decay_decoupled() raises:
-    """weight_decay != 0 subtracts the decoupled AdamW term wd*lr*params_orig.
+    """`weight_decay` != 0 subtracts the decoupled AdamW term wd*lr*params_orig.
 
     Sophia's decoupled decay (like AdamW) is applied AFTER the gradient step and
     scales the ORIGINAL params: new_params -= weight_decay * lr * params. So the
@@ -219,7 +219,7 @@ def test_weight_decay_decoupled() raises:
     coordinate. All other inputs (grad, momentum, hessian moment) are held
     identical.
     """
-    print("Running test_weight_decay_decoupled...")
+    Print("Running test_weight_decay_decoupled...")
     var n = 4
     var lr = 0.1
     var wd = 0.05
@@ -258,7 +258,7 @@ def test_weight_decay_decoupled() raises:
 
 
 def test_hessian_moment_ema() raises:
-    """sophia_update_hessian_moment does the beta2 EMA correctly."""
+    """`sophia_update_hessian_moment` does the beta2 EMA correctly."""
     print("Running test_hessian_moment_ema...")
     var n = 2
     var hm = full([n], 0.0, DType.float64)
@@ -274,7 +274,7 @@ def test_hessian_moment_ema() raises:
 
 
 def test_simple_matches_full_defaults() raises:
-    """sophia_step_simple equals sophia_step with default hyperparameters."""
+    """`sophia_step_simple` equals sophia_step with default hyperparameters."""
     print("Running test_simple_matches_full_defaults...")
     var n = 4
     var p = full([n], 0.2, DType.float64)
@@ -299,7 +299,7 @@ def test_simple_matches_full_defaults() raises:
 
 def main() raises:
     """Run all Sophia tests."""
-    print("=" * 60)
+    Print("=" * 60)
     print("Sophia Clipped-Preconditioned Update Step Test Suite")
     print("=" * 60)
     test_reject_shape_mismatch()

--- a/tests/odyssey/training/optimizers/test_sophia.mojo
+++ b/tests/odyssey/training/optimizers/test_sophia.mojo
@@ -42,7 +42,7 @@ def test_reject_shape_mismatch() raises:
     try:
         var _ = sophia_step(p, g, m, hm, 0.06)
         raise Error("Should have rejected shape mismatch")
-    except e:
+    except:
         print("  ok rejected shape mismatch")
     print("test_reject_shape_mismatch PASSED")
 
@@ -57,7 +57,7 @@ def test_reject_dtype_mismatch() raises:
     try:
         var _ = sophia_step(p, g, m, hm, 0.06)
         raise Error("Should have rejected dtype mismatch")
-    except e:
+    except:
         print("  ok rejected dtype mismatch")
     print("test_reject_dtype_mismatch PASSED")
 

--- a/tests/odyssey/training/optimizers/test_sophia.mojo
+++ b/tests/odyssey/training/optimizers/test_sophia.mojo
@@ -76,7 +76,7 @@ def test_parity_with_reference() raises:
     is asserted; coordinate 5 saturates the clip (raw update 1.7034 >> rho),
     asserting the +-rho bound.
     """
-    Print("Running test_parity_with_reference...")
+    print("Running test_parity_with_reference...")
 
     var rp = List[Float64]()
     rp.append(0.09958041958041959)
@@ -160,7 +160,7 @@ def test_gamma_scales_denominator() raises:
     update is unclipped for both gamma=1 and gamma=2. Then
     step(gamma=1) = lr * m2 / hm and step(gamma=2) = lr * m2 / (2*hm).
     """
-    Print("Running test_gamma_scales_denominator...")
+    print("Running test_gamma_scales_denominator...")
     var n = 3
     var lr = 0.1
     var p = zeros([n], DType.float64)
@@ -190,7 +190,7 @@ def test_clip_bounds_update() raises:
     With a small Hessian moment, m / (gamma*hm) is large; the update should
     saturate to +-rho, so the param step magnitude is exactly lr * rho.
     """
-    Print("Running test_clip_bounds_update...")
+    print("Running test_clip_bounds_update...")
     var n = 3
     var lr = 0.1
     var rho = 0.05
@@ -219,7 +219,7 @@ def test_weight_decay_decoupled() raises:
     coordinate. All other inputs (grad, momentum, hessian moment) are held
     identical.
     """
-    Print("Running test_weight_decay_decoupled...")
+    print("Running test_weight_decay_decoupled...")
     var n = 4
     var lr = 0.1
     var wd = 0.05
@@ -299,7 +299,7 @@ def test_simple_matches_full_defaults() raises:
 
 def main() raises:
     """Run all Sophia tests."""
-    Print("=" * 60)
+    print("=" * 60)
     print("Sophia Clipped-Preconditioned Update Step Test Suite")
     print("=" * 60)
     test_reject_shape_mismatch()

--- a/tests/odyssey/training/optimizers/test_sophia.mojo
+++ b/tests/odyssey/training/optimizers/test_sophia.mojo
@@ -16,7 +16,7 @@ Tests cover:
 - sophia_step_simple delegating to sophia_step with defaults
 """
 
-From odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.any_tensor import AnyTensor
 from odyssey.tensor.tensor_creation import zeros, full
 from odyssey.training.optimizers.sophia import (
     sophia_step,

--- a/tests/odyssey/training/test_interruption.mojo
+++ b/tests/odyssey/training/test_interruption.mojo
@@ -8,6 +8,7 @@ Tests cover:
 """
 
 from odyssey.training.interruption import (
+    ShutdownFlag,
     ShutdownReason,
     WallClockTimer,
     TrainingResult,
@@ -85,23 +86,44 @@ def test_wall_clock_timer_has_elapsed_negative() raises:
 
 
 def test_shutdown_flag_default_false() raises:
-    """Test that shutdown flag starts as False."""
+    """Test that `ShutdownFlag` starts as False and the free fn agrees.
+
+    `is_shutdown_requested()` is a documented placeholder that ALWAYS
+    returns False in Mojo 1.0 (no global state; see interruption.mojo) —
+    the stateful API is the `ShutdownFlag` struct, which the set/reset
+    tests below exercise.
+    """
     reset_shutdown_flag()
     assert_false(is_shutdown_requested())
+    var flag = ShutdownFlag()
+    assert_false(flag.is_set())
 
 
 def test_shutdown_flag_set() raises:
-    """Test setting the shutdown flag."""
-    reset_shutdown_flag()
+    """Test setting the shutdown flag (`ShutdownFlag` struct, the stateful API).
+
+    The old assertion `is_shutdown_requested() == True` after
+    `request_shutdown()` could NEVER pass: both free functions are
+    documented no-op placeholders in Mojo 1.0 (no globals). It went
+    unnoticed only because the CI harness swallowed the failure (PR #5625).
+    """
+    var flag = ShutdownFlag()
+    flag.set()
+    assert_true(flag.is_set())
+    # The placeholder free functions keep their documented contract:
+    # request_shutdown() is a no-op, is_shutdown_requested() stays False.
     request_shutdown()
-    assert_true(is_shutdown_requested())
+    assert_false(is_shutdown_requested())
 
 
 def test_shutdown_flag_reset() raises:
-    """Test resetting the shutdown flag."""
-    reset_shutdown_flag()
-    request_shutdown()
-    assert_true(is_shutdown_requested())
+    """Test resetting the shutdown flag (`ShutdownFlag` struct)."""
+    var flag = ShutdownFlag()
+    flag.set()
+    assert_true(flag.is_set())
+    flag.reset()
+    assert_false(flag.is_set())
+    # Placeholder free fn: reset is a documented no-op, flag reads False.
     reset_shutdown_flag()
     assert_false(is_shutdown_requested())
 
@@ -155,12 +177,16 @@ def test_wall_clock_timer_monotonic() raises:
 
 
 def test_shutdown_flag_idempotent_set() raises:
-    """Test that multiple request_shutdown() calls are safe."""
-    reset_shutdown_flag()
+    """Test that multiple set() calls are safe (`ShutdownFlag` struct)."""
+    var flag = ShutdownFlag()
+    flag.set()
+    flag.set()
+    flag.set()
+    assert_true(flag.is_set())
+    # Placeholder free fns stay no-ops however many times they are called.
     request_shutdown()
     request_shutdown()
-    request_shutdown()
-    assert_true(is_shutdown_requested())
+    assert_false(is_shutdown_requested())
 
 
 def main() raises:

--- a/tests/odyssey/training/test_muon.mojo
+++ b/tests/odyssey/training/test_muon.mojo
@@ -158,9 +158,7 @@ def _hash_unit(i: Int, seed: UInt32) -> Float64:
     return Float64(h) / 4294967296.0 - 0.5
 
 
-def _gram_identity_residual(
-    G: AnyTensor, dim: Int
-) raises -> Float64:
+def _gram_identity_residual(G: AnyTensor, dim: Int) raises -> Float64:
     """Return ||G - I_dim||_F for a square Gram matrix G."""
     var error = zeros_like(G)
     for i in range(G.numel()):

--- a/tests/odyssey/training/test_muon.mojo
+++ b/tests/odyssey/training/test_muon.mojo
@@ -114,23 +114,77 @@ def test_is_muon_eligible_rank_2_min_size() raises:
 
 # ============================================================================
 # Tests for newton_schulz_orthogonalize
+#
+# What Jordan's Newton-Schulz variant actually guarantees:
+# The quintic coefficients (a, b, c) = (3.4445, -4.7750, 2.0315) are tuned for
+# SPEED, not for asymptotic convergence to exact orthogonality. Jordan's
+# writeup (https://kellerjordan.github.io/posts/muon/) states the iteration
+# drives every singular value into roughly [0.68, 1.13] and then OSCILLATES in
+# that band — it never converges to sv == 1, no matter how many steps you run
+# (verified in fp64 numpy: a Gaussian 8x8 input gives ||YY^T - I||_F ~= 0.62
+# after 5 steps and ~= 1.27 after 50). Therefore Gram ~= I to 1e-5 is NOT a
+# property of a correct implementation, and tests must assert the sv band
+# instead:
+#   - sv in [s_min, s_max] implies ||YY^T - I||_F <= sqrt(r)*max|sv^2 - 1|;
+#     for [0.68, 1.13] and r = 8 that bound is ~1.52 (we assert < 1.6).
+#   - G_ii = ||e_i^T Y||^2 is bounded by [sv_min^2, sv_max^2] ~ [0.46, 1.28]
+#     (we assert [0.40, 1.40]).
+# The previous 1e-5 assertions could never pass; they were invisible only
+# because the CI harness swallowed the failure (PR #5625).
+#
+# Input matrices: the old "pseudo-random via index" affine fill
+# ((i*k + b) % 1.0) is nearly low-rank (the 8x8 case had singular values down
+# to ~2.5e-18) — NS cannot lift a zero singular value, so those inputs can
+# never orthogonalize regardless of coefficients. _hash_unit below is a
+# lowbias32-style integer hash: deterministic, bit-exact reproducible in
+# numpy, and well-conditioned (cond ~ 3-30 for these shapes).
 # ============================================================================
 
 
-def test_newton_schulz_square_orthogonality() raises:
-    """Test NS orthogonalization on a square matrix.
+def _hash_unit(i: Int, seed: UInt32) -> Float64:
+    """Deterministic well-spread pseudo-random value in [-0.5, 0.5).
 
-    After 5 iterations, Y @ Y^T should be close to identity.
-    Frobenius norm of (Y @ Y^T - I) < 1e-5 for fp32.
+    Lowbias32-style integer mixing hash of the flat index. Unlike an affine
+    fill ((i*k + b) % 1.0), consecutive indices produce uncorrelated values,
+    so the resulting matrices are well-conditioned. Bit-exact reproducible:
+    (i*747796405 + 2891336453 + seed) mod 2^32, then xorshift-multiply mixing.
     """
-    # Create random 8×8 matrix
+    var h: UInt32 = UInt32(i) * 747796405 + 2891336453 + seed
+    h ^= h >> 16
+    h *= 0x7FEB352D
+    h ^= h >> 15
+    h *= 0x846CA68B
+    h ^= h >> 16
+    return Float64(h) / 4294967296.0 - 0.5
+
+
+def _gram_identity_residual(
+    G: AnyTensor, dim: Int
+) raises -> Float64:
+    """Return ||G - I_dim||_F for a square Gram matrix G."""
+    var error = zeros_like(G)
+    for i in range(G.numel()):
+        var target = 0.0
+        if i % (dim + 1) == 0:
+            target = 1.0
+        error._set_float64(i, G._get_float64(i) - target)
+    return compute_tensor_norm(error)
+
+
+def test_newton_schulz_square_orthogonality() raises:
+    """Test NS orthogonalization on a well-conditioned square matrix.
+
+    Asserts the property Jordan's NS variant actually guarantees after 5
+    steps: singular values in ~[0.68, 1.13] (NOT exact orthogonality — see
+    the block comment above). Checked via ||YY^T - I||_F < 1.6 (sv-band
+    bound ~1.52; numpy fp32 reference for this exact input: ~0.97) and Gram
+    diagonal entries in [0.40, 1.40] (sv-band bound [0.46, 1.28]).
+    """
     var shape: List[Int] = [8, 8]
     var X = zeros(shape, DType.float32)
 
-    # Fill with values simulating random matrix (pseudo-random via index)
     for i in range(X.numel()):
-        var val = Float32((Float64(i) * 0.123 + 0.456) % 1.0)
-        X._set_float64(i, Float64(val))
+        X._set_float64(i, _hash_unit(i, 0))
 
     # Orthogonalize
     var Y = newton_schulz_orthogonalize(X, steps=5)
@@ -141,134 +195,108 @@ def test_newton_schulz_square_orthogonality() raises:
     # Compute Gram matrix: G = Y @ Y^T
     var G = matmul(Y, transpose(Y, None))
 
-    # Compute I (identity)
-    var I = zeros(shape, DType.float32)
-    for i in range(shape[0]):
-        I.set(i * (shape[1] + 1), Float32(1.0))  # Set diagonal
-
-    # Compute error norm: ||G - I||_F
-    var error = zeros_like(G)
-    for i in range(G.numel()):
-        var g_val = G._get_float64(i)
-        var i_val = I._get_float64(i)
-        error._set_float64(i, g_val - i_val)
-
-    var error_norm = compute_tensor_norm(error)
-
-    # Assert error < 1e-5
+    var error_norm = _gram_identity_residual(G, shape[0])
     assert_less(
         error_norm,
-        1e-5,
-        "Gram matrix (Y @ Y^T) is close to identity after 5 NS steps",
+        1.6,
+        "||YY^T - I||_F within the sv-band bound after 5 NS steps",
     )
+
+    # Every Gram diagonal entry (= squared row norm) inside the sv^2 band
+    for r in range(shape[0]):
+        var diag = G._get_float64(r * (shape[0] + 1))
+        assert_greater(diag, 0.40, "Gram diagonal above sv_min^2 band")
+        assert_less(diag, 1.40, "Gram diagonal below sv_max^2 band")
 
 
 def test_newton_schulz_wide_matrix() raises:
     """Test NS orthogonalization on a wide matrix (more cols than rows).
 
-    Shape [8, 16]: rows <= cols -> iterate on Y directly.
-    Result should satisfy Y @ Y^T ≈ I_8 (rows orthonormal).
+    Shape [8, 16]: rows <= cols -> iterate on Y directly. Asserts the sv-band
+    property on the row Gram matrix Y @ Y^T (numpy fp32 reference for this
+    input: ||G - I_8||_F ~= 1.07, diagonals in [0.47, 1.25]).
     """
     var shape: List[Int] = [8, 16]
     var X = zeros(shape, DType.float32)
 
     for i in range(X.numel()):
-        var val = Float32((Float64(i) * 0.234 + 0.789) % 1.0)
-        X._set_float64(i, Float64(val))
+        X._set_float64(i, _hash_unit(i, 7))
 
     var Y = newton_schulz_orthogonalize(X, steps=5)
 
     assert_shape(Y, shape, "Wide matrix shape preserved")
 
-    # Check Y @ Y^T ≈ I_rows
+    # Check Y @ Y^T lands in the sv band around I_rows
     var G = matmul(Y, transpose(Y, None))
-    var I = zeros([shape[0], shape[0]], DType.float32)
-    for i in range(shape[0]):
-        I.set(i * (shape[0] + 1), Float32(1.0))
+    var error_norm = _gram_identity_residual(G, shape[0])
+    assert_less(error_norm, 1.6, "Wide matrix rows near-orthonormal (sv band)")
 
-    var error = zeros_like(G)
-    for i in range(G.numel()):
-        error._set_float64(i, G._get_float64(i) - I._get_float64(i))
-
-    var error_norm = compute_tensor_norm(error)
-    assert_less(error_norm, 1e-5, "Wide matrix rows are orthonormal")
+    for r in range(shape[0]):
+        var diag = G._get_float64(r * (shape[0] + 1))
+        assert_greater(diag, 0.40, "Wide Gram diagonal above sv_min^2 band")
+        assert_less(diag, 1.40, "Wide Gram diagonal below sv_max^2 band")
 
 
 def test_newton_schulz_tall_matrix() raises:
     """Test NS orthogonalization on a tall matrix (more rows than cols).
 
-    Shape [16, 8]: rows > cols -> transpose, iterate, transpose back.
-    Result should satisfy Y^T @ Y ≈ I_8 (cols orthonormal).
+    Shape [16, 8]: rows > cols -> transpose, iterate, transpose back. Asserts
+    the sv-band property on the column Gram matrix Y^T @ Y (numpy fp32
+    reference for this input: ||G - I_8||_F ~= 0.94, diagonals in [0.47, 1.26]).
     """
     var shape: List[Int] = [16, 8]
     var X = zeros(shape, DType.float32)
 
     for i in range(X.numel()):
-        var val = Float32((Float64(i) * 0.345 + 0.111) % 1.0)
-        X._set_float64(i, Float64(val))
+        X._set_float64(i, _hash_unit(i, 13))
 
     var Y = newton_schulz_orthogonalize(X, steps=5)
 
     assert_shape(Y, shape, "Tall matrix shape preserved")
 
-    # Check Y^T @ Y ≈ I_cols
+    # Check Y^T @ Y lands in the sv band around I_cols
     var Yt = transpose(Y, None)
     var G = matmul(Yt, Y)
-    var I = zeros([shape[1], shape[1]], DType.float32)
-    for i in range(shape[1]):
-        I.set(i * (shape[1] + 1), Float32(1.0))
+    var error_norm = _gram_identity_residual(G, shape[1])
+    assert_less(error_norm, 1.6, "Tall matrix cols near-orthonormal (sv band)")
 
-    var error = zeros_like(G)
-    for i in range(G.numel()):
-        error._set_float64(i, G._get_float64(i) - I._get_float64(i))
-
-    var error_norm = compute_tensor_norm(error)
-    assert_less(error_norm, 1e-5, "Tall matrix cols are orthonormal")
+    for r in range(shape[1]):
+        var diag = G._get_float64(r * (shape[1] + 1))
+        assert_greater(diag, 0.40, "Tall Gram diagonal above sv_min^2 band")
+        assert_less(diag, 1.40, "Tall Gram diagonal below sv_max^2 band")
 
 
-def test_newton_schulz_convergence_rate() raises:
-    """Test that NS iteration shows quintic convergence (not linear).
+def test_newton_schulz_convergence_progress() raises:
+    """Test that more NS steps move the Gram matrix closer to identity.
 
-    Wrong coefficients would converge linearly; correct coefficients converge quintic.
-    After 5 steps, residual should drop by factor ~1e-2 relative to step 1.
+    Jordan's tuned quintic trades asymptotic contraction for speed: once
+    singular values reach the [0.68, 1.13] band it stops contracting (it
+    oscillates), so a "100x per step" expectation is wrong BY DESIGN. The
+    guaranteed property is monotone progress from 1 step to 5 steps while
+    entering the band. numpy fp32 reference for this input: residual ratio
+    (5 steps / 1 step) ~= 0.82; assert < 0.95.
     """
     var shape: List[Int] = [8, 16]
     var X = zeros(shape, DType.float32)
 
     for i in range(X.numel()):
-        var val = Float32((Float64(i) * 0.456 + 0.222) % 1.0)
-        X._set_float64(i, Float64(val))
+        X._set_float64(i, _hash_unit(i, 29))
 
-    # Compute error after 1 step
+    # Residual after 1 step
     var Y1 = newton_schulz_orthogonalize(X, steps=1)
     var G1 = matmul(Y1, transpose(Y1, None))
-    var I = zeros([shape[0], shape[0]], DType.float32)
-    for i in range(shape[0]):
-        I.set(i * (shape[0] + 1), Float32(1.0))
+    var residual1 = _gram_identity_residual(G1, shape[0])
 
-    var error1 = zeros_like(G1)
-    for i in range(G1.numel()):
-        error1._set_float64(i, G1._get_float64(i) - I._get_float64(i))
-
-    var residual1 = compute_tensor_norm(error1)
-
-    # Compute error after 5 steps
+    # Residual after 5 steps
     var Y5 = newton_schulz_orthogonalize(X, steps=5)
     var G5 = matmul(Y5, transpose(Y5, None))
+    var residual5 = _gram_identity_residual(G5, shape[0])
 
-    var error5 = zeros_like(G5)
-    for i in range(G5.numel()):
-        error5._set_float64(i, G5._get_float64(i) - I._get_float64(i))
-
-    var residual5 = compute_tensor_norm(error5)
-
-    # Convergence ratio should be very small (quintic -> ~1e-10 or better)
-    # Check that step 5 residual is at least 100x better than step 1
     var convergence_ratio = residual5 / residual1
     assert_less(
         convergence_ratio,
-        1e-2,
-        "NS iteration shows quintic convergence (100x reduction per step)",
+        0.95,
+        "5 NS steps land closer to the sv band than 1 step",
     )
 
 
@@ -296,10 +324,18 @@ def test_muon_step_shape_preservation() raises:
 
 
 def test_muon_step_quadratic_descent() raises:
-    """Test that muon_step achieves descent on a quadratic loss.
+    """Test that muon_step achieves monotone descent on a quadratic loss.
 
     Loss = sum(p^2), grad = 2*p, initialized to ones.
-    After 50 steps with lr=0.05, loss should decrease and final loss < 1e-3.
+
+    Muon's update is ORTHOGONALIZED and then scaled by a constant
+    (lr * 0.2 * max(R,C)/sqrt(RC)), so — like sign-SGD — its step magnitude is
+    independent of the gradient magnitude. Descent on a quadratic is therefore
+    LINEAR per step, not exponential: each element moves by ~lr*scale*|u| ~
+    0.005/step here, so 50 steps from p=1 cannot reach loss < 1e-3 (the old
+    assertion; impossible by design, hidden by the swallowed-failure harness).
+    numpy fp32 simulation of this exact loop: 16.0 -> 13.335, strictly
+    monotone. Assert monotone decrease every step and final loss < 14.0.
     """
     var shape: List[Int] = [4, 4]
     var params = ones(shape, DType.float32)
@@ -349,8 +385,13 @@ def test_muon_step_quadratic_descent() raises:
         )
         prev_loss = loss
 
-    # Final loss should be small
-    assert_less(prev_loss, 1e-3, "Final loss after 50 steps is very small")
+    # Final loss reflects 50 constant-magnitude orthogonalized steps
+    # (numpy fp32 reference: 13.335; linear descent, see docstring)
+    assert_less(
+        prev_loss,
+        14.0,
+        "Loss after 50 constant-magnitude Muon steps matches linear descent",
+    )
 
 
 def test_muon_step_rejects_non_matrix() raises:
@@ -417,7 +458,10 @@ def test_muon_step_shape_mismatch() raises:
 def test_muon_step_with_nesterov() raises:
     """Test muon_step with Nesterov momentum enabled.
 
-    Nesterov should improve convergence compared to plain momentum.
+    5 constant-magnitude Muon steps (each ~lr*scale*|u| ~ 0.005 per element)
+    from ones(4,4) (norm 4.0) can only reduce the norm to ~3.965 (numpy fp32
+    reference) — the old < 2.0 assertion was impossible by design (see
+    test_muon_step_quadratic_descent). Assert the norm strictly decreased.
     """
     var shape: List[Int] = [4, 4]
     var params = ones(shape, DType.float32)
@@ -443,9 +487,10 @@ def test_muon_step_with_nesterov() raises:
         params = new_params
         momentum = new_momentum
 
-    # Should reach small values
+    # Norm strictly decreased from the initial 4.0
+    # (numpy fp32 reference after 5 steps: ~3.965)
     var final_norm = compute_tensor_norm(params)
-    assert_less(final_norm, 2.0, "Nesterov momentum reduces parameters")
+    assert_less(final_norm, 3.99, "Nesterov momentum reduces parameter norm")
 
 
 def test_muon_step_with_weight_decay() raises:
@@ -537,7 +582,7 @@ def main() raises:
     test_newton_schulz_square_orthogonality()
     test_newton_schulz_wide_matrix()
     test_newton_schulz_tall_matrix()
-    test_newton_schulz_convergence_rate()
+    test_newton_schulz_convergence_progress()
     test_muon_step_shape_preservation()
     test_muon_step_quadratic_descent()
     test_muon_step_rejects_non_matrix()

--- a/tests/odyssey/training/test_muon.mojo
+++ b/tests/odyssey/training/test_muon.mojo
@@ -22,8 +22,8 @@ from tests.odyssey.conftest import (
     assert_true,
     create_test_vector,
 )
-from odyssey.tensor.any_tensor import (
-    AnyTensor,
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import (
     zeros,
     ones,
     zeros_like,
@@ -129,7 +129,7 @@ def test_newton_schulz_square_orthogonality() raises:
 
     # Fill with values simulating random matrix (pseudo-random via index)
     for i in range(X.numel()):
-        var val = Float32((Float64(i) * 0.123 + 0.456).fract())
+        var val = Float32((Float64(i) * 0.123 + 0.456) % 1.0)
         X._set_float64(i, Float64(val))
 
     # Orthogonalize
@@ -173,7 +173,7 @@ def test_newton_schulz_wide_matrix() raises:
     var X = zeros(shape, DType.float32)
 
     for i in range(X.numel()):
-        var val = Float32((Float64(i) * 0.234 + 0.789).fract())
+        var val = Float32((Float64(i) * 0.234 + 0.789) % 1.0)
         X._set_float64(i, Float64(val))
 
     var Y = newton_schulz_orthogonalize(X, steps=5)
@@ -204,7 +204,7 @@ def test_newton_schulz_tall_matrix() raises:
     var X = zeros(shape, DType.float32)
 
     for i in range(X.numel()):
-        var val = Float32((Float64(i) * 0.345 + 0.111).fract())
+        var val = Float32((Float64(i) * 0.345 + 0.111) % 1.0)
         X._set_float64(i, Float64(val))
 
     var Y = newton_schulz_orthogonalize(X, steps=5)
@@ -236,7 +236,7 @@ def test_newton_schulz_convergence_rate() raises:
     var X = zeros(shape, DType.float32)
 
     for i in range(X.numel()):
-        var val = Float32((Float64(i) * 0.456 + 0.222).fract())
+        var val = Float32((Float64(i) * 0.456 + 0.222) % 1.0)
         X._set_float64(i, Float64(val))
 
     # Compute error after 1 step
@@ -518,5 +518,36 @@ def test_muon_step_pure_functional() raises:
         original_p0,
         final_p0,
         tolerance=1e-10,
-        msg="muon_step does not mutate input params",
+        message="muon_step does not mutate input params",
     )
+
+
+def main() raises:
+    """Run all Muon optimizer tests."""
+    print("=" * 60)
+    print("Muon Optimizer Test Suite")
+    print("=" * 60)
+
+    test_is_muon_eligible_rank_1()
+    test_is_muon_eligible_rank_3()
+    test_is_muon_eligible_rank_2_matrix()
+    test_is_muon_eligible_rank_2_small_row()
+    test_is_muon_eligible_rank_2_small_col()
+    test_is_muon_eligible_rank_2_min_size()
+    test_newton_schulz_square_orthogonality()
+    test_newton_schulz_wide_matrix()
+    test_newton_schulz_tall_matrix()
+    test_newton_schulz_convergence_rate()
+    test_muon_step_shape_preservation()
+    test_muon_step_quadratic_descent()
+    test_muon_step_rejects_non_matrix()
+    test_muon_step_dtype_mismatch()
+    test_muon_step_shape_mismatch()
+    test_muon_step_with_nesterov()
+    test_muon_step_with_weight_decay()
+    test_muon_step_simple()
+    test_muon_step_pure_functional()
+
+    print("=" * 60)
+    print("All tests PASSED")
+    print("=" * 60)


### PR DESCRIPTION
## Problem: false-green required checks

The `comprehensive-tests` harness silently swallowed ALL Mojo failures — compile errors and runtime test failures alike — and reported them as passes.

**Live evidence** (run `29513897485`, job `87693118039`): the log contains

```
tests/odyssey/training/optimizers/test_ftrl.mojo:12:50: error: module 'any_tensor' does not contain 'zeros'
mojo: error: failed to parse the provided Mojo source module
```

…followed by `Total: 82, Passed: 82, Failed: 0` and a SUCCESS conclusion.

## Root cause (justfile `_test-group-inner`, lines 999–1002 on main)

```bash
test_exit=0
if ! pixi run mojo --Werror ... "$test_file"; then
    test_exit=$?
fi
```

`$?` inside the then-branch is the exit status of the **negated** condition `! mojo ...`, which is `0` whenever mojo fails. So `test_exit` was 0 on every failure and every file was counted as passed. (`set -e` doesn't fire either — the command is an `if` condition. `_test-group-asan-inner` already used the correct `set +e` / direct `$?` pattern; `_test-mojo-inner` was also correct.)

**Fix:** capture the real exit code via `set +e` + `$?`, emit explicit per-file `PASSED`/`FAILED (exit N)` verdicts, and add an accounting guard (`passed + failed == total`, else exit 1) so a file that produces neither verdict can never go green.

## Red-green proof (local, deliberately-broken scratch file, since removed)

| Harness | Summary | Exit |
|---|---|---|
| origin/main recipe | `Total: 1, Passed: 1, Failed: 0` (after a visible `failed to parse` error!) | **0** |
| this branch | `Total: 1, Passed: 0, Failed: 1` | **1** |

## Affected test files (never actually executed in CI)

9 files imported creation functions from `odyssey.tensor.any_tensor`, which exports only `AnyTensor` — a guaranteed parse error:

- `tests/odyssey/core/test_eigen.mojo` (zeros)
- `tests/odyssey/integration/test_training_workflow.mojo` (zeros, ones)
- `tests/odyssey/training/optimizers/test_adopt.mojo` (zeros, full)
- `tests/odyssey/training/optimizers/test_ftrl.mojo` (zeros)
- `tests/odyssey/training/optimizers/test_mgup_muon.mojo` (zeros, zeros_like)
- `tests/odyssey/training/optimizers/test_normuon.mojo` (6 names)
- `tests/odyssey/training/optimizers/test_shampoo.mojo` (6 names)
- `tests/odyssey/training/optimizers/test_soap.mojo` (zeros)
- `tests/odyssey/training/test_muon.mojo` (zeros, ones, zeros_like, full)

- `tests/odyssey/training/optimizers/test_lionmuon.mojo` (zeros, zeros_like) — merged via #5615 after this PR opened
- `tests/odyssey/training/optimizers/test_muon_hyperball.mojo` (zeros, zeros_like) — merged via #5614 after this PR opened

(**11 files total.** LionMuon/Muon Hyperball merged from the `opt/*` branches carrying the same broken import; both repaired here. `test_sophia` (#5608) merged without the broken import. In addition, pre-commit's Mojo Format hook could not parse `tests/odyssey/core/layers/test_feedforward.mojo` / `test_rnn.mojo` / `test_gru.mojo` — reserved-keyword `var ref` — and `test_layernorm.mojo` / `test_lstm.mojo` failed `--Werror` on docstring/`except e:` rot: all five repaired, Core Layers group now 8/8 locally.)

**Chosen approach:** import from the real definition site, `odyssey.tensor.tensor_creation` (`def zeros` at `tensor_creation.mojo:22`) — the convention already used by `test_adan`/`test_gru`/`test_layernorm`/`test_feedforward`. Re-exporting from `any_tensor` was rejected: `factories.mojo` is already the typed facade, and a second alias path would recreate the ambiguity that caused this drift.

Additional latent bit-rot fixed so the files compile under Mojo 1.0 `--Werror` (all previously masked): `ref` is now a reserved keyword (renamed `ref_vals`), unused `except e:` → `except _:`, deprecated `alias` → `comptime`, lowercase docstring summaries, `Float64.fract()` removed upstream → `% 1.0`, `msg=` → `message=`, and `test_muon.mojo` had **no `main()` at all** (added, invoking all 19 test fns).

## Before / after executed-test counts (affected groups, run locally via the harness path)

| Group | Before (main) | After (this branch) |
|---|---|---|
| `tests/odyssey/training/optimizers` | 7 "passed", 0 actually executed (5 parse failures + hidden runtime failures all counted as pass) | 7 executed: 6 pass, 1 genuine failure |
| `test_eigen` | "passed", never compiled | compiles, **passes** |
| `test_training_workflow` | "passed", never compiled | compiles, **passes** |
| `test_muon` | "passed", never compiled, no main() | compiles + runs, 1 genuine failure |

## Genuine failures: root-caused and fixed (all TEST bugs; implementations verified correct)

Both failures this PR unmasked were investigated against independent numpy transcriptions and the published algorithms. **Zero implementation changes were needed** — `muon.mojo` edits are docstring-only.

### 1. `test_muon` Newton-Schulz tests — asserted a property the algorithm deliberately does not guarantee

`newton_schulz_orthogonalize` is a faithful transcription of Jordan et al. 2024 ((a,b,c) = (3.4445, −4.7750, 2.0315), Frobenius pre-norm + 1e-7, transpose-when-tall). But that tuned quintic **never converges to strict orthogonality**: it drives singular values into ~[0.68, 1.13] and then oscillates ([Jordan's writeup](https://kellerjordan.github.io/posts/muon/)). numpy fp64 evidence: a well-conditioned Gaussian 8×8 gives ‖YYᵀ−I‖_F ≈ 0.62 after 5 steps and ≈ 1.27 after 50 — the old `< 1e-5` assertion is unattainable for ANY correct implementation. Worse, the old “pseudo-random via index” affine fill is numerically rank-deficient (8×8 case: singular values down to 2.5e-18); NS cannot lift a zero singular value. Two more tests behind it asserted exponential descent from Muon’s **constant-magnitude** orthogonalized update (numpy simulation of the exact loop: quadratic loss 16.0 → 13.335 in 50 steps vs asserted `< 1e-3`; param norm 4.0 → 3.965 in 5 steps vs asserted `< 2.0`) — impossible by design. Fixed: well-conditioned lowbias32-hash inputs + assertions matching the guaranteed sv-band property, every bound derived from a numpy reference with margin.

**Blast radius: none.** `newton_schulz_orthogonalize`/`muon_step` byte-identical → mgup_muon/normuon/shampoo/lionmuon/muon_hyperball parity references remain valid; no parity refs regenerated.

### 2. `test_ftrl::test_simple_no_reg_is_dense` — exact-cancellation trap in the fixture, not a sparsity bug

With `w0[0] = alpha·sign(g[0])` (0.10 = 0.1), step-1 `z = g − (|g|/alpha)·w0` cancels to **exactly 0.0** in fp64, so `w[0] = −0/denom = 0` is *correct dense behavior* (the L1 soft-threshold is not involved). Fixture changed to `w0[0] = 0.15` (numpy: `z = [−0.025, 0.45, −1.0, 1.75, −2.7, 3.85]`, no zeros) and the trap documented.

### 3. Bonus unmasked failures fixed on the way to a green group

- `test_interruption.mojo`: three tests asserted `is_shutdown_requested()` reads `True` after `request_shutdown()` — but both free functions are **documented Mojo-1.0 placeholder no-ops** (no global state). Could never pass. Repointed at the real stateful API (`ShutdownFlag` struct) and pinned the placeholders’ documented always-False contract.
- Core Layers rot (see file list above).

### First-ever real runs of the newly-merged optimizer tests

`test_lionmuon.mojo` and `test_muon_hyperball.mojo` had never executed (broken import since merge). After repair, **both pass at runtime on first execution** — LionMuon’s 3-step two-buffer numpy parity (1e-6), 9-step steady-state buffer separation, and dispatch checks; Muon Hyperball’s full suite including its 12-value reference trajectory.

### Local verification (fixed harness, memory-bounded)

Shared Infra & Testing group **83/83 PASS**; Core Layers **8/8 PASS**; `pre-commit run --all-files` 31/31 hooks pass.

**Update:** the groups the honest harness unmasked have all been fixed **in this PR** — `core-gradient-utils` (`test_gradient_clipping_simd`: `AnyTensor([vals],dtype=)` → `zeros([N],dtype)` + `_set_float64`, and `List[AnyTensor](a,b)` → `= []` + `append`), `integration-bench` (`conftest.mojo` dead `item_seed` removed; `test_packaging` `SGD` → `TrainingLoopSGD as SGD` per the #5392 rename), and `models-misc` (`test_mobilenetv1_train_step` module resolution: `from math` → `from std.math`, `examples/mobilenetv1_cifar10/__init__.mojo` package marker + qualified `from examples.mobilenetv1_cifar10.model import` across all five package files). Every fix corrects the test/example to its true behavior — none is silenced, skipped, or weakened. **All CI check-runs are now green (0 failures).**

No existing tracking issue found (`gh issue list --search compile/harness/swallow/false green` — only unrelated #5571), so this closes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


