### PR TITLE
ci: add merge queue readiness contract

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,6 +15,47 @@ The CI/CD strategy uses GitHub Actions with the following principles:
 6. **PR Comments**: Test summaries automatically comment on PRs for quick feedback
 7. **Scheduled Runs**: Weekly security and benchmark runs ensure ongoing system health
 
+## Merge Queue Readiness
+
+The repository-side merge queue contract is
+[`configs/github/merge-queue-policy.json`](../../configs/github/merge-queue-policy.json).
+It is the only source of truth for the required check contexts and queue rule. Inspect it
+without copying policy values into another document:
+
+```bash
+POLICY=configs/github/merge-queue-policy.json
+jq -r '.required_contexts[]' "$POLICY"
+jq '.merge_queue_rule' "$POLICY"
+```
+
+The workflows that emit required contexts all handle `merge_group` with the
+`checks_requested` activity while retaining their existing pull request and push triggers:
+
+- `_required.yml`
+- `comprehensive-tests.yml`
+- `pre-commit.yml`
+- `workflow-smoke-test.yml`
+
+The publishing workflow in `release.yml` remains tag/manual-only and must not run for merge
+groups. Focused executable coverage lives in
+`tests/smoke/test_merge_queue_workflow_properties.py` and verifies trigger boundaries, exact
+policy values, and one-to-one required-context emission.
+
+This repository does not activate or mutate live GitHub rulesets. The Odysseus rollout tracked
+by `HomericIntelligence/Odysseus#386` is the sole activation authority. That operator must:
+
+1. Snapshot every active `main` ruleset and retain the pre-edit activation-ruleset snapshot as
+   the rollback payload.
+2. Refuse activation unless the union of live required contexts exactly equals
+   `.required_contexts` and the target ruleset has no existing `merge_queue` rule.
+3. Append exactly `.merge_queue_rule`, read it back, and restore the snapshot if read-back differs.
+4. Queue a representative pull request and select actual `merge_group` runs for the four workflows.
+5. Confirm each policy context appears exactly once and completes successfully before recording
+   the live response, run URLs, and queued merge result on Odyssey issue #5624.
+
+Keep issue #5624 open until activation and queued smoke evidence are recorded. A readiness PR
+references the issue with `Refs #5624`; it does not close it.
+
 To get the current workflow count:
 
 ```bash
@@ -26,7 +67,7 @@ ls .github/workflows/*.yml | wc -l
 | Workflow | Trigger | Purpose | Duration |
 | --- | --- | --- | --- |
 | **Test Workflows** | | | |
-| [comprehensive-tests.yml](#comprehensive-tests) | PR, push main, manual | All Mojo tests in 17 groups | < 10 min |
+| [comprehensive-tests.yml](#comprehensive-tests) | PR, merge queue, push main, manual | All Mojo tests in 17 groups | < 10 min |
 | [test-gradients.yml](#test-gradients) | PR on gradient changes, push main | Backward pass validation | < 5 min |
 | [test-data-utilities.yml](#test-data-utilities) | PR/push on data changes | Data loading and processing | < 5 min |
 | [coverage.yml](#coverage) | PR, push main, manual | Code coverage tracking | < 5 min |
@@ -35,7 +76,7 @@ ls .github/workflows/*.yml | wc -l
 | [validate-configs.yml](#validate-configs) | PR/push on config changes | YAML and schema validation | < 5 min |
 | [test-agents.yml](#test-agents) | PR on agent configs, push main | Agent configuration testing | < 3 min |
 | [validate-workflows.yml](#validate-workflows) | PR, push main on .github/ | Validate workflow checkout order | < 3 min |
-| [pre-commit.yml](#pre-commit) | PR, push main, manual | Code formatting and linting | < 5 min |
+| [pre-commit.yml](#pre-commit) | PR, merge queue, push main, manual | Code formatting and linting | < 5 min |
 | [type-check.yml](#type-check) | PR on scripts, push main, manual | Python type checking | < 3 min |
 | [notebook-validation.yml](#notebook-validation) | PR/push on notebooks | Jupyter notebook validation | < 5 min |
 | [paper-validation.yml](#paper-validation) | PR/push on papers/, manual | Paper implementation validation | < 15 min |
@@ -54,7 +95,7 @@ ls .github/workflows/*.yml | wc -l
 | precommit-benchmark.yml | Push main, manual | Pre-commit hook performance tracking | < 5 min |
 | **Maintenance Workflows** | | | |
 | [mojo-version-check.yml](#mojo-version-check) | Weekly Sunday 3 AM UTC, manual | Check for new Mojo releases | < 3 min |
-| workflow-smoke-test.yml | PR | Workflow validation smoke tests | < 2 min |
+| workflow-smoke-test.yml | PR, merge queue, push main, manual | Workflow validation smoke tests | < 2 min |
 | worktree-sync-check.yml | PR | Check if PR branch is significantly behind origin/main | < 2 min |
 | **AI/Automation Workflows** | | | |
 | [claude.yml](#claude) | Issue/PR comments mentioning @claude | Claude Code agent integration | N/A |

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -1,5 +1,5 @@
 # Canonical required-checks workflow for the org-wide homeric-main-baseline ruleset.
-# This workflow defines the 9 canonical status-check contexts that branch protection
+# This workflow defines the 12 canonical status-check contexts that branch protection
 # requires. All job name: strings are the EXACT context strings — do not rename.
 #
 # Reference implementation: HomericIntelligence/ProjectScylla _required.yml
@@ -8,6 +8,8 @@ name: Required Checks
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [main]
 

--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -9,6 +9,10 @@ on:
   # Run on all pull requests
   pull_request:
 
+  # Run the same required contexts for merge queue candidates
+  merge_group:
+    types: [checks_requested]
+
   # Run on pushes to main
   push:
     branches:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,10 @@ on:
   # Run on all pull requests
   pull_request:
 
+  # Run the same required contexts for merge queue candidates
+  merge_group:
+    types: [checks_requested]
+
   # Run on pushes to main
   push:
     branches:

--- a/.github/workflows/workflow-smoke-test.yml
+++ b/.github/workflows/workflow-smoke-test.yml
@@ -6,17 +6,24 @@ name: Workflow Smoke Tests
 #   - pre-commit.yml: pull_request trigger present
 #   - comprehensive-tests.yml: matrix coverage maintained
 #   - validate-configs.yml: agent config validation on PRs
+#   - required-context workflows: merge_group/checks_requested coverage
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   push:
     branches:
       - main
     paths:
+      - '.github/workflows/_required.yml'
+      - '.github/workflows/workflow-smoke-test.yml'
       - '.github/workflows/security.yml'
       - '.github/workflows/pre-commit.yml'
       - '.github/workflows/comprehensive-tests.yml'
       - '.github/workflows/validate-configs.yml'
+      - 'configs/github/merge-queue-policy.json'
+      - 'tests/smoke/test_merge_queue_workflow_properties.py'
       - 'tests/smoke/test_security_workflow_properties.py'
       - '.github/workflows/pre-commit.yml'
       - 'tests/smoke/test_pre_commit_workflow_properties.py'
@@ -190,6 +197,7 @@ jobs:
       - name: Run other workflow smoke tests
         run: |
           pixi run python -m pytest \
+            tests/smoke/test_merge_queue_workflow_properties.py \
             tests/smoke/test_pre_commit_workflow_properties.py \
             tests/smoke/test_comprehensive_tests_workflow_properties.py \
             tests/smoke/test_validate_configs_workflow_properties.py \

--- a/configs/github/merge-queue-policy.json
+++ b/configs/github/merge-queue-policy.json
@@ -1,0 +1,50 @@
+{
+  "repository": "HomericIntelligence/Odyssey",
+  "target_branch": "main",
+  "activation_ruleset": "homeric-main-baseline",
+  "required_contexts": [
+    "Audit Shared Links",
+    "Build Validation",
+    "Code Quality Analysis",
+    "Core Layers",
+    "Data Utilities Test Suite",
+    "Gradient Checking Tests",
+    "Gradient Coverage Report",
+    "Mojo Package Compilation",
+    "Mojo Syntax Validation",
+    "Other Workflow Property Checks",
+    "Python Tests",
+    "Security Workflow Property Checks",
+    "Test Coverage Validation",
+    "Test Metrics",
+    "build",
+    "deps/version-sync",
+    "install",
+    "integration-tests",
+    "lint",
+    "lint-notebooks",
+    "mypy",
+    "package",
+    "pre-commit",
+    "python-syntax",
+    "release",
+    "schema-validation",
+    "security/dependency-scan",
+    "security/secrets-scan",
+    "test",
+    "unit-tests",
+    "validate-notebooks"
+  ],
+  "merge_queue_rule": {
+    "type": "merge_queue",
+    "parameters": {
+      "check_response_timeout_minutes": 60,
+      "grouping_strategy": "ALLGREEN",
+      "max_entries_to_build": 10,
+      "max_entries_to_merge": 5,
+      "merge_method": "SQUASH",
+      "min_entries_to_merge": 1,
+      "min_entries_to_merge_wait_minutes": 5
+    }
+  }
+}

--- a/tests/smoke/test_merge_queue_workflow_properties.py
+++ b/tests/smoke/test_merge_queue_workflow_properties.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Regression tests for staged merge-queue readiness.
+
+The live rulesets remain operator-owned. These tests lock the repository-side
+contract that activation and the queued smoke check will consume.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+POLICY_PATH = REPO_ROOT / "configs" / "github" / "merge-queue-policy.json"
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+REQUIRED_WORKFLOWS = (
+    "_required.yml",
+    "comprehensive-tests.yml",
+    "pre-commit.yml",
+    "workflow-smoke-test.yml",
+)
+
+EXPECTED_REQUIRED_CONTEXTS = [
+    "Audit Shared Links",
+    "Build Validation",
+    "Code Quality Analysis",
+    "Core Layers",
+    "Data Utilities Test Suite",
+    "Gradient Checking Tests",
+    "Gradient Coverage Report",
+    "Mojo Package Compilation",
+    "Mojo Syntax Validation",
+    "Other Workflow Property Checks",
+    "Python Tests",
+    "Security Workflow Property Checks",
+    "Test Coverage Validation",
+    "Test Metrics",
+    "build",
+    "deps/version-sync",
+    "install",
+    "integration-tests",
+    "lint",
+    "lint-notebooks",
+    "mypy",
+    "package",
+    "pre-commit",
+    "python-syntax",
+    "release",
+    "schema-validation",
+    "security/dependency-scan",
+    "security/secrets-scan",
+    "test",
+    "unit-tests",
+    "validate-notebooks",
+]
+
+EXPECTED_MERGE_QUEUE_RULE = {
+    "type": "merge_queue",
+    "parameters": {
+        "check_response_timeout_minutes": 60,
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 10,
+        "max_entries_to_merge": 5,
+        "merge_method": "SQUASH",
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 5,
+    },
+}
+
+
+def _load_yaml(path: Path) -> dict[Any, Any]:
+    """Load one workflow and normalize PyYAML's YAML 1.1 ``on`` key."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), f"{path} must contain a YAML mapping"
+    return data
+
+
+def _on_block(workflow: dict[Any, Any]) -> dict[str, Any]:
+    """Return a workflow trigger mapping despite PyYAML treating ``on`` as bool."""
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "workflow on block must be a mapping"
+    return triggers
+
+
+def test_policy_matches_live_required_contexts_and_approved_queue_rule() -> None:
+    """The policy artifact must be the exact reviewed activation contract."""
+    policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+
+    assert policy == {
+        "repository": "HomericIntelligence/Odyssey",
+        "target_branch": "main",
+        "activation_ruleset": "homeric-main-baseline",
+        "required_contexts": EXPECTED_REQUIRED_CONTEXTS,
+        "merge_queue_rule": EXPECTED_MERGE_QUEUE_RULE,
+    }
+    assert policy["required_contexts"] == sorted(policy["required_contexts"])
+
+
+def test_every_required_context_workflow_handles_merge_group() -> None:
+    """Every workflow posting a required context must run for queue candidates."""
+    for workflow_name in REQUIRED_WORKFLOWS:
+        workflow = _load_yaml(WORKFLOW_DIR / workflow_name)
+        assert _on_block(workflow).get("merge_group") == {"types": ["checks_requested"]}, (
+            f"{workflow_name} must handle merge_group/checks_requested"
+        )
+
+
+def test_existing_pull_request_and_push_triggers_are_preserved() -> None:
+    """Queue readiness must not narrow the existing PR or main-push coverage."""
+    required_triggers = _on_block(_load_yaml(WORKFLOW_DIR / "_required.yml"))
+    assert set(required_triggers) == {"pull_request", "merge_group", "push"}
+    assert required_triggers["pull_request"] is None
+    assert required_triggers["push"] == {"branches": ["main"]}
+
+    for workflow_name in REQUIRED_WORKFLOWS[1:3]:
+        triggers = _on_block(_load_yaml(WORKFLOW_DIR / workflow_name))
+        assert set(triggers) == {
+            "pull_request",
+            "merge_group",
+            "push",
+            "workflow_dispatch",
+        }
+        assert triggers["pull_request"] is None
+        assert triggers["push"] == {"branches": ["main"]}
+
+    smoke_triggers = _on_block(_load_yaml(WORKFLOW_DIR / "workflow-smoke-test.yml"))
+    assert set(smoke_triggers) == {
+        "pull_request",
+        "merge_group",
+        "push",
+        "workflow_dispatch",
+    }
+    assert smoke_triggers["pull_request"] is None
+    assert smoke_triggers["push"]["branches"] == ["main"]
+    assert set(smoke_triggers["push"]["paths"]) == {
+        ".github/workflows/_required.yml",
+        ".github/workflows/comprehensive-tests.yml",
+        ".github/workflows/pre-commit.yml",
+        ".github/workflows/security.yml",
+        ".github/workflows/validate-configs.yml",
+        ".github/workflows/workflow-smoke-test.yml",
+        "configs/github/merge-queue-policy.json",
+        "tests/smoke/test_comprehensive_tests_workflow_properties.py",
+        "tests/smoke/test_merge_queue_workflow_properties.py",
+        "tests/smoke/test_pre_commit_workflow_properties.py",
+        "tests/smoke/test_security_workflow_properties.py",
+        "tests/smoke/test_validate_configs_workflow_properties.py",
+    }
+
+
+def test_required_contexts_are_emitted_once_across_queue_workflows() -> None:
+    """The queue candidate must receive every pinned context exactly once."""
+    emitted: list[str] = []
+    for workflow_name in REQUIRED_WORKFLOWS:
+        jobs = _load_yaml(WORKFLOW_DIR / workflow_name).get("jobs")
+        assert isinstance(jobs, dict), f"{workflow_name} must define jobs"
+        for job_id, job in jobs.items():
+            assert isinstance(job, dict), f"{workflow_name}:{job_id} must be a mapping"
+            job_name = str(job.get("name", job_id))
+            emitted.append(job_name)
+            if job_name in EXPECTED_REQUIRED_CONTEXTS:
+                assert job.get("if") in (None, "always()"), f"{workflow_name}:{job_id} must not skip merge_group runs"
+
+    required_emitted = [name for name in emitted if name in EXPECTED_REQUIRED_CONTEXTS]
+    assert sorted(required_emitted) == EXPECTED_REQUIRED_CONTEXTS
+    assert len(required_emitted) == len(set(required_emitted))
+
+
+def test_queue_workflows_preserve_minimum_permissions() -> None:
+    """Adding queue triggers must not broaden the workflows' token permissions."""
+    expected_permissions = {
+        "_required.yml": {"contents": "read"},
+        "comprehensive-tests.yml": {
+            "contents": "read",
+            "pull-requests": "write",
+        },
+        "pre-commit.yml": {"contents": "read"},
+        "workflow-smoke-test.yml": {"contents": "read"},
+    }
+
+    for workflow_name, permissions in expected_permissions.items():
+        workflow = _load_yaml(WORKFLOW_DIR / workflow_name)
+        assert workflow.get("permissions") == permissions
+
+
+def test_release_workflow_remains_tag_or_manual_only() -> None:
+    """Queue readiness must not execute the real publishing workflow."""
+    triggers = _on_block(_load_yaml(WORKFLOW_DIR / "release.yml"))
+
+    assert triggers["push"] == {"tags": ["v*"]}
+    assert "workflow_dispatch" in triggers
+    assert "pull_request" not in triggers
+    assert "merge_group" not in triggers
+
+
+def test_merge_queue_regression_runs_in_required_smoke_workflow() -> None:
+    """The focused regression itself must run in a required queue context."""
+    smoke_workflow = (WORKFLOW_DIR / "workflow-smoke-test.yml").read_text(encoding="utf-8")
+    assert "tests/smoke/test_merge_queue_workflow_properties.py" in smoke_workflow


### PR DESCRIPTION
## Summary

- add a policy-as-code contract for the 31 currently required status contexts and the approved merge-queue parameters
- run all four required-context workflows for `merge_group / checks_requested` while preserving existing pull-request, push, permission, security-gate, and release behavior
- add executable trigger/context/policy regressions and an artifact-driven staged-activation runbook

## Live baseline inspected

- `homeric-main-baseline` is active with 12 required contexts
- `homeric-main-extras` is active with 19 required contexts
- neither live ruleset currently contains a `merge_queue` rule
- this PR does not mutate GitHub rulesets or branch protection

## Verification

- TDD RED: 3 failed, 3 passed before the policy/workflow implementation
- focused merge-queue regression: 7 passed
- workflow smoke suite: 33 passed
- checkout-first validator: 24 workflow files passed
- changed-file Ruff, format, mypy, markdownlint, YAML, security, and pre-commit hooks passed
- full Python suite: 1223 passed, 222 skipped, 3 failed; all 3 failures reproduce unchanged on detached `origin/main`

## Staged rollout

The Odysseus umbrella rollout in HomericIntelligence/Odysseus#386 remains the sole authority for live activation. After this PR lands and receives the required human workflow review, that rollout must append the artifact's queue rule, read it back, and record a representative successful `merge_group` cycle. Odyssey issue #5624 stays open for that operational evidence.

Refs #5624
