### PR TITLE
test(optimizers): add PyTorch-parity tests for the 7 untested optimizer ops (Stage A)

### DIFF
--- a/tests/odyssey/training/optimizers/parity_refs/adam_parity_reference.py
+++ b/tests/odyssey/training/optimizers/parity_refs/adam_parity_reference.py
@@ -1,0 +1,99 @@
+"""Adam parity reference (arXiv:1412.6980).
+
+Computes ONE Adam update step for a fixed (params, grad, m, v, t) under the
+exact update Odyssey's `adam_step` implements (adam.mojo):
+
+    effective_grad = grad + weight_decay * params        (coupled L2, wd added to grad)
+    m      = beta1 * m + (1 - beta1) * effective_grad
+    v      = beta2 * v + (1 - beta2) * effective_grad**2
+    m_hat  = m / (1 - beta1**t)
+    v_hat  = v / (1 - beta2**t)
+    params = params - lr * m_hat / (sqrt(v_hat) + epsilon)   (eps OUTSIDE the sqrt)
+
+and prints the resulting params + m + v as JSON.
+
+This is exactly `torch.optim.Adam` with `amsgrad=False, maximize=False` — torch
+also adds coupled weight_decay to the gradient and places eps outside the sqrt
+(`denom = v_hat.sqrt().add_(eps)`, see torch/optim/adam.py `_single_tensor_adam`
+and https://pytorch.org/docs/stable/generated/torch.optim.Adam.html). We drive
+the real `torch.optim.Adam` when torch is importable (authoritative), falling
+back to the identical numpy closed form otherwise, and print which path was
+used.
+
+To make the single hand-seeded step deterministic we set the optimizer's
+`step` state to t-1 before calling `.step()` so torch's internal
+`state['step'] += 1` lands on t, and seed `exp_avg`/`exp_avg_sq` to our fixed
+m/v.
+"""
+
+import json
+
+import numpy as np
+
+LR, B1, B2, EPS, WD = 0.001, 0.9, 0.999, 1e-8, 0.01
+T = 3  # non-trivial timestep so bias correction is exercised
+
+params = np.array([0.10, -0.20, 0.30, -0.40, 0.50, -0.60], dtype=np.float64)
+grad = np.array([0.02, -0.03, 0.015, 0.025, -0.01, 0.04], dtype=np.float64)
+m = np.array([0.005, -0.004, 0.003, -0.002, 0.001, -0.006], dtype=np.float64)
+v = np.array([1e-4, 2e-4, 1.5e-4, 3e-4, 0.5e-4, 4e-4], dtype=np.float64)
+
+
+def _numpy_reference():
+    eff = grad + WD * params
+    new_m = B1 * m + (1.0 - B1) * eff
+    new_v = B2 * v + (1.0 - B2) * eff * eff
+    m_hat = new_m / (1.0 - B1**T)
+    v_hat = new_v / (1.0 - B2**T)
+    new_params = params - LR * m_hat / (np.sqrt(v_hat) + EPS)
+    return new_params, new_m, new_v
+
+
+def _torch_reference():
+    import torch
+
+    p = torch.tensor(params, dtype=torch.float64, requires_grad=True)
+    p.grad = torch.tensor(grad, dtype=torch.float64)
+    opt = torch.optim.Adam(
+        [p], lr=LR, betas=(B1, B2), eps=EPS, weight_decay=WD, amsgrad=False
+    )
+    st = opt.state[p]
+    st["step"] = torch.tensor(float(T - 1))
+    st["exp_avg"] = torch.tensor(m, dtype=torch.float64)
+    st["exp_avg_sq"] = torch.tensor(v, dtype=torch.float64)
+    opt.step()
+    return (
+        p.detach().numpy().copy(),
+        st["exp_avg"].detach().numpy().copy(),
+        st["exp_avg_sq"].detach().numpy().copy(),
+    )
+
+
+try:
+    new_params, new_m, new_v = _torch_reference()
+    source = "torch.optim.Adam"
+except Exception:
+    new_params, new_m, new_v = _numpy_reference()
+    source = "numpy-closed-form"
+
+print(
+    json.dumps(
+        {
+            "source": source,
+            "lr": LR,
+            "beta1": B1,
+            "beta2": B2,
+            "epsilon": EPS,
+            "weight_decay": WD,
+            "t": T,
+            "params_in": params.tolist(),
+            "grad": grad.tolist(),
+            "m_in": m.tolist(),
+            "v_in": v.tolist(),
+            "new_params": new_params.tolist(),
+            "new_m": new_m.tolist(),
+            "new_v": new_v.tolist(),
+        },
+        indent=2,
+    )
+)

--- a/tests/odyssey/training/optimizers/parity_refs/adam_parity_reference.py
+++ b/tests/odyssey/training/optimizers/parity_refs/adam_parity_reference.py
@@ -54,9 +54,7 @@ def _torch_reference():
 
     p = torch.tensor(params, dtype=torch.float64, requires_grad=True)
     p.grad = torch.tensor(grad, dtype=torch.float64)
-    opt = torch.optim.Adam(
-        [p], lr=LR, betas=(B1, B2), eps=EPS, weight_decay=WD, amsgrad=False
-    )
+    opt = torch.optim.Adam([p], lr=LR, betas=(B1, B2), eps=EPS, weight_decay=WD, amsgrad=False)
     st = opt.state[p]
     st["step"] = torch.tensor(float(T - 1))
     st["exp_avg"] = torch.tensor(m, dtype=torch.float64)

--- a/tests/odyssey/training/optimizers/parity_refs/adamw_parity_reference.py
+++ b/tests/odyssey/training/optimizers/parity_refs/adamw_parity_reference.py
@@ -1,0 +1,70 @@
+"""AdamW parity reference (Loshchilov & Hutter 2019, arXiv:1711.05101).
+
+Computes ONE AdamW update step for a fixed (params, grad, m, v, t) under the
+exact update Odyssey's `adamw_step` implements (adamw.mojo):
+
+    m      = beta1 * m + (1 - beta1) * grad            (grad NOT decayed)
+    v      = beta2 * v + (1 - beta2) * grad**2
+    m_hat  = m / (1 - beta1**t)
+    v_hat  = v / (1 - beta2**t)
+    p'     = params - lr * m_hat / (sqrt(v_hat) + epsilon)
+    params = p' - weight_decay * p'                    (decoupled, on p')
+
+and prints the resulting params + m + v as JSON.
+
+IMPORTANT — this deviates from `torch.optim.AdamW` in the weight-decay term:
+torch applies `p *= (1 - lr * weight_decay)` to the PRE-update parameters
+(decoupled decay scaled by lr, see torch/optim/adamw.py), whereas Odyssey's
+adamw.mojo applies `p' -= weight_decay * p'` — i.e. `p' * (1 - weight_decay)`
+— to the POST-gradient-update parameters, with NO lr factor. So this reference
+models Odyssey's implemented formula (numpy closed form) and does NOT drive
+torch.optim.AdamW, because the two disagree by design at the pinned SHA. The
+docstring records the divergence so a future maintainer who wants exact
+torch-AdamW semantics knows the gap is in the decay term, not the Adam core
+(which IS torch-equivalent — see adam_parity_reference.py).
+"""
+
+import json
+
+import numpy as np
+
+LR, B1, B2, EPS, WD = 0.001, 0.9, 0.999, 1e-8, 0.01
+T = 3
+
+params = np.array([0.10, -0.20, 0.30, -0.40, 0.50, -0.60], dtype=np.float64)
+grad = np.array([0.02, -0.03, 0.015, 0.025, -0.01, 0.04], dtype=np.float64)
+m = np.array([0.005, -0.004, 0.003, -0.002, 0.001, -0.006], dtype=np.float64)
+v = np.array([1e-4, 2e-4, 1.5e-4, 3e-4, 0.5e-4, 4e-4], dtype=np.float64)
+
+# Odyssey adamw formula (grad NOT decayed into the moments; decoupled decay
+# applied to the post-gradient-update params without an lr factor).
+new_m = B1 * m + (1.0 - B1) * grad
+new_v = B2 * v + (1.0 - B2) * grad * grad
+m_hat = new_m / (1.0 - B1**T)
+v_hat = new_v / (1.0 - B2**T)
+p_after_grad = params - LR * m_hat / (np.sqrt(v_hat) + EPS)
+new_params = p_after_grad - WD * p_after_grad
+
+print(
+    json.dumps(
+        {
+            "source": "numpy-odyssey-formula",
+            "note": "decoupled decay applied to post-update params, no lr factor "
+            "(differs from torch.optim.AdamW; see docstring)",
+            "lr": LR,
+            "beta1": B1,
+            "beta2": B2,
+            "epsilon": EPS,
+            "weight_decay": WD,
+            "t": T,
+            "params_in": params.tolist(),
+            "grad": grad.tolist(),
+            "m_in": m.tolist(),
+            "v_in": v.tolist(),
+            "new_params": new_params.tolist(),
+            "new_m": new_m.tolist(),
+            "new_v": new_v.tolist(),
+        },
+        indent=2,
+    )
+)

--- a/tests/odyssey/training/optimizers/parity_refs/lars_parity_reference.py
+++ b/tests/odyssey/training/optimizers/parity_refs/lars_parity_reference.py
@@ -1,0 +1,61 @@
+"""LARS parity reference (You, Gitman & Ginsburg 2017, arXiv:1708.03888).
+
+Computes ONE LARS step for a fixed (params, grad, velocity) under the exact
+update Odyssey's `lars_step` implements (lars.mojo):
+
+    param_norm  = ||params||_2            (global L2 over the whole tensor)
+    grad_norm   = ||grad||_2
+    eff_grad    = grad + weight_decay * params
+    trust_ratio = trust_coefficient * param_norm
+                  / (grad_norm + weight_decay * param_norm + epsilon)
+    velocity    = momentum * velocity + trust_ratio * eff_grad
+    params      = params - lr * velocity
+
+and prints the resulting params + velocity as JSON.
+
+This is the layer-wise-adaptive LARS rule (the trust ratio scales the
+per-layer update by the ratio of weight norm to gradient norm). The reference
+is a numpy closed form of the published algorithm; `pytorch_optimizer`'s LARS
+uses the same trust-ratio formulation. The single global norm here corresponds
+to treating the whole tensor as one LARS "layer" (matching lars.mojo, which
+takes the L2 norm of the entire params/grad tensor).
+"""
+
+import json
+
+import numpy as np
+
+LR, MOMENTUM, WD, TRUST, EPS = 0.1, 0.9, 0.0001, 0.001, 1e-8
+
+params = np.array([0.10, -0.20, 0.30, -0.40, 0.50, -0.60], dtype=np.float64)
+grad = np.array([0.02, -0.03, 0.015, 0.025, -0.01, 0.04], dtype=np.float64)
+velocity = np.array([0.005, -0.004, 0.003, -0.002, 0.001, -0.006], dtype=np.float64)
+
+param_norm = np.sqrt(np.sum(params * params))
+grad_norm = np.sqrt(np.sum(grad * grad))
+eff_grad = grad + WD * params
+trust_ratio = TRUST * param_norm / (grad_norm + WD * param_norm + EPS)
+new_velocity = MOMENTUM * velocity + trust_ratio * eff_grad
+new_params = params - LR * new_velocity
+
+print(
+    json.dumps(
+        {
+            "source": "numpy-closed-form",
+            "lr": LR,
+            "momentum": MOMENTUM,
+            "weight_decay": WD,
+            "trust_coefficient": TRUST,
+            "epsilon": EPS,
+            "param_norm": param_norm,
+            "grad_norm": grad_norm,
+            "trust_ratio": trust_ratio,
+            "params_in": params.tolist(),
+            "grad": grad.tolist(),
+            "velocity_in": velocity.tolist(),
+            "new_params": new_params.tolist(),
+            "new_velocity": new_velocity.tolist(),
+        },
+        indent=2,
+    )
+)

