### PR TITLE
feat(optimizers): add Schedule-Free (anytime iterate averaging)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ bash scripts/run_primitive_test.sh --list     # list known primitives + paths
 | MGUP-Muon | optimizer | `bash scripts/run_primitive_test.sh mgup_muon` |
 | SOAP | optimizer | `bash scripts/run_primitive_test.sh soap` |
 | FTRL-Proximal | optimizer | `bash scripts/run_primitive_test.sh ftrl` |
+| Schedule-Free (online iterate averaging — anytime) | optimizer | `bash scripts/run_primitive_test.sh schedule_free` |
 
 A primitive whose test file is not on the current branch is reported as
 `SKIP` (not a failure), so the runner works incrementally as each primitive

--- a/scripts/run_primitive_test.sh
+++ b/scripts/run_primitive_test.sh
@@ -32,6 +32,7 @@ TEST[ftrl]="tests/odyssey/training/optimizers/test_ftrl.mojo"
 TEST[lionmuon]="tests/odyssey/training/optimizers/test_lionmuon.mojo"
 TEST[mgup_muon]="tests/odyssey/training/optimizers/test_mgup_muon.mojo"
 TEST[muon_hyperball]="tests/odyssey/training/optimizers/test_muon_hyperball.mojo"
+TEST[schedule_free]="tests/odyssey/training/optimizers/test_schedule_free.mojo"
 TEST[soap]="tests/odyssey/training/optimizers/test_soap.mojo"
 TEST[sophia]="tests/odyssey/training/optimizers/test_sophia.mojo"
 # --- layers ---

--- a/src/odyssey/training/optimizers/__init__.mojo
+++ b/src/odyssey/training/optimizers/__init__.mojo
@@ -132,6 +132,12 @@ from odyssey.training.optimizers.soap import (
     init_soap_state,
 )
 
