### PR TITLE
chore(recipe): bump conda package to 0.2.0 + Mojo >=1.0.0b2

### DIFF
--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -1,6 +1,6 @@
 context:
-  version: "0.1.0"
-  mojo_version: ">=1.0.0b1"
+  version: "0.2.0"
+  mojo_version: ">=1.0.0b2"
 
 package:
   name: "odyssey"


### PR DESCRIPTION
## Summary

`conda.recipe/recipe.yaml` still declared `version: 0.1.0` / `mojo_version: >=1.0.0b1`, while main's `pixi.toml` has been at `version = 0.2.0` / `mojo = ==1.0.0b2` since the toolchain repin. Bump the recipe context to match so a **v0.2.0 release** builds the current package.

Since 0.1.0, main has gained (all merged):
- **Layers:** RNN, LSTM, GRU, LayerNorm, Transformer FeedForward
- **Optimizers:** ADOPT, Sophia, Adan, Muon-Hyperball, LionMuon, MGUP-Muon, SOAP, FTRL-Proximal

The package name is already `odyssey`; this is a pure version/toolchain-floor bump so `release.yml` (which reads `context.version`) produces a correct 0.2.0 `.conda`.

## Test plan
- [x] YAML valid; pre-commit clean (trailing-ws / EOF / check-yaml pass).
- [ ] Follow-up: cut the v0.2.0 release (workflow_dispatch `release.yml`) once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)