### PR TITLE
ci: fast (<5 min) merge-queue smoke gate

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,8 +28,11 @@ jq -r '.required_contexts[]' "$POLICY"
 jq '.merge_queue_rule' "$POLICY"
 ```
 
-The workflows that emit required contexts all handle `merge_group` with the
-`checks_requested` activity while retaining their existing pull request and push triggers:
+Merge-queue checks are served by EXACTLY ONE workflow: `merge-queue-smoke.yml`, whose single
+fast `merge-queue-smoke` job (< 5 min, one runner slot) handles `merge_group` with the
+`checks_requested` activity. The workflows that emit the PR-side contexts retain their
+existing pull request and push triggers but intentionally do NOT run for merge groups
+(re-running the full matrix per queue entry serialized on runner slots, 70-90 min per merge):
 
 - `_required.yml`
 - `comprehensive-tests.yml`
@@ -39,19 +42,23 @@ The workflows that emit required contexts all handle `merge_group` with the
 The publishing workflow in `release.yml` remains tag/manual-only and must not run for merge
 groups. Focused executable coverage lives in
 `tests/smoke/test_merge_queue_workflow_properties.py` and verifies trigger boundaries, exact
-policy values, and one-to-one required-context emission.
+policy values, single-workflow merge-group ownership, and one-emission of every PR context.
 
 This repository does not activate or mutate live GitHub rulesets. The Odysseus rollout tracked
 by `HomericIntelligence/Odysseus#386` is the sole activation authority. That operator must:
 
 1. Snapshot every active `main` ruleset and retain the pre-edit activation-ruleset snapshot as
    the rollback payload.
-2. Refuse activation unless the union of live required contexts exactly equals
-   `.required_contexts` and the target ruleset has no existing `merge_queue` rule.
+2. Replace ALL `required_status_checks` contexts (in every ruleset) with exactly
+   `.required_contexts` (the single `merge-queue-smoke` context) and set
+   `min_entries_to_merge_wait_minutes` to 0. PR-side checks keep running but become
+   non-blocking. Until that flip lands, the queue must not be used: `merge_group` no longer
+   produces the old contexts.
 3. Append exactly `.merge_queue_rule`, read it back, and restore the snapshot if read-back differs.
-4. Queue a representative pull request and select actual `merge_group` runs for the four workflows.
-5. Confirm each policy context appears exactly once and completes successfully before recording
-   the live response, run URLs, and queued merge result on Odyssey issue #5624.
+4. Queue a representative pull request and select the actual `merge_group` run of
+   `merge-queue-smoke.yml`.
+5. Confirm the `merge-queue-smoke` context appears exactly once and completes successfully before
+   recording the live response, run URLs, and queued merge result on Odyssey issue #5624.
 
 Keep issue #5624 open until activation and queued smoke evidence are recorded. A readiness PR
 references the issue with `Refs #5624`; it does not close it.
