### PR TITLE
ci(justfile): wrap 4 unprotected mojo invocations with MOJO_TARGET_CPU

### DIFF
--- a/justfile
+++ b/justfile
@@ -218,7 +218,7 @@ podman-test-image target="runtime":
 # Run tests in container image
 podman-run-tests target="runtime":
     @podman run --rm {{REGISTRY}}/{{REPO_NAME}}:{{target}} \
-        uv run mojo test -I . tests/
+        uv run mojo test {{MOJO_TARGET_CPU}} -I . tests/
 
 # Interactive shell in container image
 podman-run-shell target="runtime":
@@ -692,7 +692,7 @@ train model="lenet_emnist" precision="fp32" epochs="10" batch_size="32" lr="0.00
     MODEL="{{model}}"
     if [ "$MODEL" = "lenet" ] || [ "$MODEL" = "lenet5" ]; then MODEL="lenet_emnist"; fi
     echo "Training $MODEL with precision={{precision}}, epochs={{epochs}}"
-    just _run "uv run mojo run -I . examples/$MODEL/run_train.mojo \
+    just _run "uv run mojo run {{MOJO_TARGET_CPU}} -I . examples/$MODEL/run_train.mojo \
         --epochs {{epochs}} --batch-size {{batch_size}} \
         --lr {{lr}} --precision {{precision}}"
 
@@ -702,7 +702,7 @@ infer model="lenet_emnist" checkpoint="lenet5_weights":
     MODEL="{{model}}"
     if [ "$MODEL" = "lenet" ] || [ "$MODEL" = "lenet5" ]; then MODEL="lenet_emnist"; fi
     echo "Running inference for $MODEL with checkpoint={{checkpoint}}"
-    just _run "uv run mojo run -I . examples/$MODEL/run_infer.mojo \
+    just _run "uv run mojo run {{MOJO_TARGET_CPU}} -I . examples/$MODEL/run_infer.mojo \
         --checkpoint {{checkpoint}} --test-set"
 
 # Run inference on single image. Accepts lenet/lenet5 as aliases for lenet_emnist.
@@ -711,7 +711,7 @@ infer-image checkpoint image_path model="lenet_emnist":
     MODEL="{{model}}"
     if [ "$MODEL" = "lenet" ] || [ "$MODEL" = "lenet5" ]; then MODEL="lenet_emnist"; fi
     echo "Running inference on {{image_path}}"
-    just _run "uv run mojo run -I . examples/$MODEL/run_infer.mojo \
+    just _run "uv run mojo run {{MOJO_TARGET_CPU}} -I . examples/$MODEL/run_infer.mojo \
         --checkpoint {{checkpoint}} --image {{image_path}}"
 
 # Download EMNIST dataset (balanced split) and flatten to datasets/emnist/


### PR DESCRIPTION
## Summary

Closes #5571.

Per `#5571`, stripped AVX-512 from the 4 remaining unprotected `mojo run`
/ `mojo test` invocations in `justfile`, matching the existing protected
pattern used by `_test-example-backward-inner` (lines ~1467/~1499).
Without these flags the upstream `modular/modular#6413` mis-emission
can SIGILL on host CPUs missing the affected AVX-512 subfeatures.

Inserted `{{MOJO_TARGET_CPU}}` flag on:
* L221  `podman-run-tests`  (mojo test)
* L695  `train`             (mojo run via `just _run`)
* L705  `infer-test-set`    (mojo run via `just _run`)
* L714  `infer-image`       (mojo run via `just _run`)

Files: `justfile` (1 file, +4/-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>