### PR TITLE
fix(docs): correct optimizers/__init__.mojo parent-package re-export claim

### DIFF
--- a/src/odyssey/training/optimizers/__init__.mojo
+++ b/src/odyssey/training/optimizers/__init__.mojo
@@ -28,15 +28,13 @@ Includes:
 All optimizers follow pure functional design - caller manages state
 
 Note:
-    All symbols in this module are re-exported cleanly through the parent
-    `odyssey.training` package. You may import directly from either location:
+    Optimizer symbols are accessed only via the canonical submodule path
+    `odyssey.training.optimizers`. The parent `odyssey.training` package
+    deliberately keeps optimizer symbols out of its import surface:
 
     ```mojo
     from odyssey.training.optimizers import sgd_step
-    from odyssey.training import sgd_step  # also works
     ```
-
-    No Mojo re-export limitation applies here (unlike `odyssey.training.callbacks`).
 """
 
 # Export optimizer implementations


### PR DESCRIPTION
Closes #5647

The module-level docstring in `optimizers/__init__.mojo` falsely claimed that optimizer symbols were importable via `from odyssey.training import sgd_step`. The parent `odyssey.training` package does not re-export optimizer symbols — the only canonical import path is `odyssey.training.optimizers`. Update the docstring to point users at the canonical path so the example no longer silently suggests a non-working import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>