### PR TITLE
test(optimizers): upgrade 3 smoke-only _step_simple tests to delegation parity

### DIFF
--- a/tests/odyssey/training/optimizers/test_normuon.mojo
+++ b/tests/odyssey/training/optimizers/test_normuon.mojo
@@ -166,18 +166,126 @@ def test_zero_grad_no_nan() raises:
     print("test_zero_grad_no_nan PASSED")
 
 
+def _normuon_abs_diff(a: Float64, b: Float64) -> Float64:
+    """Mirror of the helper shape used in sibling tests."""
+    var d = a - b
+    if d < 0:
+        d = -d
+    return d
+
+
 def test_normuon_step_simple() raises:
-    """Test the convenience normuon_step_simple function."""
-    print("Running test_normuon_step_simple...")
+    """`normuon_step_simple` delegates to `normuon_step` with documented defaults.
 
-    var params = randn([8, 16], DType.float32)
-    var grad = randn([8, 16], DType.float32)
-    var m = zeros_like(params)
-    var lr = 0.01
+    Replacement rationale:
+        The previous test only asserted the call returned without raising,
+        which silently accepts a broken delegation contract (e.g. if
+        `normuon_step_simple` returned a zero-initialized tensor instead of
+        delegating, the smoke check would still pass). This upgrade replaces
+        the smoke check with element-wise parity on `new_params` AND
+        `new_momentum` across two paths: zero-grad (exercises the row/col
+        norm init at lr scale) and non-zero-grad (exercises the actual
+        NorMuon update). Defaults match normuon.mojo: norm_axis=0, eps=1e-8,
+        momentum=0.95.
+    """
+    print("Running test_normuon_step_simple (delegation parity)...")
 
-    var (_, _) = normuon_step_simple(params, grad, m, lr)
+    # --- Pass 1: zero gradients ---
+    var shape: List[Int] = [8, 16]
+    var params_zi = zeros(shape, DType.float32)
+    var grad_zi = zeros(shape, DType.float32)
+    var mr_f = zeros(shape, DType.float32)
+    var mr_s = zeros(shape, DType.float32)
 
-    print("  ✓ normuon_step_simple completed")
+    var full_p1 = normuon_step(
+        params_zi,
+        grad_zi,
+        mr_f,
+        learning_rate=0.01,
+        norm_axis=0,
+        eps=1e-8,
+        momentum=0.95,
+    )
+    var simple_p1 = normuon_step_simple(params_zi, grad_zi, mr_s, 0.01)
+
+    var n_total = params_zi.numel()
+    for i in range(n_total):
+        var diff_p = _normuon_abs_diff(
+            full_p1[0]._get_float64(i), simple_p1[0]._get_float64(i)
+        )
+        if diff_p > 1e-3:
+            raise Error(
+                "normuon_step_simple params diverged at "
+                + String(i)
+                + " (zero-grad); diff="
+                + String(diff_p)
+            )
+        var diff_m = _normuon_abs_diff(
+            full_p1[1]._get_float64(i), simple_p1[1]._get_float64(i)
+        )
+        if diff_m > 1e-3:
+            raise Error(
+                "normuon_step_simple momentum diverged at "
+                + String(i)
+                + " (zero-grad); diff="
+                + String(diff_m)
+            )
+
+    # --- Pass 2: non-zero gradient ---
+    var params = randn(shape, DType.float32)
+    var grad = randn(shape, DType.float32)
+    var m_full = zeros_like(params)
+    var m_simple = zeros_like(params)
+
+    var full_p2 = normuon_step(
+        params,
+        grad,
+        m_full,
+        learning_rate=0.01,
+        norm_axis=0,
+        eps=1e-8,
+        momentum=0.95,
+    )
+    var simple_p2 = normuon_step_simple(params, grad, m_simple, 0.01)
+
+    for i in range(n_total):
+        var diff_p = _normuon_abs_diff(
+            full_p2[0]._get_float64(i), simple_p2[0]._get_float64(i)
+        )
+        if diff_p > 1e-3:
+            raise Error(
+                "normuon_step_simple params diverged at "
+                + String(i)
+                + " (non-zero-grad); diff="
+                + String(diff_p)
+            )
+        var diff_m = _normuon_abs_diff(
+            full_p2[1]._get_float64(i), simple_p2[1]._get_float64(i)
+        )
+        if diff_m > 1e-3:
+            raise Error(
+                "normuon_step_simple momentum diverged at "
+                + String(i)
+                + " (non-zero-grad); diff="
+                + String(diff_m)
+            )
+
+    # Positive no-op: non-zero grad must change params (delta > eps).
+    var p_before = params._get_float64(0)
+    var p_after = full_p2[0]._get_float64(0)
+    if _normuon_abs_diff(p_before, p_after) < 1e-6:
+        raise Error(
+            "normuon_step_simple must change params under non-zero grad;"
+            " before="
+            + String(p_before)
+            + " after="
+            + String(p_after)
+        )
+
+    print(
+        "  ok normuon_step_simple delegates to normuon_step defaults"
+        " (params/momentum across 2 paths)"
+    )
     print("test_normuon_step_simple PASSED")
 
 