--- a/tests/odyssey/training/optimizers/parity_refs/lion_parity_reference.py
+++ b/tests/odyssey/training/optimizers/parity_refs/lion_parity_reference.py
@@ -1,0 +1,60 @@
+"""Lion parity reference (Chen et al. 2023, arXiv:2302.06675).
+
+Computes ONE Lion step for a fixed (params, grad, momentum) under the exact
+update Odyssey's `lion_step` implements (lion.mojo):
+
+    update  = sign(beta1 * momentum + (1 - beta1) * grad)
+    params  = params - lr * update
+    params  = params - lr * weight_decay * params        (decoupled)
+    momentum = beta2 * momentum + (1 - beta2) * grad      (EMA updated AFTER)
+
+and prints the resulting params + momentum as JSON.
+
+This matches the reference Lion (lucidrains/lion-pytorch and
+kozistr/pytorch_optimizer Lion): the update direction is the SIGN of the
+beta1-interpolated momentum, the momentum EMA uses beta2 and is updated after
+the step, and decoupled weight decay is lr-scaled. Note the sign of exactly
+zero: numpy `np.sign(0)=0` and Odyssey's `sign` likewise yields 0, so we pick
+inputs where no interpolated coordinate is exactly zero to avoid a
+sign(0)-convention ambiguity. NumPy is used as the calculator for the
+published algorithm (a single hand-seeded step of pytorch_optimizer.Lion
+needs its state pre-created; the closed form is unambiguous).
+"""
+
+import json
+
+import numpy as np
+
+LR, B1, B2, WD = 0.001, 0.9, 0.99, 0.01
+
+params = np.array([0.10, -0.20, 0.30, -0.40, 0.50, -0.60], dtype=np.float64)
+grad = np.array([0.02, -0.03, 0.015, 0.025, -0.01, 0.04], dtype=np.float64)
+momentum = np.array([0.05, -0.04, 0.03, -0.02, 0.01, -0.06], dtype=np.float64)
+
+interp = B1 * momentum + (1.0 - B1) * grad
+update = np.sign(interp)
+# assert no exact-zero coordinate so sign() convention is unambiguous
+assert np.all(interp != 0.0), "pick inputs with no zero interpolation"
+
+new_params = params - LR * update
+new_params = new_params - LR * WD * params  # decoupled, lr-scaled, on original p
+new_momentum = B2 * momentum + (1.0 - B2) * grad
+
+print(
+    json.dumps(
+        {
+            "source": "numpy-closed-form",
+            "lr": LR,
+            "beta1": B1,
+            "beta2": B2,
+            "weight_decay": WD,
+            "params_in": params.tolist(),
+            "grad": grad.tolist(),
+            "momentum_in": momentum.tolist(),
+            "sign_update": update.tolist(),
+            "new_params": new_params.tolist(),
+            "new_momentum": new_momentum.tolist(),
+        },
+        indent=2,
+    )
+)

--- a/tests/odyssey/training/optimizers/parity_refs/muon_parity_reference.py
+++ b/tests/odyssey/training/optimizers/parity_refs/muon_parity_reference.py
@@ -1,0 +1,80 @@
+"""Muon parity reference (Jordan et al. 2024; https://github.com/KellerJordan/Muon).
+
+Computes ONE Muon step for a fixed rank-2 (params, grad, momentum) under the
+exact update Odyssey's `muon_step` implements (muon.mojo), including a faithful
+numpy replica of `newton_schulz_orthogonalize`:
+
+    new_momentum = momentum_beta * momentum + grad
+    dir          = grad + momentum_beta * new_momentum   (nesterov=True; else new_momentum)
+    u_orth       = newton_schulz(dir, steps=5)
+    scale        = 0.2 * max(R, C) / sqrt(R * C)
+    params       = params - lr * scale * u_orth
+    params       = params - lr * weight_decay * params    (on original params)
+
+Newton-Schulz (Jordan quintic, coeffs a=3.4445, b=-4.7750, c=2.0315):
+    1. Y = X / (||X||_F + 1e-7)          (Frobenius pre-normalization)
+    2. if rows > cols: iterate on Y^T (shorter dim), transpose back at the end
+    3. repeat 5x:  A = Y @ Y^T;  B = b*A + c*(A @ A);  Y = a*Y + B @ Y
+
+This is the reference Muon (KellerJordan/Muon torch optim). numpy is used as the
+calculator because the Jordan iteration deliberately does NOT converge to exact
+orthogonality (singular values end in ~[0.68, 1.13]) — so the "parity" is
+against Odyssey's implemented iteration, not an idealized orthogonal matrix.
+The 2x3 shape (rows < cols) exercises the non-transposed NS path.
+"""
+
+import json
+
+import numpy as np
+
+LR, BETA, WD, NS_STEPS = 0.01, 0.95, 0.01, 5
+A_COEF, B_COEF, C_COEF = 3.4445, -4.7750, 2.0315
+
+# 2x3 matrix (rows < cols → no transpose inside NS).
+params = np.array([[0.10, -0.20, 0.30], [-0.40, 0.50, -0.60]], dtype=np.float64)
+grad = np.array([[0.02, -0.03, 0.015], [0.025, -0.01, 0.04]], dtype=np.float64)
+momentum = np.array([[0.05, -0.04, 0.03], [-0.02, 0.01, -0.06]], dtype=np.float64)
+
+
+def newton_schulz(X, steps=5):
+    rows, cols = X.shape
+    transposed = rows > cols
+    Y = X.T.copy() if transposed else X.copy()
+    norm = np.sqrt(np.sum(Y * Y))  # Frobenius norm
+    Y = Y / (norm + 1e-7)
+    for _ in range(steps):
+        A = Y @ Y.T
+        B = B_COEF * A + C_COEF * (A @ A)
+        Y = A_COEF * Y + B @ Y
+    return Y.T if transposed else Y
+
+
+new_momentum = BETA * momentum + grad
+direction = grad + BETA * new_momentum  # nesterov=True
+u_orth = newton_schulz(direction, NS_STEPS)
+
+R, C = float(params.shape[0]), float(params.shape[1])
+scale = 0.2 * max(R, C) / np.sqrt(R * C)
+params_after_grad = params - LR * scale * u_orth
+new_params = params_after_grad - LR * WD * params  # wd on original params
+
+print(
+    json.dumps(
+        {
+            "source": "numpy-newton-schulz-replica",
+            "lr": LR,
+            "momentum_beta": BETA,
+            "weight_decay": WD,
+            "ns_steps": NS_STEPS,
+            "nesterov": True,
+            "params_in": params.tolist(),
+            "grad": grad.tolist(),
+            "momentum_in": momentum.tolist(),
+            "scale": scale,
+            "u_orth": u_orth.tolist(),
+            "new_params": new_params.tolist(),
+            "new_momentum": new_momentum.tolist(),
+        },
+        indent=2,
+    )
+)

--- a/tests/odyssey/training/optimizers/parity_refs/rmsprop_parity_reference.py
+++ b/tests/odyssey/training/optimizers/parity_refs/rmsprop_parity_reference.py
@@ -41,9 +41,7 @@ def _torch_reference():
 
     p = torch.tensor(params, dtype=torch.float64, requires_grad=True)
     p.grad = torch.tensor(grad, dtype=torch.float64)
-    opt = torch.optim.RMSprop(
-        [p], lr=LR, alpha=ALPHA, eps=EPS, weight_decay=WD, momentum=0.0, centered=False
-    )
+    opt = torch.optim.RMSprop([p], lr=LR, alpha=ALPHA, eps=EPS, weight_decay=WD, momentum=0.0, centered=False)
     opt.state[p]["step"] = torch.tensor(0.0)
     opt.state[p]["square_avg"] = torch.tensor(square_avg, dtype=torch.float64)
     opt.step()

--- a/tests/odyssey/training/optimizers/parity_refs/rmsprop_parity_reference.py
+++ b/tests/odyssey/training/optimizers/parity_refs/rmsprop_parity_reference.py
@@ -1,0 +1,79 @@
+"""RMSprop parity reference (Tieleman & Hinton 2012 lecture 6.5).
+
+Computes ONE RMSprop step for a fixed (params, grad, square_avg) under the
+exact update Odyssey's `rmsprop_step` implements (rmsprop.mojo), for the
+centered=False, momentum=0 path:
+
+    effective_grad  = grad + weight_decay * params
+    square_avg      = alpha * square_avg + (1 - alpha) * effective_grad**2
+    params          = params - lr * effective_grad / (sqrt(square_avg) + epsilon)
+
+and prints the resulting params + square_avg as JSON.
+
+This matches `torch.optim.RMSprop(centered=False, momentum=0)`, which also
+places eps outside the sqrt (`avg = square_avg.sqrt().add_(eps)`, see
+torch/optim/rmsprop.py and
+https://pytorch.org/docs/stable/generated/torch.optim.RMSprop.html) and adds
+coupled weight_decay to the gradient. We drive the real torch.optim.RMSprop
+when importable (authoritative), else the identical numpy closed form.
+"""
+
+import json
+
+import numpy as np
+
+LR, ALPHA, EPS, WD = 0.01, 0.99, 1e-8, 0.0
+
+params = np.array([0.10, -0.20, 0.30, -0.40, 0.50, -0.60], dtype=np.float64)
+grad = np.array([0.02, -0.03, 0.015, 0.025, -0.01, 0.04], dtype=np.float64)
+square_avg = np.array([1e-4, 2e-4, 1.5e-4, 3e-4, 0.5e-4, 4e-4], dtype=np.float64)
+
+
+def _numpy_reference():
+    eff = grad + WD * params
+    new_sq = ALPHA * square_avg + (1.0 - ALPHA) * eff * eff
+    new_params = params - LR * eff / (np.sqrt(new_sq) + EPS)
+    return new_params, new_sq
+
+
+def _torch_reference():
+    import torch
+
+    p = torch.tensor(params, dtype=torch.float64, requires_grad=True)
+    p.grad = torch.tensor(grad, dtype=torch.float64)
+    opt = torch.optim.RMSprop(
+        [p], lr=LR, alpha=ALPHA, eps=EPS, weight_decay=WD, momentum=0.0, centered=False
+    )
+    opt.state[p]["step"] = torch.tensor(0.0)
+    opt.state[p]["square_avg"] = torch.tensor(square_avg, dtype=torch.float64)
+    opt.step()
+    return (
+        p.detach().numpy().copy(),
+        opt.state[p]["square_avg"].detach().numpy().copy(),
+    )
+
+
+try:
+    new_params, new_sq = _torch_reference()
+    source = "torch.optim.RMSprop"
+except Exception:
+    new_params, new_sq = _numpy_reference()
+    source = "numpy-closed-form"
+
+print(
+    json.dumps(
+        {
+            "source": source,
+            "lr": LR,
+            "alpha": ALPHA,
+            "epsilon": EPS,
+            "weight_decay": WD,
+            "params_in": params.tolist(),
+            "grad": grad.tolist(),
+            "square_avg_in": square_avg.tolist(),
+            "new_params": new_params.tolist(),
+            "new_square_avg": new_sq.tolist(),
+        },
+        indent=2,
+    )
+)

