### PR TITLE
feat(layers): add MLP-Mixer block (arXiv:2105.01601)

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ bash scripts/run_primitive_test.sh --list     # list known primitives + paths
 | GRU | layer | `bash scripts/run_primitive_test.sh gru` |
 | LayerNorm | layer | `bash scripts/run_primitive_test.sh layernorm` |
 | Transformer FeedForward (FFN) | layer | `bash scripts/run_primitive_test.sh ffn` |
+| MLP-Mixer block (1-layer) | layer | `bash scripts/run_primitive_test.sh mlp_mixer` |
 | ADOPT | optimizer | `bash scripts/run_primitive_test.sh adopt` |
 | Sophia (clipped update step; caller-supplied Hessian estimates) | optimizer | `bash scripts/run_primitive_test.sh sophia` |
 | Adan | optimizer | `bash scripts/run_primitive_test.sh adan` |

--- a/scripts/run_primitive_test.sh
+++ b/scripts/run_primitive_test.sh
@@ -39,6 +39,7 @@ TEST[ffn]="tests/odyssey/core/layers/test_feedforward.mojo"
 TEST[gru]="tests/odyssey/core/layers/test_gru.mojo"
 TEST[layernorm]="tests/odyssey/core/layers/test_layernorm.mojo"
 TEST[lstm]="tests/odyssey/core/layers/test_lstm.mojo"
