### PR TITLE
docs(dev): record test file provenance for test_optimizer_delegator_equivalence.mojo

### DIFF
--- a/docs/dev/optimizer-extension-guide.md
+++ b/docs/dev/optimizer-extension-guide.md
@@ -181,6 +181,23 @@ should be replaced with a delegating wrapper per this guide. New
 optimizers MUST NOT INLINE math in their OO wrapper — they must call
 `<name>_step`.
 
+## Test provenance
+
+| Test file | Introduced in |
+| --- | --- |
+| `tests/odyssey/training/optimizers/test_optimizer_delegator_equivalence.mojo` | PR #5684 (`bd8d6d99`) |
+
+Role: byte-identical regression barrier between `<name>_step` (functional)
+and `optimizers_oo/<name>.mojo` (OO). Assertions cover K=1, K=3, and
+raise-contract invocation shapes. See `## Drift prevention` for the
+rationale.
+
+Confirmed via
+`git log --follow tests/odyssey/training/optimizers/test_optimizer_delegator_equivalence.mojo`:
+the first commit in chronological order is `bd8d6d99`, the squash-merge
+of PR #5684. This is the canonical answer for any future contributor or
+agent investigating the test file's origin.
+
 ## Reference list (canonical examples)
 
 | Optimizer | Functional core | OO wrapper (canonical home: `optimizers_oo/`) |


### PR DESCRIPTION
## Summary

Adds a `## Test provenance` section to
`docs/dev/optimizer-extension-guide.md` recording that PR #5684 introduced
`tests/odyssey/training/optimizers/test_optimizer_delegator_equivalence.mojo`
(squash-merge commit `bd8d6d99`). The test file is the regression barrier
that proves the canonical functional `<name>_step` and the OO wrapper in
`optimizers_oo/<name>.mojo` produce byte-identical outputs across K=1,
K=3, and the 3 raise-contract invocation shapes.

Earlier review suggested genericizing the attribution under the mistaken
belief that PR #5684 did not touch the file. The git evidence (`git log --follow`
returns `bd8d6d99` as the file's first commit) shows the opposite.
Capturing this in the dev-guide prevents future readers from re-deriving
the same investigation.

## Changes Made

- Single new section `## Test provenance` between `## Drift prevention`
  and `## Reference list (canonical examples)`.
- One 2-column table (Test file / Introduced in) + role prose + the
  `Confirmed via` evidence sentence.
- All inserted lines ≤ 120 chars (MD013).

## Files Modified

- `docs/dev/optimizer-extension-guide.md` (+17 / -1 lines)

## Verification

| Check | Result |
| --- | --- |
| `git log --follow ... test_optimizer_delegator_equivalence.mojo` first commit | `bd8d6d99` |
| `markdownlint-cli2` exit on the edited file | 0 |
| `pre-commit run --files ...` exit | 0 |
| Lines exceeding MD013 (120 chars) in inserted section | 0 |

## Notes

Documentation-only. No code path touched.

This documents the lineage in the canonical extension-point guide
(`docs/dev/optimizer-extension-guide.md`) rather than the
`.agents/skills/odyssey-mojo-test-local/SKILL.md` candidate, because
SKILL.md isn't yet on `main`. If SKILL.md gets added later, cross-link
the two rather than duplicating the finding.

## Related

- **PR #5684** (merged): the introducing PR for the test file.
- **PR #5687** (merged): the rename-only refactor that previously
  genericized this attribution.
- **PR #5688**: the compile-fix follow-up to #5687.
- **`.agents/skills/odyssey-mojo-test-local/SKILL.md`**: canonical
  `mojo --Werror` invocation (on divergent branch; not yet on `main`).
