### PR TITLE
chore(gitignore): consolidate Python bytecode rules (#5667)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 # Legacy pixi env dirs (kept ignored in case a stale checkout still has them)
 .pixi/
 
-# Python cache directories
+# Python cache directories (see #5667: also covers
+#   tests/odyssey/core/layers/parity_refs/* generators).
 __pycache__
 *.pyc
 
@@ -60,4 +61,3 @@ checkpoints/
 /test_cumulative.mojo
 lenet5_weights_autograd/
 .claude-prompt-*.md
-__pycache__/


### PR DESCRIPTION
## Summary

Closes #5667.

The canonical `__pycache__` entry already covers every `__pycache__/`
directory recursively. The duplicate `__pycache__/` form at the tail
of `.gitignore` was functionally redundant; removed. A 2-line comment
now references #5667 and `tests/odyssey/core/layers/parity_refs/*`
generators so future readers know why the rule is in place.

Files: `.gitignore` (1 file, +2/-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>