### PR TITLE
feat(optimizers): add ScheduleFree+ (large-batch-stable schedule-free)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ bash scripts/run_primitive_test.sh --list     # list known primitives + paths
 | MGUP-Muon | optimizer | `bash scripts/run_primitive_test.sh mgup_muon` |
 | SOAP | optimizer | `bash scripts/run_primitive_test.sh soap` |
 | FTRL-Proximal | optimizer | `bash scripts/run_primitive_test.sh ftrl` |
+| ScheduleFree+ (large-batch-stable schedule-free) | optimizer | `bash scripts/run_primitive_test.sh schedule_free_plus` |
 
 A primitive whose test file is not on the current branch is reported as
 `SKIP` (not a failure), so the runner works incrementally as each primitive

--- a/scripts/run_primitive_test.sh
+++ b/scripts/run_primitive_test.sh
@@ -32,6 +32,7 @@ TEST[ftrl]="tests/odyssey/training/optimizers/test_ftrl.mojo"
 TEST[lionmuon]="tests/odyssey/training/optimizers/test_lionmuon.mojo"
 TEST[mgup_muon]="tests/odyssey/training/optimizers/test_mgup_muon.mojo"
 TEST[muon_hyperball]="tests/odyssey/training/optimizers/test_muon_hyperball.mojo"
+TEST[schedule_free_plus]="tests/odyssey/training/optimizers/test_schedule_free_plus.mojo"
 TEST[soap]="tests/odyssey/training/optimizers/test_soap.mojo"
 TEST[sophia]="tests/odyssey/training/optimizers/test_sophia.mojo"
 # --- layers ---

--- a/src/odyssey/training/optimizers/__init__.mojo
+++ b/src/odyssey/training/optimizers/__init__.mojo
@@ -132,6 +132,12 @@ from odyssey.training.optimizers.soap import (
     init_soap_state,
 )
 