@@ -67,7 +74,7 @@ ls .github/workflows/*.yml | wc -l
 | Workflow | Trigger | Purpose | Duration |
 | --- | --- | --- | --- |
 | **Test Workflows** | | | |
-| [comprehensive-tests.yml](#comprehensive-tests) | PR, merge queue, push main, manual | All Mojo tests in 17 groups | < 10 min |
+| [comprehensive-tests.yml](#comprehensive-tests) | PR, push main, manual | All Mojo tests in 17 groups | < 10 min |
 | [comprehensive-test-pr-comments.yml](#comprehensive-test-pr-comments) | Completed comprehensive PR tests | Trusted test-report PR comments | < 1 min |
 | [test-gradients.yml](#test-gradients) | PR on gradient changes, push main | Backward pass validation | < 5 min |
 | [test-data-utilities.yml](#test-data-utilities) | PR/push on data changes | Data loading and processing | < 5 min |
@@ -77,7 +84,7 @@ ls .github/workflows/*.yml | wc -l
 | [validate-configs.yml](#validate-configs) | PR/push on config changes | YAML and schema validation | < 5 min |
 | [test-agents.yml](#test-agents) | PR on agent configs, push main | Agent configuration testing | < 3 min |
 | [validate-workflows.yml](#validate-workflows) | PR, push main on .github/ | Validate workflow checkout order | < 3 min |
-| [pre-commit.yml](#pre-commit) | PR, merge queue, push main, manual | Code formatting and linting | < 5 min |
+| [pre-commit.yml](#pre-commit) | PR, push main, manual | Code formatting and linting | < 5 min |
 | [type-check.yml](#type-check) | PR on scripts, push main, manual | Python type checking | < 3 min |
 | [notebook-validation.yml](#notebook-validation) | PR/push on notebooks | Jupyter notebook validation | < 5 min |
 | [paper-validation.yml](#paper-validation) | PR/push on papers/, manual | Paper implementation validation | < 15 min |
@@ -96,8 +103,9 @@ ls .github/workflows/*.yml | wc -l
 | precommit-benchmark.yml | Push main, manual | Pre-commit hook performance tracking | < 5 min |
 | **Maintenance Workflows** | | | |
 | [mojo-version-check.yml](#mojo-version-check) | Weekly Sunday 3 AM UTC, manual | Check for new Mojo releases | < 3 min |
-| workflow-smoke-test.yml | PR, merge queue, push main, manual | Workflow validation smoke tests | < 2 min |
+| workflow-smoke-test.yml | PR, push main, manual | Workflow validation smoke tests | < 2 min |
 | worktree-sync-check.yml | PR | Check if PR branch is significantly behind origin/main | < 2 min |
+| merge-queue-smoke.yml | Merge queue | Single fast `merge-queue-smoke` job for merge-queue entries | < 5 min |
 | **AI/Automation Workflows** | | | |
 | [claude.yml](#claude) | Issue/PR comments mentioning @claude | Claude Code agent integration | N/A |
 | [claude-code-review.yml](#claude-code-review) | PR opened/synchronized | Automated Claude code review | < 5 min |
@@ -110,7 +118,7 @@ ls .github/workflows/*.yml | wc -l
 
 **File**: `comprehensive-tests.yml`
 
-**Triggers**: Pull requests, `merge_group` (`checks_requested`), pushes to main, manual dispatch
+**Triggers**: Pull requests, pushes to main, manual dispatch (merge-queue checks run in `merge-queue-smoke.yml`)
 
 **Purpose**: Run all Mojo tests organized into 17 logical groups for comprehensive coverage.
 
@@ -321,7 +329,7 @@ or executes pull-request code with its narrowly scoped `pull-requests: write` to
 
 **File**: `pre-commit.yml`
 
-**Triggers**: PR, `merge_group` (`checks_requested`), pushes to main, manual dispatch
+**Triggers**: PR, pushes to main, manual dispatch (merge-queue checks run in `merge-queue-smoke.yml`)
 
 **Purpose**: Run pre-commit hooks for code formatting and linting.
 

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -673,4 +673,3 @@ jobs:
           fi
 
           echo "Release readiness OK (dry-run): version=$version. No artifacts published."
-

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -8,8 +8,10 @@ name: Required Checks
 
 on:
   pull_request:
-  merge_group:
-    types: [checks_requested]
+  # merge_group intentionally removed: merge-queue checks are served by the
+  # single fast `merge-queue-smoke` job in merge-queue-smoke.yml. Re-running
+  # the full required matrix per queue entry serialized on runner slots
+  # (70-90 min per merge). PR-side jobs in this workflow are unchanged.
   push:
     branches: [main]
 
@@ -671,3 +673,4 @@ jobs:
           fi
 
           echo "Release readiness OK (dry-run): version=$version. No artifacts published."
+

--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -9,9 +9,8 @@ on:
   # Run on all pull requests
   pull_request:
 
-  # Run the same required contexts for merge queue candidates
-  merge_group:
-    types: [checks_requested]
+  # merge_group intentionally removed: merge-queue checks are served by the
+  # single fast `merge-queue-smoke` job in merge-queue-smoke.yml (see that file).
 
   # Run on pushes to main
   push:

--- a/.github/workflows/merge-queue-smoke.yml
+++ b/.github/workflows/merge-queue-smoke.yml
@@ -1,0 +1,82 @@
+# Fast merge-queue gate. This is the ONLY workflow that runs on merge_group
+# events: _required.yml, pre-commit.yml, comprehensive-tests.yml, and
+# workflow-smoke-test.yml no longer trigger there, so re-running the full
+# required matrix per queue entry (70-90 min of runner-slot starvation) is
+# replaced by this single job. PR-side CI is completely untouched; after the
+# ruleset flip, `merge-queue-smoke` is the only ruleset-required context and
+# is produced exclusively on merge_group events by this job.
+#
+# The steps below are real, fail-fast validations borrowed from the repo's
+# fastest gating jobs (workflow-smoke-test property greps, schema-validation,
+# deps/version-sync). They are NOT decorative: a malformed workflow, a
+# dropped pull_request trigger, or a version drift in the merge group fails
+# the queue entry.
+name: Merge Queue Smoke
+
+on:
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mq-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  merge-queue-smoke:
+    name: merge-queue-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Check pull_request triggers on gating workflows
+        run: |
+          set -euo pipefail
+          for wf in security.yml pre-commit.yml comprehensive-tests.yml validate-configs.yml; do
+            if ! grep -qP '^\s+pull_request\b' ".github/workflows/$wf"; then
+              echo "ERROR: $wf is missing pull_request trigger"
+              exit 1
+            fi
+            echo "OK: pull_request trigger present in $wf"
+          done
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        with:
+          python-version: '3.11'
+
+      - name: Install check-jsonschema
+        run: pip install check-jsonschema
+
+      - name: Validate workflow YAML schemas
+        run: |
+          find .github/workflows -name "*.yml" | sort | \
+            xargs check-jsonschema \
+              --schemafile https://json.schemastore.org/github-workflow
+
+      - name: Cross-check pyproject.toml and pixi.toml versions
+        run: |
+          python3 - <<'EOF'
+          import tomllib, sys
+
+          with open("pyproject.toml", "rb") as f:
+              pyproject = tomllib.load(f)
+          with open("pixi.toml", "rb") as f:
+              pixi = tomllib.load(f)
+
+          pyproject_ver = pyproject.get("project", {}).get("version") or \
+                          pyproject.get("tool", {}).get("poetry", {}).get("version")
+          pixi_ver = pixi.get("workspace", {}).get("version") or \
+                     pixi.get("package", {}).get("version")
+
+          print(f"pyproject.toml version : {pyproject_ver}")
+          print(f"pixi.toml version      : {pixi_ver}")
+
+          if pyproject_ver and pixi_ver and pyproject_ver != pixi_ver:
+              print(f"::error::Version mismatch: pyproject.toml={pyproject_ver}, pixi.toml={pixi_ver}")
+              sys.exit(1)
+          print("Versions are consistent.")
+          EOF

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,9 +7,8 @@ on:
   # Run on all pull requests
   pull_request:
 
-  # Run the same required contexts for merge queue candidates
-  merge_group:
-    types: [checks_requested]
+  # merge_group intentionally removed: merge-queue checks are served by the
+  # single fast `merge-queue-smoke` job in merge-queue-smoke.yml (see that file).
 
   # Run on pushes to main
   push:

--- a/.github/workflows/workflow-smoke-test.yml
+++ b/.github/workflows/workflow-smoke-test.yml
@@ -10,8 +10,8 @@ name: Workflow Smoke Tests
 
 on:
   pull_request:
-  merge_group:
-    types: [checks_requested]
+  # merge_group intentionally removed: merge-queue checks are served by the
+  # single fast `merge-queue-smoke` job in merge-queue-smoke.yml (see that file).
   push:
     branches:
       - main

--- a/configs/github/merge-queue-policy.json
+++ b/configs/github/merge-queue-policy.json
@@ -3,37 +3,7 @@
   "target_branch": "main",
   "activation_ruleset": "homeric-main-baseline",
   "required_contexts": [
-    "Audit Shared Links",
-    "Build Validation",
-    "Code Quality Analysis",
-    "Core Layers",
-    "Data Utilities Test Suite",
-    "Gradient Checking Tests",
-    "Gradient Coverage Report",
-    "Mojo Package Compilation",
-    "Mojo Syntax Validation",
-    "Other Workflow Property Checks",
-    "Python Tests",
-    "Security Workflow Property Checks",
-    "Test Coverage Validation",
-    "Test Metrics",
-    "build",
-    "deps/version-sync",
-    "install",
-    "integration-tests",
-    "lint",
-    "lint-notebooks",
-    "mypy",
-    "package",
-    "pre-commit",
-    "python-syntax",
-    "release",
-    "schema-validation",
-    "security/dependency-scan",
-    "security/secrets-scan",
-    "test",
-    "unit-tests",
-    "validate-notebooks"
+    "merge-queue-smoke"
   ],
   "merge_queue_rule": {
     "type": "merge_queue",
@@ -44,7 +14,7 @@
       "max_entries_to_merge": 5,
       "merge_method": "SQUASH",
       "min_entries_to_merge": 1,
-      "min_entries_to_merge_wait_minutes": 5
+      "min_entries_to_merge_wait_minutes": 0
     }
   }
 }

--- a/tests/smoke/test_merge_queue_workflow_properties.py
+++ b/tests/smoke/test_merge_queue_workflow_properties.py
@@ -3,6 +3,15 @@
 
 The live rulesets remain operator-owned. These tests lock the repository-side
 contract that activation and the queued smoke check will consume.
+
+Contract (fast merge-queue gate): merge_group events run EXACTLY ONE job —
+`merge-queue-smoke` in merge-queue-smoke.yml — finishing well under five
+minutes on a single runner slot. The former per-queue-entry re-run of the
+full required matrix serialized on runner slots (70-90 min per merge).
+PR-side CI is completely untouched: the four PR workflows still emit every
+pinned context on pull_request events. The activation ruleset will pin
+`merge-queue-smoke` as the ONLY required context (PR-side checks keep
+running but become non-blocking after the flip).
 """
 
 import json
@@ -15,15 +24,25 @@ REPO_ROOT = Path(__file__).parent.parent.parent
 POLICY_PATH = REPO_ROOT / "configs" / "github" / "merge-queue-policy.json"
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 PR_COMMENT_WORKFLOW = "comprehensive-test-pr-comments.yml"
+QUEUE_SMOKE_WORKFLOW = "merge-queue-smoke.yml"
 
-REQUIRED_WORKFLOWS = (
+# Workflows that emit the PR-side pinned contexts. They must NOT run on
+# merge_group any more — the queue is served solely by merge-queue-smoke.yml.
+PR_CONTEXT_WORKFLOWS = (
     "_required.yml",
     "comprehensive-tests.yml",
     "pre-commit.yml",
     "workflow-smoke-test.yml",
 )
 
+# The single context the activation ruleset pins (produced exclusively on
+# merge_group events by merge-queue-smoke.yml).
 EXPECTED_REQUIRED_CONTEXTS = [
+    "merge-queue-smoke",
+]
+
+# PR-side contexts that must keep being emitted exactly once per PR head.
+EXPECTED_PR_CONTEXTS = [
     "Audit Shared Links",
     "Build Validation",
     "Code Quality Analysis",
@@ -66,7 +85,7 @@ EXPECTED_MERGE_QUEUE_RULE = {
         "max_entries_to_merge": 5,
         "merge_method": "SQUASH",
         "min_entries_to_merge": 1,
-        "min_entries_to_merge_wait_minutes": 5,
+        "min_entries_to_merge_wait_minutes": 0,
     },
 }
 
@@ -85,7 +104,7 @@ def _on_block(workflow: dict[Any, Any]) -> dict[str, Any]:
     return triggers
 
 
-def test_policy_matches_live_required_contexts_and_approved_queue_rule() -> None:
+def test_policy_matches_single_context_and_approved_queue_rule() -> None:
     """The policy artifact must be the exact reviewed activation contract."""
     policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
 
@@ -99,27 +118,43 @@ def test_policy_matches_live_required_contexts_and_approved_queue_rule() -> None
     assert policy["required_contexts"] == sorted(policy["required_contexts"])
 
 
-def test_every_required_context_workflow_handles_merge_group() -> None:
-    """Every workflow posting a required context must run for queue candidates."""
-    for workflow_name in REQUIRED_WORKFLOWS:
+def test_queue_smoke_is_the_only_merge_group_workflow() -> None:
+    """merge_group must run exactly one workflow with one fast smoke job."""
+    merge_group_workflows = [
+        path.name for path in sorted(WORKFLOW_DIR.glob("*.yml")) if "merge_group" in _on_block(_load_yaml(path))
+    ]
+    assert merge_group_workflows == [QUEUE_SMOKE_WORKFLOW]
+
+    smoke = _load_yaml(WORKFLOW_DIR / QUEUE_SMOKE_WORKFLOW)
+    assert _on_block(smoke) == {"merge_group": {"types": ["checks_requested"]}}
+
+    jobs = smoke.get("jobs")
+    assert isinstance(jobs, dict) and list(jobs) == ["merge-queue-smoke"]
+    gate = jobs["merge-queue-smoke"]
+    assert gate.get("name") == "merge-queue-smoke"
+    assert int(gate.get("timeout-minutes", 0)) <= 5
+
+
+def test_pr_context_workflows_do_not_run_for_merge_group() -> None:
+    """The heavy PR workflows must not re-run per queue entry."""
+    for workflow_name in PR_CONTEXT_WORKFLOWS:
         workflow = _load_yaml(WORKFLOW_DIR / workflow_name)
-        assert _on_block(workflow).get("merge_group") == {"types": ["checks_requested"]}, (
-            f"{workflow_name} must handle merge_group/checks_requested"
+        assert "merge_group" not in _on_block(workflow), (
+            f"{workflow_name} must not handle merge_group; the queue is served solely by {QUEUE_SMOKE_WORKFLOW}"
         )
 
 
 def test_existing_pull_request_and_push_triggers_are_preserved() -> None:
-    """Queue readiness must not narrow the existing PR or main-push coverage."""
+    """Queue changes must not narrow the existing PR or main-push coverage."""
     required_triggers = _on_block(_load_yaml(WORKFLOW_DIR / "_required.yml"))
-    assert set(required_triggers) == {"pull_request", "merge_group", "push"}
+    assert set(required_triggers) == {"pull_request", "push"}
     assert required_triggers["pull_request"] is None
     assert required_triggers["push"] == {"branches": ["main"]}
 
-    for workflow_name in REQUIRED_WORKFLOWS[1:3]:
+    for workflow_name in PR_CONTEXT_WORKFLOWS[1:3]:
         triggers = _on_block(_load_yaml(WORKFLOW_DIR / workflow_name))
         assert set(triggers) == {
             "pull_request",
-            "merge_group",
             "push",
             "workflow_dispatch",
         }
@@ -129,7 +164,6 @@ def test_existing_pull_request_and_push_triggers_are_preserved() -> None:
     smoke_triggers = _on_block(_load_yaml(WORKFLOW_DIR / "workflow-smoke-test.yml"))
     assert set(smoke_triggers) == {
         "pull_request",
-        "merge_group",
         "push",
         "workflow_dispatch",
     }
@@ -152,31 +186,32 @@ def test_existing_pull_request_and_push_triggers_are_preserved() -> None:
     }
 
 
-def test_required_contexts_are_emitted_once_across_queue_workflows() -> None:
-    """The queue candidate must receive every pinned context exactly once."""
+def test_pr_contexts_are_emitted_once_across_pr_workflows() -> None:
+    """Every PR-side pinned context must be emitted exactly once per head."""
     emitted: list[str] = []
-    for workflow_name in REQUIRED_WORKFLOWS:
+    for workflow_name in PR_CONTEXT_WORKFLOWS:
         jobs = _load_yaml(WORKFLOW_DIR / workflow_name).get("jobs")
         assert isinstance(jobs, dict), f"{workflow_name} must define jobs"
         for job_id, job in jobs.items():
             assert isinstance(job, dict), f"{workflow_name}:{job_id} must be a mapping"
             job_name = str(job.get("name", job_id))
             emitted.append(job_name)
-            if job_name in EXPECTED_REQUIRED_CONTEXTS:
-                assert job.get("if") in (None, "always()"), f"{workflow_name}:{job_id} must not skip merge_group runs"
+            if job_name in EXPECTED_PR_CONTEXTS:
+                assert job.get("if") in (None, "always()"), f"{workflow_name}:{job_id} must not skip pull_request runs"
 
-    required_emitted = [name for name in emitted if name in EXPECTED_REQUIRED_CONTEXTS]
-    assert sorted(required_emitted) == EXPECTED_REQUIRED_CONTEXTS
-    assert len(required_emitted) == len(set(required_emitted))
+    pr_emitted = [name for name in emitted if name in EXPECTED_PR_CONTEXTS]
+    assert sorted(pr_emitted) == EXPECTED_PR_CONTEXTS
+    assert len(pr_emitted) == len(set(pr_emitted))
 
 
 def test_queue_workflows_preserve_minimum_permissions() -> None:
-    """Adding queue triggers must not broaden the workflows' token permissions."""
+    """Queue-facing workflows must keep read-only token permissions."""
     expected_permissions = {
         "_required.yml": {"contents": "read"},
         "comprehensive-tests.yml": {"contents": "read"},
         "pre-commit.yml": {"contents": "read"},
         "workflow-smoke-test.yml": {"contents": "read"},
+        QUEUE_SMOKE_WORKFLOW: {"contents": "read"},
     }
 
     for workflow_name, permissions in expected_permissions.items():


### PR DESCRIPTION
Closes #5671

## Diagnosis

Merge-group runs re-executed the full required matrix across four workflows (`_required.yml`, `comprehensive-tests.yml`, `pre-commit.yml`, `workflow-smoke-test.yml`) — 30+ jobs per queue entry. Each job waited 8-16+ minutes for a runner slot, so a single queue entry took **70-90 minutes** to merge and serialized the whole queue on runner-slot starvation.

## Design

- The four workflows above no longer trigger on `merge_group`. Their `pull_request`/`push`/`workflow_dispatch` triggers and every existing job are unchanged — **PR-side CI is completely untouched** (no new jobs in existing workflows).
- New `.github/workflows/merge-queue-smoke.yml`: the ONLY workflow triggering on `merge_group` (`checks_requested`). Single job named `merge-queue-smoke`, `timeout-minutes: 5`, one runner slot, real fail-fast validations borrowed from the fastest gating jobs: workflow property greps (pull_request triggers on security/pre-commit/comprehensive/validate-configs), workflow schema validation (`check-jsonschema`), and the pyproject/pixi version cross-check. No `continue-on-error`, no `|| true`.
- `configs/github/merge-queue-policy.json` (the activation contract) now pins `required_contexts: ["merge-queue-smoke"]` and `min_entries_to_merge_wait_minutes: 0`; `tests/smoke/test_merge_queue_workflow_properties.py` updated minimally for the new topology (single-workflow merge-group ownership, one-emission of every PR context, unchanged permissions). `.github/workflows/README.md` updated to match.
- All action SHAs reuse the pins already present in this repo.

## Post-merge ruleset rollout (operator step — NOT part of this PR)

After merge, replace ALL `required_status_checks` contexts (in every ruleset — 15556491 `homeric-main-baseline` AND 18221116 `homeric-main-extras`) with the single context `merge-queue-smoke` and set `min_entries_to_merge_wait_minutes` to 0; PR-side checks keep running but become non-blocking; the queue must not be used between merge and flip.

## Validation

- `python3 -m pytest tests/smoke/` — 35 passed (incl. the updated merge-queue property tests)
- `pixi run ruff format --check` / `ruff check` / `mypy` on the edited test — clean
- `markdownlint-cli2` on the README — 0 errors; `scripts/validate_test_coverage.py` — ok
- `check-jsonschema --builtin-schema vendor.github-workflows .github/workflows/*.yml` — ok
- `_required.yml` diff vs base is a trigger-comment-only change; all jobs byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)