--- a/tests/odyssey/training/optimizers/parity_refs/sgd_parity_reference.py
+++ b/tests/odyssey/training/optimizers/parity_refs/sgd_parity_reference.py
@@ -1,0 +1,88 @@
+"""SGD (momentum + weight-decay) parity reference.
+
+Computes ONE SGD update step for a fixed (params, grad, velocity) under the
+exact update Odyssey's `sgd_step` implements (sgd.mojo):
+
+    effective_grad = grad + weight_decay * params          (wd applied first)
+    velocity       = momentum * velocity + effective_grad
+    params         = params - lr * velocity
+
+and prints the resulting params + velocity as JSON, so the Mojo `sgd_step`
+can be compared on identical inputs.
+
+This is exactly `torch.optim.SGD` with the default flags
+`dampening=0, nesterov=False, maximize=False` (PyTorch applies weight_decay to
+the gradient BEFORE the momentum buffer update — see
+torch/optim/sgd.py `_single_tensor_sgd`, and the SGD docs
+https://pytorch.org/docs/stable/generated/torch.optim.SGD.html). We drive the
+real `torch.optim.SGD` when torch is importable so the reference is
+authoritative, and fall back to the closed-form numpy calculator (identical
+algebra) when it is not, printing which path produced the numbers.
+
+One wrinkle worth stating: torch seeds its momentum buffer with the raw
+gradient on the FIRST step (`buf = grad.clone()`) rather than
+`momentum*0 + grad`. Those coincide here because we pass velocity=0, so a
+single hand-seeded step matches either reading; the numpy path uses the
+Odyssey formula directly.
+"""
+
+import json
+
+import numpy as np
+
+# Fixed 6-vector inputs. Non-trivial momentum, weight_decay, and a starting
+# velocity so the parity assert exercises every term of the update.
+LR, MOMENTUM, WEIGHT_DECAY = 0.1, 0.9, 0.01
+
+params = np.array([0.10, -0.20, 0.30, -0.40, 0.50, -0.60], dtype=np.float64)
+grad = np.array([0.02, -0.03, 0.015, 0.025, -0.01, 0.04], dtype=np.float64)
+velocity = np.array([0.005, -0.004, 0.003, -0.002, 0.001, -0.006], dtype=np.float64)
+
+
+def _numpy_reference():
+    eff_grad = grad + WEIGHT_DECAY * params
+    new_velocity = MOMENTUM * velocity + eff_grad
+    new_params = params - LR * new_velocity
+    return new_params, new_velocity
+
+
+def _torch_reference():
+    import torch
+
+    p = torch.tensor(params, dtype=torch.float64, requires_grad=True)
+    p.grad = torch.tensor(grad, dtype=torch.float64)
+    opt = torch.optim.SGD(
+        [p], lr=LR, momentum=MOMENTUM, weight_decay=WEIGHT_DECAY, dampening=0.0
+    )
+    # Seed the momentum buffer to our fixed `velocity` so the single step is
+    # deterministic and matches the Odyssey hand-seeded call.
+    opt.state[p]["momentum_buffer"] = torch.tensor(velocity, dtype=torch.float64)
+    opt.step()
+    new_params = p.detach().numpy().copy()
+    new_velocity = opt.state[p]["momentum_buffer"].detach().numpy().copy()
+    return new_params, new_velocity
+
+
+try:
+    new_params, new_velocity = _torch_reference()
+    source = "torch.optim.SGD"
+except Exception:
+    new_params, new_velocity = _numpy_reference()
+    source = "numpy-closed-form"
+
+print(
+    json.dumps(
+        {
+            "source": source,
+            "lr": LR,
+            "momentum": MOMENTUM,
+            "weight_decay": WEIGHT_DECAY,
+            "params_in": params.tolist(),
+            "grad": grad.tolist(),
+            "velocity_in": velocity.tolist(),
+            "new_params": new_params.tolist(),
+            "new_velocity": new_velocity.tolist(),
+        },
+        indent=2,
+    )
+)

--- a/tests/odyssey/training/optimizers/parity_refs/sgd_parity_reference.py
+++ b/tests/odyssey/training/optimizers/parity_refs/sgd_parity_reference.py
@@ -51,9 +51,7 @@ def _torch_reference():
 
     p = torch.tensor(params, dtype=torch.float64, requires_grad=True)
     p.grad = torch.tensor(grad, dtype=torch.float64)
-    opt = torch.optim.SGD(
-        [p], lr=LR, momentum=MOMENTUM, weight_decay=WEIGHT_DECAY, dampening=0.0
-    )
+    opt = torch.optim.SGD([p], lr=LR, momentum=MOMENTUM, weight_decay=WEIGHT_DECAY, dampening=0.0)
     # Seed the momentum buffer to our fixed `velocity` so the single step is
     # deterministic and matches the Odyssey hand-seeded call.
     opt.state[p]["momentum_buffer"] = torch.tensor(velocity, dtype=torch.float64)