+# ScheduleFree+ optimizer (large-batch-stable schedule-free — Defazio 2026)
+from odyssey.training.optimizers.schedule_free_plus import (
+    schedule_free_plus_step,
+    schedule_free_plus_step_simple,
+)
+
 # Optimizer utilities (common helper functions)
 from odyssey.training.optimizers.optimizer_utils import (
     initialize_optimizer_state,

--- a/src/odyssey/training/optimizers/schedule_free_plus.mojo
+++ b/src/odyssey/training/optimizers/schedule_free_plus.mojo
@@ -1,0 +1,296 @@
+"""ScheduleFree+ optimizer (large-batch-stable schedule-free).
+
+ScheduleFree+ is the large-batch-stability variant of Schedule-Free. The base
+Schedule-Free method removes explicit learning-rate schedules via online iterate
+averaging over the fast sequence `z` and the running average `x`, evaluating the
+gradient at an interpolated query point `y`. At LLM / large-batch scale the base
+method can diverge and its uniform averaging under-performs on long runs.
+ScheduleFree+ adds three stability mechanisms — this module transcribes them
+EXACTLY as written in the tracking issue (mvillmow/Random#78), whose rule wins
+over any base-paper ambiguity:
+
+    (1) Inner momentum — a momentum buffer `m` is accumulated INSIDE the base-seq
+        update, and the fast sequence `z` steps on the momentum buffer (not the
+        raw gradient). Momentum helps large-batch training where the raw-gradient
+        step diverges.
+
+            m_{t+1} = mu * m_t + (1 - mu) * g_t
+            z_{t+1} = z_t - lr_t * m_{t+1}
+
+    (2) Polyak step-size — the per-step step size `lr_t` is a scaled Polyak step
+        formed from the (caller-supplied) globally-reduced objective `f(y_t)`,
+        the correlation between the gradient and `(z_t - x_t)`, and an L1 EMA of
+        the gradient magnitude:
+
+            gnorm_t = rho * gnorm_{t-1} + (1 - rho) * mean(|g_t|)   (L1-EMA norm)
+            polyak  = max(0, f(y_t) + beta_sf * <g_t, z_t - x_t>) / (gnorm_t + eps)
+            lr_t    = learning_rate * polyak
+
+    (3) Increasing outer momentum — the outer momentum `beta_out` (the
+        interpolation / averaging weight) anneals from `beta_sf` up to `beta_max`
+        across the run, which helps long training runs:
+
+            frac      = min(1, (t - 1) / max(1, horizon - 1))
+            beta_out  = beta_sf + (beta_max - beta_sf) * frac
+            x_{t+1}   = beta_out * x_t + (1 - beta_out) * z_{t+1}
+            y_{t+1}   = (1 - beta_out) * z_{t+1} + beta_out * x_{t+1}  (next query)
+
+`z`, `x`, and `m` are the caller-managed persisted state; `gnorm` (a scalar L1
+EMA) is threaded through the return; `y` is recomputed each step. The model does
+its forward/backward pass at `y` (the "train" buffer), while `x` is the
+"eval"/checkpoint buffer. On the FIRST step, initialize `z = x = params`,
+`m = 0`, and `gnorm = 0.0` (so `y_1 = params`). The Polyak numerator requires the
+globally-reduced objective `f(y_t)` at the current query point — the caller
+supplies it (per the issue's "Polyak step needs the globally-reduced objective
+f(y_t)").
+
+Key characteristics:
+    - Three persisted buffers (`z`, `x`, `m`) plus one scalar (`gnorm`) — one
+      buffer more than base Schedule-Free (the added inner-momentum buffer).
+    - Anytime: `x` is a valid checkpoint at every step; no horizon/schedule for
+      the LR itself (the `horizon` argument only paces the outer-momentum anneal
+      and is NOT a training-length dependency for the averaged iterate).
+    - The integer step `t` is caller-managed (drives the outer-momentum anneal).
+    - dtypes: implemented against the float32/float64 elementwise SIMD API
+      (`add_simd`/`subtract_simd`/`multiply_simd` on matching-dtype tensors);
+      the scalar reductions (`<g, z-x>`, `mean(|g|)`) read every element as
+      Float64 and so work for any real params dtype. All buffers must share the
+      params dtype; the step raises on a params/gradients dtype OR shape mismatch
+      (see the guards below). No mixed dtypes: float32 params with float16
+      gradients raises.
+
+References:
+    Base Schedule-Free method:
+        Defazio, A., Yang, X. A., Mehta, H., Mishchenko, K., Khaled, A., &
+        Cutkosky, A. (2024). The Road Less Scheduled. NeurIPS 2024.
+        arXiv:2405.15682. https://github.com/facebookresearch/schedule_free
+    ScheduleFree+ (large-batch-stable variant):
+        Defazio, A. (2026). ScheduleFree+: Scaling Learning-Rate-Free &
+        Schedule-Free Learning to Large Language Models. arXiv:2605.19095.
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import full_like
+from odyssey.core.arithmetic_simd import (
+    subtract_simd,
+    multiply_simd,
+    add_simd,
+)
+
+
+def _dot_float64(a: AnyTensor, b: AnyTensor) -> Float64:
+    """Scalar dot product <a, b> read elementwise as Float64 (dtype-agnostic).
+    """
+    var acc = 0.0
+    for i in range(a.numel()):
+        acc += a._get_float64(i) * b._get_float64(i)
+    return acc
+
+
+def _mean_abs_float64(a: AnyTensor) -> Float64:
+    """Mean absolute value of `a` read elementwise as Float64 (L1-EMA input)."""
+    var acc = 0.0
+    var n = a.numel()
+    if n == 0:
+        return 0.0
+    for i in range(n):
+        var v = a._get_float64(i)
+        if v < 0:
+            v = -v
+        acc += v
+    return acc / Float64(n)
+
+
+def schedule_free_plus_step(
+    params: AnyTensor,
+    gradients: AnyTensor,
+    z: AnyTensor,
+    x: AnyTensor,
+    m: AnyTensor,
+    gnorm: Float64,
+    objective: Float64,
+    step: Int,
+    learning_rate: Float64,
+    mu: Float64 = 0.9,
+    beta_sf: Float64 = 0.9,
+    beta_max: Float64 = 0.98,
+    rho: Float64 = 0.9,
+    epsilon: Float64 = 1e-8,
+    horizon: Int = 1000,
+) raises -> Tuple[AnyTensor, AnyTensor, AnyTensor, Float64, AnyTensor, Float64]:
+    """Perform a single ScheduleFree+ optimization step - pure functional.
+
+    Returns `(new_z, new_x, new_m, new_gnorm, y_next, lr_t)`: the advanced fast
+    sequence `z_{t+1}`, the advanced running average `x_{t+1}` (the
+    eval/checkpoint buffer), the advanced inner-momentum buffer `m_{t+1}`, the
+    advanced L1-EMA gradient-norm scalar `gnorm_{t+1}`, the NEXT gradient query
+    point `y_{t+1} = (1 - beta_out) * z_{t+1} + beta_out * x_{t+1}` (the train
+    buffer the caller should evaluate the next gradient/objective at), and the
+    Polyak step size `lr_t` actually used this step (returned for logging).
+
+    IMPORTANT: `gradients` and `objective` must be the gradient and the
+    globally-reduced objective value evaluated at the CURRENT query point
+    `y_t = (1 - beta_out) * z_t + beta_out * x_t`, NOT at `z_t` or `x_t`. The
+    caller is responsible for having formed `y_t` (returned as `y_next` by the
+    previous call) and evaluated the gradient and objective there. On the FIRST
+    step, initialize `z = x = params`, `m = 0`, and `gnorm = 0.0` so that
+    `y_1 = params`.
+
+    Args:
+        params: Model parameters (used for shape/dtype guards; the live state is
+            `z`/`x`/`m`). Initialize `z = x = params`, `m = 0` on step 1.
+        gradients: Gradient of the loss w.r.t. the query point `y_t`.
+        z: Fast-sequence buffer `z_t` (steps on the inner-momentum buffer). Init
+            to `params`.
+        x: Running-average buffer `x_t` (eval/checkpoint iterate). Init to
+            `params`.
+        m: Inner-momentum buffer `m_t`. Init to zeros.
+        gnorm: L1-EMA of the gradient magnitude `gnorm_{t-1}` (scalar). Init to
+            0.0 on step 1.
+        objective: The globally-reduced objective value `f(y_t)` at the current
+            query point (Polyak numerator). Caller supplies it.
+        step: 1-indexed step counter `t`; drives the outer-momentum anneal.
+        learning_rate: Base step size the Polyak factor scales.
+        mu: Inner-momentum coefficient (default 0.9).
+        beta_sf: Base outer momentum AND the Polyak correlation weight (default
+            0.9; the outer-momentum anneal starts here).
+        beta_max: Outer momentum annealed to across the run (default 0.98).
+        rho: L1-EMA decay for the gradient-magnitude normaliser (default 0.9).
+        epsilon: Numerical-stability term added to the L1-EMA denominator
+            (default 1e-8).
+        horizon: Anneal length (in steps) for the increasing outer momentum;
+            `beta_out` reaches `beta_max` at `step == horizon` (default 1000).
+            This paces the outer-momentum anneal ONLY — it is not a schedule for
+            the LR or the averaged iterate.
+
+    Returns:
+        Tuple of (new_z, new_x, new_m, new_gnorm, y_next, lr_t).
+
+    Raises:
+        Error: If tensor shapes or dtypes don't match.
+    """
+    if params.shape() != gradients.shape():
+        raise Error(
+            "schedule_free_plus_step: params and gradients must have the same"
+            " shape"
+        )
+    if params.shape() != z.shape():
+        raise Error(
+            "schedule_free_plus_step: params and z must have the same shape"
+        )
+    if params.shape() != x.shape():
+        raise Error(
+            "schedule_free_plus_step: params and x must have the same shape"
+        )
+    if params.shape() != m.shape():
+        raise Error(
+            "schedule_free_plus_step: params and m must have the same shape"
+        )
+    if params.dtype() != gradients.dtype():
+        raise Error(
+            "schedule_free_plus_step: params and gradients must have the same"
+            " dtype"
+        )
+
+    # (1) Inner momentum: m_{t+1} = mu * m_t + (1 - mu) * g_t
+    var mu_t = full_like(m, mu)
+    var one_minus_mu = full_like(m, 1.0 - mu)
+    var new_m = add_simd(
+        multiply_simd(mu_t, m),
+        multiply_simd(one_minus_mu, gradients),
+    )
+
+    # (2) Polyak step-size.
+    #   gnorm_t = rho * gnorm_{t-1} + (1 - rho) * mean(|g_t|)   (L1-EMA norm)
+    var new_gnorm = rho * gnorm + (1.0 - rho) * _mean_abs_float64(gradients)
+    #   polyak  = max(0, f(y_t) + beta_sf * <g_t, z_t - x_t>) / (gnorm_t + eps)
+    var corr = _dot_float64(gradients, subtract_simd(z, x))
+    var polyak_num = objective + beta_sf * corr
+    if polyak_num < 0.0:
+        polyak_num = 0.0
+    var polyak = polyak_num / (new_gnorm + epsilon)
+    var lr_t = learning_rate * polyak
+
+    # Fast sequence steps on the momentum buffer: z_{t+1} = z_t - lr_t * m_{t+1}
+    var lr_tensor = full_like(z, lr_t)
+    var new_z = subtract_simd(z, multiply_simd(lr_tensor, new_m))
+
+    # (3) Increasing outer momentum: anneal beta_out from beta_sf to beta_max.
+    var frac = Float64(step - 1) / Float64(horizon - 1 if horizon > 1 else 1)
+    if frac > 1.0:
+        frac = 1.0
+    var beta_out = beta_sf + (beta_max - beta_sf) * frac
+
+    #   x_{t+1} = beta_out * x_t + (1 - beta_out) * z_{t+1}
+    var beta_out_t = full_like(x, beta_out)
+    var one_minus_beta_out = full_like(x, 1.0 - beta_out)
+    var new_x = add_simd(
+        multiply_simd(beta_out_t, x),
+        multiply_simd(one_minus_beta_out, new_z),
+    )
+
+    #   y_{t+1} = (1 - beta_out) * z_{t+1} + beta_out * x_{t+1}
+    var one_minus_beta_out_z = full_like(new_z, 1.0 - beta_out)
+    var beta_out_x = full_like(new_x, beta_out)
+    var y_next = add_simd(
+        multiply_simd(one_minus_beta_out_z, new_z),
+        multiply_simd(beta_out_x, new_x),
+    )
+
+    return (new_z, new_x, new_m, new_gnorm, y_next, lr_t)
+
+
+def schedule_free_plus_step_simple(
+    params: AnyTensor,
+    gradients: AnyTensor,
+    z: AnyTensor,
+    x: AnyTensor,
+    m: AnyTensor,
+    gnorm: Float64,
+    objective: Float64,
+    step: Int,
+    learning_rate: Float64,
+) raises -> Tuple[AnyTensor, AnyTensor, AnyTensor, Float64, AnyTensor, Float64]:
+    """Simplified ScheduleFree+ step with default hyperparameters.
+
+    Convenience wrapper around `schedule_free_plus_step` with the default inner
+    momentum `mu = 0.9`, `beta_sf = 0.9`, `beta_max = 0.98`, `rho = 0.9`,
+    `epsilon = 1e-8`, and `horizon = 1000`. The caller still manages the
+    `z`/`x`/`m` buffers, the scalar `gnorm`, the objective `f(y_t)`, and the
+    integer step `t`. On step 1, initialize `z = x = params`, `m = 0`,
+    `gnorm = 0.0` (see `schedule_free_plus_step`).
+
+    Args:
+        params: Model parameters (shape/dtype guards; live state is `z`/`x`/`m`).
+        gradients: Gradient of the loss w.r.t. the query point `y_t`.
+        z: Fast-sequence buffer `z_t`. Init to `params`.
+        x: Running-average buffer `x_t`. Init to `params`.
+        m: Inner-momentum buffer `m_t`. Init to zeros.
+        gnorm: L1-EMA gradient-norm scalar `gnorm_{t-1}`. Init to 0.0.
+        objective: Globally-reduced objective `f(y_t)` at the query point.
+        step: 1-indexed step counter `t`.
+        learning_rate: Base step size scaled by the Polyak factor.
+
+    Returns:
+        Tuple of (new_z, new_x, new_m, new_gnorm, y_next, lr_t).
+
+    Raises:
+        Error: If tensor shapes or dtypes don't match.
+    """
+    return schedule_free_plus_step(
+        params,
+        gradients,
+        z,
+        x,
+        m,
+        gnorm,
+        objective,
+        step,
+        learning_rate=learning_rate,
+        mu=0.9,
+        beta_sf=0.9,
+        beta_max=0.98,
+        rho=0.9,
+        epsilon=1e-8,
+        horizon=1000,
+    )

--- a/src/odyssey/training/optimizers/schedule_free_plus.mojo
+++ b/src/odyssey/training/optimizers/schedule_free_plus.mojo
@@ -58,6 +58,16 @@ Key characteristics:
       params dtype; the step raises on a params/gradients dtype OR shape mismatch
       (see the guards below). No mixed dtypes: float32 params with float16
       gradients raises.
+    - Polyak floor: the numerator `max(0, f(y_t) + beta_sf*<g, z-x>)` bakes in
+      the Polyak floor `f* = 0`, i.e. it assumes `f(y_t) >= 0`. A persistently
+      negative objective drives `lr_t -> 0` and freezes the fast sequence `z`.
+    - Freeze semantics: when `lr_t == 0` the fast step is a no-op so
+      `new_z == z` (frozen), but `new_x` and `y_next` still interpolate toward
+      the (frozen) `z` via the outer momentum and keep moving.
+    - No bias correction: neither EMA (the inner-momentum buffer `m` nor the
+      L1-EMA `gnorm`) is bias-corrected, so a warm-from-zero step-1 can report a
+      large `lr_t` (e.g. ~4.8 in the parity fixture) while the still-small `m`
+      keeps the actual parameter step small.
 
 References:
     Base Schedule-Free method:

--- a/tests/odyssey/training/optimizers/parity_refs/schedule_free_plus_parity_reference.py
+++ b/tests/odyssey/training/optimizers/parity_refs/schedule_free_plus_parity_reference.py
@@ -1,0 +1,136 @@
+"""ScheduleFree+ parity reference (large-batch-stable schedule-free).
+
+Runs SEVERAL ScheduleFree+ steps for a fixed (params, grad, objective)
+sequence with the documented initial state and prints the resulting state after
+each step, so the Mojo `schedule_free_plus_step` can be compared on identical
+inputs. The step counter drives BOTH the increasing outer-momentum anneal AND
+the L1-EMA bias behaviour, so multiple steps with DIFFERENT gradients are needed
+to exercise every sequence.
+
+This is a hand-rolled NumPy transcription of the ScheduleFree+ update rule
+EXACTLY as written in the tracking issue body (mvillmow/Random#78), which wins
+over any base-paper ambiguity. NumPy is used only as a calculator for that
+transcribed algorithm; there is no external optimizer to defer to for this
+variant. The base Schedule-Free method is Defazio et al. 2024
+("The Road Less Scheduled", arXiv:2405.15682); the ScheduleFree+ stability
+variant is Defazio 2026 ("ScheduleFree+: Scaling Learning-Rate-Free &
+Schedule-Free Learning to Large Language Models", arXiv:2605.19095). The three
+mechanisms transcribed below are the issue's rule:
+
+    (1) Inner momentum: a momentum buffer m accumulates the gradient and the
+        fast sequence z steps on the momentum buffer (momentum INSIDE the
+        base-seq z-update), NOT on the raw gradient.
+
+        m_{t+1} = mu * m_t + (1 - mu) * g_t
+        z_{t+1} = z_t - lr_t * m_{t+1}
+
+    (2) Polyak step-size: the per-step lr_t is derived from the (caller-supplied)
+        objective value f(y_t), the correlation between the gradient and
+        (z_t - x_t), and an L1 EMA of the gradient magnitude:
+
+        s_t     = beta_sf * gamma_ema_L1_{t}                 # rho * EMA
+        gnorm_t = rho * gnorm_{t-1} + (1 - rho) * mean(|g_t|)  # L1 EMA of grad
+        polyak  = max(0, f(y_t) + beta_sf * <g_t, z_t - x_t>) / (gnorm_t + eps)
+        lr_t    = learning_rate * polyak                     # scaled Polyak lr
+
+    (3) Increasing outer momentum: the interpolation/averaging weight c anneals
+        the outer momentum beta_out from beta_sf up to beta_max across the run:
+
+        frac      = min(1, (t - 1) / max(1, horizon - 1))
+        beta_out  = beta_sf + (beta_max - beta_sf) * frac
+        c_{t+1}   = (1 - beta_out)                            # averaging weight
+        x_{t+1}   = beta_out * x_t + (1 - beta_out) * z_{t+1}
+
+    Query point (where the caller evaluates the next gradient/objective):
+        y_{t+1}   = (1 - beta_out) * z_{t+1} + beta_out * x_{t+1}
+
+On the first step the state is initialized z_1 = x_1 = params, m_1 = 0,
+gnorm_0 = 0. The caller supplies f(y_t) (the globally-reduced objective at the
+current query point), per the issue's "Polyak step needs the globally-reduced
+objective f(y_t)".
+"""
+
+import json
+
+import numpy as np
+
+LR = 0.1
+MU = 0.9  # inner momentum coefficient
+BETA_SF = 0.9  # base outer momentum / Polyak correlation weight
+BETA_MAX = 0.98  # annealed-to outer momentum
+RHO = 0.9  # L1-EMA decay for the gradient-magnitude normaliser
+EPS = 1e-8
+HORIZON = 4  # anneal horizon (steps) for the increasing outer momentum
+
+params = np.array([0.1, -0.2, 0.3, -0.4, 0.5])
+# One gradient + objective per step; different each step so every sequence moves.
+grads = [
+    np.array([0.05, 0.15, -0.25, 0.35, -0.45]),
+    np.array([0.08, 0.05, -0.20, 0.40, -0.30]),
+    np.array([-0.02, 0.20, -0.10, 0.25, -0.35]),
+]
+objectives = [1.2, 0.9, 0.7]  # f(y_t) supplied by the caller each step
+
+
+def sfplus_step(params, g, f_y, z, x, m, gnorm, t):
+    # (1) Inner momentum buffer, then fast z-sequence steps on it.
+    m = MU * m + (1.0 - MU) * g
+
+    # (2) Polyak step-size from the objective, correlation, and L1-EMA norm.
+    gnorm = RHO * gnorm + (1.0 - RHO) * float(np.mean(np.abs(g)))
+    corr = float(np.dot(g, z - x))
+    polyak = max(0.0, f_y + BETA_SF * corr) / (gnorm + EPS)
+    lr_t = LR * polyak
+    z = z - lr_t * m
+
+    # (3) Increasing outer momentum anneal beta_sf -> beta_max.
+    frac = min(1.0, (t - 1) / max(1, HORIZON - 1))
+    beta_out = BETA_SF + (BETA_MAX - BETA_SF) * frac
+    x = beta_out * x + (1.0 - beta_out) * z
+
+    # Next query point.
+    y = (1.0 - beta_out) * z + beta_out * x
+    return params, z, x, m, gnorm, y, lr_t, beta_out
+
+
+# Initial state.
+z = params.copy()
+x = params.copy()
+m = np.zeros_like(params)
+gnorm = 0.0
+
+step_outs = []
+for i, (g, f_y) in enumerate(zip(grads, objectives), start=1):
+    params, z, x, m, gnorm, y, lr_t, beta_out = sfplus_step(params, g, f_y, z, x, m, gnorm, i)
+    step_outs.append(
+        {
+            "z": z.tolist(),
+            "x": x.tolist(),
+            "m": m.tolist(),
+            "gnorm": gnorm,
+            "y": y.tolist(),
+            "lr_t": lr_t,
+            "beta_out": beta_out,
+        }
+    )
+
+print(
+    json.dumps(
+        {
+            "inputs": {
+                "params": params.tolist(),
+                "grads": [g.tolist() for g in grads],
+                "objectives": objectives,
+                "lr": LR,
+                "mu": MU,
+                "beta_sf": BETA_SF,
+                "beta_max": BETA_MAX,
+                "rho": RHO,
+                "eps": EPS,
+                "horizon": HORIZON,
+            },
+            "steps": step_outs,
+        },
+        indent=2,
+    )
+)

--- a/tests/odyssey/training/optimizers/test_schedule_free_plus.mojo
+++ b/tests/odyssey/training/optimizers/test_schedule_free_plus.mojo
@@ -1,0 +1,319 @@
+"""Unit tests for the ScheduleFree+ optimizer (arXiv:2605.19095).
+
+ScheduleFree+ is the large-batch-stable schedule-free variant: inner momentum,
+Polyak step-size, and increasing outer momentum. Tests cover:
+
+- Shape/dtype guards on schedule_free_plus_step (incl. the inner-momentum buffer)
+- Numerical parity across THREE steps with the NumPy reference in
+  parity_refs/schedule_free_plus_parity_reference.py (a hand-rolled transcription
+  of the tracking-issue rule mvillmow/Random#78) to 1e-9, on the z / x / m /
+  gnorm / y sequences and the Polyak lr_t — multiple steps so the increasing
+  outer-momentum anneal (beta_out 0.9 -> 0.9267 -> 0.9533) and the L1-EMA norm
+  evolve.
+- schedule_free_plus_step_simple matches schedule_free_plus_step defaults
+- descent direction on the fast sequence for a positive gradient
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros, full
+from odyssey.training.optimizers.schedule_free_plus import (
+    schedule_free_plus_step,
+    schedule_free_plus_step_simple,
+)
+
+
+def _abs_diff(a: Float64, b: Float64) -> Float64:
+    var d = a - b
+    if d < 0:
+        d = -d
+    return d
+
+
+def _set(t: AnyTensor, vals: List[Float64]) raises:
+    for i in range(len(vals)):
+        t.store[DType.float64](i, vals[i])
+
+
+def test_reject_shape_mismatch() raises:
+    """`schedule_free_plus_step` rejects a params/gradients shape mismatch."""
+    print("Running test_reject_shape_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([5], DType.float32)
+    var z = zeros([4], DType.float32)
+    var x = zeros([4], DType.float32)
+    var m = zeros([4], DType.float32)
+    try:
+        var _ = schedule_free_plus_step(p, g, z, x, m, 0.0, 1.0, 1, 0.1)
+        raise Error("Should have rejected shape mismatch")
+    except _:
+        print("  ok rejected shape mismatch")
+    print("test_reject_shape_mismatch PASSED")
+
+
+def test_reject_m_shape_mismatch() raises:
+    """`schedule_free_plus_step` rejects a params/momentum-buffer shape mismatch.
+    """
+    print("Running test_reject_m_shape_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float32)
+    var z = zeros([4], DType.float32)
+    var x = zeros([4], DType.float32)
+    var m = zeros([5], DType.float32)
+    try:
+        var _ = schedule_free_plus_step(p, g, z, x, m, 0.0, 1.0, 1, 0.1)
+        raise Error("Should have rejected m shape mismatch")
+    except _:
+        print("  ok rejected m shape mismatch")
+    print("test_reject_m_shape_mismatch PASSED")
+
+
+def test_reject_dtype_mismatch() raises:
+    """`schedule_free_plus_step` rejects a params/gradients dtype mismatch."""
+    print("Running test_reject_dtype_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float16)
+    var z = zeros([4], DType.float32)
+    var x = zeros([4], DType.float32)
+    var m = zeros([4], DType.float32)
+    try:
+        var _ = schedule_free_plus_step(p, g, z, x, m, 0.0, 1.0, 1, 0.1)
+        raise Error("Should have rejected dtype mismatch")
+    except _:
+        print("  ok rejected dtype mismatch")
+    print("test_reject_dtype_mismatch PASSED")
+
+
+def test_parity_with_reference() raises:
+    """Three ScheduleFree+ steps must match the NumPy reference to 1e-9.
+
+    Fixed inputs + reference outputs transcribed from
+    parity_refs/schedule_free_plus_parity_reference.py (lr=0.1, mu=0.9,
+    beta_sf=0.9, beta_max=0.98, rho=0.9, eps=1e-8, horizon=4). The reference is a
+    hand-rolled NumPy transcription of the tracking-issue rule
+    (mvillmow/Random#78): inner momentum, Polyak step-size, increasing outer
+    momentum. Three steps with DIFFERENT gradients + objectives so the anneal
+    (beta_out 0.9 -> 0.9267 -> 0.9533), the L1-EMA norm, and every sequence move.
+    """
+    print("Running test_parity_with_reference...")
+    var n = 5
+
+    # Reference z_{t+1} after each step.
+    var z1 = List[Float64]()
+    z1.append(0.07600000959999617)
+    z1.append(-0.2719999712000115)
+    z1.append(0.41999995200001916)
+    z1.append(-0.5679999328000269)
+    z1.append(0.7159999136000346)
+    var z2 = List[Float64]()
+    z2.append(0.053692333443643214)
+    z2.append(-0.3050153319114139)
+    z2.append(0.4958460509316192)
+    z2.append(-0.6955998404143658)
+    z2.append(0.8418152071218652)
+    var z3 = List[Float64]()
+    z3.append(0.045322476994239635)
+    z3.append(-0.3381780604379697)
+    z3.append(0.5395050318704)
+    z3.append(-0.776448129468875)
+    z3.append(0.9308976252238957)
+
+    # Reference x_{t+1} after each step.
+    var x1 = List[Float64]()
+    x1.append(0.09760000095999963)
+    x1.append(-0.20719999712000117)
+    x1.append(0.31199999520000193)
+    x1.append(-0.4167999932800027)
+    x1.append(0.5215999913600035)
+    var x3 = List[Float64]()
+    x3.append(0.0920907493525651)
+    x3.append(-0.22015068548047934)
+    x3.append(0.33546977894087976)
+    x3.append(-0.453074780059588)
+    x3.append(0.563087149135581)
+
+    # Reference m_{t+1} and gnorm_{t+1} / lr_t at selected steps.
+    var m3 = List[Float64]()
+    m3.append(0.009249999999999998)
+    m3.append(0.036649999999999995)
+    m3.append(-0.04825)
+    m3.append(0.08934999999999998)
+    m3.append(-0.09844999999999997)
+
+    var p = zeros([n], DType.float64)
+    _set(
+        p,
+        [0.1, -0.2, 0.3, -0.4, 0.5],
+    )
+    var g1 = zeros([n], DType.float64)
+    _set(g1, [0.05, 0.15, -0.25, 0.35, -0.45])
+    var g2 = zeros([n], DType.float64)
+    _set(g2, [0.08, 0.05, -0.20, 0.40, -0.30])
+    var g3 = zeros([n], DType.float64)
+    _set(g3, [-0.02, 0.20, -0.10, 0.25, -0.35])
+
+    # Initial state: z = x = params, m = 0, gnorm = 0.
+    var z = zeros([n], DType.float64)
+    _set(z, [0.1, -0.2, 0.3, -0.4, 0.5])
+    var x = zeros([n], DType.float64)
+    _set(x, [0.1, -0.2, 0.3, -0.4, 0.5])
+    var m = zeros([n], DType.float64)
+
+    # Step 1: objective f(y_1) = 1.2.
+    var r1 = schedule_free_plus_step(
+        p, g1, z, x, m, 0.0, 1.2, 1, 0.1, 0.9, 0.9, 0.98, 0.9, 1e-8, 4
+    )
+    var nz1 = r1[0]
+    var nx1 = r1[1]
+    for i in range(n):
+        if _abs_diff(nz1.load[DType.float64](i), z1[i]) > 1e-9:
+            raise Error("sf+ step-1 z mismatch at " + String(i))
+        if _abs_diff(nx1.load[DType.float64](i), x1[i]) > 1e-9:
+            raise Error("sf+ step-1 x mismatch at " + String(i))
+    if _abs_diff(r1[5], 4.799998080000768) > 1e-9:
+        raise Error("sf+ step-1 lr_t mismatch")
+    print("  ok step 1 (z, x, lr_t) matches reference")
+
+    # Step 2: objective f(y_2) = 0.9, feed g2 and the returned state.
+    var r2 = schedule_free_plus_step(
+        p,
+        g2,
+        r1[0],
+        r1[1],
+        r1[2],
+        r1[3],
+        0.9,
+        2,
+        0.1,
+        0.9,
+        0.9,
+        0.98,
+        0.9,
+        1e-8,
+        4,
+    )
+    var nz2 = r2[0]
+    for i in range(n):
+        if _abs_diff(nz2.load[DType.float64](i), z2[i]) > 1e-9:
+            raise Error("sf+ step-2 z mismatch at " + String(i))
+    if _abs_diff(r2[3], 0.04309999999999999) > 1e-9:
+        raise Error("sf+ step-2 gnorm mismatch")
+    if _abs_diff(r2[5], 1.7846140925082368) > 1e-9:
+        raise Error("sf+ step-2 lr_t mismatch")
+    print("  ok step 2 (z, gnorm, lr_t) matches reference")
+
+    # Step 3: objective f(y_3) = 0.7, feed g3 and the returned state.
+    var r3 = schedule_free_plus_step(
+        p,
+        g3,
+        r2[0],
+        r2[1],
+        r2[2],
+        r2[3],
+        0.7,
+        3,
+        0.1,
+        0.9,
+        0.9,
+        0.98,
+        0.9,
+        1e-8,
+        4,
+    )
+    var nz3 = r3[0]
+    var nx3 = r3[1]
+    var nm3 = r3[2]
+    for i in range(n):
+        if _abs_diff(nz3.load[DType.float64](i), z3[i]) > 1e-9:
+            raise Error("sf+ step-3 z mismatch at " + String(i))
+        if _abs_diff(nx3.load[DType.float64](i), x3[i]) > 1e-9:
+            raise Error("sf+ step-3 x mismatch at " + String(i))
+        if _abs_diff(nm3.load[DType.float64](i), m3[i]) > 1e-9:
+            raise Error("sf+ step-3 m mismatch at " + String(i))
+    if _abs_diff(r3[5], 0.9048493458814681) > 1e-9:
+        raise Error("sf+ step-3 lr_t mismatch")
+    print("  ok step 3 (z, x, m, lr_t) matches reference")
+    print("test_parity_with_reference PASSED")
+
+
+def test_step_simple_matches_defaults() raises:
+    """`schedule_free_plus_step_simple` == full step with default hyperparams.
+
+    The simple wrapper hard-codes horizon=1000, so the explicit call uses the
+    same horizon (not the parity test's 4) to isolate the default-forwarding.
+    """
+    print("Running test_step_simple_matches_defaults...")
+    var n = 5
+    var p = zeros([n], DType.float64)
+    _set(p, [0.1, -0.2, 0.3, -0.4, 0.5])
+    var g = zeros([n], DType.float64)
+    _set(g, [0.05, 0.15, -0.25, 0.35, -0.45])
+    var z = zeros([n], DType.float64)
+    _set(z, [0.1, -0.2, 0.3, -0.4, 0.5])
+    var x = zeros([n], DType.float64)
+    _set(x, [0.1, -0.2, 0.3, -0.4, 0.5])
+    var m = zeros([n], DType.float64)
+
+    var simple = schedule_free_plus_step_simple(p, g, z, x, m, 0.0, 1.2, 1, 0.1)
+    var full_call = schedule_free_plus_step(
+        p, g, z, x, m, 0.0, 1.2, 1, 0.1, 0.9, 0.9, 0.98, 0.9, 1e-8, 1000
+    )
+    var sz = simple[0]
+    var fz = full_call[0]
+    var sx = simple[1]
+    var fx = full_call[1]
+    for i in range(n):
+        if (
+            _abs_diff(sz.load[DType.float64](i), fz.load[DType.float64](i))
+            > 1e-12
+        ):
+            raise Error("simple != full (z) at " + String(i))
+        if (
+            _abs_diff(sx.load[DType.float64](i), fx.load[DType.float64](i))
+            > 1e-12
+        ):
+            raise Error("simple != full (x) at " + String(i))
+    if _abs_diff(simple[5], full_call[5]) > 1e-12:
+        raise Error("simple != full (lr_t)")
+    print("  ok schedule_free_plus_step_simple matches defaults")
+    print("test_step_simple_matches_defaults PASSED")
+
+
+def test_descent_direction() raises:
+    """A positive gradient must decrease the fast sequence `z`.
+
+    With z = x = params (step 1), the correlation <g, z-x> = 0, so the Polyak
+    numerator is f(y) > 0 and lr_t > 0; the fast step z -= lr_t * m with m > 0
+    (positive gradient) must decrease z below params.
+    """
+    print("Running test_descent_direction...")
+    var n = 3
+    var p = full([n], 1.0, DType.float64)
+    var g = full([n], 0.5, DType.float64)
+    var z = full([n], 1.0, DType.float64)
+    var x = full([n], 1.0, DType.float64)
+    var m = zeros([n], DType.float64)
+    var res = schedule_free_plus_step(
+        p, g, z, x, m, 0.0, 1.0, 1, 0.01, 0.9, 0.9, 0.98, 0.9, 1e-8, 1000
+    )
+    var nz = res[0]
+    for i in range(n):
+        if not (nz.load[DType.float64](i) < 1.0):
+            raise Error("positive gradient should decrease z")
+    print("  ok positive gradient decreased the fast sequence z")
+    print("test_descent_direction PASSED")
+
+
+def main() raises:
+    """Run all ScheduleFree+ tests."""
+    print("=" * 60)
+    print("ScheduleFree+ Optimizer Test Suite")
+    print("=" * 60)
+    test_reject_shape_mismatch()
+    test_reject_m_shape_mismatch()
+    test_reject_dtype_mismatch()
+    test_parity_with_reference()
+    test_step_simple_matches_defaults()
+    test_descent_direction()
+    print("=" * 60)
+    print("All ScheduleFree+ tests PASSED")
+    print("=" * 60)


### PR DESCRIPTION

Closes #5645
Tracking: mvillmow/Random#78

## What

Adds **ScheduleFree+** — the large-batch-stability variant of Schedule-Free — as
a pure-functional optimizer step in `src/odyssey/training/optimizers/`, mirroring
the existing first-order-moment optimizers (`adan.mojo`, `adopt.mojo`).

ScheduleFree+ (Defazio 2026, arXiv:2605.19095) extends base Schedule-Free
(Defazio et al. 2024, arXiv:2405.15682) with three stability mechanisms,
transcribed here **exactly as written in the tracking issue
(mvillmow/Random#78)**, whose rule wins over any base-paper ambiguity:

1. **Inner momentum** — a momentum buffer `m` accumulated inside the base-seq
   update; the fast sequence `z` steps on `m`, not the raw gradient
   (`m = mu*m + (1-mu)*g`; `z -= lr_t * m`).
2. **Polyak step-size** —
   `lr_t = lr * max(0, f(y_t) + beta_sf*<g, z-x>) / (L1-EMA(|g|) + eps)`, using
   the caller-supplied globally-reduced objective `f(y_t)`.
3. **Increasing outer momentum** — `beta_out` annealed `beta_sf -> beta_max`
   over a paced `horizon`, driving the running-average `x` and the query-point
   interpolation `y`.

## API

- `schedule_free_plus_step(params, gradients, z, x, m, gnorm, objective, step,
  learning_rate, mu=0.9, beta_sf=0.9, beta_max=0.98, rho=0.9, epsilon=1e-8,
  horizon=1000) -> (new_z, new_x, new_m, new_gnorm, y_next, lr_t)`
- `schedule_free_plus_step_simple(...)` — default-hyperparameter wrapper.

Pure-functional (state in, state out). Guards: `params`/`gradients` shape +
dtype, and a `params`/momentum-buffer shape guard. **dtypes:** implemented
against the float32/float64 elementwise SIMD API; the two scalar reductions
(`<g, z-x>`, `mean(|g|)`) read each element as Float64 and so work for any real
params dtype. A mixed-dtype `params`/`gradients` pair **raises** (guarded and
tested).

## Files

- `src/odyssey/training/optimizers/schedule_free_plus.mojo` (new)
- `tests/odyssey/training/optimizers/test_schedule_free_plus.mojo` (new)
- `tests/odyssey/training/optimizers/parity_refs/schedule_free_plus_parity_reference.py`
  (new)
- `src/odyssey/training/optimizers/__init__.mojo` (+re-export block)
- `scripts/run_primitive_test.sh` (+1 registration line)
- `README.md` (+1 primitive-table row)

## Parity methodology

The parity reference is a hand-rolled NumPy transcription of the tracking issue's
update rule (there is no public reference optimizer for this variant). It runs 3
steps with different gradients + objectives so the increasing outer-momentum
anneal (`beta_out` 0.9 -> 0.9267 -> 0.9533), the L1-EMA norm, and every sequence
evolve. The committed Mojo fixtures were regenerated from the script and diffed —
**zero drift**.

## Test evidence

```
$ pixi run mojo -I src -I . tests/odyssey/training/optimizers/test_schedule_free_plus.mojo
============================================================
ScheduleFree+ Optimizer Test Suite
============================================================
Running test_reject_shape_mismatch...
  ok rejected shape mismatch
test_reject_shape_mismatch PASSED
Running test_reject_m_shape_mismatch...
  ok rejected m shape mismatch
test_reject_m_shape_mismatch PASSED
Running test_reject_dtype_mismatch...
  ok rejected dtype mismatch
test_reject_dtype_mismatch PASSED
Running test_parity_with_reference...
  ok step 1 (z, x, lr_t) matches reference
  ok step 2 (z, gnorm, lr_t) matches reference
  ok step 3 (z, x, m, lr_t) matches reference
test_parity_with_reference PASSED
Running test_step_simple_matches_defaults...
  ok schedule_free_plus_step_simple matches defaults
test_step_simple_matches_defaults PASSED
Running test_descent_direction...
  ok positive gradient decreased the fast sequence z
test_descent_direction PASSED
============================================================
All ScheduleFree+ tests PASSED
============================================================
```

```
$ bash scripts/run_primitive_test.sh schedule_free_plus
...
✅ schedule_free_plus PASSED
```

pre-commit clean on all touched files (Mojo Format, Ruff Format/Check, mypy,
Bandit, Markdown Lint all pass).

## References

- Defazio, A., et al. (2024). The Road Less Scheduled. NeurIPS 2024.
  arXiv:2405.15682.
- Defazio, A. (2026). ScheduleFree+: Scaling Learning-Rate-Free & Schedule-Free
  Learning to Large Language Models. arXiv:2605.19095.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
