### PR TITLE
ci: add merge queue readiness contract

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -68,6 +68,7 @@ ls .github/workflows/*.yml | wc -l
 | --- | --- | --- | --- |
 | **Test Workflows** | | | |
 | [comprehensive-tests.yml](#comprehensive-tests) | PR, merge queue, push main, manual | All Mojo tests in 17 groups | < 10 min |
+| [comprehensive-test-pr-comments.yml](#comprehensive-test-pr-comments) | Completed comprehensive PR tests | Trusted test-report PR comments | < 1 min |
 | [test-gradients.yml](#test-gradients) | PR on gradient changes, push main | Backward pass validation | < 5 min |
 | [test-data-utilities.yml](#test-data-utilities) | PR/push on data changes | Data loading and processing | < 5 min |
 | [coverage.yml](#coverage) | PR, push main, manual | Code coverage tracking | < 5 min |
@@ -160,6 +161,20 @@ ls .github/workflows/*.yml | wc -l
 
 - `fail-fast: false` - all groups run even if one fails
 - Overall workflow fails if any tests fail
+
+---
+
+#### comprehensive-test-pr-comments
+
+**File**: `comprehensive-test-pr-comments.yml`
+
+**Triggers**: Completed `Comprehensive Tests` runs whose source event is `pull_request`
+
+**Purpose**: Post or update the test-metrics and comprehensive-test reports on the pull request.
+The workflow runs from the trusted default branch, downloads reports as data, and never checks out
+or executes pull-request code with its narrowly scoped `pull-requests: write` token.
+
+**Artifacts**: Consumes `test-metrics` and `comprehensive-test-report`; creates none
 
 ---
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,6 +15,47 @@ The CI/CD strategy uses GitHub Actions with the following principles:
 6. **PR Comments**: Test summaries automatically comment on PRs for quick feedback
 7. **Scheduled Runs**: Weekly security and benchmark runs ensure ongoing system health
 
+## Merge Queue Readiness
+
+The repository-side merge queue contract is
+[`configs/github/merge-queue-policy.json`](../../configs/github/merge-queue-policy.json).
+It is the only source of truth for the required check contexts and queue rule. Inspect it
+without copying policy values into another document:
+
+```bash
+POLICY=configs/github/merge-queue-policy.json
+jq -r '.required_contexts[]' "$POLICY"
+jq '.merge_queue_rule' "$POLICY"
+```
+
+The workflows that emit required contexts all handle `merge_group` with the
+`checks_requested` activity while retaining their existing pull request and push triggers:
+
+- `_required.yml`
+- `comprehensive-tests.yml`
+- `pre-commit.yml`
+- `workflow-smoke-test.yml`
+
+The publishing workflow in `release.yml` remains tag/manual-only and must not run for merge
+groups. Focused executable coverage lives in
+`tests/smoke/test_merge_queue_workflow_properties.py` and verifies trigger boundaries, exact
+policy values, and one-to-one required-context emission.
+
+This repository does not activate or mutate live GitHub rulesets. The Odysseus rollout tracked
+by `HomericIntelligence/Odysseus#386` is the sole activation authority. That operator must:
+
+1. Snapshot every active `main` ruleset and retain the pre-edit activation-ruleset snapshot as
+   the rollback payload.
+2. Refuse activation unless the union of live required contexts exactly equals
+   `.required_contexts` and the target ruleset has no existing `merge_queue` rule.
+3. Append exactly `.merge_queue_rule`, read it back, and restore the snapshot if read-back differs.
+4. Queue a representative pull request and select actual `merge_group` runs for the four workflows.
+5. Confirm each policy context appears exactly once and completes successfully before recording
+   the live response, run URLs, and queued merge result on Odyssey issue #5624.
+
+Keep issue #5624 open until activation and queued smoke evidence are recorded. A readiness PR
+references the issue with `Refs #5624`; it does not close it.
+
 To get the current workflow count:
 
 ```bash
@@ -26,7 +67,7 @@ ls .github/workflows/*.yml | wc -l
 | Workflow | Trigger | Purpose | Duration |
 | --- | --- | --- | --- |
 | **Test Workflows** | | | |
-| [comprehensive-tests.yml](#comprehensive-tests) | PR, push main, manual | All Mojo tests in 17 groups | < 10 min |
+| [comprehensive-tests.yml](#comprehensive-tests) | PR, merge queue, push main, manual | All Mojo tests in 17 groups | < 10 min |
 | [test-gradients.yml](#test-gradients) | PR on gradient changes, push main | Backward pass validation | < 5 min |
 | [test-data-utilities.yml](#test-data-utilities) | PR/push on data changes | Data loading and processing | < 5 min |
 | [coverage.yml](#coverage) | PR, push main, manual | Code coverage tracking | < 5 min |
@@ -35,7 +76,7 @@ ls .github/workflows/*.yml | wc -l
 | [validate-configs.yml](#validate-configs) | PR/push on config changes | YAML and schema validation | < 5 min |
 | [test-agents.yml](#test-agents) | PR on agent configs, push main | Agent configuration testing | < 3 min |
 | [validate-workflows.yml](#validate-workflows) | PR, push main on .github/ | Validate workflow checkout order | < 3 min |
-| [pre-commit.yml](#pre-commit) | PR, push main, manual | Code formatting and linting | < 5 min |
+| [pre-commit.yml](#pre-commit) | PR, merge queue, push main, manual | Code formatting and linting | < 5 min |
 | [type-check.yml](#type-check) | PR on scripts, push main, manual | Python type checking | < 3 min |
 | [notebook-validation.yml](#notebook-validation) | PR/push on notebooks | Jupyter notebook validation | < 5 min |
 | [paper-validation.yml](#paper-validation) | PR/push on papers/, manual | Paper implementation validation | < 15 min |
@@ -54,7 +95,7 @@ ls .github/workflows/*.yml | wc -l
 | precommit-benchmark.yml | Push main, manual | Pre-commit hook performance tracking | < 5 min |
 | **Maintenance Workflows** | | | |
 | [mojo-version-check.yml](#mojo-version-check) | Weekly Sunday 3 AM UTC, manual | Check for new Mojo releases | < 3 min |
-| workflow-smoke-test.yml | PR | Workflow validation smoke tests | < 2 min |
+| workflow-smoke-test.yml | PR, merge queue, push main, manual | Workflow validation smoke tests | < 2 min |
 | worktree-sync-check.yml | PR | Check if PR branch is significantly behind origin/main | < 2 min |
 | **AI/Automation Workflows** | | | |
 | [claude.yml](#claude) | Issue/PR comments mentioning @claude | Claude Code agent integration | N/A |
@@ -68,7 +109,7 @@ ls .github/workflows/*.yml | wc -l
 
 **File**: `comprehensive-tests.yml`
 
-**Triggers**: Pull requests, pushes to main, manual dispatch
+**Triggers**: Pull requests, `merge_group` (`checks_requested`), pushes to main, manual dispatch
 
 **Purpose**: Run all Mojo tests organized into 17 logical groups for comprehensive coverage.
 
@@ -265,7 +306,7 @@ ls .github/workflows/*.yml | wc -l
 
 **File**: `pre-commit.yml`
 
-**Triggers**: PR, pushes to main, manual dispatch
+**Triggers**: PR, `merge_group` (`checks_requested`), pushes to main, manual dispatch
 
 **Purpose**: Run pre-commit hooks for code formatting and linting.
 

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -1,5 +1,5 @@
 # Canonical required-checks workflow for the org-wide homeric-main-baseline ruleset.
-# This workflow defines the 9 canonical status-check contexts that branch protection
+# This workflow defines the 12 canonical status-check contexts that branch protection
 # requires. All job name: strings are the EXACT context strings — do not rename.
 #
 # Reference implementation: HomericIntelligence/ProjectScylla _required.yml
@@ -8,6 +8,8 @@ name: Required Checks
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [main]
 

--- a/.github/workflows/comprehensive-test-pr-comments.yml
+++ b/.github/workflows/comprehensive-test-pr-comments.yml
@@ -1,0 +1,92 @@
+name: Comprehensive Test PR Comments
+
+# This trusted default-branch workflow consumes reports as data. It never
+# checks out or executes pull-request code with its write-scoped token.
+on:
+  workflow_run:
+    workflows: ["Comprehensive Tests"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  post-pr-comments:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.pull_requests[0]
+    runs-on: ubuntu-latest
+    name: "Post Comprehensive Test PR Comments"
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Download test metrics report
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          name: test-metrics
+          path: reports/metrics
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Download comprehensive test report
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          name: comprehensive-test-report
+          path: reports/comprehensive
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Post or update PR comments
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
+        env:
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        with:
+          script: |
+            const fs = require('fs');
+            const issue_number = Number(process.env.PR_NUMBER);
+            const reports = [
+              {
+                marker: 'Test Metrics Report',
+                path: 'reports/metrics/metrics-pr-comment.md',
+              },
+              {
+                marker: '🧪 Comprehensive Test Results',
+                path: 'reports/comprehensive/test-report.md',
+              },
+            ];
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                per_page: 100,
+              },
+            );
+
+            for (const report of reports) {
+              const body = fs.readFileSync(report.path, 'utf8');
+              const existing = comments.find(comment =>
+                comment.user.type === 'Bot' && comment.body.includes(report.marker)
+              );
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                  body,
+                });
+              }
+            }

--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -34,7 +34,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write  # For PR comments
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -1149,6 +1148,9 @@ jobs:
       - name: Display metrics
         run: cat metrics.md
 
+      - name: Build PR comment report
+        run: python scripts/build_pr_comment.py --metrics-file metrics.md --output-file metrics-pr-comment.md
+
       - name: Upload metrics artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
@@ -1156,18 +1158,8 @@ jobs:
           path: |
             metrics.json
             metrics.md
+            metrics-pr-comment.md
           retention-days: 90
-
-      - name: Build PR comment report
-        if: github.event_name == 'pull_request'
-        run: python scripts/build_pr_comment.py --metrics-file metrics.md --output-file metrics-pr-comment.md
-
-      - name: Comment on PR with metrics
-        if: github.event_name == 'pull_request'
-        uses: ./.github/actions/pr-comment
-        with:
-          report-file: metrics-pr-comment.md
-          comment-marker: "Test Metrics Report"
 
   # ============================================================================
   # Combined Test Report with Metrics
@@ -1288,13 +1280,6 @@ jobs:
           name: comprehensive-test-report
           path: test-report.md
           retention-days: 30
-
-      - name: Comment on PR
-        if: github.event_name == 'pull_request'
-        uses: ./.github/actions/pr-comment
-        with:
-          report-file: test-report.md
-          comment-marker: "\U0001F9EA Comprehensive Test Results"
 
       - name: Fail if any tests failed
         run: |

--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -9,6 +9,10 @@ on:
   # Run on all pull requests
   pull_request:
 
+  # Run the same required contexts for merge queue candidates
+  merge_group:
+    types: [checks_requested]
+
   # Run on pushes to main
   push:
     branches:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,10 @@ on:
   # Run on all pull requests
   pull_request:
 
+  # Run the same required contexts for merge queue candidates
+  merge_group:
+    types: [checks_requested]
+
   # Run on pushes to main
   push:
     branches:

--- a/.github/workflows/workflow-smoke-test.yml
+++ b/.github/workflows/workflow-smoke-test.yml
@@ -6,17 +6,24 @@ name: Workflow Smoke Tests
 #   - pre-commit.yml: pull_request trigger present
 #   - comprehensive-tests.yml: matrix coverage maintained
 #   - validate-configs.yml: agent config validation on PRs
+#   - required-context workflows: merge_group/checks_requested coverage
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   push:
     branches:
       - main
     paths:
+      - '.github/workflows/_required.yml'
+      - '.github/workflows/workflow-smoke-test.yml'
       - '.github/workflows/security.yml'
       - '.github/workflows/pre-commit.yml'
       - '.github/workflows/comprehensive-tests.yml'
       - '.github/workflows/validate-configs.yml'
+      - 'configs/github/merge-queue-policy.json'
+      - 'tests/smoke/test_merge_queue_workflow_properties.py'
       - 'tests/smoke/test_security_workflow_properties.py'
       - '.github/workflows/pre-commit.yml'
       - 'tests/smoke/test_pre_commit_workflow_properties.py'
@@ -190,6 +197,7 @@ jobs:
       - name: Run other workflow smoke tests
         run: |
           pixi run python -m pytest \
+            tests/smoke/test_merge_queue_workflow_properties.py \
             tests/smoke/test_pre_commit_workflow_properties.py \
             tests/smoke/test_comprehensive_tests_workflow_properties.py \
             tests/smoke/test_validate_configs_workflow_properties.py \

--- a/.github/workflows/workflow-smoke-test.yml
+++ b/.github/workflows/workflow-smoke-test.yml
@@ -17,6 +17,7 @@ on:
       - main
     paths:
       - '.github/workflows/_required.yml'
+      - '.github/workflows/comprehensive-test-pr-comments.yml'
       - '.github/workflows/workflow-smoke-test.yml'
       - '.github/workflows/security.yml'
       - '.github/workflows/pre-commit.yml'

--- a/configs/github/merge-queue-policy.json
+++ b/configs/github/merge-queue-policy.json
@@ -1,0 +1,50 @@
+{
+  "repository": "HomericIntelligence/Odyssey",
+  "target_branch": "main",
+  "activation_ruleset": "homeric-main-baseline",
+  "required_contexts": [
+    "Audit Shared Links",
+    "Build Validation",
+    "Code Quality Analysis",
+    "Core Layers",
+    "Data Utilities Test Suite",
+    "Gradient Checking Tests",
+    "Gradient Coverage Report",
+    "Mojo Package Compilation",
+    "Mojo Syntax Validation",
+    "Other Workflow Property Checks",
+    "Python Tests",
+    "Security Workflow Property Checks",
+    "Test Coverage Validation",
+    "Test Metrics",
+    "build",
+    "deps/version-sync",
+    "install",
+    "integration-tests",
+    "lint",
+    "lint-notebooks",
+    "mypy",
+    "package",
+    "pre-commit",
+    "python-syntax",
+    "release",
+    "schema-validation",
+    "security/dependency-scan",
+    "security/secrets-scan",
+    "test",
+    "unit-tests",
+    "validate-notebooks"
+  ],
+  "merge_queue_rule": {
+    "type": "merge_queue",
+    "parameters": {
+      "check_response_timeout_minutes": 60,
+      "grouping_strategy": "ALLGREEN",
+      "max_entries_to_build": 10,
+      "max_entries_to_merge": 5,
+      "merge_method": "SQUASH",
+      "min_entries_to_merge": 1,
+      "min_entries_to_merge_wait_minutes": 5
+    }
+  }
+}

--- a/tests/smoke/test_merge_queue_workflow_properties.py
+++ b/tests/smoke/test_merge_queue_workflow_properties.py
@@ -14,6 +14,7 @@ import yaml
 REPO_ROOT = Path(__file__).parent.parent.parent
 POLICY_PATH = REPO_ROOT / "configs" / "github" / "merge-queue-policy.json"
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+PR_COMMENT_WORKFLOW = "comprehensive-test-pr-comments.yml"
 
 REQUIRED_WORKFLOWS = (
     "_required.yml",
@@ -107,22 +108,6 @@ def test_every_required_context_workflow_handles_merge_group() -> None:
         )
 
 
-def test_detailed_workflow_docs_include_merge_group_activity() -> None:
-    """Detailed docs must name the queue event and activity for both workflows."""
-    readme = (WORKFLOW_DIR / "README.md").read_text(encoding="utf-8")
-    expected_triggers = {
-        "comprehensive-tests": (
-            "**Triggers**: Pull requests, `merge_group` (`checks_requested`), pushes to main, manual dispatch"
-        ),
-        "pre-commit": ("**Triggers**: PR, `merge_group` (`checks_requested`), pushes to main, manual dispatch"),
-    }
-
-    for section_name, expected_trigger in expected_triggers.items():
-        section = readme.split(f"#### {section_name}\n", maxsplit=1)[1]
-        section = section.split("\n#### ", maxsplit=1)[0]
-        assert expected_trigger in section
-
-
 def test_existing_pull_request_and_push_triggers_are_preserved() -> None:
     """Queue readiness must not narrow the existing PR or main-push coverage."""
     required_triggers = _on_block(_load_yaml(WORKFLOW_DIR / "_required.yml"))
@@ -152,6 +137,7 @@ def test_existing_pull_request_and_push_triggers_are_preserved() -> None:
     assert smoke_triggers["push"]["branches"] == ["main"]
     assert set(smoke_triggers["push"]["paths"]) == {
         ".github/workflows/_required.yml",
+        ".github/workflows/comprehensive-test-pr-comments.yml",
         ".github/workflows/comprehensive-tests.yml",
         ".github/workflows/pre-commit.yml",
         ".github/workflows/security.yml",
@@ -188,10 +174,7 @@ def test_queue_workflows_preserve_minimum_permissions() -> None:
     """Adding queue triggers must not broaden the workflows' token permissions."""
     expected_permissions = {
         "_required.yml": {"contents": "read"},
-        "comprehensive-tests.yml": {
-            "contents": "read",
-            "pull-requests": "write",
-        },
+        "comprehensive-tests.yml": {"contents": "read"},
         "pre-commit.yml": {"contents": "read"},
         "workflow-smoke-test.yml": {"contents": "read"},
     }
@@ -199,6 +182,45 @@ def test_queue_workflows_preserve_minimum_permissions() -> None:
     for workflow_name, permissions in expected_permissions.items():
         workflow = _load_yaml(WORKFLOW_DIR / workflow_name)
         assert workflow.get("permissions") == permissions
+
+
+def test_merge_group_cannot_receive_write_scope() -> None:
+    """Merge-group jobs stay read-only; only trusted PR comments can write."""
+    workflow = _load_yaml(WORKFLOW_DIR / "comprehensive-tests.yml")
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict)
+
+    assert not {
+        job_id
+        for job_id, job in jobs.items()
+        if isinstance(job, dict) and "write" in job.get("permissions", {}).values()
+    }
+
+    comment_workflow = _load_yaml(WORKFLOW_DIR / PR_COMMENT_WORKFLOW)
+    assert _on_block(comment_workflow) == {
+        "workflow_run": {
+            "workflows": ["Comprehensive Tests"],
+            "types": ["completed"],
+        }
+    }
+    assert comment_workflow.get("permissions") == {"contents": "read"}
+
+    comment_jobs = comment_workflow.get("jobs")
+    assert isinstance(comment_jobs, dict)
+    assert set(comment_jobs) == {"post-pr-comments"}
+    comment_job = comment_jobs["post-pr-comments"]
+    assert comment_job.get("if") == (
+        "github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0]"
+    )
+    assert comment_job.get("permissions") == {
+        "actions": "read",
+        "contents": "read",
+        "pull-requests": "write",
+    }
+
+    uses = [str(step.get("uses", "")) for step in comment_job.get("steps", [])]
+    assert all(not action.startswith("actions/checkout@") for action in uses)
+    assert all(not action.startswith("./") for action in uses)
 
 
 def test_release_workflow_remains_tag_or_manual_only() -> None:

--- a/tests/smoke/test_merge_queue_workflow_properties.py
+++ b/tests/smoke/test_merge_queue_workflow_properties.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Regression tests for staged merge-queue readiness.
+
+The live rulesets remain operator-owned. These tests lock the repository-side
+contract that activation and the queued smoke check will consume.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+POLICY_PATH = REPO_ROOT / "configs" / "github" / "merge-queue-policy.json"
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+REQUIRED_WORKFLOWS = (
+    "_required.yml",
+    "comprehensive-tests.yml",
+    "pre-commit.yml",
+    "workflow-smoke-test.yml",
+)
+
+EXPECTED_REQUIRED_CONTEXTS = [
+    "Audit Shared Links",
+    "Build Validation",
+    "Code Quality Analysis",
+    "Core Layers",
+    "Data Utilities Test Suite",
+    "Gradient Checking Tests",
+    "Gradient Coverage Report",
+    "Mojo Package Compilation",
+    "Mojo Syntax Validation",
+    "Other Workflow Property Checks",
+    "Python Tests",
+    "Security Workflow Property Checks",
+    "Test Coverage Validation",
+    "Test Metrics",
+    "build",
+    "deps/version-sync",
+    "install",
+    "integration-tests",
+    "lint",
+    "lint-notebooks",
+    "mypy",
+    "package",
+    "pre-commit",
+    "python-syntax",
+    "release",
+    "schema-validation",
+    "security/dependency-scan",
+    "security/secrets-scan",
+    "test",
+    "unit-tests",
+    "validate-notebooks",
+]
+
+EXPECTED_MERGE_QUEUE_RULE = {
+    "type": "merge_queue",
+    "parameters": {
+        "check_response_timeout_minutes": 60,
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 10,
+        "max_entries_to_merge": 5,
+        "merge_method": "SQUASH",
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 5,
+    },
+}
+
+
+def _load_yaml(path: Path) -> dict[Any, Any]:
+    """Load one workflow and normalize PyYAML's YAML 1.1 ``on`` key."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), f"{path} must contain a YAML mapping"
+    return data
+
+
+def _on_block(workflow: dict[Any, Any]) -> dict[str, Any]:
+    """Return a workflow trigger mapping despite PyYAML treating ``on`` as bool."""
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "workflow on block must be a mapping"
+    return triggers
+
+
+def test_policy_matches_live_required_contexts_and_approved_queue_rule() -> None:
+    """The policy artifact must be the exact reviewed activation contract."""
+    policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+
+    assert policy == {
+        "repository": "HomericIntelligence/Odyssey",
+        "target_branch": "main",
+        "activation_ruleset": "homeric-main-baseline",
+        "required_contexts": EXPECTED_REQUIRED_CONTEXTS,
+        "merge_queue_rule": EXPECTED_MERGE_QUEUE_RULE,
+    }
+    assert policy["required_contexts"] == sorted(policy["required_contexts"])
+
+
+def test_every_required_context_workflow_handles_merge_group() -> None:
+    """Every workflow posting a required context must run for queue candidates."""
+    for workflow_name in REQUIRED_WORKFLOWS:
+        workflow = _load_yaml(WORKFLOW_DIR / workflow_name)
+        assert _on_block(workflow).get("merge_group") == {"types": ["checks_requested"]}, (
+            f"{workflow_name} must handle merge_group/checks_requested"
+        )
+
+
+def test_detailed_workflow_docs_include_merge_group_activity() -> None:
+    """Detailed docs must name the queue event and activity for both workflows."""
+    readme = (WORKFLOW_DIR / "README.md").read_text(encoding="utf-8")
+    expected_triggers = {
+        "comprehensive-tests": (
+            "**Triggers**: Pull requests, `merge_group` (`checks_requested`), pushes to main, manual dispatch"
+        ),
+        "pre-commit": ("**Triggers**: PR, `merge_group` (`checks_requested`), pushes to main, manual dispatch"),
+    }
+
+    for section_name, expected_trigger in expected_triggers.items():
+        section = readme.split(f"#### {section_name}\n", maxsplit=1)[1]
+        section = section.split("\n#### ", maxsplit=1)[0]
+        assert expected_trigger in section
+
+
+def test_existing_pull_request_and_push_triggers_are_preserved() -> None:
+    """Queue readiness must not narrow the existing PR or main-push coverage."""
+    required_triggers = _on_block(_load_yaml(WORKFLOW_DIR / "_required.yml"))
+    assert set(required_triggers) == {"pull_request", "merge_group", "push"}
+    assert required_triggers["pull_request"] is None
+    assert required_triggers["push"] == {"branches": ["main"]}
+
+    for workflow_name in REQUIRED_WORKFLOWS[1:3]:
+        triggers = _on_block(_load_yaml(WORKFLOW_DIR / workflow_name))
+        assert set(triggers) == {
+            "pull_request",
+            "merge_group",
+            "push",
+            "workflow_dispatch",
+        }
+        assert triggers["pull_request"] is None
+        assert triggers["push"] == {"branches": ["main"]}
+
+    smoke_triggers = _on_block(_load_yaml(WORKFLOW_DIR / "workflow-smoke-test.yml"))
+    assert set(smoke_triggers) == {
+        "pull_request",
+        "merge_group",
+        "push",
+        "workflow_dispatch",
+    }
+    assert smoke_triggers["pull_request"] is None
+    assert smoke_triggers["push"]["branches"] == ["main"]
+    assert set(smoke_triggers["push"]["paths"]) == {
+        ".github/workflows/_required.yml",
+        ".github/workflows/comprehensive-tests.yml",
+        ".github/workflows/pre-commit.yml",
+        ".github/workflows/security.yml",
+        ".github/workflows/validate-configs.yml",
+        ".github/workflows/workflow-smoke-test.yml",
+        "configs/github/merge-queue-policy.json",
+        "tests/smoke/test_comprehensive_tests_workflow_properties.py",
+        "tests/smoke/test_merge_queue_workflow_properties.py",
+        "tests/smoke/test_pre_commit_workflow_properties.py",
+        "tests/smoke/test_security_workflow_properties.py",
+        "tests/smoke/test_validate_configs_workflow_properties.py",
+    }
+
+
+def test_required_contexts_are_emitted_once_across_queue_workflows() -> None:
+    """The queue candidate must receive every pinned context exactly once."""
+    emitted: list[str] = []
+    for workflow_name in REQUIRED_WORKFLOWS:
+        jobs = _load_yaml(WORKFLOW_DIR / workflow_name).get("jobs")
+        assert isinstance(jobs, dict), f"{workflow_name} must define jobs"
+        for job_id, job in jobs.items():
+            assert isinstance(job, dict), f"{workflow_name}:{job_id} must be a mapping"
+            job_name = str(job.get("name", job_id))
+            emitted.append(job_name)
+            if job_name in EXPECTED_REQUIRED_CONTEXTS:
+                assert job.get("if") in (None, "always()"), f"{workflow_name}:{job_id} must not skip merge_group runs"
+
+    required_emitted = [name for name in emitted if name in EXPECTED_REQUIRED_CONTEXTS]
+    assert sorted(required_emitted) == EXPECTED_REQUIRED_CONTEXTS
+    assert len(required_emitted) == len(set(required_emitted))
+
+
+def test_queue_workflows_preserve_minimum_permissions() -> None:
+    """Adding queue triggers must not broaden the workflows' token permissions."""
+    expected_permissions = {
+        "_required.yml": {"contents": "read"},
+        "comprehensive-tests.yml": {
+            "contents": "read",
+            "pull-requests": "write",
+        },
+        "pre-commit.yml": {"contents": "read"},
+        "workflow-smoke-test.yml": {"contents": "read"},
+    }
+
+    for workflow_name, permissions in expected_permissions.items():
+        workflow = _load_yaml(WORKFLOW_DIR / workflow_name)
+        assert workflow.get("permissions") == permissions
+
+
+def test_release_workflow_remains_tag_or_manual_only() -> None:
+    """Queue readiness must not execute the real publishing workflow."""
+    triggers = _on_block(_load_yaml(WORKFLOW_DIR / "release.yml"))
+
+    assert triggers["push"] == {"tags": ["v*"]}
+    assert "workflow_dispatch" in triggers
+    assert "pull_request" not in triggers
+    assert "merge_group" not in triggers
+
+
+def test_merge_queue_regression_runs_in_required_smoke_workflow() -> None:
+    """The focused regression itself must run in a required queue context."""
+    smoke_workflow = (WORKFLOW_DIR / "workflow-smoke-test.yml").read_text(encoding="utf-8")
+    assert "tests/smoke/test_merge_queue_workflow_properties.py" in smoke_workflow


### PR DESCRIPTION
## Summary

- replace #5626 with the same seven-file merge-queue readiness change rebased onto current `origin/main`
- document `merge_group` / `checks_requested` explicitly in the detailed `comprehensive-tests` and `pre-commit` sections
- add a focused regression that keeps those detailed trigger descriptions aligned with the workflows

## Safety and rollout

- no live ruleset or branch-protection mutation
- no secrets or force-push
- independent human workflow review remains a required external gate before merge
- live activation and representative queued-run evidence remain operator-owned under HomericIntelligence/Odysseus#386

## Verification

- focused merge-queue regression: 8 passed
- complete workflow smoke suite: 34 passed
- checkout-first validator: 24 workflow files passed
- changed-file pre-commit: passed, including mypy, Ruff, markdownlint, YAML, and security hooks
- full Python suite: 1225 passed, 222 skipped, 3 failed; all three failures reproduce on detached current `origin/main` (`bd84a78b`)
- commit: SSH signature verified locally (`G`) and one valid DCO `Signed-off-by` trailer

Supersedes #5626.

Refs #5624