--- a/tests/odyssey/training/optimizers/test_adam.mojo
+++ b/tests/odyssey/training/optimizers/test_adam.mojo
@@ -1,0 +1,208 @@
+"""Unit tests for the Adam update step (arXiv:1412.6980).
+
+Odyssey's `adam_step` is pure-functional: it returns (new_params, new_m, new_v)
+and the caller tracks the timestep t. The implemented update (adam.mojo) is
+
+    effective_grad = grad + weight_decay * params        (coupled L2)
+    m      = beta1 * m + (1 - beta1) * effective_grad
+    v      = beta2 * v + (1 - beta2) * effective_grad**2
+    m_hat  = m / (1 - beta1**t)
+    v_hat  = v / (1 - beta2**t)
+    params = params - lr * m_hat / (sqrt(v_hat) + epsilon)   (eps outside sqrt)
+
+which is exactly `torch.optim.Adam` (amsgrad=False).
+
+Tests cover:
+- Shape/dtype guards on adam_step
+- The uninitialized-moment guard (empty m or v)
+- The positive-timestep guard (t <= 0 rejected)
+- Numerical parity with the reference algorithm (1e-9) at t=3 (bias correction
+  active) with non-zero weight_decay and seeded m/v. Reference numbers
+  transcribed from parity_refs/adam_parity_reference.py (drives torch.optim.Adam
+  when importable, else the identical numpy closed form).
+- adam_step_simple delegating to adam_step with defaults (no weight decay).
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros, full
+from odyssey.training.optimizers.adam import (
+    adam_step,
+    adam_step_simple,
+)
+
+
+def _abs_diff(a: Float64, b: Float64) -> Float64:
+    var d = a - b
+    if d < 0:
+        d = -d
+    return d
+
+
+def test_reject_shape_mismatch() raises:
+    """`adam_step` rejects a params/gradients shape mismatch."""
+    print("Running test_reject_shape_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([5], DType.float32)
+    var m = zeros([4], DType.float32)
+    var v = zeros([4], DType.float32)
+    try:
+        var _ = adam_step(p, g, m, v, 1, 0.001)
+        raise Error("Should have rejected shape mismatch")
+    except:
+        print("  ok rejected shape mismatch")
+    print("test_reject_shape_mismatch PASSED")
+
+
+def test_reject_dtype_mismatch() raises:
+    """`adam_step` rejects a params/gradients dtype mismatch."""
+    print("Running test_reject_dtype_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float16)
+    var m = zeros([4], DType.float32)
+    var v = zeros([4], DType.float32)
+    try:
+        var _ = adam_step(p, g, m, v, 1, 0.001)
+        raise Error("Should have rejected dtype mismatch")
+    except:
+        print("  ok rejected dtype mismatch")
+    print("test_reject_dtype_mismatch PASSED")
+
+
+def test_reject_empty_moments() raises:
+    """`adam_step` requires initialized moment buffers m and v."""
+    print("Running test_reject_empty_moments...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float32)
+    var m = zeros([0], DType.float32)  # empty
+    var v = zeros([4], DType.float32)
+    try:
+        var _ = adam_step(p, g, m, v, 1, 0.001)
+        raise Error("Should have rejected empty moment buffer")
+    except:
+        print("  ok rejected empty moment buffer")
+    print("test_reject_empty_moments PASSED")
+
+
+def test_reject_nonpositive_timestep() raises:
+    """`adam_step` rejects t <= 0 (timestep starts at 1)."""
+    print("Running test_reject_nonpositive_timestep...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float32)
+    var m = zeros([4], DType.float32)
+    var v = zeros([4], DType.float32)
+    try:
+        var _ = adam_step(p, g, m, v, 0, 0.001)
+        raise Error("Should have rejected t=0")
+    except:
+        print("  ok rejected non-positive timestep")
+    print("test_reject_nonpositive_timestep PASSED")
+
+
+def test_parity_with_reference() raises:
+    """One Adam step at t=3 must match the reference to 1e-9.
+
+    Fixed inputs and reference outputs transcribed from
+    parity_refs/adam_parity_reference.py (lr=1e-3, betas=(0.9,0.999),
+    eps=1e-8, weight_decay=0.01, t=3, seeded m/v).
+    """
+    print("Running test_parity_with_reference...")
+    var n = 6
+    var p = zeros([n], DType.float64)
+    var g = zeros([n], DType.float64)
+    var m = zeros([n], DType.float64)
+    var v = zeros([n], DType.float64)
+    p.store[DType.float64](0, 0.10)
+    p.store[DType.float64](1, -0.20)
+    p.store[DType.float64](2, 0.30)
+    p.store[DType.float64](3, -0.40)
+    p.store[DType.float64](4, 0.50)
+    p.store[DType.float64](5, -0.60)
+    g.store[DType.float64](0, 0.02)
+    g.store[DType.float64](1, -0.03)
+    g.store[DType.float64](2, 0.015)
+    g.store[DType.float64](3, 0.025)
+    g.store[DType.float64](4, -0.01)
+    g.store[DType.float64](5, 0.04)
+    m.store[DType.float64](0, 0.005)
+    m.store[DType.float64](1, -0.004)
+    m.store[DType.float64](2, 0.003)
+    m.store[DType.float64](3, -0.002)
+    m.store[DType.float64](4, 0.001)
+    m.store[DType.float64](5, -0.006)
+    v.store[DType.float64](0, 1e-4)
+    v.store[DType.float64](1, 2e-4)
+    v.store[DType.float64](2, 1.5e-4)
+    v.store[DType.float64](3, 3e-4)
+    v.store[DType.float64](4, 0.5e-4)
+    v.store[DType.float64](5, 4e-4)
+
+    var rp = List[Float64]()
+    rp.append(0.09986689975575956)
+    rp.append(-0.1999030661990727)
+    rp.append(0.29992581958253395)
+    rp.append(-0.4000034981041159)
+    rp.append(0.49998856969788646)
+    rp.append(-0.599979818003792)
+    var rm = List[Float64]()
+    rm.append(0.0066)
+    rm.append(-0.0068)
+    rm.append(0.0045)
+    rm.append(0.0002999999999999997)
+    rm.append(0.0004000000000000002)
+    rm.append(-0.002000000000000001)
+    var rv = List[Float64]()
+    rv.append(0.00010034100000000001)
+    rv.append(0.000200824)
+    rv.append(0.000150174)
+    rv.append(0.00030014099999999997)
+    rv.append(4.9975e-05)
+    rv.append(0.000400756)
+
+    var out = adam_step(p, g, m, v, 3, 0.001, 0.9, 0.999, 1e-8, 0.01)
+    var np = out[0]
+    var nm = out[1]
+    var nv = out[2]
+    for i in range(n):
+        if _abs_diff(np.load[DType.float64](i), rp[i]) > 1e-9:
+            raise Error("params parity mismatch at " + String(i))
+        if _abs_diff(nm.load[DType.float64](i), rm[i]) > 1e-9:
+            raise Error("m parity mismatch at " + String(i))
+        if _abs_diff(nv.load[DType.float64](i), rv[i]) > 1e-9:
+            raise Error("v parity mismatch at " + String(i))
+    print("  ok parity to 1e-9 on all 6 coordinates (params, m, v)")
+    print("test_parity_with_reference PASSED")
+
+
+def test_adam_step_simple_delegates() raises:
+    """`adam_step_simple` matches adam_step with default betas/eps, no wd."""
+    print("Running test_adam_step_simple_delegates...")
+    var n = 4
+    var p = full([n], 0.5, DType.float64)
+    var g = full([n], 0.1, DType.float64)
+    var m = zeros([n], DType.float64)
+    var v = zeros([n], DType.float64)
+    var full_out = adam_step(p, g, m, v, 1, 0.001)  # defaults, wd=0
+    var simple_out = adam_step_simple(p, g, m, v, 1, 0.001)
+    for i in range(n):
+        if (
+            _abs_diff(
+                full_out[0].load[DType.float64](i),
+                simple_out[0].load[DType.float64](i),
+            )
+            > 1e-12
+        ):
+            raise Error(
+                "adam_step_simple diverged from adam_step at " + String(i)
+            )
+    print("  ok adam_step_simple delegates to adam_step defaults")
+    print("test_adam_step_simple_delegates PASSED")
+
+
+def main() raises:
+    test_reject_shape_mismatch()
+    test_reject_dtype_mismatch()
+    test_reject_empty_moments()
+    test_reject_nonpositive_timestep()
+    test_parity_with_reference()
+    test_adam_step_simple_delegates()
+    print("\nAll Adam parity tests PASSED")

--- a/tests/odyssey/training/optimizers/test_adamw.mojo
+++ b/tests/odyssey/training/optimizers/test_adamw.mojo
@@ -1,0 +1,230 @@
+"""Unit tests for the AdamW update step (Loshchilov & Hutter 2019, arXiv:1711.05101).
+
+Odyssey's `adamw_step` is pure-functional: it returns (new_params, new_m, new_v).
+The implemented update (adamw.mojo) is the Adam core with DECOUPLED weight decay:
+
+    m      = beta1 * m + (1 - beta1) * grad            (grad NOT decayed)
+    v      = beta2 * v + (1 - beta2) * grad**2
+    m_hat  = m / (1 - beta1**t)
+    v_hat  = v / (1 - beta2**t)
+    p'     = params - lr * m_hat / (sqrt(v_hat) + epsilon)
+    params = p' - weight_decay * p'                    (decoupled, on p', no lr)
+
+NOTE: the decoupled-decay term differs from `torch.optim.AdamW`, which applies
+`p *= (1 - lr*weight_decay)` to the PRE-update params. Odyssey applies
+`p' *= (1 - weight_decay)` to the POST-update params with no lr factor. The
+parity reference (parity_refs/adamw_parity_reference.py) models Odyssey's
+implemented formula and records the divergence; the Adam core itself is
+torch-equivalent (test_adam.mojo).
+
+Tests cover:
+- Shape/dtype guards, empty-moment guard, positive-timestep guard
+- Numerical parity with the reference (1e-9) at t=3 with weight_decay=0.01
+- weight_decay=0 collapses AdamW to plain Adam on params (no decay term)
+- adamw_step_simple delegation
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros, full
+from odyssey.training.optimizers.adamw import (
+    adamw_step,
+    adamw_step_simple,
+)
+from odyssey.training.optimizers.adam import adam_step
+
+
+def _abs_diff(a: Float64, b: Float64) -> Float64:
+    var d = a - b
+    if d < 0:
+        d = -d
+    return d
+
+
+def test_reject_shape_mismatch() raises:
+    """`adamw_step` rejects a params/gradients shape mismatch."""
+    print("Running test_reject_shape_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([5], DType.float32)
+    var m = zeros([4], DType.float32)
+    var v = zeros([4], DType.float32)
+    try:
+        var _ = adamw_step(p, g, m, v, 1, 0.001)
+        raise Error("Should have rejected shape mismatch")
+    except:
+        print("  ok rejected shape mismatch")
+    print("test_reject_shape_mismatch PASSED")
+
+
+def test_reject_dtype_mismatch() raises:
+    """`adamw_step` rejects a params/gradients dtype mismatch."""
+    print("Running test_reject_dtype_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float16)
+    var m = zeros([4], DType.float32)
+    var v = zeros([4], DType.float32)
+    try:
+        var _ = adamw_step(p, g, m, v, 1, 0.001)
+        raise Error("Should have rejected dtype mismatch")
+    except:
+        print("  ok rejected dtype mismatch")
+    print("test_reject_dtype_mismatch PASSED")
+
+
+def test_reject_empty_moments() raises:
+    """`adamw_step` requires initialized moment buffers m and v."""
+    print("Running test_reject_empty_moments...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float32)
+    var m = zeros([0], DType.float32)
+    var v = zeros([4], DType.float32)
+    try:
+        var _ = adamw_step(p, g, m, v, 1, 0.001)
+        raise Error("Should have rejected empty moment buffer")
+    except:
+        print("  ok rejected empty moment buffer")
+    print("test_reject_empty_moments PASSED")
+
+
+def test_reject_nonpositive_timestep() raises:
+    """`adamw_step` rejects t <= 0."""
+    print("Running test_reject_nonpositive_timestep...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float32)
+    var m = zeros([4], DType.float32)
+    var v = zeros([4], DType.float32)
+    try:
+        var _ = adamw_step(p, g, m, v, 0, 0.001)
+        raise Error("Should have rejected t=0")
+    except:
+        print("  ok rejected non-positive timestep")
+    print("test_reject_nonpositive_timestep PASSED")
+
+
+def test_parity_with_reference() raises:
+    """One AdamW step at t=3 must match the reference to 1e-9.
+
+    Fixed inputs and reference outputs transcribed from
+    parity_refs/adamw_parity_reference.py (lr=1e-3, betas=(0.9,0.999),
+    eps=1e-8, weight_decay=0.01, t=3, seeded m/v).
+    """
+    print("Running test_parity_with_reference...")
+    var n = 6
+    var p = zeros([n], DType.float64)
+    var g = zeros([n], DType.float64)
+    var m = zeros([n], DType.float64)
+    var v = zeros([n], DType.float64)
+    p.store[DType.float64](0, 0.10)
+    p.store[DType.float64](1, -0.20)
+    p.store[DType.float64](2, 0.30)
+    p.store[DType.float64](3, -0.40)
+    p.store[DType.float64](4, 0.50)
+    p.store[DType.float64](5, -0.60)
+    g.store[DType.float64](0, 0.02)
+    g.store[DType.float64](1, -0.03)
+    g.store[DType.float64](2, 0.015)
+    g.store[DType.float64](3, 0.025)
+    g.store[DType.float64](4, -0.01)
+    g.store[DType.float64](5, 0.04)
+    m.store[DType.float64](0, 0.005)
+    m.store[DType.float64](1, -0.004)
+    m.store[DType.float64](2, 0.003)
+    m.store[DType.float64](3, -0.002)
+    m.store[DType.float64](4, 0.001)
+    m.store[DType.float64](5, -0.006)
+    v.store[DType.float64](0, 1e-4)
+    v.store[DType.float64](1, 2e-4)
+    v.store[DType.float64](2, 1.5e-4)
+    v.store[DType.float64](3, 3e-4)
+    v.store[DType.float64](4, 0.5e-4)
+    v.store[DType.float64](5, 4e-4)
+
+    var rp = List[Float64]()
+    rp.append(0.09887020074073723)
+    rp.append(-0.19790682925242264)
+    rp.append(0.29693143469020056)
+    rp.append(-0.39600807814475314)
+    rp.append(0.49500282687934843)
+    rp.append(-0.5939860216178512)
+    var rm = List[Float64]()
+    rm.append(0.006500000000000001)
+    rm.append(-0.0066)
+    rm.append(0.0042)
+    rm.append(0.0006999999999999995)
+    rm.append(-9.999999999999972e-05)
+    rm.append(-0.001400000000000001)
+    var rv = List[Float64]()
+    rv.append(0.0001003)
+    rv.append(0.0002007)
+    rv.append(0.00015007499999999998)
+    rv.append(0.00030032499999999994)
+    rv.append(5.0050000000000004e-05)
+    rv.append(0.0004012)
+
+    var out = adamw_step(p, g, m, v, 3, 0.001, 0.9, 0.999, 1e-8, 0.01)
+    var np = out[0]
+    var nm = out[1]
+    var nv = out[2]
+    for i in range(n):
+        if _abs_diff(np.load[DType.float64](i), rp[i]) > 1e-9:
+            raise Error("params parity mismatch at " + String(i))
+        if _abs_diff(nm.load[DType.float64](i), rm[i]) > 1e-9:
+            raise Error("m parity mismatch at " + String(i))
+        if _abs_diff(nv.load[DType.float64](i), rv[i]) > 1e-9:
+            raise Error("v parity mismatch at " + String(i))
+    print("  ok parity to 1e-9 on all 6 coordinates (params, m, v)")
+    print("test_parity_with_reference PASSED")
+
+
+def test_zero_wd_collapses_to_adam_params() raises:
+    """With weight_decay=0, AdamW's params match Adam's params (wd term absent).
+
+    The Adam-core moment recursion is identical; only the decoupled decay term
+    distinguishes them, and it vanishes at wd=0. (Adam couples wd into the
+    gradient, so this equivalence holds only at wd=0.)
+    """
+    print("Running test_zero_wd_collapses_to_adam_params...")
+    var n = 4
+    var p = full([n], 0.5, DType.float64)
+    var g = full([n], 0.1, DType.float64)
+    var m = zeros([n], DType.float64)
+    var v = zeros([n], DType.float64)
+    var aw = adamw_step(p, g, m, v, 1, 0.001, 0.9, 0.999, 1e-8, 0.0)
+    var ad = adam_step(p, g, m, v, 1, 0.001, 0.9, 0.999, 1e-8, 0.0)
+    for i in range(n):
+        if (
+            _abs_diff(
+                aw[0].load[DType.float64](i), ad[0].load[DType.float64](i)
+            )
+            > 1e-12
+        ):
+            raise Error("AdamW(wd=0) != Adam(wd=0) at " + String(i))
+    print("  ok AdamW(wd=0) params == Adam(wd=0) params")
+    print("test_zero_wd_collapses_to_adam_params PASSED")
+
+
+def test_adamw_step_simple_delegates() raises:
+    """`adamw_step_simple` runs and returns finite state with defaults."""
+    print("Running test_adamw_step_simple_delegates...")
+    var n = 4
+    var p = full([n], 0.5, DType.float64)
+    var g = full([n], 0.1, DType.float64)
+    var m = zeros([n], DType.float64)
+    var v = zeros([n], DType.float64)
+    var out = adamw_step_simple(p, g, m, v, 1, 0.001)
+    # smoke: params moved off the starting 0.5 and stayed finite
+    var moved = _abs_diff(out[0].load[DType.float64](0), 0.5) > 0.0
+    if not moved:
+        raise Error("adamw_step_simple did not update params")
+    print("  ok adamw_step_simple produced a finite update")
+    print("test_adamw_step_simple_delegates PASSED")
+
+
+def main() raises:
+    test_reject_shape_mismatch()
+    test_reject_dtype_mismatch()
+    test_reject_empty_moments()
+    test_reject_nonpositive_timestep()
+    test_parity_with_reference()
+    test_zero_wd_collapses_to_adam_params()
+    test_adamw_step_simple_delegates()
+    print("\nAll AdamW parity tests PASSED")

--- a/tests/odyssey/training/optimizers/test_lars.mojo
+++ b/tests/odyssey/training/optimizers/test_lars.mojo
@@ -1,0 +1,157 @@
+"""Unit tests for the LARS update step (You, Gitman & Ginsburg 2017, arXiv:1708.03888).
+
+Odyssey's `lars_step` is pure-functional: it returns (new_params, new_velocity).
+The implemented update (lars.mojo) is the layer-wise-adaptive rule
+
+    param_norm  = ||params||_2
+    grad_norm   = ||grad||_2
+    eff_grad    = grad + weight_decay * params
+    trust_ratio = trust_coefficient * param_norm
+                  / (grad_norm + weight_decay * param_norm + epsilon)
+    velocity    = momentum * velocity + trust_ratio * eff_grad
+    params      = params - lr * velocity
+
+Tests cover:
+- Shape/dtype guards and the empty-velocity guard
+- Numerical parity with the reference (1e-9): trust ratio, momentum buffer, and
+  the parameter step. Reference numbers from parity_refs/lars_parity_reference.py.
+- lars_step_simple delegation.
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros, full
+from odyssey.training.optimizers.lars import (
+    lars_step,
+    lars_step_simple,
+)
+
+
+def _abs_diff(a: Float64, b: Float64) -> Float64:
+    var d = a - b
+    if d < 0:
+        d = -d
+    return d
+
+
+def test_reject_shape_mismatch() raises:
+    """`lars_step` rejects a params/gradients shape mismatch."""
+    print("Running test_reject_shape_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([5], DType.float32)
+    var v = zeros([4], DType.float32)
+    try:
+        var _ = lars_step(p, g, v, 0.1)
+        raise Error("Should have rejected shape mismatch")
+    except:
+        print("  ok rejected shape mismatch")
+    print("test_reject_shape_mismatch PASSED")
+
+
+def test_reject_dtype_mismatch() raises:
+    """`lars_step` rejects a params/gradients dtype mismatch."""
+    print("Running test_reject_dtype_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float16)
+    var v = zeros([4], DType.float32)
+    try:
+        var _ = lars_step(p, g, v, 0.1)
+        raise Error("Should have rejected dtype mismatch")
+    except:
+        print("  ok rejected dtype mismatch")
+    print("test_reject_dtype_mismatch PASSED")
+
+
+def test_reject_empty_velocity() raises:
+    """`lars_step` requires an initialized velocity buffer."""
+    print("Running test_reject_empty_velocity...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float32)
+    var v = zeros([0], DType.float32)
+    try:
+        var _ = lars_step(p, g, v, 0.1)
+        raise Error("Should have rejected empty velocity")
+    except:
+        print("  ok rejected empty velocity")
+    print("test_reject_empty_velocity PASSED")
+
+
+def test_parity_with_reference() raises:
+    """One LARS step must match the reference to 1e-9.
+
+    Fixed inputs and reference outputs transcribed from
+    parity_refs/lars_parity_reference.py (lr=0.1, momentum=0.9,
+    weight_decay=1e-4, trust_coefficient=1e-3, eps=1e-8, seeded velocity).
+    """
+    print("Running test_parity_with_reference...")
+    var n = 6
+    var p = zeros([n], DType.float64)
+    var g = zeros([n], DType.float64)
+    var v = zeros([n], DType.float64)
+    p.store[DType.float64](0, 0.10)
+    p.store[DType.float64](1, -0.20)
+    p.store[DType.float64](2, 0.30)
+    p.store[DType.float64](3, -0.40)
+    p.store[DType.float64](4, 0.50)
+    p.store[DType.float64](5, -0.60)
+    g.store[DType.float64](0, 0.02)
+    g.store[DType.float64](1, -0.03)
+    g.store[DType.float64](2, 0.015)
+    g.store[DType.float64](3, 0.025)
+    g.store[DType.float64](4, -0.01)
+    g.store[DType.float64](5, 0.04)
+    v.store[DType.float64](0, 0.005)
+    v.store[DType.float64](1, -0.004)
+    v.store[DType.float64](2, 0.003)
+    v.store[DType.float64](3, -0.002)
+    v.store[DType.float64](4, 0.001)
+    v.store[DType.float64](5, -0.006)
+
+    var rp = List[Float64]()
+    rp.append(0.09951928360999032)
+    rp.append(-0.19959391773972562)
+    rp.append(0.2997069281688233)
+    rp.append(-0.39985831489728346)
+    rp.append(0.49992527376714624)
+    rp.append(-0.5995213099758614)
+    var rv = List[Float64]()
+    rv.append(0.004807163900096844)
+    rv.append(-0.0040608226027439905)
+    rv.append(0.0029307183117668945)
+    rv.append(-0.0014168510271655567)
+    rv.append(0.0007472623285375517)
+    rv.append(-0.004786900241385911)
+
+    var out = lars_step(p, g, v, 0.1, 0.9, 0.0001, 0.001, 1e-8)
+    var np = out[0]
+    var nv = out[1]
+    for i in range(n):
+        if _abs_diff(np.load[DType.float64](i), rp[i]) > 1e-9:
+            raise Error("params parity mismatch at " + String(i))
+        if _abs_diff(nv.load[DType.float64](i), rv[i]) > 1e-9:
+            raise Error("velocity parity mismatch at " + String(i))
+    print("  ok parity to 1e-9 on all 6 coordinates (params, velocity)")
+    print("test_parity_with_reference PASSED")
+
+
+def test_lars_step_simple_runs() raises:
+    """`lars_step_simple` runs with defaults and produces a finite update."""
+    print("Running test_lars_step_simple_runs...")
+    var n = 4
+    var p = full([n], 0.5, DType.float64)
+    var g = full([n], 0.1, DType.float64)
+    var v = zeros([n], DType.float64)
+    var out = lars_step_simple(p, g, v, 0.1)
+    # smoke: params moved off 0.5 and stayed finite
+    if _abs_diff(out[0].load[DType.float64](0), 0.5) == 0.0:
+        raise Error("lars_step_simple did not update params")
+    print("  ok lars_step_simple produced a finite update")
+    print("test_lars_step_simple_runs PASSED")
+
+
+def main() raises:
+    test_reject_shape_mismatch()
+    test_reject_dtype_mismatch()
+    test_reject_empty_velocity()
+    test_parity_with_reference()
+    test_lars_step_simple_runs()
+    print("\nAll LARS parity tests PASSED")

--- a/tests/odyssey/training/optimizers/test_lion.mojo
+++ b/tests/odyssey/training/optimizers/test_lion.mojo
@@ -1,0 +1,190 @@
+"""Unit tests for the Lion update step (Chen et al. 2023, arXiv:2302.06675).
+
+Odyssey's `lion_step` is pure-functional: it returns (new_params, new_momentum).
+The implemented update (lion.mojo) is
+
+    update   = sign(beta1 * momentum + (1 - beta1) * grad)
+    params   = params - lr * update
+    params   = params - lr * weight_decay * params        (decoupled, lr-scaled)
+    momentum = beta2 * momentum + (1 - beta2) * grad       (EMA updated AFTER)
+
+which matches the reference Lion (lucidrains/lion-pytorch,
+kozistr/pytorch_optimizer Lion).
+
+Tests cover:
+- Shape guards (params/grad and params/momentum) and dtype guard
+- Numerical parity with the reference (1e-9): the sign update, the lr-scaled
+  decoupled weight decay, and the beta2 momentum EMA. Reference numbers from
+  parity_refs/lion_parity_reference.py (numpy closed form; inputs chosen so no
+  interpolated coordinate is exactly zero, avoiding a sign(0) ambiguity).
+- The update is exactly +/- lr (before weight decay) since it is a sign.
+- lion_step_simple delegation.
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros, full
+from odyssey.training.optimizers.lion import (
+    lion_step,
+    lion_step_simple,
+)
+
+
+def _abs_diff(a: Float64, b: Float64) -> Float64:
+    var d = a - b
+    if d < 0:
+        d = -d
+    return d
+
+
+def test_reject_shape_mismatch() raises:
+    """`lion_step` rejects a params/gradients shape mismatch."""
+    print("Running test_reject_shape_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([5], DType.float32)
+    var m = zeros([4], DType.float32)
+    try:
+        var _ = lion_step(p, g, m, 0.001)
+        raise Error("Should have rejected shape mismatch")
+    except:
+        print("  ok rejected shape mismatch")
+    print("test_reject_shape_mismatch PASSED")
+
+
+def test_reject_momentum_shape_mismatch() raises:
+    """`lion_step` rejects a params/momentum shape mismatch."""
+    print("Running test_reject_momentum_shape_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float32)
+    var m = zeros([5], DType.float32)
+    try:
+        var _ = lion_step(p, g, m, 0.001)
+        raise Error("Should have rejected momentum shape mismatch")
+    except:
+        print("  ok rejected momentum shape mismatch")
+    print("test_reject_momentum_shape_mismatch PASSED")
+
+
+def test_reject_dtype_mismatch() raises:
+    """`lion_step` rejects a params/gradients dtype mismatch."""
+    print("Running test_reject_dtype_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float16)
+    var m = zeros([4], DType.float32)
+    try:
+        var _ = lion_step(p, g, m, 0.001)
+        raise Error("Should have rejected dtype mismatch")
+    except:
+        print("  ok rejected dtype mismatch")
+    print("test_reject_dtype_mismatch PASSED")
+
+
+def test_parity_with_reference() raises:
+    """One Lion step must match the reference to 1e-9.
+
+    Fixed inputs and reference outputs transcribed from
+    parity_refs/lion_parity_reference.py (lr=1e-3, beta1=0.9, beta2=0.99,
+    weight_decay=0.01; sign update [+,-,+,-,+,-]).
+    """
+    print("Running test_parity_with_reference...")
+    var n = 6
+    var p = zeros([n], DType.float64)
+    var g = zeros([n], DType.float64)
+    var m = zeros([n], DType.float64)
+    p.store[DType.float64](0, 0.10)
+    p.store[DType.float64](1, -0.20)
+    p.store[DType.float64](2, 0.30)
+    p.store[DType.float64](3, -0.40)
+    p.store[DType.float64](4, 0.50)
+    p.store[DType.float64](5, -0.60)
+    g.store[DType.float64](0, 0.02)
+    g.store[DType.float64](1, -0.03)
+    g.store[DType.float64](2, 0.015)
+    g.store[DType.float64](3, 0.025)
+    g.store[DType.float64](4, -0.01)
+    g.store[DType.float64](5, 0.04)
+    m.store[DType.float64](0, 0.05)
+    m.store[DType.float64](1, -0.04)
+    m.store[DType.float64](2, 0.03)
+    m.store[DType.float64](3, -0.02)
+    m.store[DType.float64](4, 0.01)
+    m.store[DType.float64](5, -0.06)
+
+    var rp = List[Float64]()
+    rp.append(0.098999)
+    rp.append(-0.198998)
+    rp.append(0.298997)
+    rp.append(-0.398996)
+    rp.append(0.498995)
+    rp.append(-0.598994)
+    var rm = List[Float64]()
+    rm.append(0.0497)
+    rm.append(-0.039900000000000005)
+    rm.append(0.029849999999999998)
+    rm.append(-0.01955)
+    rm.append(0.009800000000000001)
+    rm.append(-0.059)
+
+    var out = lion_step(p, g, m, 0.001, 0.9, 0.99, 0.01)
+    var np = out[0]
+    var nm = out[1]
+    for i in range(n):
+        if _abs_diff(np.load[DType.float64](i), rp[i]) > 1e-9:
+            raise Error("params parity mismatch at " + String(i))
+        if _abs_diff(nm.load[DType.float64](i), rm[i]) > 1e-9:
+            raise Error("momentum parity mismatch at " + String(i))
+    print("  ok parity to 1e-9 on all 6 coordinates (params, momentum)")
+    print("test_parity_with_reference PASSED")
+
+
+def test_update_is_sign_scaled_by_lr() raises:
+    """With weight_decay=0, |params - new_params| == lr on every coordinate.
+
+    Lion's update is the SIGN of the interpolated momentum, so the raw step is
+    exactly +/- lr independent of gradient magnitude. Inputs give a non-zero
+    interpolation on every coordinate.
+    """
+    print("Running test_update_is_sign_scaled_by_lr...")
+    var n = 4
+    var p = full([n], 0.5, DType.float64)
+    var g = full([n], 0.1, DType.float64)  # positive → interp > 0 → sign +1
+    var m = full([n], 0.2, DType.float64)
+    var out = lion_step(p, g, m, 0.01, 0.9, 0.99, 0.0)  # wd=0
+    for i in range(n):
+        # sign(+) = +1, so step = -lr*1 → new = 0.5 - 0.01 = 0.49
+        if _abs_diff(out[0].load[DType.float64](i), 0.49) > 1e-12:
+            raise Error("sign update not +/- lr at " + String(i))
+    print("  ok raw update is exactly +/- lr (sign step)")
+    print("test_update_is_sign_scaled_by_lr PASSED")
+
+
+def test_lion_step_simple_delegates() raises:
+    """`lion_step_simple` matches lion_step at defaults (betas 0.9/0.99, wd=0).
+    """
+    print("Running test_lion_step_simple_delegates...")
+    var n = 4
+    var p = full([n], 0.5, DType.float64)
+    var g = full([n], 0.1, DType.float64)
+    var m = full([n], 0.2, DType.float64)
+    var full_out = lion_step(p, g, m, 0.01, 0.9, 0.99, 0.0)
+    var simple_out = lion_step_simple(p, g, m, 0.01)
+    for i in range(n):
+        if (
+            _abs_diff(
+                full_out[0].load[DType.float64](i),
+                simple_out[0].load[DType.float64](i),
+            )
+            > 1e-12
+        ):
+            raise Error("lion_step_simple diverged at " + String(i))
+    print("  ok lion_step_simple delegates to lion_step defaults")
+    print("test_lion_step_simple_delegates PASSED")
+
+
+def main() raises:
+    test_reject_shape_mismatch()
+    test_reject_momentum_shape_mismatch()
+    test_reject_dtype_mismatch()
+    test_parity_with_reference()
+    test_update_is_sign_scaled_by_lr()
+    test_lion_step_simple_delegates()
+    print("\nAll Lion parity tests PASSED")

--- a/tests/odyssey/training/optimizers/test_muon.mojo
+++ b/tests/odyssey/training/optimizers/test_muon.mojo
@@ -1,0 +1,182 @@
+"""Unit tests for the Muon update step (Jordan et al. 2024).
+
+Odyssey's `muon_step` is pure-functional: it returns (new_params, new_momentum)
+and is specialized for rank-2 (matrix) parameters. The implemented update
+(muon.mojo) is
+
+    new_momentum = momentum_beta * momentum + grad
+    dir          = grad + momentum_beta * new_momentum   (nesterov=True)
+    u_orth       = newton_schulz_orthogonalize(dir, steps=5)   (Jordan quintic)
+    scale        = 0.2 * max(R, C) / sqrt(R * C)
+    params       = params - lr * scale * u_orth
+    params       = params - lr * weight_decay * params
+
+The Newton-Schulz iteration uses Jordan's tuned coefficients
+(a, b, c) = (3.4445, -4.7750, 2.0315) and deliberately does NOT converge to
+exact orthogonality, so parity is asserted against Odyssey's implemented
+iteration (faithfully replicated in numpy in the parity reference), not an
+idealized orthogonal matrix.
+
+Tests cover:
+- Shape/dtype guards, empty-momentum guard, and the rank-2-required guard
+- Numerical parity (1e-9) on a 2x3 matrix (rows < cols → NS non-transposed
+  path). Reference numbers from parity_refs/muon_parity_reference.py.
+- newton_schulz_orthogonalize on a square matrix returns an approximately
+  orthogonal factor (Y @ Y^T singular values in the Jordan band, checked
+  loosely as diagonal near 1).
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros, full
+from odyssey.training.optimizers.muon import (
+    muon_step,
+    newton_schulz_orthogonalize,
+)
+
+
+def _abs_diff(a: Float64, b: Float64) -> Float64:
+    var d = a - b
+    if d < 0:
+        d = -d
+    return d
+
+
+def test_reject_shape_mismatch() raises:
+    """`muon_step` rejects a params/gradients shape mismatch."""
+    print("Running test_reject_shape_mismatch...")
+    var p = zeros([2, 3], DType.float32)
+    var g = zeros([2, 4], DType.float32)
+    var m = zeros([2, 3], DType.float32)
+    try:
+        var _ = muon_step(p, g, m, 0.01)
+        raise Error("Should have rejected shape mismatch")
+    except:
+        print("  ok rejected shape mismatch")
+    print("test_reject_shape_mismatch PASSED")
+
+
+def test_reject_non_rank2() raises:
+    """`muon_step` rejects non-matrix (rank != 2) parameters."""
+    print("Running test_reject_non_rank2...")
+    var p = zeros([6], DType.float32)  # rank-1
+    var g = zeros([6], DType.float32)
+    var m = zeros([6], DType.float32)
+    try:
+        var _ = muon_step(p, g, m, 0.01)
+        raise Error("Should have rejected rank-1 params")
+    except:
+        print("  ok rejected non-rank-2 params")
+    print("test_reject_non_rank2 PASSED")
+
+
+def test_reject_empty_momentum() raises:
+    """`muon_step` requires an initialized momentum buffer."""
+    print("Running test_reject_empty_momentum...")
+    var p = zeros([2, 3], DType.float32)
+    var g = zeros([2, 3], DType.float32)
+    var m = zeros([0], DType.float32)
+    try:
+        var _ = muon_step(p, g, m, 0.01)
+        raise Error("Should have rejected empty momentum")
+    except:
+        print("  ok rejected empty momentum")
+    print("test_reject_empty_momentum PASSED")
+
+
+def test_parity_with_reference() raises:
+    """One Muon step on a 2x3 matrix must match the reference to 1e-9.
+
+    Fixed inputs and reference outputs transcribed from
+    parity_refs/muon_parity_reference.py (lr=0.01, beta=0.95, wd=0.01,
+    ns_steps=5, nesterov=True). The reference faithfully replicates Odyssey's
+    Newton-Schulz iteration in numpy.
+    """
+    print("Running test_parity_with_reference...")
+    var p = zeros([2, 3], DType.float64)
+    var g = zeros([2, 3], DType.float64)
+    var m = zeros([2, 3], DType.float64)
+    # row 0
+    p.store[DType.float64](0, 0.10)
+    p.store[DType.float64](1, -0.20)
+    p.store[DType.float64](2, 0.30)
+    # row 1
+    p.store[DType.float64](3, -0.40)
+    p.store[DType.float64](4, 0.50)
+    p.store[DType.float64](5, -0.60)
+    g.store[DType.float64](0, 0.02)
+    g.store[DType.float64](1, -0.03)
+    g.store[DType.float64](2, 0.015)
+    g.store[DType.float64](3, 0.025)
+    g.store[DType.float64](4, -0.01)
+    g.store[DType.float64](5, 0.04)
+    m.store[DType.float64](0, 0.05)
+    m.store[DType.float64](1, -0.04)
+    m.store[DType.float64](2, 0.03)
+    m.store[DType.float64](3, -0.02)
+    m.store[DType.float64](4, 0.01)
+    m.store[DType.float64](5, -0.06)
+
+    var rp = List[Float64]()
+    rp.append(0.09914161539750362)
+    rp.append(-0.19856436781395365)
+    rp.append(0.29946522526790975)
+    rp.append(-0.4009765522043971)
+    rp.append(0.49903193843928556)
+    rp.append(-0.6009030572792634)
+    var rm = List[Float64]()
+    rm.append(0.0675)
+    rm.append(-0.068)
+    rm.append(0.0435)
+    rm.append(0.006000000000000002)
+    rm.append(-0.0005000000000000004)
+    rm.append(-0.016999999999999994)
+
+    var out = muon_step(p, g, m, 0.01, 0.95, 0.01, 5, True)
+    var np = out[0]
+    var nm = out[1]
+    for i in range(6):
+        if _abs_diff(np.load[DType.float64](i), rp[i]) > 1e-9:
+            raise Error("params parity mismatch at " + String(i))
+        if _abs_diff(nm.load[DType.float64](i), rm[i]) > 1e-9:
+            raise Error("momentum parity mismatch at " + String(i))
+    print("  ok parity to 1e-9 on all 6 entries (params, momentum)")
+    print("test_parity_with_reference PASSED")
+
+
+def test_newton_schulz_approx_orthogonal() raises:
+    """NS on a square matrix yields Y with Y @ Y^T diagonal near 1.
+
+    The Jordan iteration lands singular values in ~[0.68, 1.13], so we check
+    the diagonal of Y @ Y^T loosely (within 0.5 of 1.0) — a smoke test that
+    the orthogonalization ran and produced a well-scaled result, not an exact
+    orthogonality assertion.
+    """
+    print("Running test_newton_schulz_approx_orthogonal...")
+    var x = zeros([2, 2], DType.float64)
+    x.store[DType.float64](0, 1.0)
+    x.store[DType.float64](1, 0.3)
+    x.store[DType.float64](2, 0.2)
+    x.store[DType.float64](3, 0.9)
+    var y = newton_schulz_orthogonalize(x, 5)
+    # Y @ Y^T diagonal: y00^2 + y01^2 and y10^2 + y11^2
+    var y00 = y.load[DType.float64](0)
+    var y01 = y.load[DType.float64](1)
+    var y10 = y.load[DType.float64](2)
+    var y11 = y.load[DType.float64](3)
+    var d0 = y00 * y00 + y01 * y01
+    var d1 = y10 * y10 + y11 * y11
+    if _abs_diff(d0, 1.0) > 0.5 or _abs_diff(d1, 1.0) > 0.5:
+        raise Error(
+            "NS diagonal not near 1: d0=" + String(d0) + " d1=" + String(d1)
+        )
+    print("  ok NS produced an approximately-orthogonal factor")
+    print("test_newton_schulz_approx_orthogonal PASSED")
+
+
+def main() raises:
+    test_reject_shape_mismatch()
+    test_reject_non_rank2()
+    test_reject_empty_momentum()
+    test_parity_with_reference()
+    test_newton_schulz_approx_orthogonal()
+    print("\nAll Muon parity tests PASSED")

--- a/tests/odyssey/training/optimizers/test_rmsprop.mojo
+++ b/tests/odyssey/training/optimizers/test_rmsprop.mojo
@@ -1,0 +1,179 @@
+"""Unit tests for the RMSprop update step (Tieleman & Hinton 2012).
+
+Odyssey's `rmsprop_step` is pure-functional: it returns
+(new_params, new_square_avg, new_buf). The implemented update (rmsprop.mojo)
+for the centered=False, momentum=0 path is
+
+    effective_grad = grad + weight_decay * params
+    square_avg     = alpha * square_avg + (1 - alpha) * effective_grad**2
+    params         = params - lr * effective_grad / (sqrt(square_avg) + epsilon)
+
+which matches `torch.optim.RMSprop(centered=False, momentum=0)`.
+
+Tests cover:
+- Shape/dtype guards, empty square_avg guard, positive-timestep guard
+- Numerical parity with the reference (1e-9) at alpha=0.99, wd=0, momentum=0.
+  Reference numbers from parity_refs/rmsprop_parity_reference.py (drives
+  torch.optim.RMSprop when importable, else the identical numpy closed form).
+- rmsprop_step_simple delegation.
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros, full
+from odyssey.training.optimizers.rmsprop import (
+    rmsprop_step,
+    rmsprop_step_simple,
+)
+
+
+def _abs_diff(a: Float64, b: Float64) -> Float64:
+    var d = a - b
+    if d < 0:
+        d = -d
+    return d
+
+
+def test_reject_shape_mismatch() raises:
+    """`rmsprop_step` rejects a params/gradients shape mismatch."""
+    print("Running test_reject_shape_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([5], DType.float32)
+    var sq = zeros([4], DType.float32)
+    try:
+        var _ = rmsprop_step(p, g, sq, 1, 0.01)
+        raise Error("Should have rejected shape mismatch")
+    except:
+        print("  ok rejected shape mismatch")
+    print("test_reject_shape_mismatch PASSED")
+
+
+def test_reject_dtype_mismatch() raises:
+    """`rmsprop_step` rejects a params/gradients dtype mismatch."""
+    print("Running test_reject_dtype_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float16)
+    var sq = zeros([4], DType.float32)
+    try:
+        var _ = rmsprop_step(p, g, sq, 1, 0.01)
+        raise Error("Should have rejected dtype mismatch")
+    except:
+        print("  ok rejected dtype mismatch")
+    print("test_reject_dtype_mismatch PASSED")
+
+
+def test_reject_empty_square_avg() raises:
+    """`rmsprop_step` requires an initialized square_avg buffer."""
+    print("Running test_reject_empty_square_avg...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float32)
+    var sq = zeros([0], DType.float32)
+    try:
+        var _ = rmsprop_step(p, g, sq, 1, 0.01)
+        raise Error("Should have rejected empty square_avg")
+    except:
+        print("  ok rejected empty square_avg")
+    print("test_reject_empty_square_avg PASSED")
+
+
+def test_reject_nonpositive_timestep() raises:
+    """`rmsprop_step` rejects t <= 0."""
+    print("Running test_reject_nonpositive_timestep...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float32)
+    var sq = zeros([4], DType.float32)
+    try:
+        var _ = rmsprop_step(p, g, sq, 0, 0.01)
+        raise Error("Should have rejected t=0")
+    except:
+        print("  ok rejected non-positive timestep")
+    print("test_reject_nonpositive_timestep PASSED")
+
+
+def test_parity_with_reference() raises:
+    """One RMSprop step must match the reference to 1e-9.
+
+    Fixed inputs and reference outputs transcribed from
+    parity_refs/rmsprop_parity_reference.py (lr=0.01, alpha=0.99, eps=1e-8,
+    wd=0, momentum=0, seeded square_avg).
+    """
+    print("Running test_parity_with_reference...")
+    var n = 6
+    var p = zeros([n], DType.float64)
+    var g = zeros([n], DType.float64)
+    var sq = zeros([n], DType.float64)
+    p.store[DType.float64](0, 0.10)
+    p.store[DType.float64](1, -0.20)
+    p.store[DType.float64](2, 0.30)
+    p.store[DType.float64](3, -0.40)
+    p.store[DType.float64](4, 0.50)
+    p.store[DType.float64](5, -0.60)
+    g.store[DType.float64](0, 0.02)
+    g.store[DType.float64](1, -0.03)
+    g.store[DType.float64](2, 0.015)
+    g.store[DType.float64](3, 0.025)
+    g.store[DType.float64](4, -0.01)
+    g.store[DType.float64](5, 0.04)
+    sq.store[DType.float64](0, 1e-4)
+    sq.store[DType.float64](1, 2e-4)
+    sq.store[DType.float64](2, 1.5e-4)
+    sq.store[DType.float64](3, 3e-4)
+    sq.store[DType.float64](4, 0.5e-4)
+    sq.store[DType.float64](5, 4e-4)
+
+    var rp = List[Float64]()
+    rp.append(0.08029343385417073)
+    rp.append(-0.17914857308703608)
+    rp.append(0.28778306551461014)
+    rp.append(-0.41435619519148703)
+    rp.append(0.5140719310926535)
+    rp.append(-0.6197065758545528)
+    var rsq = List[Float64]()
+    rsq.append(0.00010300000000000001)
+    rsq.append(0.00020700000000000002)
+    rsq.append(0.00015074999999999998)
+    rsq.append(0.00030324999999999997)
+    rsq.append(5.050000000000001e-05)
+    rsq.append(0.00041200000000000004)
+
+    var out = rmsprop_step(p, g, sq, 1, 0.01, 0.99, 1e-8, 0.0, 0.0)
+    var np = out[0]
+    var nsq = out[1]
+    for i in range(n):
+        if _abs_diff(np.load[DType.float64](i), rp[i]) > 1e-9:
+            raise Error("params parity mismatch at " + String(i))
+        if _abs_diff(nsq.load[DType.float64](i), rsq[i]) > 1e-9:
+            raise Error("square_avg parity mismatch at " + String(i))
+    print("  ok parity to 1e-9 on all 6 coordinates (params, square_avg)")
+    print("test_parity_with_reference PASSED")
+
+
+def test_rmsprop_step_simple_delegates() raises:
+    """`rmsprop_step_simple` matches the full step at defaults (wd=0, mom=0)."""
+    print("Running test_rmsprop_step_simple_delegates...")
+    var n = 4
+    var p = full([n], 0.5, DType.float64)
+    var g = full([n], 0.1, DType.float64)
+    var sq = full([n], 1e-4, DType.float64)
+    var full_out = rmsprop_step(p, g, sq, 1, 0.01, 0.99, 1e-8, 0.0, 0.0)
+    var simple_out = rmsprop_step_simple(p, g, sq, 0.01, 0.99, 1e-8)
+    for i in range(n):
+        if (
+            _abs_diff(
+                full_out[0].load[DType.float64](i),
+                simple_out[0].load[DType.float64](i),
+            )
+            > 1e-12
+        ):
+            raise Error("rmsprop_step_simple diverged at " + String(i))
+    print("  ok rmsprop_step_simple delegates to the full step")
+    print("test_rmsprop_step_simple_delegates PASSED")
+
+
+def main() raises:
+    test_reject_shape_mismatch()
+    test_reject_dtype_mismatch()
+    test_reject_empty_square_avg()
+    test_reject_nonpositive_timestep()
+    test_parity_with_reference()
+    test_rmsprop_step_simple_delegates()
+    print("\nAll RMSprop parity tests PASSED")

--- a/tests/odyssey/training/optimizers/test_sgd.mojo
+++ b/tests/odyssey/training/optimizers/test_sgd.mojo
@@ -1,0 +1,178 @@
+"""Unit tests for the SGD (momentum + weight-decay) update step.
+
+Odyssey's `sgd_step` is pure-functional: it returns (new_params, new_velocity)
+and the caller manages state. The implemented update (sgd.mojo) is
+
+    effective_grad = grad + weight_decay * params          (wd applied first)
+    velocity       = momentum * velocity + effective_grad
+    params         = params - lr * velocity
+
+which is exactly `torch.optim.SGD` with `dampening=0, nesterov=False`.
+
+Tests cover:
+- Shape/dtype guards on sgd_step
+- The momentum-required-buffer guard
+- Numerical parity with the reference algorithm (1e-9) on a fixed 6-vector
+  with non-zero momentum, weight_decay, and starting velocity so every term
+  of the update is asserted. Reference numbers transcribed from
+  parity_refs/sgd_parity_reference.py (which drives torch.optim.SGD when torch
+  is importable, else the identical numpy closed form).
+- The no-momentum / no-weight-decay path collapses to params - lr * grad
+- sgd_step_simple delegating to plain SGD (no momentum, no weight decay)
+"""
+
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros, full
+from odyssey.training.optimizers.sgd import (
+    sgd_step,
+    sgd_step_simple,
+)
+
+
+def _abs_diff(a: Float64, b: Float64) -> Float64:
+    var d = a - b
+    if d < 0:
+        d = -d
+    return d
+
+
+def test_reject_shape_mismatch() raises:
+    """`sgd_step` rejects a params/gradients shape mismatch."""
+    print("Running test_reject_shape_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([5], DType.float32)
+    var v = zeros([4], DType.float32)
+    try:
+        var _ = sgd_step(p, g, v, 0.01)
+        raise Error("Should have rejected shape mismatch")
+    except:
+        print("  ok rejected shape mismatch")
+    print("test_reject_shape_mismatch PASSED")
+
+
+def test_reject_dtype_mismatch() raises:
+    """`sgd_step` rejects a params/gradients dtype mismatch."""
+    print("Running test_reject_dtype_mismatch...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float16)
+    var v = zeros([4], DType.float32)
+    try:
+        var _ = sgd_step(p, g, v, 0.01)
+        raise Error("Should have rejected dtype mismatch")
+    except:
+        print("  ok rejected dtype mismatch")
+    print("test_reject_dtype_mismatch PASSED")
+
+
+def test_reject_empty_velocity_with_momentum() raises:
+    """`sgd_step` requires a velocity buffer when momentum > 0."""
+    print("Running test_reject_empty_velocity_with_momentum...")
+    var p = zeros([4], DType.float32)
+    var g = zeros([4], DType.float32)
+    var v = zeros([0], DType.float32)  # empty buffer
+    try:
+        var _ = sgd_step(p, g, v, 0.01, 0.9)
+        raise Error("Should have rejected empty velocity with momentum")
+    except:
+        print("  ok rejected empty velocity with momentum")
+    print("test_reject_empty_velocity_with_momentum PASSED")
+
+
+def test_parity_with_reference() raises:
+    """One SGD step (momentum + weight decay) must match the reference to 1e-9.
+
+    Fixed inputs and reference outputs transcribed from
+    parity_refs/sgd_parity_reference.py (lr=0.1, momentum=0.9,
+    weight_decay=0.01, starting velocity non-zero).
+    """
+    print("Running test_parity_with_reference...")
+    var n = 6
+    var p = zeros([n], DType.float64)
+    var g = zeros([n], DType.float64)
+    var v = zeros([n], DType.float64)
+    p.store[DType.float64](0, 0.10)
+    p.store[DType.float64](1, -0.20)
+    p.store[DType.float64](2, 0.30)
+    p.store[DType.float64](3, -0.40)
+    p.store[DType.float64](4, 0.50)
+    p.store[DType.float64](5, -0.60)
+    g.store[DType.float64](0, 0.02)
+    g.store[DType.float64](1, -0.03)
+    g.store[DType.float64](2, 0.015)
+    g.store[DType.float64](3, 0.025)
+    g.store[DType.float64](4, -0.01)
+    g.store[DType.float64](5, 0.04)
+    v.store[DType.float64](0, 0.005)
+    v.store[DType.float64](1, -0.004)
+    v.store[DType.float64](2, 0.003)
+    v.store[DType.float64](3, -0.002)
+    v.store[DType.float64](4, 0.001)
+    v.store[DType.float64](5, -0.006)
+
+    var rp = List[Float64]()
+    rp.append(0.09745000000000001)
+    rp.append(-0.19644)
+    rp.append(0.29793)
+    rp.append(-0.40192)
+    rp.append(0.50041)
+    rp.append(-0.60286)
+    var rv = List[Float64]()
+    rv.append(0.025500000000000002)
+    rv.append(-0.0356)
+    rv.append(0.0207)
+    rv.append(0.019200000000000002)
+    rv.append(-0.0041)
+    rv.append(0.0286)
+
+    var out = sgd_step(p, g, v, 0.1, 0.9, 0.01)
+    var np = out[0]
+    var nv = out[1]
+    for i in range(n):
+        if _abs_diff(np.load[DType.float64](i), rp[i]) > 1e-9:
+            raise Error("params parity mismatch at " + String(i))
+        if _abs_diff(nv.load[DType.float64](i), rv[i]) > 1e-9:
+            raise Error("velocity parity mismatch at " + String(i))
+    print("  ok parity to 1e-9 on all 6 coordinates")
+    print("test_parity_with_reference PASSED")
+
+
+def test_plain_sgd_no_momentum_no_wd() raises:
+    """With momentum=0 and weight_decay=0, params = params - lr * grad."""
+    print("Running test_plain_sgd_no_momentum_no_wd...")
+    var n = 3
+    var p = full([n], 1.0, DType.float64)
+    var g = full([n], 0.5, DType.float64)
+    var v = zeros([n], DType.float64)
+    var out = sgd_step(p, g, v, 0.1)  # momentum=0, wd=0 defaults
+    var np = out[0]
+    for i in range(n):
+        # 1.0 - 0.1 * 0.5 = 0.95
+        if _abs_diff(np.load[DType.float64](i), 0.95) > 1e-9:
+            raise Error("plain SGD mismatch at " + String(i))
+    print("  ok plain SGD = params - lr*grad")
+    print("test_plain_sgd_no_momentum_no_wd PASSED")
+
+
+def test_sgd_step_simple_delegates() raises:
+    """`sgd_step_simple` matches plain sgd_step (no momentum, no weight decay).
+    """
+    print("Running test_sgd_step_simple_delegates...")
+    var n = 3
+    var p = full([n], 1.0, DType.float64)
+    var g = full([n], 0.5, DType.float64)
+    var simple = sgd_step_simple(p, g, 0.1)
+    for i in range(n):
+        if _abs_diff(simple.load[DType.float64](i), 0.95) > 1e-9:
+            raise Error("sgd_step_simple mismatch at " + String(i))
+    print("  ok sgd_step_simple delegates to plain SGD")
+    print("test_sgd_step_simple_delegates PASSED")
+
+
+def main() raises:
+    test_reject_shape_mismatch()
+    test_reject_dtype_mismatch()
+    test_reject_empty_velocity_with_momentum()
+    test_parity_with_reference()
+    test_plain_sgd_no_momentum_no_wd()
+    test_sgd_step_simple_delegates()
+    print("\nAll SGD parity tests PASSED")


### PR DESCRIPTION
## Summary

Seven optimizer ops shipped with a `*_step` implementation but **no
PyTorch-parity test**: `sgd`, `adam`, `adamw`, `rmsprop`, `lion`, `muon`,
`lars`. This PR closes that gap, bringing the untested set up to the same
1e-9 numerical-parity bar the Regime-A optimizers already meet.

Each op gets:
- `tests/odyssey/training/optimizers/parity_refs/<op>_parity_reference.py` — a
  reference that drives the real `torch.optim.*` when torch is importable
  (authoritative) and falls back to the identical numpy closed form otherwise,
  printing which path produced the numbers.
- `tests/odyssey/training/optimizers/test_<op>.mojo` — shape/dtype/state guards
  + a `test_parity_with_reference` asserting one hand-seeded step to **1e-9**
  against the transcribed reference, plus op-specific properties.

All 7 verified green locally under **Mojo 1.0.0b2**:

```
sgd: All SGD parity tests PASSED
adam: All Adam parity tests PASSED
adamw: All AdamW parity tests PASSED
rmsprop: All RMSprop parity tests PASSED
lion: All Lion parity tests PASSED
muon: All Muon parity tests PASSED
lars: All LARS parity tests PASSED
```

## Notable findings

- **AdamW diverges from `torch.optim.AdamW` in the decay term.** torch applies
  `p *= (1 - lr*wd)` to the PRE-update params; `adamw.mojo` applies
  `p' *= (1 - wd)` to the POST-update params with **no lr factor**. The Adam
  core is torch-equivalent (see `test_adam.mojo`); only the decoupled-decay
  term differs. The reference models Odyssey's implemented formula and both
  docstrings record the gap so a maintainer who wants exact torch-AdamW
  semantics knows where to look.
- **Muon parity is asserted against a faithful numpy replica of Odyssey's
  Jordan-quintic Newton-Schulz** ((a,b,c)=(3.4445,-4.7750,2.0315), Frobenius
  pre-norm, 5 steps) — the iteration deliberately does not converge to exact
  orthogonality, so parity is against the implemented iteration, verified to
  1e-9 on a 2×3 matrix.

## Test plan

- [x] `mojo format` clean on all 7 tests (one file at a time)
- [x] `ruff check` clean on all 7 parity references
- [x] All 7 tests green under Mojo 1.0.0b2 locally
- [ ] CI green

Part of the Stage A optimizer-standardization track (uniform parity-test
methodology across all optimizer ops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)