### PR TITLE
feat(layers): add permutation-equivariant DeepSets block (arXiv:1703.06114)

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ bash scripts/run_primitive_test.sh --list     # list known primitives + paths
 | GRU | layer | `bash scripts/run_primitive_test.sh gru` |
 | LayerNorm | layer | `bash scripts/run_primitive_test.sh layernorm` |
 | Transformer FeedForward (FFN) | layer | `bash scripts/run_primitive_test.sh ffn` |
+| DeepSets (permutation-equivariant linear block) | layer | `bash scripts/run_primitive_test.sh deepsets` |
 | ADOPT | optimizer | `bash scripts/run_primitive_test.sh adopt` |
 | Sophia (clipped update step; caller-supplied Hessian estimates) | optimizer | `bash scripts/run_primitive_test.sh sophia` |
 | Adan | optimizer | `bash scripts/run_primitive_test.sh adan` |

--- a/scripts/run_primitive_test.sh
+++ b/scripts/run_primitive_test.sh
@@ -35,6 +35,7 @@ TEST[muon_hyperball]="tests/odyssey/training/optimizers/test_muon_hyperball.mojo
 TEST[soap]="tests/odyssey/training/optimizers/test_soap.mojo"
 TEST[sophia]="tests/odyssey/training/optimizers/test_sophia.mojo"
 # --- layers ---
+TEST[deepsets]="tests/odyssey/core/layers/test_deepsets.mojo"
 TEST[ffn]="tests/odyssey/core/layers/test_feedforward.mojo"
 TEST[gru]="tests/odyssey/core/layers/test_gru.mojo"
 TEST[layernorm]="tests/odyssey/core/layers/test_layernorm.mojo"

--- a/src/odyssey/core/layers/__init__.mojo
+++ b/src/odyssey/core/layers/__init__.mojo
@@ -10,6 +10,7 @@ Components:
     - ReLU: Rectified Linear Unit activation
     - RNNCell: Vanilla (Elman) recurrent cell (tanh)
     - FeedForward: Transformer position-wise feed-forward (Linear->act->Linear)
+    - DeepSetsEquivariant: Permutation-equivariant Deep Sets linear block
     - Sigmoid: Sigmoid activation function
     - Tanh: Hyperbolic tangent activation
     - BatchNorm: Batch normalization
@@ -44,6 +45,7 @@ from odyssey.core.layers.lstm import LSTMCell
 from odyssey.core.layers.layernorm import LayerNorm
 from odyssey.core.layers.gru import GRUCell
 from odyssey.core.layers.feedforward import FeedForward
+from odyssey.core.layers.deepsets import DeepSetsEquivariant
 
 # from .activation import ReLU, Sigmoid, Tanh
 # from .pooling import MaxPool2D, AvgPool2D