+# Schedule-Free optimizer (online iterate averaging — anytime; Defazio et al. 2024)
+from odyssey.training.optimizers.schedule_free import (
+    schedule_free_step,
+    schedule_free_step_simple,
+)
+
 # Optimizer utilities (common helper functions)
 from odyssey.training.optimizers.optimizer_utils import (
     initialize_optimizer_state,

--- a/src/odyssey/training/optimizers/schedule_free.mojo
+++ b/src/odyssey/training/optimizers/schedule_free.mojo
@@ -117,6 +117,10 @@ def schedule_free_step(
         raise Error(
             "schedule_free_step: params and gradients must have the same dtype"
         )
+    if params.dtype() != z.dtype():
+        raise Error("schedule_free_step: params and z must have the same dtype")
+    if params.dtype() != x.dtype():
+        raise Error("schedule_free_step: params and x must have the same dtype")
 
     # Fast sequence: z_{t+1} = z_t - gamma * g_t
     var lr_t = full_like(z, learning_rate)

--- a/src/odyssey/training/optimizers/schedule_free.mojo
+++ b/src/odyssey/training/optimizers/schedule_free.mojo
@@ -1,0 +1,186 @@
+"""Schedule-Free optimizer (online iterate averaging — anytime).
+
+Schedule-Free replaces explicit learning-rate schedules with online iterate
+averaging + interpolation over THREE coupled sequences. There is no fixed
+training horizon: the averaged iterate `x` is a good checkpoint at ANY step, so
+you get optimal-checkpoint behavior at every step instead of only at the end of
+a tuned schedule.
+
+The method maintains two persisted buffers, the fast sequence `z` and the
+running average `x`, and forms a third derived point `y` — the query point where
+the gradient is evaluated. Concretely, per step t (1-indexed):
+
+    y_t     = (1 - beta) * z_t + beta * x_t          (gradient query point)
+    g_t     = grad( f, y_t )                          (caller supplies this)
+    z_{t+1} = z_t - gamma * g_t                       (fast SGD-style sequence)
+    c_{t+1} = (r + 1) / (t + r + 1)                   (averaging weight)
+    x_{t+1} = (1 - c_{t+1}) * x_t + c_{t+1} * z_{t+1} (running average of z)
+
+`z` and `x` are the caller-managed state; `y` is recomputed each step. The model
+does its forward/backward pass at `y` (the "train" buffer), while `x` is the
+"eval"/checkpoint buffer — the .train()/.eval() buffer switch in the reference
+implementations. On the first step the state is initialized `z_1 = x_1 = params`
+(so `y_1 = params`); this pure-functional `schedule_free_step` advances the state
+and also returns the NEXT query point `y_{t+1}` for convenience.
+
+With the weight-power `r = 0` the schedule `c_{t+1} = (r+1)/(t+r+1) = 1/(t+1)`
+reduces `x` to the plain uniform average of the `z` iterates; larger `r`
+down-weights early iterates (a polynomial-decay weighting). `beta` (~0.9–0.95)
+is the interpolation between the fast and averaged sequences at the query point.
+
+Key characteristics:
+    - Two persisted buffers (`z`, `x`) — same memory as SGD+momentum, no
+      second-moment tensor. This is the Schedule-Free wrapper around SGD; a
+      base optimizer other than SGD would replace the `z` update below.
+    - Anytime: `x` is a valid checkpoint at every step; no horizon/schedule.
+    - The integer step `t` is caller-managed (drives the averaging weight
+      `c_{t+1}`); there is no EMA-style bias correction.
+    - dtypes: implemented against the float32/float64 elementwise SIMD API
+      (`add_simd`/`subtract_simd`/`multiply_simd` on matching-dtype tensors).
+      All buffers must share the params dtype; the step raises on a
+      params/gradients dtype OR shape mismatch (see the guards below). No mixed
+      dtypes: passing e.g. float32 params with float16 gradients raises.
+
+Reference:
+    Defazio, A., Yang, X. A., Mehta, H., Mishchenko, K., Khaled, A., &
+    Cutkosky, A. (2024). The Road Less Scheduled. Advances in Neural
+    Information Processing Systems (NeurIPS) 2024.
+    arXiv preprint arXiv:2405.15682
+    https://github.com/facebookresearch/schedule_free
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import full_like
+from odyssey.core.arithmetic_simd import (
+    subtract_simd,
+    multiply_simd,
+    add_simd,
+)
+
+
+def schedule_free_step(
+    params: AnyTensor,
+    gradients: AnyTensor,
+    z: AnyTensor,
+    x: AnyTensor,
+    step: Int,
+    learning_rate: Float64,
+    beta: Float64 = 0.9,
+    weight_power: Float64 = 0.0,
+) raises -> Tuple[AnyTensor, AnyTensor, AnyTensor]:
+    """Perform a single Schedule-Free (SGD) optimization step - pure functional.
+
+    Returns `(new_z, new_x, y_next)`: the advanced fast sequence `z_{t+1}`, the
+    advanced running average `x_{t+1}` (the eval/checkpoint buffer), and the
+    NEXT gradient query point `y_{t+1} = (1-beta)*z_{t+1} + beta*x_{t+1}` (the
+    train buffer the caller should evaluate the next gradient at). Caller manages
+    all state, including the integer step `t`.
+
+    IMPORTANT: `gradients` must be the gradient evaluated at the CURRENT query
+    point `y_t = (1-beta)*z_t + beta*x_t`, NOT at `z_t` or `x_t`. The caller is
+    responsible for having formed `y_t` (returned as `y_next` by the previous
+    call) and evaluated the gradient there. `params` is accepted only for the
+    shape/dtype guards and is otherwise unused (the state lives in `z`/`x`); on
+    the FIRST step, initialize both `z` and `x` to `params` so that
+    `y_1 = params`.
+
+    Args:
+        params: Model parameters (used for shape/dtype guards; the live state is
+            `z`/`x`). Initialize `z = x = params` on step 1.
+        gradients: Gradient of the loss w.r.t. the query point `y_t`.
+        z: Fast-sequence buffer `z_t` (SGD-style iterate). Init to `params`.
+        x: Running-average buffer `x_t` (eval/checkpoint iterate). Init to
+            `params`.
+        step: 1-indexed step counter `t`; drives the averaging weight
+            `c_{t+1} = (r+1)/(t+r+1)`.
+        learning_rate: Step size `gamma` for the fast `z` update.
+        beta: Interpolation between `z` and `x` at the query point (default 0.9;
+            paper's useful range ~0.9–0.95).
+        weight_power: Averaging weight power `r` (default 0.0 → uniform average
+            `c_{t+1} = 1/(t+1)`; larger `r` down-weights early iterates).
+
+    Returns:
+        Tuple of (new_z, new_x, y_next).
+
+    Raises:
+        Error: If tensor shapes or dtypes don't match.
+    """
+    if params.shape() != gradients.shape():
+        raise Error(
+            "schedule_free_step: params and gradients must have the same shape"
+        )
+    if params.shape() != z.shape():
+        raise Error("schedule_free_step: params and z must have the same shape")
+    if params.shape() != x.shape():
+        raise Error("schedule_free_step: params and x must have the same shape")
+    if params.dtype() != gradients.dtype():
+        raise Error(
+            "schedule_free_step: params and gradients must have the same dtype"
+        )
+
+    # Fast sequence: z_{t+1} = z_t - gamma * g_t
+    var lr_t = full_like(z, learning_rate)
+    var new_z = subtract_simd(z, multiply_simd(lr_t, gradients))
+
+    # Averaging weight: c_{t+1} = (r + 1) / (t + r + 1)
+    var c = (weight_power + 1.0) / (Float64(step) + weight_power + 1.0)
+
+    # Running average: x_{t+1} = (1 - c) * x_t + c * z_{t+1}
+    var one_minus_c = full_like(x, 1.0 - c)
+    var c_t = full_like(new_z, c)
+    var new_x = add_simd(
+        multiply_simd(one_minus_c, x),
+        multiply_simd(c_t, new_z),
+    )
+
+    # Next query point: y_{t+1} = (1 - beta) * z_{t+1} + beta * x_{t+1}
+    var one_minus_beta = full_like(new_z, 1.0 - beta)
+    var beta_t = full_like(new_x, beta)
+    var y_next = add_simd(
+        multiply_simd(one_minus_beta, new_z),
+        multiply_simd(beta_t, new_x),
+    )
+
+    return (new_z, new_x, y_next)
+
+
+def schedule_free_step_simple(
+    params: AnyTensor,
+    gradients: AnyTensor,
+    z: AnyTensor,
+    x: AnyTensor,
+    step: Int,
+    learning_rate: Float64,
+) raises -> Tuple[AnyTensor, AnyTensor, AnyTensor]:
+    """Simplified Schedule-Free step with default hyperparameters.
+
+    Convenience wrapper around `schedule_free_step` with the default
+    interpolation `beta = 0.9` and uniform averaging (`weight_power = 0.0`,
+    i.e. `c_{t+1} = 1/(t+1)`). Caller still manages the `z`/`x` buffers and the
+    integer step `t`. On step 1, initialize `z = x = params` (see
+    `schedule_free_step`).
+
+    Args:
+        params: Model parameters (shape/dtype guards; live state is `z`/`x`).
+        gradients: Gradient of the loss w.r.t. the query point `y_t`.
+        z: Fast-sequence buffer `z_t`. Init to `params`.
+        x: Running-average buffer `x_t`. Init to `params`.
+        step: 1-indexed step counter `t`.
+        learning_rate: Step size `gamma`.
+
+    Returns:
+        Tuple of (new_z, new_x, y_next).
+
+    Raises:
+        Error: If tensor shapes or dtypes don't match.
+    """
+    return schedule_free_step(
+        params,
+        gradients,
+        z,
+        x,
+        step,
+        learning_rate=learning_rate,
+        beta=0.9,
+        weight_power=0.0,
+    )

--- a/tests/odyssey/training/optimizers/parity_refs/schedule_free_parity_reference.py
+++ b/tests/odyssey/training/optimizers/parity_refs/schedule_free_parity_reference.py
@@ -1,0 +1,87 @@
+"""Schedule-Free parity reference (Defazio et al. 2024, "The Road Less Scheduled").
+
+Runs THREE Schedule-Free SGD steps for a fixed (params, grad) sequence with
+zero initial state and prints the resulting z, x, and next-query-point y after
+each step, so the Mojo `schedule_free_step` can be compared on identical inputs.
+
+The official `schedulefree` PyPI package is NOT available in the pinned
+interpreter, so this reference is a hand-rolled NumPy transcription of the exact
+update rule pinned in the tracking issue (mvillmow/Random#77). NumPy is used
+only as a calculator for that verified algorithm — the issue's rule WINS over
+any paper ambiguity.
+
+Schedule-Free update rule (per step t, 1-indexed; three sequences y/z/x):
+    y_t     = (1 - beta) * z_t + beta * x_t          (gradient query point)
+    g_t     = grad( f, y_t )                          (caller supplies this)
+    z_{t+1} = z_t - gamma * g_t                       (fast SGD-style sequence)
+    c_{t+1} = (r + 1) / (t + r + 1)                   (averaging weight)
+    x_{t+1} = (1 - c_{t+1}) * x_t + c_{t+1} * z_{t+1} (running average of z)
+
+`z` and `x` are the persisted state; `y` is recomputed each step and is the
+point the model uses for the forward/backward pass (train buffer). `x` is the
+eval/checkpoint buffer. On step 1 the state is initialized z_1 = x_1 = params.
+
+This transcription mirrors the reference `schedulefree.SGDScheduleFree`
+(z <- z - gamma*g; x <- (1-c)*x + c*z; y = (1-beta)*z + beta*x), with the
+weight schedule c_{t+1} = (r+1)/(t+r+1) — the r=0 default reduces to the
+uniform average c_{t+1} = 1/(t+1).
+"""
+
+import json
+
+import numpy as np
+
+# Hyperparameters. beta ~ 0.9 (interpolation), r = 0 (uniform-average weight
+# power), gamma = base learning rate.
+GAMMA, BETA, R = 0.1, 0.9, 0.0
+
+params = np.array([0.1, -0.2, 0.3, -0.4, 0.5])
+grads = [
+    np.array([0.05, 0.15, -0.25, 0.35, -0.45]),
+    np.array([0.08, 0.05, -0.20, 0.40, -0.30]),
+    np.array([-0.02, 0.10, -0.15, 0.20, -0.25]),
+]
+
+
+def schedule_free_step(z, x, grad, t, gamma=GAMMA, beta=BETA, r=R):
+    """One Schedule-Free step. Returns (z_next, x_next, y_next).
+
+    `grad` is the gradient evaluated at y_t = (1-beta)*z_t + beta*x_t; the
+    caller is responsible for having formed y_t and evaluated the gradient
+    there. This function advances the z/x state and returns the NEXT query
+    point y_{t+1} for convenience.
+    """
+    z_next = z - gamma * grad
+    c = (r + 1.0) / (t + r + 1.0)
+    x_next = (1.0 - c) * x + c * z_next
+    y_next = (1.0 - beta) * z_next + beta * x_next
+    return z_next, x_next, y_next
+
+
+# Step 1 state initialization: z_1 = x_1 = params, so y_1 = params.
+z = params.copy()
+x = params.copy()
+
+outs = []
+for i, g in enumerate(grads):
+    t = i + 1
+    z, x, y = schedule_free_step(z, x, g, t)
+    outs.append({"z": z.tolist(), "x": x.tolist(), "y_next": y.tolist()})
+
+print(
+    json.dumps(
+        {
+            "inputs": {
+                "params": params.tolist(),
+                "grads": [g.tolist() for g in grads],
+                "gamma": GAMMA,
+                "beta": BETA,
+                "r": R,
+            },
+            "step1_out": outs[0],
+            "step2_out": outs[1],
+            "step3_out": outs[2],
+        },
+        indent=2,
+    )
+)

--- a/tests/odyssey/training/optimizers/test_schedule_free.mojo
+++ b/tests/odyssey/training/optimizers/test_schedule_free.mojo
@@ -70,6 +70,11 @@ def test_parity_with_reference() raises:
     z and x are initialized to params (so y_1 = params); each step feeds the
     gradient evaluated at the current query point y_t. Three steps exercise the
     evolving averaging weight c_{t+1} = 1/(t+1): c_2=1/2, c_3=1/3, c_4=1/4.
+
+    All three returned sequences are asserted against the reference: the fast
+    sequence z, the averaged iterate x, AND the next query point y_next =
+    (1-beta)*z + beta*x (res[2]) — so an interpolation sign/coefficient bug in
+    the y blend is caught independently of the z/x math.
     """
     print("Running test_parity_with_reference...")
 
@@ -115,6 +120,26 @@ def test_parity_with_reference() raises:
     x3.append(-0.45125000000000004)
     x3.append(0.555)
 
+    # --- reference y_next after each step (the NEXT query point, res[2]) ---
+    var y1 = List[Float64]()
+    y1.append(0.09725)
+    y1.append(-0.20825000000000002)
+    y1.append(0.31375)
+    y1.append(-0.41924999999999996)
+    y1.append(0.52475)
+    var y2 = List[Float64]()
+    y2.append(0.09330000000000001)
+    y2.append(-0.21250000000000002)
+    y2.append(0.3255)
+    y2.append(-0.4405)
+    y2.append(0.5435000000000001)
+    var y3 = List[Float64]()
+    y3.append(0.09237500000000001)
+    y3.append(-0.21762500000000004)
+    y3.append(0.33525)
+    y3.append(-0.45562500000000006)
+    y3.append(0.5595000000000001)
+
     var p = zeros([n], DType.float64)
     var g1 = zeros([n], DType.float64)
     var g2 = zeros([n], DType.float64)
@@ -144,32 +169,41 @@ def test_parity_with_reference() raises:
     var res1 = schedule_free_step(p, g1, p, p, 1, 0.1, 0.9, 0.0)
     var nz1 = res1[0]
     var nx1 = res1[1]
+    var ny1 = res1[2]
     for i in range(n):
         if _abs_diff(nz1.load[DType.float64](i), z1[i]) > 1e-9:
             raise Error("schedule-free step-1 z mismatch at " + String(i))
         if _abs_diff(nx1.load[DType.float64](i), x1[i]) > 1e-9:
             raise Error("schedule-free step-1 x mismatch at " + String(i))
-    print("  ok step 1 z/x match reference to 1e-9")
+        if _abs_diff(ny1.load[DType.float64](i), y1[i]) > 1e-9:
+            raise Error("schedule-free step-1 y_next mismatch at " + String(i))
+    print("  ok step 1 z/x/y_next match reference to 1e-9")
 
     var res2 = schedule_free_step(p, g2, res1[0], res1[1], 2, 0.1, 0.9, 0.0)
     var nz2 = res2[0]
     var nx2 = res2[1]
+    var ny2 = res2[2]
     for i in range(n):
         if _abs_diff(nz2.load[DType.float64](i), z2[i]) > 1e-9:
             raise Error("schedule-free step-2 z mismatch at " + String(i))
         if _abs_diff(nx2.load[DType.float64](i), x2[i]) > 1e-9:
             raise Error("schedule-free step-2 x mismatch at " + String(i))
-    print("  ok step 2 z/x match reference to 1e-9 (c_3 = 1/3)")
+        if _abs_diff(ny2.load[DType.float64](i), y2[i]) > 1e-9:
+            raise Error("schedule-free step-2 y_next mismatch at " + String(i))
+    print("  ok step 2 z/x/y_next match reference to 1e-9 (c_3 = 1/3)")
 
     var res3 = schedule_free_step(p, g3, res2[0], res2[1], 3, 0.1, 0.9, 0.0)
     var nz3 = res3[0]
     var nx3 = res3[1]
+    var ny3 = res3[2]
     for i in range(n):
         if _abs_diff(nz3.load[DType.float64](i), z3[i]) > 1e-9:
             raise Error("schedule-free step-3 z mismatch at " + String(i))
         if _abs_diff(nx3.load[DType.float64](i), x3[i]) > 1e-9:
             raise Error("schedule-free step-3 x mismatch at " + String(i))
-    print("  ok step 3 z/x match reference to 1e-9 (c_4 = 1/4)")
+        if _abs_diff(ny3.load[DType.float64](i), y3[i]) > 1e-9:
+            raise Error("schedule-free step-3 y_next mismatch at " + String(i))
+    print("  ok step 3 z/x/y_next match reference to 1e-9 (c_4 = 1/4)")
     print("test_parity_with_reference PASSED")
 
 

--- a/tests/odyssey/training/optimizers/test_schedule_free.mojo
+++ b/tests/odyssey/training/optimizers/test_schedule_free.mojo
@@ -1,0 +1,283 @@
+"""Unit tests for the Schedule-Free optimizer (arXiv:2405.15682).
+
+Tests cover:
+- Shape/dtype guards on schedule_free_step
+- Numerical parity with the hand-rolled NumPy reference (1e-9) over THREE steps
+  so the z/x/y sequences and the averaging weight c_{t+1} = (r+1)/(t+r+1)
+  evolve (r=0 uniform-average case: c_2=1/2, c_3=1/3, c_4=1/4). The reference
+  transcribes the issue's pinned update rule (mvillmow/Random#77); the official
+  `schedulefree` package is not available in the pinned interpreter, so NumPy is
+  used as a calculator for that verified rule (see
+  parity_refs/schedule_free_parity_reference.py).
+- schedule_free_step_simple matches schedule_free_step with the default
+  hyperparameters
+- step-1 identity: with z = x = params, y_1 = params, so the first z step is a
+  plain SGD step and x_2 = (1-c_2)*params + c_2*z_2
+- descent direction (the averaged iterate x moves against a positive gradient)
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros, full
+from odyssey.training.optimizers.schedule_free import (
+    schedule_free_step,
+    schedule_free_step_simple,
+)
+
+
+def _abs_diff(a: Float64, b: Float64) -> Float64:
+    var d = a - b
+    if d < 0:
+        d = -d
+    return d
+
+
+def test_reject_shape_mismatch() raises:
+    """`schedule_free_step` rejects a params/gradients shape mismatch."""
+    print("Running test_reject_shape_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([5], DType.float32)
+    var z = zeros([4], DType.float32)
+    var x = zeros([4], DType.float32)
+    try:
+        var _ = schedule_free_step(p, g, z, x, 1, 0.1)
+        raise Error("Should have rejected shape mismatch")
+    except _:
+        print("  ok rejected shape mismatch")
+    print("test_reject_shape_mismatch PASSED")
+
+
+def test_reject_dtype_mismatch() raises:
+    """`schedule_free_step` rejects a params/gradients dtype mismatch."""
+    print("Running test_reject_dtype_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float16)
+    var z = zeros([4], DType.float32)
+    var x = zeros([4], DType.float32)
+    try:
+        var _ = schedule_free_step(p, g, z, x, 1, 0.1)
+        raise Error("Should have rejected dtype mismatch")
+    except _:
+        print("  ok rejected dtype mismatch")
+    print("test_reject_dtype_mismatch PASSED")
+
+
+def test_parity_with_reference() raises:
+    """Three Schedule-Free steps must match the NumPy reference to 1e-9.
+
+    Fixed inputs + reference outputs transcribed from
+    parity_refs/schedule_free_parity_reference.py (gamma=0.1, beta=0.9, r=0);
+    the reference transcribes the update rule pinned in mvillmow/Random#77.
+    z and x are initialized to params (so y_1 = params); each step feeds the
+    gradient evaluated at the current query point y_t. Three steps exercise the
+    evolving averaging weight c_{t+1} = 1/(t+1): c_2=1/2, c_3=1/3, c_4=1/4.
+    """
+    print("Running test_parity_with_reference...")
+
+    var n = 5
+
+    # --- reference z after each step ---
+    var z1 = List[Float64]()
+    z1.append(0.095)
+    z1.append(-0.21500000000000002)
+    z1.append(0.325)
+    z1.append(-0.435)
+    z1.append(0.545)
+    var z2 = List[Float64]()
+    z2.append(0.087)
+    z2.append(-0.22000000000000003)
+    z2.append(0.34500000000000003)
+    z2.append(-0.475)
+    z2.append(0.5750000000000001)
+    var z3 = List[Float64]()
+    z3.append(0.089)
+    z3.append(-0.23000000000000004)
+    z3.append(0.36000000000000004)
+    z3.append(-0.495)
+    z3.append(0.6000000000000001)
+
+    # --- reference x after each step ---
+    var x1 = List[Float64]()
+    x1.append(0.0975)
+    x1.append(-0.20750000000000002)
+    x1.append(0.3125)
+    x1.append(-0.4175)
+    x1.append(0.5225)
+    var x2 = List[Float64]()
+    x2.append(0.09400000000000001)
+    x2.append(-0.2116666666666667)
+    x2.append(0.32333333333333336)
+    x2.append(-0.4366666666666667)
+    x2.append(0.54)
+    var x3 = List[Float64]()
+    x3.append(0.09275)
+    x3.append(-0.21625000000000005)
+    x3.append(0.3325)
+    x3.append(-0.45125000000000004)
+    x3.append(0.555)
+
+    var p = zeros([n], DType.float64)
+    var g1 = zeros([n], DType.float64)
+    var g2 = zeros([n], DType.float64)
+    var g3 = zeros([n], DType.float64)
+    p.store[DType.float64](0, 0.1)
+    p.store[DType.float64](1, -0.2)
+    p.store[DType.float64](2, 0.3)
+    p.store[DType.float64](3, -0.4)
+    p.store[DType.float64](4, 0.5)
+    g1.store[DType.float64](0, 0.05)
+    g1.store[DType.float64](1, 0.15)
+    g1.store[DType.float64](2, -0.25)
+    g1.store[DType.float64](3, 0.35)
+    g1.store[DType.float64](4, -0.45)
+    g2.store[DType.float64](0, 0.08)
+    g2.store[DType.float64](1, 0.05)
+    g2.store[DType.float64](2, -0.20)
+    g2.store[DType.float64](3, 0.40)
+    g2.store[DType.float64](4, -0.30)
+    g3.store[DType.float64](0, -0.02)
+    g3.store[DType.float64](1, 0.10)
+    g3.store[DType.float64](2, -0.15)
+    g3.store[DType.float64](3, 0.20)
+    g3.store[DType.float64](4, -0.25)
+
+    # Init: z = x = params.
+    var res1 = schedule_free_step(p, g1, p, p, 1, 0.1, 0.9, 0.0)
+    var nz1 = res1[0]
+    var nx1 = res1[1]
+    for i in range(n):
+        if _abs_diff(nz1.load[DType.float64](i), z1[i]) > 1e-9:
+            raise Error("schedule-free step-1 z mismatch at " + String(i))
+        if _abs_diff(nx1.load[DType.float64](i), x1[i]) > 1e-9:
+            raise Error("schedule-free step-1 x mismatch at " + String(i))
+    print("  ok step 1 z/x match reference to 1e-9")
+
+    var res2 = schedule_free_step(p, g2, res1[0], res1[1], 2, 0.1, 0.9, 0.0)
+    var nz2 = res2[0]
+    var nx2 = res2[1]
+    for i in range(n):
+        if _abs_diff(nz2.load[DType.float64](i), z2[i]) > 1e-9:
+            raise Error("schedule-free step-2 z mismatch at " + String(i))
+        if _abs_diff(nx2.load[DType.float64](i), x2[i]) > 1e-9:
+            raise Error("schedule-free step-2 x mismatch at " + String(i))
+    print("  ok step 2 z/x match reference to 1e-9 (c_3 = 1/3)")
+
+    var res3 = schedule_free_step(p, g3, res2[0], res2[1], 3, 0.1, 0.9, 0.0)
+    var nz3 = res3[0]
+    var nx3 = res3[1]
+    for i in range(n):
+        if _abs_diff(nz3.load[DType.float64](i), z3[i]) > 1e-9:
+            raise Error("schedule-free step-3 z mismatch at " + String(i))
+        if _abs_diff(nx3.load[DType.float64](i), x3[i]) > 1e-9:
+            raise Error("schedule-free step-3 x mismatch at " + String(i))
+    print("  ok step 3 z/x match reference to 1e-9 (c_4 = 1/4)")
+    print("test_parity_with_reference PASSED")
+
+
+def test_step_simple_matches_defaults() raises:
+    """`schedule_free_step_simple` == `schedule_free_step` at default hypers."""
+    print("Running test_step_simple_matches_defaults...")
+    var n = 5
+    var p = zeros([n], DType.float64)
+    var g = zeros([n], DType.float64)
+    p.store[DType.float64](0, 0.1)
+    p.store[DType.float64](1, -0.2)
+    p.store[DType.float64](2, 0.3)
+    p.store[DType.float64](3, -0.4)
+    p.store[DType.float64](4, 0.5)
+    g.store[DType.float64](0, 0.05)
+    g.store[DType.float64](1, 0.15)
+    g.store[DType.float64](2, -0.25)
+    g.store[DType.float64](3, 0.35)
+    g.store[DType.float64](4, -0.45)
+
+    var simple = schedule_free_step_simple(p, g, p, p, 1, 0.1)
+    var full_call = schedule_free_step(p, g, p, p, 1, 0.1, 0.9, 0.0)
+
+    # Compare all three returned tensors (z, x, y_next). Tuple slots must be
+    # indexed with compile-time constants.
+    var sz = simple[0]
+    var fz = full_call[0]
+    var sx = simple[1]
+    var fx = full_call[1]
+    var sy = simple[2]
+    var fy = full_call[2]
+    for i in range(n):
+        if (
+            _abs_diff(sz.load[DType.float64](i), fz.load[DType.float64](i))
+            > 1e-12
+        ):
+            raise Error(
+                "schedule_free_step_simple z != defaults at " + String(i)
+            )
+        if (
+            _abs_diff(sx.load[DType.float64](i), fx.load[DType.float64](i))
+            > 1e-12
+        ):
+            raise Error(
+                "schedule_free_step_simple x != defaults at " + String(i)
+            )
+        if (
+            _abs_diff(sy.load[DType.float64](i), fy.load[DType.float64](i))
+            > 1e-12
+        ):
+            raise Error(
+                "schedule_free_step_simple y_next != defaults at " + String(i)
+            )
+    print("  ok schedule_free_step_simple matches defaults (z, x, y_next)")
+    print("test_step_simple_matches_defaults PASSED")
+
+
+def test_step1_identity() raises:
+    """Step 1 with z=x=params: the fast step is plain SGD, x is its blend.
+
+    y_1 = params, so z_2 = params - gamma*g and x_2 = (1-c_2)*params + c_2*z_2
+    with c_2 = 1/2. For params=1, g=0.5, gamma=0.1: z_2 = 0.95, x_2 = 0.975.
+    """
+    print("Running test_step1_identity...")
+    var n = 3
+    var p = full([n], 1.0, DType.float64)
+    var g = full([n], 0.5, DType.float64)
+    var res = schedule_free_step(p, g, p, p, 1, 0.1, 0.9, 0.0)
+    var z = res[0]
+    var x = res[1]
+    for i in range(n):
+        if _abs_diff(z.load[DType.float64](i), 0.95) > 1e-12:
+            raise Error("step-1 z should be params - gamma*g = 0.95")
+        if _abs_diff(x.load[DType.float64](i), 0.975) > 1e-12:
+            raise Error("step-1 x should be (1-c_2)*p + c_2*z_2 = 0.975")
+    print("  ok step-1 z=0.95, x=0.975 (plain SGD fast step + uniform blend)")
+    print("test_step1_identity PASSED")
+
+
+def test_descent_direction() raises:
+    """A positive gradient must decrease both z and the averaged iterate x."""
+    print("Running test_descent_direction...")
+    var n = 3
+    var p = full([n], 1.0, DType.float64)
+    var g = full([n], 0.5, DType.float64)
+    var res = schedule_free_step(p, g, p, p, 1, 0.01)
+    var z = res[0]
+    var x = res[1]
+    for i in range(n):
+        if not (z.load[DType.float64](i) < 1.0):
+            raise Error("positive gradient should decrease z")
+        if not (x.load[DType.float64](i) < 1.0):
+            raise Error("positive gradient should decrease averaged x")
+    print("  ok positive gradient decreased both z and x")
+    print("test_descent_direction PASSED")
+
+
+def main() raises:
+    """Run all Schedule-Free tests."""
+    print("=" * 60)
+    print("Schedule-Free Optimizer Test Suite")
+    print("=" * 60)
+    test_reject_shape_mismatch()
+    test_reject_dtype_mismatch()
+    test_parity_with_reference()
+    test_step_simple_matches_defaults()
+    test_step1_identity()
+    test_descent_direction()
+    print("=" * 60)
+    print("All Schedule-Free tests PASSED")
+    print("=" * 60)


### PR DESCRIPTION
## What

Adds the **Schedule-Free** optimizer (Defazio et al. 2024, "The Road Less Scheduled", NeurIPS 2024, arXiv:2405.15682) as a pure-functional optimizer step, mirroring the first-order-moment sibling convention (`adan.mojo`, `adopt.mojo`: state in, state out; caller manages all buffers and the integer step).

Schedule-Free replaces explicit LR schedules with online iterate averaging over three coupled sequences y/z/x — the averaged iterate `x` is a valid checkpoint at **any** step (anytime), so there's no fixed horizon.

## Update rule

```
y_t     = (1 - beta) * z_t + beta * x_t          (gradient query point)
z_{t+1} = z_t - gamma * grad(f, y_t)             (fast SGD-style sequence)
c_{t+1} = (r + 1) / (t + r + 1)                  (averaging weight)
x_{t+1} = (1 - c_{t+1}) * x_t + c_{t+1} * z_{t+1}  (running average of z)
```

`z`/`x` persist (SGD+momentum memory, no second-moment tensor); `y` is the train buffer, `x` the eval/checkpoint buffer. Step 1 initializes `z = x = params`. Follows the rule pinned in the tracking issue (the issue's rule wins over any paper ambiguity).

## Files

- `src/odyssey/training/optimizers/schedule_free.mojo` — `schedule_free_step` (beta, weight_power r hyperparameters) + `schedule_free_step_simple` (defaults beta=0.9, r=0). float32/float64 SIMD API; raises on params/gradients shape OR dtype mismatch (mixed dtypes documented + guarded with a raises-test).
- `tests/odyssey/training/optimizers/test_schedule_free.mojo` — 6 tests.
- `tests/odyssey/training/optimizers/parity_refs/schedule_free_parity_reference.py` — NumPy reference transcribing the issue rule (official `schedulefree` PyPI package not in the pinned interpreter; NumPy used as a calculator). Committed fixtures re-generated and diffed exact before commit.
- one-line registrations: optimizers `__init__.mojo` export, README primitive table row, `scripts/run_primitive_test.sh`.

## Test evidence

`bash scripts/run_primitive_test.sh schedule_free`:

```
▶  schedule_free  (tests/odyssey/training/optimizers/test_schedule_free.mojo)
============================================================
Schedule-Free Optimizer Test Suite
============================================================
Running test_reject_shape_mismatch...
  ok rejected shape mismatch
test_reject_shape_mismatch PASSED
Running test_reject_dtype_mismatch...
  ok rejected dtype mismatch
test_reject_dtype_mismatch PASSED
Running test_parity_with_reference...
  ok step 1 z/x match reference to 1e-9
  ok step 2 z/x match reference to 1e-9 (c_3 = 1/3)
  ok step 3 z/x match reference to 1e-9 (c_4 = 1/4)
test_parity_with_reference PASSED
Running test_step_simple_matches_defaults...
  ok schedule_free_step_simple matches defaults (z, x, y_next)
test_step_simple_matches_defaults PASSED
Running test_step1_identity...
  ok step-1 z=0.95, x=0.975 (plain SGD fast step + uniform blend)
test_step1_identity PASSED
Running test_descent_direction...
  ok positive gradient decreased both z and x
test_descent_direction PASSED
============================================================
All Schedule-Free tests PASSED
============================================================
✅ schedule_free PASSED
```

Committed fixtures verified exact against a re-run of the reference generator; `mojo format` clean on both new files (one-at-a-time); `ruff check` clean; `markdownlint-cli2 README.md` = 0 issues; repo pre-commit on all touched files = all hooks Passed/Skipped.

## Notes

- Base optimizer is SGD (the `z` update is the SGD step); a different base would replace that line. Parent of ScheduleFree+ / SF-NorMuon; combines with Prodigy.
- No BatchNorm dependency; pure elementwise first-order math (no matrix ops).

Closes #5641
Tracking: mvillmow/Random#77

🤖 Generated with [Claude Code](https://claude.com/claude-code)