--- a/tests/odyssey/training/test_lars.mojo
+++ b/tests/odyssey/training/test_lars.mojo
@@ -327,32 +327,135 @@ def test_lars_weight_decay() raises:
     assert_less(val_with_wd_0, val_without_wd_0)
 
 
-def test_lars_step_simple() raises:
-    """Test LARS simplified step function with default hyperparameters.
-
-    Simplified API uses sensible defaults:
-    - momentum = 0.9
-    - weight_decay = 0.0001
-    - trust_coefficient = 0.001
-    - epsilon = 1e-8
+def _lars_abs_diff(a: Float64, b: Float64) -> Float64:
+    """Mirror of the helper shape used in sibling tests (test_eigen, test_muon, test_rnn).
     """
+    var d = a - b
+    if d < 0:
+        d = -d
+    return d
+
+
+def test_lars_step_simple() raises:
+    """`lars_step_simple` delegates to `lars_step` with documented defaults.
+
+    Replacement rationale:
+        The previous test only asserted that `lars_step_simple` returned a
+        non-zero result, which silently accepts a broken delegation (e.g. if
+        `lars_step_simple` forgot to call `lars_step` and returned a default
+        value, the smoke check would still pass). This upgrade replaces the
+        smoke check with element-wise parity on `new_params` AND `new_velocity`
+        across two paths: zero-grad (exercises the trust-ratio / weight-decay
+        init path) and non-zero-grad (exercises the actual LARS update).
+        Defaults match lars.mojo: momentum=0.9, weight_decay=0.0001,
+        trust_coefficient=0.001, epsilon=1e-8.
+    """
+    # --- Pass 1: zero gradients ---
     var shape: List[Int] = [1]
+    var params_zi = ones(shape, DType.float32)
+    params_zi.set(0, Float32(1.0))
+    var grads_zi = zeros(shape, DType.float32)
+    var vel_f = zeros(shape, DType.float32)
+    var vel_s = zeros(shape, DType.float32)
+
+    var full_p1 = lars_step(
+        params_zi,
+        grads_zi,
+        vel_f,
+        learning_rate=1.0,
+        momentum=0.9,
+        weight_decay=0.0001,
+        trust_coefficient=0.001,
+        epsilon=1e-8,
+    )
+    var simple_p1 = lars_step_simple(
+        params_zi, grads_zi, vel_s, learning_rate=1.0
+    )
+
+    for i in range(params_zi.numel()):
+        var diff_p = _lars_abs_diff(
+            Float64(full_p1[0]._data.bitcast[Float32]()[i]),
+            Float64(simple_p1[0]._data.bitcast[Float32]()[i]),
+        )
+        if diff_p > 1e-12:
+            raise Error(
+                "lars_step_simple params diverged at "
+                + String(i)
+                + " (zero-grad); diff="
+                + String(diff_p)
+            )
+        var diff_v = _lars_abs_diff(
+            Float64(full_p1[1]._data.bitcast[Float32]()[i]),
+            Float64(simple_p1[1]._data.bitcast[Float32]()[i]),
+        )
+        if diff_v > 1e-12:
+            raise Error(
+                "lars_step_simple velocity diverged at "
+                + String(i)
+                + " (zero-grad); diff="
+                + String(diff_v)
+            )
+
+    # Positive no-op: zero-grad + weight_decay must shrink params from 1.0
+    # (params *= (1 - lr*wd) = (1 - 1.0*0.0001) = 0.9999). A broken delegation
+    # that returned params unchanged would still score 1.0 here.
+    var params_after_zi = Float64(full_p1[0]._data.bitcast[Float32]()[0])
+    if params_after_zi >= 1.0:
+        raise Error(
+            "lars weight decay must shrink params from 1.0; got "
+            + String(params_after_zi)
+        )
+
+    # --- Pass 2: non-zero gradient ---
     var params = ones(shape, DType.float32)
     params.set(0, Float32(1.0))
-
     var grads = zeros(shape, DType.float32)
     grads.set(0, Float32(0.1))
+    var vel_full = zeros(shape, DType.float32)
+    var vel_simple = zeros(shape, DType.float32)
 
-    var velocity = zeros(shape, DType.float32)
+    var full_p2 = lars_step(
+        params,
+        grads,
+        vel_full,
+        learning_rate=1.0,
+        momentum=0.9,
+        weight_decay=0.0001,
+        trust_coefficient=0.001,
+        epsilon=1e-8,
+    )
+    var simple_p2 = lars_step_simple(
+        params, grads, vel_simple, learning_rate=1.0
+    )
 
-    # Should accept minimal parameters
-    var result = lars_step_simple(params, grads, velocity, learning_rate=1.0)
+    for i in range(params.numel()):
+        var diff_p = _lars_abs_diff(
+            Float64(full_p2[0]._data.bitcast[Float32]()[i]),
+            Float64(simple_p2[0]._data.bitcast[Float32]()[i]),
+        )
+        if diff_p > 1e-12:
+            raise Error(
+                "lars_step_simple params diverged at "
+                + String(i)
+                + " (non-zero-grad); diff="
+                + String(diff_p)
+            )
+        var diff_v = _lars_abs_diff(
+            Float64(full_p2[1]._data.bitcast[Float32]()[i]),
+            Float64(simple_p2[1]._data.bitcast[Float32]()[i]),
+        )
+        if diff_v > 1e-12:
+            raise Error(
+                "lars_step_simple velocity diverged at "
+                + String(i)
+                + " (non-zero-grad); diff="
+                + String(diff_v)
+            )
 
-    var new_params = result[0]
-
-    # Parameter should change
-    var new_val = Float64(new_params._data.bitcast[Float32]()[0])
-    assert_not_equal(new_val, 1.0)
+    print(
+        "  ok lars_step_simple delegates to lars_step defaults"
+        " (params/velocity across 2 paths)"
+    )
 
 
 def test_lars_adaptive_scaling_small_gradients() raises:

--- a/tests/odyssey/training/test_muon.mojo
+++ b/tests/odyssey/training/test_muon.mojo
@@ -518,23 +518,127 @@ def test_muon_step_with_weight_decay() raises:
     assert_less(final_norm, initial_norm, "Weight decay shrinks parameters")
 
 
+def _muon_abs_diff(a: Float64, b: Float64) -> Float64:
+    """Mirror of the helper shape used in sibling tests."""
+    var d = a - b
+    if d < 0:
+        d = -d
+    return d
+
+
 def test_muon_step_simple() raises:
-    """Test muon_step_simple with default hyperparameters.
+    """`muon_step_simple` delegates to `muon_step` with documented defaults.
 
-    Should work the same as muon_step with paper defaults.
+    Replacement rationale:
+        The previous test only asserted return-shape, which silently accepts
+        a broken delegation contract (e.g. if `muon_step_simple` returned a
+        default-constructed or zero tensor, the shape assertion would still
+        pass). This upgrade replaces the smoke check with element-wise parity
+        on `new_params` AND `new_momentum` across two paths: zero-grad
+        (exercises the orthogonalized-momentum init) and non-zero-grad
+        (exercises the actual Muon update). Defaults match muon.mojo:
+        momentum_beta=0.95, weight_decay=0.0, nesterov=True, ns_steps=5.
     """