+TEST[mlp_mixer]="tests/odyssey/core/layers/test_mlp_mixer.mojo"
 TEST[rnn]="tests/odyssey/core/layers/test_rnn.mojo"
 
 run_one() {

--- a/src/odyssey/core/layers/__init__.mojo
+++ b/src/odyssey/core/layers/__init__.mojo
@@ -10,6 +10,7 @@ Components:
     - ReLU: Rectified Linear Unit activation
     - RNNCell: Vanilla (Elman) recurrent cell (tanh)
     - FeedForward: Transformer position-wise feed-forward (Linear->act->Linear)
+    - MLPMixerBlock: 1-layer MLP-Mixer block (token-mixing + channel-mixing MLPs)
     - Sigmoid: Sigmoid activation function
     - Tanh: Hyperbolic tangent activation
     - BatchNorm: Batch normalization
@@ -44,6 +45,7 @@ from odyssey.core.layers.lstm import LSTMCell
 from odyssey.core.layers.layernorm import LayerNorm
 from odyssey.core.layers.gru import GRUCell
 from odyssey.core.layers.feedforward import FeedForward
+from odyssey.core.layers.mlp_mixer import MLPMixerBlock
 
 # from .activation import ReLU, Sigmoid, Tanh
 # from .pooling import MaxPool2D, AvgPool2D

--- a/src/odyssey/core/layers/mlp_mixer.mojo
+++ b/src/odyssey/core/layers/mlp_mixer.mojo
@@ -1,0 +1,240 @@
+"""1-layer MLP-Mixer block (token-mixing + channel-mixing MLPs).
+
+A single Mixer layer from Tolstikhin et al. 2021 ("MLP-Mixer: An all-MLP
+Architecture for Vision", §2 "Mixer Architecture", Eq. 1-2). The block operates
+on a sequence of tokens (patch embeddings) laid out batch-first as
+`[batch, seq, dim]` and mixes information along BOTH axes with pure MLPs — no
+convolution, no self-attention:
+
+    U = X + TokenMLP( LayerNorm_1(X)^T )^T      # token-mixing (across `seq`)
+    Y = U + ChannelMLP( LayerNorm_2(U) )        # channel-mixing (across `dim`)
+
+Both sublayers are pre-normalized (LayerNorm applied to the input of the MLP,
+not its output) and wrapped in a residual/skip connection, exactly as in the
+reference. Each MLP is the standard two-layer expansion MLP
+`fc2(act(fc1(x)))` with a GELU non-linearity (the paper uses GELU; §2).
+
+Transcription of the two mixing directions (the crux of the block):
+
+  * Channel-mixing MLP acts on the feature (`dim`) axis. Since `dim` is the last
+    axis, this is the ordinary position-wise MLP: reshape `[batch, seq, dim]`
+    -> `[batch*seq, dim]`, apply the MLP, reshape back. `fc1: dim -> channel_hidden`,
+    `fc2: channel_hidden -> dim`.
+
+  * Token-mixing MLP acts on the token (`seq`) axis. The reference applies it to
+    the TRANSPOSE of the (LayerNorm'd) input so the MLP's linear layers contract
+    over `seq`: transpose `[batch, seq, dim]` -> `[batch, dim, seq]`, reshape to
+    `[batch*dim, seq]`, apply the MLP (`fc1: seq -> token_hidden`,
+    `fc2: token_hidden -> seq`), reshape back to `[batch, dim, seq]` and transpose
+    to `[batch, seq, dim]`. The LayerNorm itself still normalizes over the
+    feature (`dim`) axis — the transpose is applied only to feed the token MLP,
+    matching Eq. 1 where LayerNorm precedes the transpose.
+
+Design/convention notes:
+  * Batch-first `[batch, seq, dim]`. `forward()` consumes a FULL sequence at once
+    (all `seq` tokens present) — established convention for sequence-consuming
+    Odyssey layers; there is no per-step/streaming interface.
+  * This block is a thin composition of two `LayerNorm` modules and two
+    `FeedForward` MLPs, so it reuses their initialization (Xavier-style Linear,
+    gamma=1/beta=0 LayerNorm) and epsilon convention (1e-5) unchanged. LayerNorm
+    is reused verbatim from `layernorm.mojo` — the pre-norm sublayers are NOT a
+    reimplementation.
+  * No BatchNorm anywhere (BN couples batch elements and is inappropriate for
+    this token/channel-local block); LayerNorm only.
+
+Reference:
+    Tolstikhin, I., Houlsby, N., Kolesnikov, A., Beyer, L., Zhai, X.,
+    Unterthiner, T., Yung, J., Steiner, A., Keysers, D., Uszkoreit, J.,
+    Lucic, M., & Dosovitskiy, A. (2021). MLP-Mixer: An all-MLP Architecture for
+    Vision. NeurIPS 2021. arXiv:2105.01601, §2 "Mixer Architecture", Eq. 1-2.
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros
+from odyssey.core.module import Module
+from odyssey.core.layers.feedforward import FeedForward
+from odyssey.core.layers.layernorm import LayerNorm
+
+
+struct MLPMixerBlock[dtype: DType = DType.float32](Copyable, Module, Movable):
+    """A single MLP-Mixer block: token-mixing MLP then channel-mixing MLP.
+
+    Both sublayers are pre-LayerNorm with a residual connection. Input and
+    output are batch-first `[batch, seq, dim]` and shape-preserving.
+
+    Parameters:
+        dtype: Data type for all weights, biases, and LayerNorm params
+            (default: float32).
+
+    Attributes:
+        norm_token: Pre-norm LayerNorm for the token-mixing sublayer (over `dim`).
+        token_mlp: Token-mixing MLP (contracts over `seq`; seq -> token_hidden -> seq).
+        norm_channel: Pre-norm LayerNorm for the channel-mixing sublayer (over `dim`).
+        channel_mlp: Channel-mixing MLP (contracts over `dim`; dim -> channel_hidden -> dim).
+        seq_len: Number of tokens (sequence length) the block is built for.
+        dim: Feature (channel) dimension per token.
+        token_hidden: Hidden width of the token-mixing MLP.
+        channel_hidden: Hidden width of the channel-mixing MLP.
+    """
+
+    var norm_token: LayerNorm[Self.dtype]
+    var token_mlp: FeedForward[Self.dtype]
+    var norm_channel: LayerNorm[Self.dtype]
+    var channel_mlp: FeedForward[Self.dtype]
+    var seq_len: Int
+    var dim: Int
+    var token_hidden: Int
+    var channel_hidden: Int
+
+    def __init__(
+        out self,
+        seq_len: Int,
+        dim: Int,
+        token_hidden: Int = -1,
+        channel_hidden: Int = -1,
+    ) raises:
+        """Initialize the Mixer block.
+
+        Args:
+            seq_len: Number of tokens (sequence length). Must be positive.
+            dim: Feature dimension per token. Must be positive.
+            token_hidden: Hidden width of the token-mixing MLP. If <= 0, defaults
+                to `4 * seq_len` (the FeedForward 4x expansion default).
+            channel_hidden: Hidden width of the channel-mixing MLP. If <= 0,
+                defaults to `4 * dim`.
+
+        Raises:
+            Error: If seq_len <= 0 or dim <= 0, or if sub-layer construction fails.
+
+        Example:
+            ```mojo
+            var mixer = MLPMixerBlock(seq_len=4, dim=8, token_hidden=6, channel_hidden=16)
+            var y = mixer.forward(x)   # x: [2, 4, 8] -> y: [2, 4, 8]
+            ```
+        """
+        if seq_len <= 0:
+            raise Error("MLPMixerBlock: seq_len must be positive")
+        if dim <= 0:
+            raise Error("MLPMixerBlock: dim must be positive")
+        self.seq_len = seq_len
+        self.dim = dim
+        # FeedForward already applies the 4x default when its d_ff arg is <= 0,
+        # but resolve the concrete widths here so the attributes report the
+        # actual sizes rather than the -1 sentinel.
+        self.token_hidden = token_hidden if token_hidden > 0 else 4 * seq_len
+        self.channel_hidden = channel_hidden if channel_hidden > 0 else 4 * dim
+        # Pre-norm LayerNorms normalize over the feature (dim) axis in both
+        # sublayers, per Eq. 1-2.
+        self.norm_token = LayerNorm[Self.dtype](dim)
+        self.norm_channel = LayerNorm[Self.dtype](dim)
+        # Token MLP contracts over seq; channel MLP contracts over dim.
+        self.token_mlp = FeedForward[Self.dtype](seq_len, self.token_hidden)
+        self.channel_mlp = FeedForward[Self.dtype](dim, self.channel_hidden)
+
+    def forward(mut self, input: AnyTensor) raises -> AnyTensor:
+        """Forward pass through one Mixer block.
+
+        Args:
+            input: Batch-first tensor of shape `[batch, seq, dim]`, where
+                `seq == seq_len` and `dim == dim`. The block consumes the whole
+                sequence at once.
+
+        Returns:
+            Tensor of shape `[batch, seq, dim]` (same shape as `input`).
+
+        Raises:
+            Error: If `input` is not rank-3, or its `seq`/`dim` axes do not match
+                the block's configured `seq_len`/`dim`, or a tensor op fails.
+        """
+        var shape = input.shape()
+        if len(shape) != 3:
+            raise Error(
+                "MLPMixerBlock: input must be rank-3 [batch, seq, dim], got"
+                " rank "
+                + String(len(shape))
+            )
+        var batch = shape[0]
+        var seq = shape[1]
+        var d = shape[2]
+        if seq != self.seq_len:
+            raise Error(
+                "MLPMixerBlock: input seq ("
+                + String(seq)
+                + ") does not match seq_len ("
+                + String(self.seq_len)
+                + ")"
+            )
+        if d != self.dim:
+            raise Error(
+                "MLPMixerBlock: input dim ("
+                + String(d)
+                + ") does not match dim ("
+                + String(self.dim)
+                + ")"
+            )
+
+        # --- Token-mixing sublayer: U = X + TokenMLP( LayerNorm_1(X)^T )^T ---
+        # LayerNorm normalizes over the last (dim) axis. The MLP operating
+        # position-wise over the feature axis means it acts on [*, dim]; reshape
+        # [batch, seq, dim] -> [batch*seq, dim] for the norm, then back.
+        var x_flat = input.reshape([batch * seq, d])
+        var norm1_flat = self.norm_token.forward(x_flat)
+        var norm1 = norm1_flat.reshape([batch, seq, d])
+        # Transpose seq<->dim so the token MLP contracts over seq: [batch, dim, seq].
+        var norm1_t = norm1.transpose(1, 2)
+        # reshape needs a contiguous flat buffer; transpose returns a view.
+        from odyssey.core.shape import as_contiguous
+
+        var norm1_t_c = as_contiguous(norm1_t)
+        var tok_in = norm1_t_c.reshape([batch * d, seq])
+        var tok_out_flat = self.token_mlp.forward(tok_in)
+        var tok_out = tok_out_flat.reshape([batch, d, seq])
+        # Transpose back to [batch, seq, dim] and add the residual.
+        var tok_out_t = as_contiguous(tok_out.transpose(1, 2))
+        var u = input + tok_out_t
+
+        # --- Channel-mixing sublayer: Y = U + ChannelMLP( LayerNorm_2(U) ) ---
+        var u_flat = u.reshape([batch * seq, d])
+        var norm2_flat = self.norm_channel.forward(u_flat)
+        var chan_out_flat = self.channel_mlp.forward(norm2_flat)
+        var chan_out = chan_out_flat.reshape([batch, seq, d])
+        var y = u + chan_out
+        return y
+
+    def parameters(self) raises -> List[AnyTensor]:
+        """Collect trainable parameters from all four sub-modules.
+
+        Returns:
+            List of parameters in order: norm_token (gamma, beta),
+            token_mlp (fc1.w/b, fc2.w/b), norm_channel (gamma, beta),
+            channel_mlp (fc1.w/b, fc2.w/b) — 12 tensors total.
+
+        Raises:
+            Error if tensor copying fails.
+        """
+        var params = List[AnyTensor]()
+        for p in self.norm_token.parameters():
+            params.append(p)
+        for p in self.token_mlp.parameters():
+            params.append(p)
+        for p in self.norm_channel.parameters():
+            params.append(p)
+        for p in self.channel_mlp.parameters():
+            params.append(p)
+        return params^
+
+    def train(mut self):
+        """Switch all sub-modules to training mode (all are mode-independent).
+        """
+        self.norm_token.train()
+        self.token_mlp.train()
+        self.norm_channel.train()
+        self.channel_mlp.train()
+
+    def eval(mut self):
+        """Switch all sub-modules to inference mode (all are mode-independent).
+        """
+        self.norm_token.eval()
+        self.token_mlp.eval()
+        self.norm_channel.eval()
+        self.channel_mlp.eval()

--- a/tests/odyssey/core/layers/parity_refs/mlp_mixer_parity_reference.py
+++ b/tests/odyssey/core/layers/parity_refs/mlp_mixer_parity_reference.py
@@ -1,0 +1,110 @@
+"""MLP-Mixer block parity reference.
+
+Computes the forward pass of ONE MLP-Mixer block (Tolstikhin et al. 2021,
+arXiv:2105.01601, §2, Eq. 1-2) in PyTorch with FIXED ramp weights and a FIXED
+input, and prints the flattened output as JSON so the Mojo MLPMixerBlock test can
+set the same weights and assert equality.
+
+Block transcribed (batch-first x of shape [B, S, D]):
+
+    n1 = LayerNorm_D(x)                        # normalize over feature axis D
+    t  = n1.transpose(1, 2)                    # [B, D, S]
+    t  = fc_t2(gelu(fc_t1(t)))                 # token MLP: S -> Ht -> S
+    u  = x + t.transpose(1, 2)                 # residual, back to [B, S, D]
+    n2 = LayerNorm_D(u)                        # normalize over feature axis D
+    y  = u + fc_c2(gelu(fc_c1(n2)))            # channel MLP: D -> Hc -> D, residual
+
+Conventions matched to Odyssey:
+  * Odyssey `Linear` uses y = x @ W + b with W of shape (in, out); torch.nn.Linear
+    stores weight as (out, in), so we copy the TRANSPOSE of each Odyssey W.
+  * GELU is exact (erf-based), i.e. torch.nn.functional.gelu(..., approximate="none"),
+    matching Odyssey's default FeedForward activation.
+  * LayerNorm epsilon = 1e-5, normalized over the last (feature) dim only — matches
+    Odyssey layernorm.mojo default (biased/population variance, torch default).
+  * gamma=1, beta=0 for both LayerNorms (Odyssey LayerNorm init), so they are
+    identity-affine here and the parity isolates the mixing MLPs + normalization.
+
+Config: batch=2, seq=4, dim=8, token_hidden=6, channel_hidden=16, float64.
+Weights/inputs are deterministic ramps so they transcribe cleanly into Mojo.
+"""
+
+import json
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+torch.manual_seed(0)
+B, S, D = 2, 4, 8
+HT, HC = 6, 16  # token_hidden, channel_hidden
+EPS = 1e-5
+
+# --- Deterministic ramp params (Odyssey layout: W (in, out)) ---
+# Token MLP: fc_t1 (S, HT), fc_t2 (HT, S)
+WT1 = torch.arange(S * HT, dtype=torch.float64).reshape(S, HT) * 0.01 - 0.1
+bT1 = torch.arange(HT, dtype=torch.float64) * 0.02 - 0.05
+WT2 = torch.arange(HT * S, dtype=torch.float64).reshape(HT, S) * 0.005 - 0.06
+bT2 = torch.arange(S, dtype=torch.float64) * 0.03 - 0.04
+
+# Channel MLP: fc_c1 (D, HC), fc_c2 (HC, D)
+WC1 = torch.arange(D * HC, dtype=torch.float64).reshape(D, HC) * 0.002 - 0.12
+bC1 = torch.arange(HC, dtype=torch.float64) * 0.01 - 0.07
+WC2 = torch.arange(HC * D, dtype=torch.float64).reshape(HC, D) * 0.003 - 0.09
+bC2 = torch.arange(D, dtype=torch.float64) * 0.02 - 0.03
+
+# Input [B, S, D]
+X = torch.arange(B * S * D, dtype=torch.float64).reshape(B, S, D) * 0.01 - 0.15
+
+# --- Build torch modules (weights = transpose of Odyssey layout) ---
+ln1 = nn.LayerNorm(D, eps=EPS).double()  # gamma=1, beta=0 by default
+ln2 = nn.LayerNorm(D, eps=EPS).double()
+fc_t1 = nn.Linear(S, HT).double()
+fc_t2 = nn.Linear(HT, S).double()
+fc_c1 = nn.Linear(D, HC).double()
+fc_c2 = nn.Linear(HC, D).double()
+
+with torch.no_grad():
+    fc_t1.weight.copy_(WT1.T)
+    fc_t1.bias.copy_(bT1)
+    fc_t2.weight.copy_(WT2.T)
+    fc_t2.bias.copy_(bT2)
+    fc_c1.weight.copy_(WC1.T)
+    fc_c1.bias.copy_(bC1)
+    fc_c2.weight.copy_(WC2.T)
+    fc_c2.bias.copy_(bC2)
+
+with torch.no_grad():
+    # Token-mixing sublayer
+    n1 = ln1(X)  # [B, S, D], normalized over D
+    t = n1.transpose(1, 2)  # [B, D, S]
+    t = fc_t2(F.gelu(fc_t1(t), approximate="none"))  # [B, D, S]
+    u = X + t.transpose(1, 2)  # [B, S, D]
+    # Channel-mixing sublayer
+    n2 = ln2(u)  # [B, S, D]
+    y = u + fc_c2(F.gelu(fc_c1(n2), approximate="none"))  # [B, S, D]
+
+print(
+    json.dumps(
+        {
+            "config": {
+                "batch": B,
+                "seq": S,
+                "dim": D,
+                "token_hidden": HT,
+                "channel_hidden": HC,
+                "eps": EPS,
+            },
+            "WT1": WT1.flatten().tolist(),
+            "bT1": bT1.tolist(),
+            "WT2": WT2.flatten().tolist(),
+            "bT2": bT2.tolist(),
+            "WC1": WC1.flatten().tolist(),
+            "bC1": bC1.tolist(),
+            "WC2": WC2.flatten().tolist(),
+            "bC2": bC2.tolist(),
+            "X": X.flatten().tolist(),
+            "out": y.flatten().tolist(),
+        },
+        indent=2,
+    )
+)

--- a/tests/odyssey/core/layers/test_mlp_mixer.mojo
+++ b/tests/odyssey/core/layers/test_mlp_mixer.mojo
@@ -1,0 +1,275 @@
+"""Unit tests for the 1-layer MLP-Mixer block (MLPMixerBlock).
+
+Tests cover:
+- Construction + shape preservation ([batch, seq, dim] -> [batch, seq, dim])
+- Default hidden dims (token_hidden -> 4*seq_len, channel_hidden -> 4*dim)
+- Parameter collection (12 tensors: 2 LayerNorm x 2 + 2 FeedForward x 4)
+- seq_len / dim / rank validation (raises)
+- dtype-guard: a scalar loaded with the wrong dtype misreads the buffer (the
+  test uses the tensor's own dtype throughout)
+- Numerical parity with a PyTorch reference (LayerNorm -> transpose -> token MLP
+  -> residual -> LayerNorm -> channel MLP -> residual) on ramp weights + input,
+  tolerance 1e-5. Reference: parity_refs/mlp_mixer_parity_reference.py.
+- Package-path import (from odyssey.core.layers import MLPMixerBlock) so the
+  export line, not just the docstring Components entry, is exercised.
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros
+from odyssey.core.layers.mlp_mixer import MLPMixerBlock
+
+# Package-path import: guards that __init__.mojo actually EXPORTS the symbol
+# (a docstring-only Components line would not satisfy this import).
+from odyssey.core.layers import MLPMixerBlock as MLPMixerBlockPkg
+
+
+def test_shape_preserved() raises:
+    """Mixer maps [batch, seq, dim] -> [batch, seq, dim]."""
+    print("Running test_shape_preserved...")
+    var mixer = MLPMixerBlock[DType.float32](seq_len=4, dim=8)
+    var x = zeros([2, 4, 8], DType.float32)
+    var y = mixer.forward(x)
+    if y.shape()[0] != 2 or y.shape()[1] != 4 or y.shape()[2] != 8:
+        raise Error("Mixer must preserve [batch, seq, dim] shape")
+    print("  ok shape preserved (2, 4, 8)")
+    print("test_shape_preserved PASSED")
+
+
+def test_default_hidden_dims() raises:
+    """Default token_hidden is 4*seq_len, channel_hidden is 4*dim."""
+    print("Running test_default_hidden_dims...")
+    var mixer = MLPMixerBlock[DType.float32](seq_len=5, dim=6)
+    if mixer.token_hidden != 20:
+        raise Error("default token_hidden should be 4 * seq_len = 20")
+    if mixer.channel_hidden != 24:
+        raise Error("default channel_hidden should be 4 * dim = 24")
+    print("  ok defaults token_hidden=20, channel_hidden=24")
+    print("test_default_hidden_dims PASSED")
+
+
+def test_parameter_count() raises:
+    """`parameters()` returns 12 tensors (2 LayerNorm + 2 FeedForward)."""
+    print("Running test_parameter_count...")
+    var mixer = MLPMixerBlock[DType.float32](
+        seq_len=4, dim=8, token_hidden=6, channel_hidden=16
+    )
+    var params = mixer.parameters()
+    if len(params) != 12:
+        raise Error("Mixer should expose 12 parameter tensors")
+    print("  ok 12 parameter tensors")
+    print("test_parameter_count PASSED")
+
+
+def test_reject_bad_dims() raises:
+    """Non-positive seq_len/dim must raise."""
+    print("Running test_reject_bad_dims...")
+    try:
+        var _ = MLPMixerBlock[DType.float32](seq_len=0, dim=8)
+        raise Error("Should have rejected seq_len = 0")
+    except _:
+        print("  ok rejected seq_len = 0")
+    try:
+        var _ = MLPMixerBlock[DType.float32](seq_len=4, dim=0)
+        raise Error("Should have rejected dim = 0")
+    except _:
+        print("  ok rejected dim = 0")
+    print("test_reject_bad_dims PASSED")
+
+
+def test_reject_shape_mismatch() raises:
+    """Wrong rank / seq / dim on forward must raise."""
+    print("Running test_reject_shape_mismatch...")
+    var mixer = MLPMixerBlock[DType.float32](seq_len=4, dim=8)
+    # Wrong rank (2D)
+    try:
+        var bad = zeros([4, 8], DType.float32)
+        var _ = mixer.forward(bad)
+        raise Error("Should have rejected rank-2 input")
+    except _:
+        print("  ok rejected rank-2 input")
+    # Wrong seq
+    try:
+        var bad = zeros([2, 5, 8], DType.float32)
+        var _ = mixer.forward(bad)
+        raise Error("Should have rejected seq mismatch")
+    except _:
+        print("  ok rejected seq mismatch")
+    # Wrong dim
+    try:
+        var bad = zeros([2, 4, 7], DType.float32)
+        var _ = mixer.forward(bad)
+        raise Error("Should have rejected dim mismatch")
+    except _:
+        print("  ok rejected dim mismatch")
+    print("test_reject_shape_mismatch PASSED")
+
+
+def test_package_import() raises:
+    """The package-path export builds and constructs (guards __init__.mojo)."""
+    print("Running test_package_import...")
+    var mixer = MLPMixerBlockPkg[DType.float32](seq_len=4, dim=8)
+    var x = zeros([1, 4, 8], DType.float32)
+    var y = mixer.forward(x)
+    if y.shape()[2] != 8:
+        raise Error("package-path MLPMixerBlock forward failed")
+    print("  ok package-path import + forward")
+    print("test_package_import PASSED")
+
+
+def test_parity_with_pytorch() raises:
+    """Forward must match the PyTorch MLP-Mixer reference to 1e-5.
+
+    Ramp weights/input are set with the SAME float arithmetic as the generator
+    (parity_refs/mlp_mixer_parity_reference.py) — verified bit-identical to the
+    reference's stored weight arrays. The 64 expected outputs are transcribed
+    literals produced by that generator (re-run + diff before committing).
+
+    Config: batch=2, seq=4, dim=8, token_hidden=6, channel_hidden=16, exact GELU,
+    LayerNorm eps=1e-5. Odyssey Linear W is (in, out); the reference sets torch's
+    (out, in) weight to the transpose so the flat ramp order matches directly.
+    """
+    print("Running test_parity_with_pytorch...")
+
+    # Expected output (flattened [2, 4, 8]) from the torch reference.
+    var out = List[Float64]()
+    out.append(0.4630923633773012)
+    out.append(0.515304118067486)
+    out.append(0.5676896096626505)
+    out.append(0.620251016093345)
+    out.append(0.6729888502803849)
+    out.append(0.7259019502812196)
+    out.append(0.778987503404756)
+    out.append(0.8322411035516328)
+    out.append(0.5721702475104775)
+    out.append(0.6246940237890714)
+    out.append(0.6774280780679043)
+    out.append(0.7303749220173466)
+    out.append(0.7835351512648738)
+    out.append(0.8369074341213943)
+    out.append(0.89048853893572)
+    out.append(0.944273399237553)
+    out.append(0.6812170290940615)
+    out.append(0.7340518246314501)
+    out.append(0.7871334392643378)
+    out.append(0.8404647184029136)
+    out.append(0.8940463403813144)
+    out.append(0.9478768037639067)
+    out.append(1.0019524579394081)
+    out.append(1.0562675760665834)
+    out.append(0.7902366807997545)
+    out.append(0.8433816212735346)
+    out.append(0.8968099219380731)
+    out.append(0.9505247619433791)
+    out.append(1.0045269023302499)
+    out.append(1.0588146719165101)
+    out.append(1.1133840011307836)
+    out.append(1.1682285027608976)
+    out.append(0.7830923633773011)
+    out.append(0.8353041180674861)
+    out.append(0.8876896096626505)
+    out.append(0.940251016093345)
+    out.append(0.9929888502803851)
+    out.append(1.0459019502812197)
+    out.append(1.098987503404756)
+    out.append(1.152241103551633)
+    out.append(0.8921702475104774)
+    out.append(0.9446940237890713)
+    out.append(0.9974280780679041)
+    out.append(1.0503749220173466)
+    out.append(1.103535151264874)
+    out.append(1.156907434121394)
+    out.append(1.2104885389357198)
+    out.append(1.264273399237553)
+    out.append(1.0012170290940614)
+    out.append(1.05405182463145)
+    out.append(1.1071334392643377)
+    out.append(1.1604647184029135)
+    out.append(1.2140463403813144)
+    out.append(1.2678768037639068)
+    out.append(1.321952457939408)
+    out.append(1.3762675760665835)
+    out.append(1.1102366807997548)
+    out.append(1.1633816212735348)
+    out.append(1.2168099219380735)
+    out.append(1.2705247619433795)
+    out.append(1.3245269023302502)
+    out.append(1.3788146719165106)
+    out.append(1.4333840011307841)
+    out.append(1.4882285027608981)
+
+    var mixer = MLPMixerBlock[DType.float64](
+        seq_len=4, dim=8, token_hidden=6, channel_hidden=16
+    )
+
+    # Token MLP: fc1 (S=4, HT=6) ramp i*0.01 - 0.1; bias (HT=6) i*0.02 - 0.05.
+    for i in range(4 * 6):
+        mixer.token_mlp.fc1.weight.store[DType.float64](
+            i, Float64(i) * 0.01 - 0.1
+        )
+    for i in range(6):
+        mixer.token_mlp.fc1.bias.store[DType.float64](
+            i, Float64(i) * 0.02 - 0.05
+        )
+    # fc2 (HT=6, S=4) ramp i*0.005 - 0.06; bias (S=4) i*0.03 - 0.04.
+    for i in range(6 * 4):
+        mixer.token_mlp.fc2.weight.store[DType.float64](
+            i, Float64(i) * 0.005 - 0.06
+        )
+    for i in range(4):
+        mixer.token_mlp.fc2.bias.store[DType.float64](
+            i, Float64(i) * 0.03 - 0.04
+        )
+
+    # Channel MLP: fc1 (D=8, HC=16) ramp i*0.002 - 0.12; bias (HC=16) i*0.01 - 0.07.
+    for i in range(8 * 16):
+        mixer.channel_mlp.fc1.weight.store[DType.float64](
+            i, Float64(i) * 0.002 - 0.12
+        )
+    for i in range(16):
+        mixer.channel_mlp.fc1.bias.store[DType.float64](
+            i, Float64(i) * 0.01 - 0.07
+        )
+    # fc2 (HC=16, D=8) ramp i*0.003 - 0.09; bias (D=8) i*0.02 - 0.03.
+    for i in range(16 * 8):
+        mixer.channel_mlp.fc2.weight.store[DType.float64](
+            i, Float64(i) * 0.003 - 0.09
+        )
+    for i in range(8):
+        mixer.channel_mlp.fc2.bias.store[DType.float64](
+            i, Float64(i) * 0.02 - 0.03
+        )
+
+    # LayerNorm params are gamma=1, beta=0 by construction (matching the
+    # reference's default nn.LayerNorm) — left untouched.
+
+    # Input [B=2, S=4, D=8] ramp i*0.01 - 0.15.
+    var x = zeros([2, 4, 8], DType.float64)
+    for i in range(2 * 4 * 8):
+        x.store[DType.float64](i, Float64(i) * 0.01 - 0.15)
+
+    var y = mixer.forward(x)
+    for i in range(64):
+        var d = y.load[DType.float64](i) - out[i]
+        if d < 0:
+            d = -d
+        if d > 1e-5:
+            raise Error("Mixer parity mismatch at index " + String(i))
+    print("  ok matches PyTorch MLP-Mixer block to 1e-5 (64 elements)")
+    print("test_parity_with_pytorch PASSED")
+
+
+def main() raises:
+    """Run all MLPMixerBlock tests."""
+    print("=" * 60)
+    print("MLP-Mixer Block Test Suite")
+    print("=" * 60)
+    test_shape_preserved()
+    test_default_hidden_dims()
+    test_parameter_count()
+    test_reject_bad_dims()
+    test_reject_shape_mismatch()
+    test_package_import()
+    test_parity_with_pytorch()
+    print("=" * 60)
+    print("All MLPMixerBlock tests PASSED")
+    print("=" * 60)


### PR DESCRIPTION

Closes #5653
Tracking: mvillmow/Random#58

## What

Adds `MLPMixerBlock` to `src/odyssey/core/layers/` — a single MLP-Mixer layer
(Tolstikhin et al. 2021, "MLP-Mixer: An all-MLP Architecture for Vision",
arXiv:2105.01601, §2, Eq. 1-2): a token-mixing MLP followed by a channel-mixing
MLP, each pre-LayerNorm with a residual. Pure MLP mixing; no convolution, no
attention.

Batch-first `[batch, seq, dim]`:

    U = X + TokenMLP( LayerNorm_1(X)^T )^T      # token-mixing across `seq`
    Y = U + ChannelMLP( LayerNorm_2(U) )        # channel-mixing across `dim`

- Channel MLP: position-wise over `dim` (reshape `[B,S,D]->[B*S,D]`).
- Token MLP: over `seq` (transpose `[B,S,D]->[B,D,S]`, reshape `[B*D,S]`, back).
- Exact GELU; LayerNorm eps=1e-5; token_hidden default `4*seq_len`,
  channel_hidden default `4*dim`.

Reuses merged `LayerNorm` and `FeedForward` modules verbatim (not
reimplemented). `Module`-trait conformer; float32 default. No BatchNorm.

`forward()` consumes a full sequence at once — established
sequence-consuming-layer convention; documented in the layer docstring.

## Files

- `src/odyssey/core/layers/mlp_mixer.mojo` (new)
- `tests/odyssey/core/layers/test_mlp_mixer.mojo` (new)
- `tests/odyssey/core/layers/parity_refs/mlp_mixer_parity_reference.py` (new)
- `src/odyssey/core/layers/__init__.mojo` (export line + Components docstring line)
- `README.md` (primitive-test table row)
- `scripts/run_primitive_test.sh` (register `mlp_mixer`)

## Test evidence

`pixi run mojo -I src -I . --Werror tests/odyssey/core/layers/test_mlp_mixer.mojo`

```
============================================================
MLP-Mixer Block Test Suite
============================================================
Running test_shape_preserved...
  ok shape preserved (2, 4, 8)
test_shape_preserved PASSED
Running test_default_hidden_dims...
  ok defaults token_hidden=20, channel_hidden=24
test_default_hidden_dims PASSED
Running test_parameter_count...
  ok 12 parameter tensors
test_parameter_count PASSED
Running test_reject_bad_dims...
  ok rejected seq_len = 0
  ok rejected dim = 0
test_reject_bad_dims PASSED
Running test_reject_shape_mismatch...
  ok rejected rank-2 input
  ok rejected seq mismatch
  ok rejected dim mismatch
test_reject_shape_mismatch PASSED
Running test_package_import...
  ok package-path import + forward
test_package_import PASSED
Running test_parity_with_pytorch...
  ok matches PyTorch MLP-Mixer block to 1e-5 (64 elements)
test_parity_with_pytorch PASSED
============================================================
All MLPMixerBlock tests PASSED
============================================================
```

`bash scripts/run_primitive_test.sh mlp_mixer` → `✅ mlp_mixer PASSED`

Parity generator re-run + diff: no diff (reproducible). Interpreter:
`/tmp/claude-1000/venvs/torch_venv/bin/python`.

pre-commit on touched files: all hooks Passed (Mojo Format, Ruff Format/Check,
Markdown Lint, mypy, Bandit, Validate Test Coverage, Check Test Count Badge).

## Parity

- Token/channel mixing block transcribed in torch as
  `LayerNorm -> transpose -> Linear->GELU->Linear -> residual -> LayerNorm ->
  Linear->GELU->Linear -> residual`, float64, matched to 1e-5 on
  `seq=4, dim=8, token_hidden=6, channel_hidden=16`.
- Odyssey `Linear` W is `(in, out)`; the torch reference sets `(out, in)` weight
  to the transpose so ramp order maps directly. Ramp weights set with identical
  float arithmetic to the generator (verified bit-identical); the 64 expected
  outputs are transcribed generator literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
