### PR TITLE
feat(optimizers): add Prodigy (parameter-free step-size estimation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ bash scripts/run_primitive_test.sh --list     # list known primitives + paths
 | LionMuon | optimizer | `bash scripts/run_primitive_test.sh lionmuon` |
 | MGUP-Muon | optimizer | `bash scripts/run_primitive_test.sh mgup_muon` |
 | SOAP | optimizer | `bash scripts/run_primitive_test.sh soap` |
+| Prodigy (parameter-free step-size estimation) | optimizer | `bash scripts/run_primitive_test.sh prodigy` |
 | FTRL-Proximal | optimizer | `bash scripts/run_primitive_test.sh ftrl` |
 
 A primitive whose test file is not on the current branch is reported as

--- a/scripts/run_primitive_test.sh
+++ b/scripts/run_primitive_test.sh
@@ -32,6 +32,7 @@ TEST[ftrl]="tests/odyssey/training/optimizers/test_ftrl.mojo"
 TEST[lionmuon]="tests/odyssey/training/optimizers/test_lionmuon.mojo"
 TEST[mgup_muon]="tests/odyssey/training/optimizers/test_mgup_muon.mojo"
 TEST[muon_hyperball]="tests/odyssey/training/optimizers/test_muon_hyperball.mojo"
+TEST[prodigy]="tests/odyssey/training/optimizers/test_prodigy.mojo"
 TEST[soap]="tests/odyssey/training/optimizers/test_soap.mojo"
 TEST[sophia]="tests/odyssey/training/optimizers/test_sophia.mojo"
 # --- layers ---

--- a/src/odyssey/training/optimizers/__init__.mojo
+++ b/src/odyssey/training/optimizers/__init__.mojo
@@ -132,6 +132,12 @@ from odyssey.training.optimizers.soap import (
     init_soap_state,
 )
 
+# Prodigy optimizer (parameter-free step-size estimation — Mishchenko & Defazio 2023)
+from odyssey.training.optimizers.prodigy import (
+    prodigy_step,
+    prodigy_step_simple,
+)
+
 # Optimizer utilities (common helper functions)
 from odyssey.training.optimizers.optimizer_utils import (
     initialize_optimizer_state,

--- a/src/odyssey/training/optimizers/prodigy.mojo
+++ b/src/odyssey/training/optimizers/prodigy.mojo
@@ -31,7 +31,8 @@ per-coordinate tensors. `gamma` is the base step-size SCHEDULE, default 1.0:
 Prodigy has "no learning rate to tune", so `gamma` normally stays fixed at 1.0
 and the d-estimate supplies the step scale. A `growth_rate` cap limits how fast
 d may grow per step (`d' <= growth_rate * d`), acting as a natural warmup; the
-default `inf` disables the cap (matching the paper's base algorithm).
+default (`1e30`) effectively disables the cap (matching the paper's base
+algorithm).
 
 Key characteristics:
     - No learning rate. `d` is estimated online and is monotone non-decreasing.

--- a/src/odyssey/training/optimizers/prodigy.mojo
+++ b/src/odyssey/training/optimizers/prodigy.mojo
@@ -1,0 +1,257 @@
+"""Prodigy optimizer (parameter-free step-size estimation, D-Adaptation family).
+
+Prodigy eliminates the learning-rate hyperparameter by estimating the distance
+to the solution, d_t ~= ||x_0 - x*||, online and using it to scale an Adam-style
+update. It is an "expeditiously adaptive" refinement of D-Adaptation: it weights
+the distance accumulators by an extra factor of d_t, which makes the estimate
+grow to the right scale far faster than D-Adaptation's linear schedule.
+
+This module implements the Adam variant (Algorithm 4 of the paper). The step is
+PURE FUNCTIONAL in the sibling idiom of this package: all state travels in and
+out. The per-coordinate buffers are the first moment `m`, second moment `v`, and
+the distance-numerator accumulator `s`; the SCALAR state is the distance
+numerator `r` and the current distance estimate `d`. The caller also supplies
+`x0`, the INITIAL parameter vector (captured once before the first step), which
+the distance accumulators reference for the whole run.
+
+Prodigy update rule (per step, using the CURRENT d in the accumulators and the
+parameter update — the paper's k=0.. recurrence):
+
+    m'  = beta1 * m + (1 - beta1) * d * g
+    v'  = beta2 * v + (1 - beta2) * d^2 * g^2
+    r'  = sqrt(beta2) * r + (1 - sqrt(beta2)) * gamma * d^2 * <g, x0 - x>
+    s'  = sqrt(beta2) * s + (1 - sqrt(beta2)) * gamma * d^2 * g
+    d_hat = r' / ||s'||_1                        (0 when ||s'||_1 == 0)
+    d'  = max(d, d_hat)                          (monotone non-decreasing)
+    x'  = x - gamma * d * m' / (sqrt(v') + d * eps)
+
+where `<.,.>` is the Euclidean inner product (a scalar), `||.||_1` is the L1
+norm (a scalar), `r`/`d` are scalars, and `m`/`v`/`s`/`x`/`x0`/`g` are
+per-coordinate tensors. `gamma` is the base step-size SCHEDULE, default 1.0:
+Prodigy has "no learning rate to tune", so `gamma` normally stays fixed at 1.0
+and the d-estimate supplies the step scale. A `growth_rate` cap limits how fast
+d may grow per step (`d' <= growth_rate * d`), acting as a natural warmup; the
+default `inf` disables the cap (matching the paper's base algorithm).
+
+Key characteristics:
+    - No learning rate. `d` is estimated online and is monotone non-decreasing.
+    - The distance estimate stays at `d0` until the numerator `r` becomes
+      positive (on step 1, x == x0 so <g, x0 - x> = 0, r stays 0, d stays d0);
+      it then grows as the parameters move away from x0.
+    - Memory: two Adam buffers (`m`, `v`) plus one distance-accumulator buffer
+      (`s`), plus the initial-parameter reference `x0` and two scalars (`r`,
+      `d`) — comparable to Adam plus one extra buffer.
+
+Dtype support:
+    Tested and numerically verified on FLOAT32 and FLOAT64 (the parity test runs
+    in float64). Like the sibling first-order optimizers in this package, the
+    step requires `params` and `gradients` to share a dtype and shape and will
+    `raise` otherwise (guarded and pinned by a raises-test). All state buffers
+    and `x0` must match the params shape. Mixed-precision (e.g. float16 params
+    with float32 state) is NOT supported and is not exercised.
+
+Reference:
+    Mishchenko, K., & Defazio, A. (2023). Prodigy: An Expeditiously Adaptive
+    Parameter-Free Learner. arXiv preprint arXiv:2306.06101.
+    (Algorithm 4, the Adam variant.)
+    https://arxiv.org/abs/2306.06101
+    https://github.com/konstmish/prodigy
+"""
+
+from std.math import sqrt as scalar_sqrt
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import full_like
+from odyssey.core.arithmetic_simd import (
+    subtract_simd,
+    multiply_simd,
+    add_simd,
+    divide_simd,
+)
+from odyssey.core.elementwise import sqrt, abs as elementwise_abs
+from odyssey.core.reduction import sum as reduce_sum
+
+
+def _scalar_sum(tensor: AnyTensor) raises -> Float64:
+    """Reduce a tensor to the scalar sum of all its elements (as Float64).
+
+    Reads the reduced scalar using the tensor's OWN dtype: `sum` preserves the
+    input dtype, so a float32 tensor must be read with `load[DType.float32]`.
+    Reading a float32-backed scalar with `load[DType.float64]` reinterprets the
+    lanes and yields garbage (the same class of bug seen in mixed-dtype helper
+    code), which would silently freeze the d-estimate on float32 runs.
+    """
+    var reduced = reduce_sum(tensor, axis=-1)
+    if tensor.dtype() == DType.float64:
+        return Float64(reduced.load[DType.float64](0))
+    else:
+        return Float64(reduced.load[DType.float32](0))
+
+
+def prodigy_step(
+    params: AnyTensor,
+    gradients: AnyTensor,
+    m: AnyTensor,
+    v: AnyTensor,
+    s: AnyTensor,
+    x0: AnyTensor,
+    r: Float64,
+    d: Float64,
+    gamma: Float64 = 1.0,
+    beta1: Float64 = 0.9,
+    beta2: Float64 = 0.999,
+    epsilon: Float64 = 1e-8,
+    growth_rate: Float64 = 1.0e30,
+) raises -> Tuple[AnyTensor, AnyTensor, AnyTensor, AnyTensor, Float64, Float64]:
+    """Perform a single Prodigy optimization step - pure functional.
+
+    Returns (new_params, new_m, new_v, new_s, new_r, new_d). The caller manages
+    all state, including the two SCALARS `r` (distance numerator) and `d` (the
+    distance estimate), and supplies `x0`, the INITIAL parameter vector captured
+    once before the first step (the distance accumulators reference it for the
+    whole run — pass the SAME `x0` on every call).
+
+    On the FIRST step, initialize `m`, `v`, `s` to zeros_like(params), `r = 0.0`,
+    `d = d0` (a small positive value such as 1e-6), and `x0 = params`. On step 1,
+    x == x0 so the inner product <g, x0 - x> is zero: `r` and `d_hat` stay 0 and
+    `d` stays at `d0`. From step 2 on, as the parameters move away from `x0`, the
+    numerator grows and `d` increases (monotone non-decreasing).
+
+    Args:
+        params: Model parameters to update.
+        gradients: Gradients of loss with respect to params.
+        m: First-moment buffer (EMA of d-weighted gradients).
+        v: Second-moment buffer (EMA of d^2-weighted squared gradients).
+        s: Distance-numerator accumulator (EMA of d^2-weighted gradients).
+        x0: Initial parameter vector (constant for the whole run; = params on
+            step 1). Referenced by the distance accumulators via <g, x0 - x>.
+        r: Scalar distance numerator from the previous step (0.0 on step 1).
+        d: Scalar distance estimate from the previous step (d0 on step 1).
+        gamma: Base step-size schedule (default 1.0). Prodigy has no learning
+            rate to tune; leave at 1.0 unless applying an external schedule.
+        beta1: EMA decay for the first moment (default: 0.9).
+        beta2: EMA decay for the second moment; its square root also decays the
+            distance accumulators r and s (default: 0.999).
+        epsilon: Numerical-stability term; enters the denominator as `d * eps`
+            (scaled by the current distance estimate, per the paper) (default:
+            1e-8).
+        growth_rate: Upper cap on per-step growth of the distance estimate:
+            `d' <= growth_rate * d`. The default (1e30) disables the cap; a
+            finite value (e.g. 1.01) provides a natural warmup by limiting how
+            fast d expands.
+
+    Returns:
+        Tuple of (new_params, new_m, new_v, new_s, new_r, new_d), where new_r
+        and new_d are Float64 scalars.
+
+    Raises:
+        Error: If tensor shapes or dtypes don't match.
+    """
+    if params.shape() != gradients.shape():
+        raise Error(
+            "prodigy_step: params and gradients must have the same shape"
+        )
+    if params.shape() != m.shape():
+        raise Error("prodigy_step: params and m must have the same shape")
+    if params.shape() != v.shape():
+        raise Error("prodigy_step: params and v must have the same shape")
+    if params.shape() != s.shape():
+        raise Error("prodigy_step: params and s must have the same shape")
+    if params.shape() != x0.shape():
+        raise Error("prodigy_step: params and x0 must have the same shape")
+    if params.dtype() != gradients.dtype():
+        raise Error(
+            "prodigy_step: params and gradients must have the same dtype"
+        )
+
+    var sqrt_beta2 = scalar_sqrt(beta2)
+    var one_minus_sqrt_beta2 = 1.0 - sqrt_beta2
+
+    # First moment: m' = beta1 * m + (1 - beta1) * d * g
+    var beta1_t = full_like(m, beta1)
+    var one_minus_beta1_d = full_like(m, (1.0 - beta1) * d)
+    var new_m = add_simd(
+        multiply_simd(beta1_t, m),
+        multiply_simd(one_minus_beta1_d, gradients),
+    )
+
+    # Second moment: v' = beta2 * v + (1 - beta2) * d^2 * g^2
+    var beta2_t = full_like(v, beta2)
+    var one_minus_beta2_d2 = full_like(v, (1.0 - beta2) * d * d)
+    var grad_sq = multiply_simd(gradients, gradients)
+    var new_v = add_simd(
+        multiply_simd(beta2_t, v),
+        multiply_simd(one_minus_beta2_d2, grad_sq),
+    )
+
+    # Distance numerator: r' = sqrt(b2)*r + (1-sqrt(b2))*gamma*d^2*<g, x0 - x>
+    var displacement = subtract_simd(x0, params)
+    var inner = _scalar_sum(multiply_simd(gradients, displacement))
+    var new_r = sqrt_beta2 * r + one_minus_sqrt_beta2 * gamma * d * d * inner
+
+    # Distance accumulator: s' = sqrt(b2)*s + (1-sqrt(b2))*gamma*d^2*g
+    var sqrt_beta2_t = full_like(s, sqrt_beta2)
+    var s_grad_coeff = full_like(s, one_minus_sqrt_beta2 * gamma * d * d)
+    var new_s = add_simd(
+        multiply_simd(sqrt_beta2_t, s),
+        multiply_simd(s_grad_coeff, gradients),
+    )
+
+    # Distance estimate: d_hat = r' / ||s'||_1 ; d' = max(d, d_hat), capped.
+    var s_l1 = _scalar_sum(elementwise_abs(new_s))
+    var d_hat = 0.0
+    if s_l1 != 0.0:
+        d_hat = new_r / s_l1
+    var new_d = d
+    if d_hat > new_d:
+        new_d = d_hat
+    # growth_rate cap: d' must not exceed growth_rate * d (natural warmup).
+    var d_cap = growth_rate * d
+    if new_d > d_cap:
+        new_d = d_cap
+
+    # Parameter update: x' = x - gamma * d * m' / (sqrt(v') + d * eps)
+    # NOTE: uses the CURRENT d (not d'), matching Algorithm 4.
+    var denom = add_simd(sqrt(new_v), full_like(new_v, d * epsilon))
+    var scaled_m = multiply_simd(full_like(new_m, gamma * d), new_m)
+    var update = divide_simd(scaled_m, denom)
+    var new_params = subtract_simd(params, update)
+
+    return (new_params, new_m, new_v, new_s, new_r, new_d)
+
+
+def prodigy_step_simple(
+    params: AnyTensor,
+    gradients: AnyTensor,
+    m: AnyTensor,
+    v: AnyTensor,
+    s: AnyTensor,
+    x0: AnyTensor,
+    r: Float64,
+    d: Float64,
+) raises -> Tuple[AnyTensor, AnyTensor, AnyTensor, AnyTensor, Float64, Float64]:
+    """Simplified Prodigy step with default hyperparameters (Mishchenko & Defazio 2023).
+
+    Convenience wrapper around `prodigy_step` for the common case: gamma = 1.0
+    (no learning rate to tune), betas (0.9, 0.999), epsilon 1e-8, and the growth
+    cap disabled. The caller still manages the m/v/s buffers, the x0 reference,
+    and the scalars r and d (initialize r = 0.0, d = d0 such as 1e-6, x0 =
+    params on step 1).
+
+    Args:
+        params: Model parameters to update.
+        gradients: Gradients of loss with respect to params.
+        m: First-moment buffer. Initialize to zeros_like(params).
+        v: Second-moment buffer. Initialize to zeros_like(params).
+        s: Distance-numerator accumulator. Initialize to zeros_like(params).
+        x0: Initial parameter vector (= params on step 1).
+        r: Scalar distance numerator from the previous step (0.0 on step 1).
+        d: Scalar distance estimate from the previous step (d0 on step 1).
+
+    Returns:
+        Tuple of (new_params, new_m, new_v, new_s, new_r, new_d).
+
+    Raises:
+        Error: If tensor shapes or dtypes don't match.
+    """
+    return prodigy_step(params, gradients, m, v, s, x0, r, d)

--- a/tests/odyssey/training/optimizers/parity_refs/prodigy_parity_reference.py
+++ b/tests/odyssey/training/optimizers/parity_refs/prodigy_parity_reference.py
@@ -1,0 +1,109 @@
+"""Prodigy parity reference (arXiv:2306.06101, Algorithm 4 — Adam variant).
+
+Runs SEVERAL Prodigy steps for a fixed (params, gradient) sequence with zero
+initial moment/accumulator state and prints, after each step, both the updated
+params AND the scalar distance estimate d. The gradient sequence is chosen so
+that the online distance estimate d_t GROWS past its tiny initial value d_0
+(a constant positive gradient on a positive starting point — a quadratic bowl
+`f(x) = 0.5*||x||^2`-style descent — makes <g, x_0 - x_k> positive and growing,
+which drives the numerator r_t up and hence d_t up). The Mojo `prodigy_step`
+is compared against these values on identical inputs.
+
+REFERENCE PROVENANCE: the official `prodigyopt` package is NOT installed in the
+project interpreter, so this file hand-rolls a NumPy transcription of the
+paper's Algorithm 4 (Adam variant) exactly as stated below. NumPy is used only
+as a calculator for that algorithm — there is no third-party Prodigy dependency
+to diff against. The transcription follows the tracking issue's update rule
+(mvillmow/Random#80): the D-Adaptation d-estimate sequence
+`d_{t+1} = max(d_t, r_{t+1} / ||s_{t+1}||_1)` with d·lr-weighted accumulators.
+
+Prodigy Adam-variant step (per step k, using CURRENT d_k in the accumulators
+and the parameter update; k here is 1-indexed for printing but the math is the
+paper's k=0.. recurrence):
+
+    m_{k+1} = beta1 * m_k + (1 - beta1) * d_k * g_k
+    v_{k+1} = beta2 * v_k + (1 - beta2) * d_k^2 * g_k^2
+    r_{k+1} = sqrt(beta2) * r_k
+              + (1 - sqrt(beta2)) * gamma * d_k^2 * <g_k, x_0 - x_k>
+    s_{k+1} = sqrt(beta2) * s_k
+              + (1 - sqrt(beta2)) * gamma * d_k^2 * g_k
+    d_hat   = r_{k+1} / ||s_{k+1}||_1        (0 if ||s||_1 == 0)
+    d_{k+1} = max(d_k, d_hat)
+    x_{k+1} = x_k - gamma * d_k * m_{k+1} / (sqrt(v_{k+1}) + d_k * eps)
+
+where gamma is the base step-size schedule (default 1.0 — Prodigy has "no
+learning rate to tune"; gamma stays fixed here), x_0 is the initial parameter
+vector, r/d are SCALARS, and s/m/v/params are per-coordinate.
+"""
+
+import json
+
+import numpy as np
+
+BETA1, BETA2, EPS, GAMMA = 0.9, 0.999, 1e-8, 1.0
+D0 = 1e-6
+N_STEPS = 5
+
+# Positive start, constant positive gradient: <g, x0 - x_k> grows as x_k
+# descends, so r_t (hence d_t) increases monotonically past D0.
+x0 = np.array([1.0, 2.0, 3.0, 4.0])
+grad = np.array([0.5, 0.5, 0.5, 0.5])
+
+sqrt_b2 = np.sqrt(BETA2)
+
+
+def run():
+    x = x0.copy()
+    m = np.zeros_like(x0)
+    v = np.zeros_like(x0)
+    s = np.zeros_like(x0)
+    r = 0.0
+    d = D0
+
+    params_per_step = []
+    d_per_step = []
+    for _ in range(N_STEPS):
+        g = grad  # constant gradient sequence
+        d_cur = d
+        m = BETA1 * m + (1.0 - BETA1) * d_cur * g
+        v = BETA2 * v + (1.0 - BETA2) * (d_cur**2) * (g * g)
+        inner = float(np.dot(g, x0 - x))
+        r = sqrt_b2 * r + (1.0 - sqrt_b2) * GAMMA * (d_cur**2) * inner
+        s = sqrt_b2 * s + (1.0 - sqrt_b2) * GAMMA * (d_cur**2) * g
+        s_l1 = float(np.sum(np.abs(s)))
+        d_hat = r / s_l1 if s_l1 != 0.0 else 0.0
+        d = max(d_cur, d_hat)
+        denom = np.sqrt(v) + d_cur * EPS
+        x = x - GAMMA * d_cur * m / denom
+
+        params_per_step.append(x.tolist())
+        d_per_step.append(d)
+
+    return params_per_step, d_per_step
+
+
+def main():
+    params_per_step, d_per_step = run()
+    print(
+        json.dumps(
+            {
+                "inputs": {
+                    "x0": x0.tolist(),
+                    "grad": grad.tolist(),
+                    "beta1": BETA1,
+                    "beta2": BETA2,
+                    "eps": EPS,
+                    "gamma": GAMMA,
+                    "d0": D0,
+                    "n_steps": N_STEPS,
+                },
+                "params_per_step": params_per_step,
+                "d_per_step": d_per_step,
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/odyssey/training/optimizers/test_prodigy.mojo
+++ b/tests/odyssey/training/optimizers/test_prodigy.mojo
@@ -1,0 +1,373 @@
+"""Unit tests for the Prodigy optimizer (arXiv:2306.06101, Algorithm 4).
+
+Tests cover:
+- Shape/dtype guards on prodigy_step (params/grad/m/v/s/x0 shape, params/grad
+  dtype) — the raises-tests that pin the documented dtype/shape contract
+- Numerical parity with the NumPy Algorithm-4 reference on FIVE steps, asserting
+  BOTH the params AND the scalar distance estimate d at each step, with a
+  gradient sequence chosen so d grows past d0 (1e-6 -> ~3.45e-5)
+- The d-estimate is monotone non-decreasing and actually grows past d0
+- prodigy_step_simple matches prodigy_step with the default hyperparameters
+- growth_rate cap limits per-step growth of d
+- descent direction (a positive gradient decreases a positive param)
+
+Reference values are transcribed from parity_refs/prodigy_parity_reference.py
+(re-run + diffed before committing). The official `prodigyopt` package is not
+installed in the project interpreter, so the reference is a NumPy transcription
+of the paper's Algorithm 4 (Adam variant), per the tracking issue's update rule.
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros, full
+from odyssey.training.optimizers.prodigy import (
+    prodigy_step,
+    prodigy_step_simple,
+)
+
+
+def _abs_diff(a: Float64, b: Float64) -> Float64:
+    var d = a - b
+    if d < 0:
+        d = -d
+    return d
+
+
+def test_reject_shape_mismatch() raises:
+    """`prodigy_step` rejects a params/gradients shape mismatch."""
+    print("Running test_reject_shape_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([5], DType.float32)
+    var m = zeros([4], DType.float32)
+    var v = zeros([4], DType.float32)
+    var s = zeros([4], DType.float32)
+    var x0 = zeros([4], DType.float32)
+    try:
+        var _ = prodigy_step(p, g, m, v, s, x0, 0.0, 1e-6)
+        raise Error("Should have rejected shape mismatch")
+    except _:
+        print("  ok rejected shape mismatch")
+    print("test_reject_shape_mismatch PASSED")
+
+
+def test_reject_state_shape_mismatch() raises:
+    """`prodigy_step` rejects a params/x0 (state) shape mismatch."""
+    print("Running test_reject_state_shape_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float32)
+    var m = zeros([4], DType.float32)
+    var v = zeros([4], DType.float32)
+    var s = zeros([4], DType.float32)
+    var x0 = zeros([5], DType.float32)  # wrong shape
+    try:
+        var _ = prodigy_step(p, g, m, v, s, x0, 0.0, 1e-6)
+        raise Error("Should have rejected x0 shape mismatch")
+    except _:
+        print("  ok rejected x0 shape mismatch")
+    print("test_reject_state_shape_mismatch PASSED")
+
+
+def test_reject_dtype_mismatch() raises:
+    """`prodigy_step` rejects a params/gradients dtype mismatch.
+
+    Pins the documented contract: params and gradients MUST share a dtype;
+    mixed dtypes raise rather than silently mis-computing.
+    """
+    print("Running test_reject_dtype_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float16)
+    var m = zeros([4], DType.float32)
+    var v = zeros([4], DType.float32)
+    var s = zeros([4], DType.float32)
+    var x0 = zeros([4], DType.float32)
+    try:
+        var _ = prodigy_step(p, g, m, v, s, x0, 0.0, 1e-6)
+        raise Error("Should have rejected dtype mismatch")
+    except _:
+        print("  ok rejected dtype mismatch")
+    print("test_reject_dtype_mismatch PASSED")
+
+
+def _make_state(n: Int) raises -> Tuple[AnyTensor, AnyTensor, AnyTensor]:
+    return (
+        zeros([n], DType.float64),
+        zeros([n], DType.float64),
+        zeros([n], DType.float64),
+    )
+
+
+def test_parity_with_reference() raises:
+    """Five Prodigy steps must match the Algorithm-4 reference to 1e-9.
+
+    Fixed inputs + reference outputs transcribed from
+    parity_refs/prodigy_parity_reference.py (gamma=1.0, betas=(0.9,0.999),
+    eps=1e-8, d0=1e-6). Asserts BOTH the params AND the scalar distance estimate
+    d at each of the 5 steps. The constant positive gradient on a positive start
+    makes <g, x0 - x> grow, driving d up from 1e-6 to ~3.45e-5.
+
+    Step 1: x == x0 so the inner product is 0, r stays 0, and d stays at d0.
+    Steps 2..5: d increases monotonically as the params move away from x0,
+    exercising the full D-Adaptation numerator/denominator recurrence.
+    """
+    print("Running test_parity_with_reference...")
+
+    var n = 4
+    var x0 = zeros([n], DType.float64)
+    x0.store[DType.float64](0, 1.0)
+    x0.store[DType.float64](1, 2.0)
+    x0.store[DType.float64](2, 3.0)
+    x0.store[DType.float64](3, 4.0)
+
+    var g = full([n], 0.5, DType.float64)
+
+    # Reference params after each step (from the NumPy reference).
+    var ref_p = List[List[Float64]]()
+    var p1 = List[Float64]()
+    p1.append(0.9999968377243398)
+    p1.append(1.9999968377243398)
+    p1.append(2.99999683772434)
+    p1.append(3.99999683772434)
+    ref_p.append(p1^)
+    var p2 = List[Float64]()
+    p2.append(0.9999925881345527)
+    p2.append(1.9999925881345528)
+    p2.append(2.999992588134553)
+    p2.append(3.999992588134553)
+    ref_p.append(p2^)
+    var p3 = List[Float64]()
+    p3.append(0.9999848264736261)
+    p3.append(1.9999848264736262)
+    p3.append(2.9999848264736264)
+    p3.append(3.9999848264736264)
+    ref_p.append(p3^)
+    var p4 = List[Float64]()
+    p4.append(0.9999622901162453)
+    p4.append(1.9999622901162453)
+    p4.append(2.9999622901162457)
+    p4.append(3.9999622901162457)
+    ref_p.append(p4^)
+    var p5 = List[Float64]()
+    p5.append(0.999901889528256)
+    p5.append(1.999901889528256)
+    p5.append(2.9999018895282563)
+    p5.append(3.9999018895282563)
+    ref_p.append(p5^)
+
+    # Reference distance estimate d after each step.
+    var ref_d = List[Float64]()
+    ref_d.append(1e-06)
+    ref_d.append(1.58153331227678e-06)
+    ref_d.append(4.822405024989585e-06)
+    ref_d.append(1.3496086407383853e-05)
+    ref_d.append(3.4509673326090946e-05)
+
+    # Initial state.
+    var state = _make_state(n)
+    var m = state[0]
+    var v = state[1]
+    var s = state[2]
+    var r = 0.0
+    var d = 1e-6
+
+    var p = zeros([n], DType.float64)
+    p.store[DType.float64](0, 1.0)
+    p.store[DType.float64](1, 2.0)
+    p.store[DType.float64](2, 3.0)
+    p.store[DType.float64](3, 4.0)
+
+    for step in range(5):
+        var res = prodigy_step(p, g, m, v, s, x0, r, d, 1.0, 0.9, 0.999, 1e-8)
+        p = res[0]
+        m = res[1]
+        v = res[2]
+        s = res[3]
+        r = res[4]
+        d = res[5]
+        for i in range(n):
+            if _abs_diff(p.load[DType.float64](i), ref_p[step][i]) > 1e-9:
+                raise Error(
+                    "prodigy param parity mismatch at step "
+                    + String(step + 1)
+                    + " idx "
+                    + String(i)
+                )
+        if _abs_diff(d, ref_d[step]) > 1e-12:
+            raise Error("prodigy d parity mismatch at step " + String(step + 1))
+    print("  ok 5 steps match the Algorithm-4 reference (params + d) to 1e-9")
+    print("test_parity_with_reference PASSED")
+
+
+def test_d_grows_and_is_monotone() raises:
+    """The distance estimate d must be monotone non-decreasing and grow past d0.
+    """
+    print("Running test_d_grows_and_is_monotone...")
+    var n = 4
+    var x0 = full([n], 1.0, DType.float64)
+    var g = full([n], 0.5, DType.float64)
+    var state = _make_state(n)
+    var m = state[0]
+    var v = state[1]
+    var s = state[2]
+    var r = 0.0
+    var d = 1e-6
+    var p = full([n], 1.0, DType.float64)
+
+    var prev_d = d
+    for _ in range(6):
+        var res = prodigy_step_simple(p, g, m, v, s, x0, r, d)
+        p = res[0]
+        m = res[1]
+        v = res[2]
+        s = res[3]
+        r = res[4]
+        d = res[5]
+        if d < prev_d:
+            raise Error("d must be monotone non-decreasing")
+        prev_d = d
+    if not (d > 1e-6):
+        raise Error("d must grow past d0")
+    print("  ok d monotone non-decreasing and grew past d0")
+    print("test_d_grows_and_is_monotone PASSED")
+
+
+def test_float32_d_grows() raises:
+    """Prodigy works on FLOAT32: the d-estimate must grow past d0.
+
+    Pins the documented float32 support and guards against the scalar-reduction
+    dtype bug (reading a float32-backed reduced scalar as float64 froze d at d0).
+    """
+    print("Running test_float32_d_grows...")
+    var n = 4
+    var x0 = full([n], 1.0, DType.float32)
+    var g = full([n], 0.5, DType.float32)
+    var m = zeros([n], DType.float32)
+    var v = zeros([n], DType.float32)
+    var s = zeros([n], DType.float32)
+    var r = 0.0
+    var d = 1e-6
+    var p = full([n], 1.0, DType.float32)
+    var prev_d = d
+    for _ in range(6):
+        var res = prodigy_step_simple(p, g, m, v, s, x0, r, d)
+        p = res[0]
+        m = res[1]
+        v = res[2]
+        s = res[3]
+        r = res[4]
+        d = res[5]
+        if d < prev_d:
+            raise Error("float32: d must be monotone non-decreasing")
+        prev_d = d
+    if not (d > 1e-6):
+        raise Error("float32: d must grow past d0 (dtype-read bug guard)")
+    print("  ok float32 d grew past d0")
+    print("test_float32_d_grows PASSED")
+
+
+def test_step_simple_matches_defaults() raises:
+    """`prodigy_step_simple` must equal `prodigy_step` with default hyperparams.
+    """
+    print("Running test_step_simple_matches_defaults...")
+    var n = 4
+    var x0 = full([n], 1.0, DType.float64)
+    var g = full([n], 0.3, DType.float64)
+    var state = _make_state(n)
+    var p = full([n], 1.0, DType.float64)
+
+    var simple = prodigy_step_simple(
+        p, g, state[0], state[1], state[2], x0, 0.0, 1e-6
+    )
+    var full_call = prodigy_step(
+        p, g, state[0], state[1], state[2], x0, 0.0, 1e-6, 1.0, 0.9, 0.999, 1e-8
+    )
+    var sp = simple[0]
+    var fp = full_call[0]
+    for i in range(n):
+        if (
+            _abs_diff(sp.load[DType.float64](i), fp.load[DType.float64](i))
+            > 1e-12
+        ):
+            raise Error(
+                "prodigy_step_simple != prodigy_step defaults at " + String(i)
+            )
+    if _abs_diff(simple[5], full_call[5]) > 1e-15:
+        raise Error("prodigy_step_simple d != prodigy_step d")
+    print("  ok prodigy_step_simple matches prodigy_step defaults")
+    print("test_step_simple_matches_defaults PASSED")
+
+
+def test_growth_rate_cap() raises:
+    """`growth_rate` caps per-step growth of d (d' <= growth_rate * d)."""
+    print("Running test_growth_rate_cap...")
+    var n = 4
+    var x0 = full([n], 1.0, DType.float64)
+    var g = full([n], 0.5, DType.float64)
+    var state = _make_state(n)
+    var m = state[0]
+    var v = state[1]
+    var s = state[2]
+    var r = 0.0
+    var d = 1e-6
+    var p = full([n], 1.0, DType.float64)
+    var growth = 1.5
+
+    # Drive several steps so the uncapped d would jump by more than 1.5x;
+    # with the cap, each step's d must satisfy d' <= 1.5 * d_prev.
+    for _ in range(6):
+        var prev_d = d
+        var res = prodigy_step(
+            p, g, m, v, s, x0, r, d, 1.0, 0.9, 0.999, 1e-8, growth
+        )
+        p = res[0]
+        m = res[1]
+        v = res[2]
+        s = res[3]
+        r = res[4]
+        d = res[5]
+        if d > growth * prev_d + 1e-18:
+            raise Error("growth_rate cap violated: d' > growth_rate * d")
+    print("  ok d growth is capped by growth_rate")
+    print("test_growth_rate_cap PASSED")
+
+
+def test_descent_direction() raises:
+    """A positive gradient must decrease the parameter."""
+    print("Running test_descent_direction...")
+    var n = 3
+    var x0 = full([n], 1.0, DType.float64)
+    var g = full([n], 0.5, DType.float64)
+    var state = _make_state(n)
+    var res = prodigy_step_simple(
+        full([n], 1.0, DType.float64),
+        g,
+        state[0],
+        state[1],
+        state[2],
+        x0,
+        0.0,
+        1e-3,
+    )
+    var np = res[0]
+    for i in range(n):
+        if not (np.load[DType.float64](i) < 1.0):
+            raise Error("positive gradient should decrease param")
+    print("  ok positive gradient decreased params")
+    print("test_descent_direction PASSED")
+
+
+def main() raises:
+    """Run all Prodigy tests."""
+    print("=" * 60)
+    print("Prodigy Optimizer Test Suite")
+    print("=" * 60)
+    test_reject_shape_mismatch()
+    test_reject_state_shape_mismatch()
+    test_reject_dtype_mismatch()
+    test_parity_with_reference()
+    test_d_grows_and_is_monotone()
+    test_float32_d_grows()
+    test_step_simple_matches_defaults()
+    test_growth_rate_cap()
+    test_descent_direction()
+    print("=" * 60)
+    print("All Prodigy tests PASSED")
+    print("=" * 60)


### PR DESCRIPTION

Closes #5643
Tracking: mvillmow/Random#80

## What

Adds the **Prodigy** optimizer (Mishchenko & Defazio 2023, arXiv:2306.06101,
Algorithm 4 — the Adam variant) to `odyssey.training.optimizers`, mirroring the
existing first-order-moment family (`adan.mojo`, `adopt.mojo`). Prodigy is a
D-Adaptation-family learner that estimates the distance-to-solution
`d_t ≈ ‖x₀ − x*‖` online and uses it to scale an Adam-style update — **no
learning rate to tune**.

## Files

- **`src/odyssey/training/optimizers/prodigy.mojo`** (new) — `prodigy_step`
  (full hyperparameters) + `prodigy_step_simple` (defaults). Pure-functional in
  the sibling idiom: per-coordinate `m`/`v`/`s` buffers plus the scalar `r`
  (distance numerator) and `d` (distance estimate) and the `x0` reference all
  travel in and out.
- **`tests/odyssey/training/optimizers/test_prodigy.mojo`** (new) — 9 tests.
- **`tests/odyssey/training/optimizers/parity_refs/prodigy_parity_reference.py`**
  (new) — committed NumPy reference (Algorithm 4 transcription; `prodigyopt`
  is not installed, so this is a hand-rolled numpy calculator for the paper's
  rule, as stated in the file header). Re-run and diffed against the committed
  fixtures before commit.
- **`src/odyssey/training/optimizers/__init__.mojo`** — one export block.
- **`README.md`** — one primitive-table row.
- **`scripts/run_primitive_test.sh`** — one registration line.

## Algorithm (Adam variant)

```
m'    = beta1 * m + (1 - beta1) * d * g
v'    = beta2 * v + (1 - beta2) * d^2 * g^2
r'    = sqrt(beta2) * r + (1 - sqrt(beta2)) * gamma * d^2 * <g, x0 - x>
s'    = sqrt(beta2) * s + (1 - sqrt(beta2)) * gamma * d^2 * g
d_hat = r' / ||s'||_1
d'    = max(d, d_hat)                 (monotone non-decreasing)
x'    = x - gamma * d * m' / (sqrt(v') + d * eps)
```

Defaults: `gamma=1.0` (no LR), `beta1=0.9`, `beta2=0.999`, `eps=1e-8`,
`d0=1e-6`, `growth_rate` cap disabled.

## Dtype support (honest)

float32 **and** float64. The parity test runs in float64; a dedicated float32
d-growth test guards the scalar-reduction dtype read (the reduced accumulator
must be read with the tensor's own dtype — reading a float32-backed scalar as
float64 froze `d` at `d0`; fixed and pinned). `params`/`gradients` must share
dtype and shape; the step raises otherwise (raises-tests included). Mixed
precision is not supported and is documented as such.

## Test evidence

```
▶  prodigy  (tests/odyssey/training/optimizers/test_prodigy.mojo)
============================================================
Prodigy Optimizer Test Suite
============================================================
Running test_reject_shape_mismatch...
  ok rejected shape mismatch
test_reject_shape_mismatch PASSED
Running test_reject_state_shape_mismatch...
  ok rejected x0 shape mismatch
test_reject_state_shape_mismatch PASSED
Running test_reject_dtype_mismatch...
  ok rejected dtype mismatch
test_reject_dtype_mismatch PASSED
Running test_parity_with_reference...
  ok 5 steps match the Algorithm-4 reference (params + d) to 1e-9
test_parity_with_reference PASSED
Running test_d_grows_and_is_monotone...
  ok d monotone non-decreasing and grew past d0
test_d_grows_and_is_monotone PASSED
Running test_float32_d_grows...
  ok float32 d grew past d0
test_float32_d_grows PASSED
Running test_step_simple_matches_defaults...
  ok prodigy_step_simple matches prodigy_step defaults
test_step_simple_matches_defaults PASSED
Running test_growth_rate_cap...
  ok d growth is capped by growth_rate
test_growth_rate_cap PASSED
Running test_descent_direction...
  ok positive gradient decreased params
test_descent_direction PASSED
============================================================
All Prodigy tests PASSED
============================================================
✅ prodigy PASSED
```

Parity reference regenerated and diffed against the committed test fixtures
(d_per_step: 1e-6, 1.58e-6, 4.82e-6, 1.35e-5, 3.45e-5 — exact match).

Quality gates: `mojo format` (per-file), `ruff check`/`ruff format`,
`markdownlint-cli2`, and repo `pre-commit run --files` on all touched files —
all pass.

## Reference

Mishchenko, K., & Defazio, A. (2023). *Prodigy: An Expeditiously Adaptive
Parameter-Free Learner.* arXiv:2306.06101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