+    # --- Pass 1: zero gradients ---
     var shape: List[Int] = [4, 4]
-    var params = ones(shape, DType.float32)
-    var gradients = zeros(shape, DType.float32)
-    var momentum = zeros_like(params)
+    var params_zi = ones(shape, DType.float32)
+    var grads_zi = zeros(shape, DType.float32)
+    var mom_f1 = zeros_like(params_zi)
+    var mom_s1 = zeros_like(params_zi)
 
-    var (new_params, new_momentum) = muon_step_simple(
-        params, gradients, momentum, learning_rate=0.01
+    var full_p1 = muon_step(
+        params_zi,
+        grads_zi,
+        mom_f1,
+        learning_rate=0.01,
+        momentum_beta=0.95,
+        weight_decay=0.0,
+        nesterov=True,
+        ns_steps=5,
+    )
+    var simple_p1 = muon_step_simple(
+        params_zi, grads_zi, mom_s1, learning_rate=0.01
     )
 
-    # Should return valid tensors of correct shape
-    assert_shape(new_params, shape, "muon_step_simple returns correct shape")
-    assert_shape(new_momentum, shape, "muon_step_simple momentum shape correct")
+    var n_total = params_zi.numel()
+    for i in range(n_total):
+        var diff_p = _muon_abs_diff(
+            full_p1[0]._get_float64(i), simple_p1[0]._get_float64(i)
+        )
+        if diff_p > 1e-12:
+            raise Error(
+                "muon_step_simple params diverged at "
+                + String(i)
+                + " (zero-grad); diff="
+                + String(diff_p)
+            )
+        var diff_m = _muon_abs_diff(
+            full_p1[1]._get_float64(i), simple_p1[1]._get_float64(i)
+        )
+        if diff_m > 1e-12:
+            raise Error(
+                "muon_step_simple momentum diverged at "
+                + String(i)
+                + " (zero-grad); diff="
+                + String(diff_m)
+            )
+
+    # --- Pass 2: non-zero gradient ---
+    var params = ones(shape, DType.float32)
+    var grads = zeros(shape, DType.float32)
+    var mom_full = zeros_like(params)
+    var mom_simple = zeros_like(params)
+    for i in range(params.numel()):
+        grads._set_float64(i, 0.1)  # constant non-zero grad
+
+    var full_p2 = muon_step(
+        params,
+        grads,
+        mom_full,
+        learning_rate=0.01,
+        momentum_beta=0.95,
+        weight_decay=0.0,
+        nesterov=True,
+        ns_steps=5,
+    )
+    var simple_p2 = muon_step_simple(
+        params, grads, mom_simple, learning_rate=0.01
+    )
+
+    for i in range(n_total):
+        var diff_p = _muon_abs_diff(
+            full_p2[0]._get_float64(i), simple_p2[0]._get_float64(i)
+        )
+        if diff_p > 1e-12:
+            raise Error(
+                "muon_step_simple params diverged at "
+                + String(i)
+                + " (non-zero-grad); diff="
+                + String(diff_p)
+            )
+        var diff_m = _muon_abs_diff(
+            full_p2[1]._get_float64(i), simple_p2[1]._get_float64(i)
+        )
+        if diff_m > 1e-12:
+            raise Error(
+                "muon_step_simple momentum diverged at "
+                + String(i)
+                + " (non-zero-grad); diff="
+                + String(diff_m)
+            )
+
+    # Positive no-op: non-zero grad must have moved params away from 1.0.
+    var moved = full_p2[0]._get_float64(0)
+    if moved == 1.0:
+        raise Error(
+            "muon_step_simple must move params under non-zero grad; got "
+            + String(moved)
+        )
+
+    print(
+        "  ok muon_step_simple delegates to muon_step defaults"
+        " (params/momentum across 2 paths)"
+    )
 
 
 def test_muon_step_pure_functional() raises:


### PR DESCRIPTION
## Summary

Closes #5681.

Replace smoke-only `test_lars_step_simple`, `test_muon_step_simple`,
and `test_normuon_step_simple` with 2-path delegation-parity tests
following the `test_shampoo_step_simple` template. Each upgrade
replaces shape-only / return-only assertions with element-wise
equality checks on every output slot across:

* **Pass 1: zero-grad** — exercises the preconditioner / norm init path.
* **Pass 2: non-zero-grad** — exercises the actual update path.

Defaults called on `_step` match the documented defaults of
`_step_simple` for each optimizer. A positive no-op assertion
confirms the underlying update path actually moves params, so a
broken delegation that returned a fresh zero tensor cannot pass
silently.

## Per-test diff summary

| Test | Old len | New len | Tolerance | Output slots compared |
| --- | --- | --- | --- | --- |
| `test_lars_step_simple` | 27 | ~110 | `1e-12` | `(new_params, new_velocity)` |
| `test_muon_step_simple` | 19 | ~110 | `1e-12` | `(new_params, new_momentum)` |
| `test_normuon_step_simple` | 15 | ~95 | `1e-3` | `(new_params, new_momentum)` |

Files:
* `tests/odyssey/training/test_lars.mojo`
* `tests/odyssey/training/test_muon.mojo`
* `tests/odyssey/training/optimizers/test_normuon.mojo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>