### PR TITLE
refactor(optimizers): standardize force_f64=False across init_*_state helpers

### DIFF
--- a/src/odyssey/training/optimizers/kl_shampoo.mojo
+++ b/src/odyssey/training/optimizers/kl_shampoo.mojo
@@ -330,7 +330,7 @@ def _sym_inv_sqrt(s: AnyTensor, ridge: Float64) raises -> AnyTensor:
 def init_kl_shampoo_state(
     params_list: List[AnyTensor],
     *,
-    force_f64: Bool = True,
+    force_f64: Bool = False,
 ) raises -> List[List[AnyTensor]]:
     """Allocate per-parameter KL-Shampoo state buffers (matrix-only).
 

--- a/src/odyssey/training/optimizers/soap.mojo
+++ b/src/odyssey/training/optimizers/soap.mojo
@@ -264,7 +264,7 @@ def _pow(base: Float64, exp: Int) raises -> Float64:
 def init_soap_state(
     params_list: List[AnyTensor],
     *,
-    force_f64: Bool = True,
+    force_f64: Bool = False,
 ) raises -> List[List[AnyTensor]]:
     """Allocate per-parameter soap state buffers (matrix-only).
 

--- a/src/odyssey/training/optimizers/splus.mojo
+++ b/src/odyssey/training/optimizers/splus.mojo
@@ -314,7 +314,7 @@ def _flip_columns(m: AnyTensor) raises -> AnyTensor:
 def init_splus_state(
     params_list: List[AnyTensor],
     *,
-    force_f64: Bool = True,
+    force_f64: Bool = False,
 ) raises -> List[List[AnyTensor]]:
     """Allocate per-parameter splus state buffers (matrix-only).
 


### PR DESCRIPTION
Closes #5685

The three matrix-only optimizers (init_kl_shampoo_state, init_soap_state,
init_splus_state) previously defaulted `force_f64=True` while every other
init_*_state helper defaults to `False`. These three optimizers already
unconditionally emit float64 state buffers regardless of the `force_f64`
kwarg (the parameter is effectively documentation-only for them, kept for
API consistency across the 24 init_*_state helpers). Align the default to
`False` to match the rest of the package — callers that depend on the
previous `True` default must now opt in explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>