--- a/src/odyssey/core/layers/deepsets.mojo
+++ b/src/odyssey/core/layers/deepsets.mojo
@@ -1,0 +1,181 @@
+"""Permutation-equivariant (Deep Sets) linear block.
+
+A single permutation-equivariant linear layer from Zaheer et al. 2017,
+"Deep Sets" (NeurIPS 2017, arXiv:1703.06114). The layer maps a *set* of feature
+vectors to a set of the same size, and is **equivariant** to permutations of the
+set elements: permuting the input elements permutes the output elements
+identically. This is the defining property (see `tests/.../test_deepsets.mojo`,
+`test_permutation_equivariance`).
+
+Equivariant form (this block, ARCH-14 variant — SUM pool, ReLU activation):
+
+    y_i = relu( x_i @ Lambda  +  (sum_j x_j) @ Gamma  +  b )
+
+Here `x_i` is the i-th element of an input set, `Lambda` and `Gamma` are learnable
+(dim, out) projections, and `b` is a learnable (out,) bias. The pooled term
+`sum_j x_j` is permutation-INVARIANT, and it is broadcast identically onto every
+set element; that invariant + shared-per-element structure is exactly the
+necessary-and-sufficient condition for permutation equivariance derived in the
+paper (Sec. "Permutation Equivariance"; the parameter-tied linear map there is
+`Lambda = lambda*I`, `Gamma = gamma*(1 1^T)` — this block uses the general
+learnable dense form, which is equivariant for ANY `Lambda`, `Gamma`).
+
+Batch-first convention `[batch, set_size, dim]`: the SET axis (axis 1) plays the
+role the sequence axis plays in the recurrent layers, and pooling reduces over it.
+
+The forward pass is documented over the full set at once (no per-element loop is
+exposed): the per-element `Lambda` transform is a single batched matmul, and the
+pooled `Gamma` term is one reduction + one matmul, broadcast back over the set.
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros, randn
+from odyssey.core.module import Module
+
+
+struct DeepSetsEquivariant[dtype: DType = DType.float32](
+    Copyable, Module, Movable
+):
+    """Permutation-equivariant Deep Sets linear block.
+
+    Implements `y_i = relu(x_i @ Lambda + (sum_j x_j) @ Gamma + b)` over a
+    batch-first `[batch, set_size, dim]` input, equivariant to permutations of
+    the set axis (axis 1).
+
+    Compile-time contract: `Self.dtype` fixes the element type of every
+    parameter and of the forward computation. The public API is float32 by
+    default; float64 is available for tight-tolerance parity checks. Inputs
+    passed to `forward` must share `Self.dtype` (matmul rejects mixed dtypes).
+
+    Parameters:
+        dtype: Element type for weights, bias, and compute (default: float32).
+
+    Attributes:
+        lam: Per-element projection `Lambda`, shape (dim, out).
+        gam: Pooled (sum-over-set) projection `Gamma`, shape (dim, out).
+        bias: Bias vector, shape (out,).
+        dim: Input feature dimension of each set element.
+        out_features: Output feature dimension of each set element.
+    """
+
+    var lam: AnyTensor
+    var gam: AnyTensor
+    var bias: AnyTensor
+    var dim: Int
+    var out_features: Int
+
+    def __init__(out self, dim: Int, out_features: Int) raises:
+        """Initialize with random `Lambda`/`Gamma` and zero bias.
+
+        Args:
+            dim: Input feature dimension of each set element.
+            out_features: Output feature dimension of each set element.
+
+        Raises:
+            Error: If dim <= 0 or out_features <= 0, or if tensor creation fails.
+
+        Example:
+            ```mojo
+            var layer = DeepSetsEquivariant(6, 5)  # dim 6 -> out 5
+            ```
+        """
+        if dim <= 0:
+            raise Error("DeepSetsEquivariant: dim must be positive")
+        if out_features <= 0:
+            raise Error("DeepSetsEquivariant: out_features must be positive")
+        self.dim = dim
+        self.out_features = out_features
+        self.lam = randn([dim, out_features], Self.dtype)
+        self.gam = randn([dim, out_features], Self.dtype)
+        self.bias = zeros([out_features], Self.dtype)
+
+    def forward(mut self, input: AnyTensor) raises -> AnyTensor:
+        """Forward pass over the full set.
+
+        Computes `y_i = relu(x_i @ Lambda + (sum_j x_j) @ Gamma + b)` for every
+        set element `i`, where the pooled term `sum_j x_j` is reduced over the
+        set axis and broadcast back over every element.
+
+        Args:
+            input: Input tensor of shape `[batch, set_size, dim]`. Its dtype must
+                equal `Self.dtype`.
+
+        Returns:
+            Output tensor of shape `[batch, set_size, out_features]`.
+
+        Raises:
+            Error: If `input` is not rank-3, if its last dim != `dim`, or if any
+                tensor operation fails.
+
+        Example:
+            ```mojo
+            var layer = DeepSetsEquivariant[DType.float32](6, 5)
+            var x = zeros([2, 4, 6], DType.float32)  # batch 2, set 4, dim 6
+            var y = layer.forward(x)                 # shape [2, 4, 5]
+            ```
+        """
+        from odyssey.core.matrix import matmul
+        from odyssey.core.reduction import sum as reduce_sum
+        from odyssey.core.activation import relu
+
+        var shape = input.shape()
+        if len(shape) != 3:
+            raise Error(
+                "DeepSetsEquivariant.forward expects rank-3 [batch, set_size,"
+                " dim] input"
+            )
+        var batch = shape[0]
+        var set_size = shape[1]
+        var feat = shape[2]
+        if feat != self.dim:
+            raise Error(
+                "DeepSetsEquivariant.forward: last input dim ("
+                + String(feat)
+                + ") != layer dim ("
+                + String(self.dim)
+                + ")"
+            )
+
+        # Per-element transform: reshape [B, S, D] -> [B*S, D], apply Lambda,
+        # reshape back to [B, S, O]. matmul is 2D-only for the broadcast case, so
+        # we fold the set axis into the batch axis for this shared transform.
+        var flat = input.reshape([batch * set_size, self.dim])
+        var per_elem = matmul(flat, self.lam)  # [B*S, O]
+        var per_elem_3d = per_elem.reshape([batch, set_size, self.out_features])
+
+        # Permutation-INVARIANT pooled term: sum over the set axis (axis 1),
+        # project with Gamma, broadcast back over the set axis.
+        var pooled = reduce_sum(input, axis=1, keepdims=False)  # [B, D]
+        var pooled_proj = matmul(pooled, self.gam)  # [B, O]
+        var pooled_3d = pooled_proj.reshape(
+            [batch, 1, self.out_features]
+        )  # broadcast over set axis
+
+        # Broadcast-add pooled term + bias, then activation.
+        var pre = (per_elem_3d + pooled_3d) + self.bias
+        return relu(pre)
+
+    def parameters(self) raises -> List[AnyTensor]:
+        """Get trainable parameters.
+
+        Returns:
+            List `[lam, gam, bias]` in a deterministic order.
+
+        Raises:
+            Error: If tensor copying fails.
+        """
+        var params = List[AnyTensor]()
+        params.append(self.lam)
+        params.append(self.gam)
+        params.append(self.bias)
+        return params^
+
+    def train(mut self):
+        """Switch to training mode (no-op; block has no mode-dependent state).
+        """
+        pass
+
+    def eval(mut self):
+        """Switch to inference mode (no-op; block has no mode-dependent state).
+        """
+        pass

--- a/tests/odyssey/core/layers/parity_refs/deepsets_parity_reference.py
+++ b/tests/odyssey/core/layers/parity_refs/deepsets_parity_reference.py
@@ -1,0 +1,60 @@
+"""Permutation-equivariant (Deep Sets) block parity reference.
+
+Computes the forward pass of a single permutation-equivariant linear layer
+(Zaheer et al. 2017, "Deep Sets", arXiv:1703.06114, equivariant layer, Eq. in
+Sec. "Permutation Equivariance") in PyTorch with FIXED ramp weights and a FIXED
+input, and prints the flattened output so the Mojo DeepSetsEquivariant test can
+set the same weights and assert equality.
+
+Layer (issue mvillmow/Random#64, ARCH-14 variant — SUM pool, ReLU activation):
+
+    y_i = relu( x_i @ Lambda  +  (sum_j x_j) @ Gamma  +  b )
+
+with the set axis being axis 1 of a batch-first [batch, set_size, dim] input.
+`Lambda` and `Gamma` are both (dim, out) in Odyssey (in, out) layout; the pooled
+term (sum over the set axis) is broadcast back across every set element before
+the elementwise transform, which is exactly what makes the map equivariant:
+permuting the set elements of `x` permutes the rows of `y` identically, because
+the pooled term is permutation-INVARIANT.
+
+Config: batch=2, set_size=4, dim=6, out=5, dtype=float64. Ramp weights are
+simple deterministic sequences so they transcribe cleanly into the Mojo test.
+
+Run:
+    python tests/odyssey/core/layers/parity_refs/deepsets_parity_reference.py
+"""
+
+import json
+
+import torch
+
+B, S, D, OUT = 2, 4, 6, 5
+
+# Odyssey-layout (in, out) ramp weight matrices + bias, and a ramp input.
+Lam = torch.arange(D * OUT, dtype=torch.float64).reshape(D, OUT) * 0.01 - 0.15
+Gam = torch.arange(D * OUT, dtype=torch.float64).reshape(D, OUT) * 0.007 - 0.10
+b = torch.arange(OUT, dtype=torch.float64) * 0.02 - 0.04
+X = torch.arange(B * S * D, dtype=torch.float64).reshape(B, S, D) * 0.01 - 0.2
+
+with torch.no_grad():
+    # Per-element transform: [B, S, D] @ [D, OUT] -> [B, S, OUT]
+    per_elem = X @ Lam
+    # Permutation-INVARIANT pooled term: sum over the set axis (axis=1), then
+    # the pooled [B, D] is projected and broadcast back over the set axis.
+    pooled = X.sum(dim=1)  # [B, D]
+    pooled_proj = pooled @ Gam  # [B, OUT]
+    out = torch.relu(per_elem + pooled_proj.unsqueeze(1) + b)  # [B, S, OUT]
+
+print(
+    json.dumps(
+        {
+            "config": {"batch": B, "set_size": S, "dim": D, "out": OUT},
+            "Lambda": Lam.flatten().tolist(),
+            "Gamma": Gam.flatten().tolist(),
+            "bias": b.tolist(),
+            "X": X.flatten().tolist(),
+            "out": out.flatten().tolist(),
+        },
+        indent=2,
+    )
+)

--- a/tests/odyssey/core/layers/test_deepsets.mojo
+++ b/tests/odyssey/core/layers/test_deepsets.mojo
@@ -1,0 +1,256 @@
+"""Unit tests for the permutation-equivariant Deep Sets block.
+
+Tests cover:
+- Construction + shape mapping ([batch, set, dim] -> [batch, set, out]).
+- Parameter collection (3 tensors: lam, gam, bias).
+- Input validation (rejects non-positive dims; rejects non-rank-3 / wrong last
+  dim input).
+- Numerical parity with a PyTorch reference (per-element Lambda + sum-pooled
+  Gamma + bias, ReLU) on fixed ramp weights/input (tolerance 1e-5).
+- THE DEFINING PROPERTY: permutation equivariance — permuting the set elements
+  of the input must permute the output rows identically, to tight tolerance.
+- Package-path import: `from odyssey.core.layers import DeepSetsEquivariant`
+  must resolve (guards docstring-without-export regressions).
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros
+from odyssey.core.layers.deepsets import DeepSetsEquivariant
+
+# Package-path import: MUST resolve via the layers package __init__ export.
+from odyssey.core.layers import DeepSetsEquivariant as DeepSetsFromPackage
+
+
+def test_shape_mapping() raises:
+    """Maps [batch, set, dim] -> [batch, set, out]."""
+    print("Running test_shape_mapping...")
+    var layer = DeepSetsEquivariant[DType.float32](6, 5)
+    var x = zeros([2, 4, 6], DType.float32)
+    var y = layer.forward(x)
+    if y.shape()[0] != 2 or y.shape()[1] != 4 or y.shape()[2] != 5:
+        raise Error("DeepSets must map [2,4,6] -> [2,4,5]")
+    print("  ok shape [2,4,6] -> [2,4,5]")
+    print("test_shape_mapping PASSED")
+
+
+def test_parameter_count() raises:
+    """`parameters()` returns 3 tensors (lam, gam, bias)."""
+    print("Running test_parameter_count...")
+    var layer = DeepSetsEquivariant[DType.float32](6, 5)
+    var params = layer.parameters()
+    if len(params) != 3:
+        raise Error("DeepSets should expose 3 parameter tensors")
+    print("  ok 3 parameter tensors")
+    print("test_parameter_count PASSED")
+
+
+def test_reject_bad_dims() raises:
+    """Non-positive dim / out_features must raise."""
+    print("Running test_reject_bad_dims...")
+    try:
+        var _ = DeepSetsEquivariant[DType.float32](0, 5)
+        raise Error("Should have rejected dim = 0")
+    except _:
+        print("  ok rejected dim = 0")
+    try:
+        var _ = DeepSetsEquivariant[DType.float32](6, 0)
+        raise Error("Should have rejected out_features = 0")
+    except _:
+        print("  ok rejected out_features = 0")
+    print("test_reject_bad_dims PASSED")
+
+
+def test_reject_bad_input_rank() raises:
+    """Non-rank-3 input and wrong last dim must raise."""
+    print("Running test_reject_bad_input_rank...")
+    var layer = DeepSetsEquivariant[DType.float32](6, 5)
+    try:
+        var bad = zeros([2, 6], DType.float32)  # rank-2
+        var _ = layer.forward(bad)
+        raise Error("Should have rejected rank-2 input")
+    except _:
+        print("  ok rejected rank-2 input")
+    try:
+        var wrong = zeros([2, 4, 7], DType.float32)  # last dim != 6
+        var _ = layer.forward(wrong)
+        raise Error("Should have rejected last-dim mismatch")
+    except _:
+        print("  ok rejected wrong last dim")
+    print("test_reject_bad_input_rank PASSED")
+
+
+def test_package_path_import() raises:
+    """`DeepSetsEquivariant` must be importable from the layers package."""
+    print("Running test_package_path_import...")
+    var layer = DeepSetsFromPackage[DType.float32](6, 5)
+    var x = zeros([2, 4, 6], DType.float32)
+    var y = layer.forward(x)
+    if y.shape()[2] != 5:
+        raise Error("package-path import produced wrong shape")
+    print("  ok imported via odyssey.core.layers package path")
+    print("test_package_path_import PASSED")
+
+
+def test_parity_with_pytorch() raises:
+    """Forward must match a PyTorch reference to 1e-5.
+
+    Fixed ramp weights/input and the reference output are transcribed from
+    parity_refs/deepsets_parity_reference.py (torch, float64, batch=2,
+    set_size=4, dim=6, out=5; sum pool, ReLU). Odyssey lam/gam use (dim, out)
+    layout, matching the reference's torch matmul `X @ W`.
+    """
+    print("Running test_parity_with_pytorch...")
+
+    # Reference output (flattened [B*S*O] = 2*4*5 = 40), from the generator.
+    var ref_vals = List[Float64]()
+    ref_vals.append(0.045000000000000005)
+    ref_vals.append(0.040220000000000006)
+    ref_vals.append(0.03544)
+    ref_vals.append(0.03065999999999999)
+    ref_vals.append(0.02587999999999999)
+    ref_vals.append(0.03600000000000001)
+    ref_vals.append(0.034820000000000004)
+    ref_vals.append(0.033639999999999996)
+    ref_vals.append(0.032459999999999996)
+    ref_vals.append(0.03127999999999999)
+    ref_vals.append(0.027000000000000017)
+    ref_vals.append(0.02942000000000002)
+    ref_vals.append(0.03184000000000001)
+    ref_vals.append(0.03426)
+    ref_vals.append(0.03667999999999999)
+    ref_vals.append(0.018000000000000023)
+    ref_vals.append(0.024020000000000017)
+    ref_vals.append(0.030040000000000008)
+    ref_vals.append(0.03606000000000001)
+    ref_vals.append(0.04207999999999999)
+    ref_vals.append(0.0)
+    ref_vals.append(0.0)
+    ref_vals.append(0.03688000000000001)
+    ref_vals.append(0.08682000000000001)
+    ref_vals.append(0.13676000000000002)
+    ref_vals.append(0.0)
+    ref_vals.append(0.0)
+    ref_vals.append(0.035080000000000014)
+    ref_vals.append(0.08862000000000003)
+    ref_vals.append(0.14216000000000004)
+    ref_vals.append(0.0)
+    ref_vals.append(0.0)
+    ref_vals.append(0.03328000000000002)
+    ref_vals.append(0.09042000000000003)
+    ref_vals.append(0.14756000000000002)
+    ref_vals.append(0.0)
+    ref_vals.append(0.0)
+    ref_vals.append(0.03148000000000002)
+    ref_vals.append(0.09222000000000002)
+    ref_vals.append(0.15296)
+
+    var layer = DeepSetsEquivariant[DType.float64](6, 5)
+    # lam[i] = i*0.01 - 0.15 (dim*out = 30 entries)
+    for i in range(30):
+        layer.lam.store[DType.float64](i, Float64(i) * 0.01 - 0.15)
+    # gam[i] = i*0.007 - 0.10
+    for i in range(30):
+        layer.gam.store[DType.float64](i, Float64(i) * 0.007 - 0.10)
+    # bias[i] = i*0.02 - 0.04
+    for i in range(5):
+        layer.bias.store[DType.float64](i, Float64(i) * 0.02 - 0.04)
+
+    # X[i] = i*0.01 - 0.2 (batch*set*dim = 48 entries)
+    var x = zeros([2, 4, 6], DType.float64)
+    for i in range(48):
+        x.store[DType.float64](i, Float64(i) * 0.01 - 0.2)
+
+    var y = layer.forward(x)
+    for i in range(40):
+        var d = y.load[DType.float64](i) - ref_vals[i]
+        if d < 0:
+            d = -d
+        if d > 1e-5:
+            raise Error("DeepSets parity mismatch at index " + String(i))
+    print("  ok matches PyTorch reference to 1e-5")
+    print("test_parity_with_pytorch PASSED")
+
+
+def test_permutation_equivariance() raises:
+    """DEFINING PROPERTY: permuting set elements permutes output rows identically.
+
+    Build a single-batch input, run forward to get `y`. Then apply a nontrivial
+    permutation of the set axis to the SAME input, run forward again, and assert
+    the second output equals `y` with its rows permuted the same way, to tight
+    tolerance. (Uses float64 so the equality is exact up to fp round-off, not a
+    loose shape check.)
+    """
+    print("Running test_permutation_equivariance...")
+
+    var S = 4
+    var D = 6
+    var O = 5
+    var layer = DeepSetsEquivariant[DType.float64](D, O)
+    # Nontrivial ramp weights so the map is not degenerate.
+    for i in range(D * O):
+        layer.lam.store[DType.float64](i, Float64(i) * 0.013 - 0.08)
+    for i in range(D * O):
+        layer.gam.store[DType.float64](i, Float64(i) * 0.009 - 0.05)
+    for i in range(O):
+        layer.bias.store[DType.float64](i, Float64(i) * 0.01 - 0.02)
+
+    # Base input [1, S, D], ramp values.
+    var x = zeros([1, S, D], DType.float64)
+    for i in range(S * D):
+        x.store[DType.float64](i, Float64(i) * 0.017 - 0.25)
+
+    var y = layer.forward(x)  # [1, S, O]
+
+    # Nontrivial permutation of the set axis: perm = [2, 0, 3, 1].
+    var perm = List[Int]()
+    perm.append(2)
+    perm.append(0)
+    perm.append(3)
+    perm.append(1)
+
+    var xp = zeros([1, S, D], DType.float64)
+    for new_pos in range(S):
+        var src = perm[new_pos]
+        for d in range(D):
+            xp.store[DType.float64](
+                new_pos * D + d, x.load[DType.float64](src * D + d)
+            )
+
+    var yp = layer.forward(xp)  # [1, S, O]
+
+    # Equivariance: yp[new_pos] must equal y[perm[new_pos]] (rows permuted the
+    # same way the input rows were).
+    for new_pos in range(S):
+        var src = perm[new_pos]
+        for o in range(O):
+            var got = yp.load[DType.float64](new_pos * O + o)
+            var want = y.load[DType.float64](src * O + o)
+            var d = got - want
+            if d < 0:
+                d = -d
+            if d > 1e-9:
+                raise Error(
+                    "equivariance broken at set pos "
+                    + String(new_pos)
+                    + ", out "
+                    + String(o)
+                )
+    print("  ok permuting input set permutes output rows identically")
+    print("test_permutation_equivariance PASSED")
+
+
+def main() raises:
+    """Run all DeepSets equivariant-block tests."""
+    print("=" * 60)
+    print("DeepSetsEquivariant (permutation-equivariant block) Test Suite")
+    print("=" * 60)
+    test_shape_mapping()
+    test_parameter_count()
+    test_reject_bad_dims()
+    test_reject_bad_input_rank()
+    test_package_path_import()
+    test_parity_with_pytorch()
+    test_permutation_equivariance()
+    print("=" * 60)
+    print("All DeepSetsEquivariant tests PASSED")
+    print("=" * 60)


### PR DESCRIPTION

Closes #5659
Tracking: mvillmow/Random#64

## What

Adds `DeepSetsEquivariant`, a single permutation-equivariant linear layer
(Zaheer et al. 2017, "Deep Sets", NeurIPS 2017, arXiv:1703.06114), as a
first-class Odyssey `Module`. ARCH-14 variant — SUM pool, ReLU activation:

```
y_i = relu( x_i @ Lambda  +  (sum_j x_j) @ Gamma  +  b )
```

Batch-first `[batch, set_size, dim]` (set axis = axis 1, reduced by pooling). The
pooled term `sum_j x_j` is permutation-INVARIANT and broadcast onto every set
element, so permuting the input set permutes the output rows identically — the
layer's defining property. `Lambda`, `Gamma` are `(dim, out)`; `b` is `(out,)`.

The forward path folds the set axis into the batch axis for the shared `Lambda`
matmul (Odyssey `matmul` is 2D-only for the broadcast case), reduces over the set
axis for the `Gamma` term, and broadcast-adds; it mirrors `Linear`/`FeedForward`
conventions (float32 default, `(in, out)` weight layout, `Self.dtype`
compile-time contract documented).

## Files

- `src/odyssey/core/layers/deepsets.mojo` — new layer.
- `src/odyssey/core/layers/__init__.mojo` — docstring Components line + export.
- `tests/odyssey/core/layers/test_deepsets.mojo` — unit tests.
- `tests/odyssey/core/layers/parity_refs/deepsets_parity_reference.py` — torch
  parity generator (ramp-seeded, f64 ground truth, JSON output).
- `README.md` — primitive-test table row.
- `scripts/run_primitive_test.sh` — `deepsets` registration.

No CHANGELOG or lockfile churn; only the owned shared-file lines are touched.

## Test evidence

`bash scripts/run_primitive_test.sh deepsets` — all 7 tests PASS:

```
test_shape_mapping PASSED               [2,4,6] -> [2,4,5]
test_parameter_count PASSED             3 params (lam, gam, bias)
test_reject_bad_dims PASSED             rejects dim<=0 / out<=0
test_reject_bad_input_rank PASSED       rejects rank-2 / wrong last dim
test_package_path_import PASSED         from odyssey.core.layers import DeepSetsEquivariant
test_parity_with_pytorch PASSED         matches torch reference to 1e-5
test_permutation_equivariance PASSED    perm(input set) -> perm(output rows), 1e-9
```

- `--Werror` compile clean.
- Parity fixtures regenerated from the committed generator and verified to
  byte-match the transcribed test values (0 mismatches over 40 outputs).
- `mojo format`, ruff, markdownlint, and pre-commit (on touched files) all clean.

## Not in this PR

The PC/BP sweep-runner wiring and the optimizer×clip×LR matrix run described in
`mvillmow/Random#64` are out of scope here — this PR lands only the reusable
Odyssey layer primitive that ablation builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
