### PR TITLE
ci: add scripts/check_dispatch_sync.py — three-way dispatch consistency (#5682)

### DIFF
--- a/.github/workflows/check-dispatch-sync.yml
+++ b/.github/workflows/check-dispatch-sync.yml
@@ -1,0 +1,59 @@
+name: Dispatch Sync Check
+
+# Three-way consistency check across the optimizer dispatch registry.
+# Enforces agreement between:
+#   1. configs/schemas/training.schema.yaml (CLI/config source of truth)
+#   2. src/odyssey/training/dispatch.mojo (all_supported_optimizers names)
+#   3. Each src/odyssey/training/optimizers/<name>.mojo (init_<name>_state exists)
+# See scripts/check_dispatch_sync.py and issue #5682 for details.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  dispatch-sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    name: Three-way dispatch consistency
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "pyyaml>=6.0.0,<7"
+
+      - name: Run dispatch sync check
+        run: |
+          python scripts/check_dispatch_sync.py --root .
+
+      - name: Surface drift summary on failure
+        if: failure()
+        run: |
+          echo "## Dispatch Sync Drift" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "The optimizer dispatch registry disagrees with the source-level" >> "$GITHUB_STEP_SUMMARY"
+          echo "buffer count for one or more optimizers. Run locally:" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo '```bash' >> "$GITHUB_STEP_SUMMARY"
+          echo "python scripts/check_dispatch_sync.py --root ." >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Fix the name list in src/odyssey/training/dispatch.mojo OR" >> "$GITHUB_STEP_SUMMARY"
+          echo "the YAML enum in configs/schemas/training.schema.yaml" >> "$GITHUB_STEP_SUMMARY"
+          echo "so both agree. See issue #5682 for context." >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/check_dispatch_sync.py
+++ b/scripts/check_dispatch_sync.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""
+Three-way consistency check for the optimizer dispatch registry.
+
+Issue: #5682 (closes the TODO documented in PR #5682).
+
+Validates that two sources of truth agree on the 24 functional optimizers
+shipped under `odyssey.training.optimizers`:
+
+  1. `configs/schemas/training.schema.yaml`
+       — the YAML schema's `optimizer.name` enum (CLI/config source of truth)
+  2. `src/odyssey/training/dispatch.mojo`
+       — the `all_supported_optimizers()` function's `String("name")` entries
+
+Plus a source-existence check:
+
+  3. `src/odyssey/training/optimizers/<name>.mojo`
+       — each `init_<name>_state(params_list, *, force_f64)` function must
+       exist for every name in the dispatch roster.
+
+When all three agree, the dispatch is internally consistent: a CLI driver can
+trust that any name from the YAML enum will route to a registered optimizer,
+and each registered optimizer has a matching `init_<name>_state` in source.
+
+Usage:
+    python scripts/check_dispatch_sync.py [--root PATH] [--strict] [--quiet]
+
+Exit codes:
+    0 — all three sources agree (24 optimizers × 3 layers)
+    1 — at least one inconsistency, drift between sources, or parse error
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print(
+        "ERROR: PyYAML is required. Install with: pip install pyyaml",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+# ============================================================================
+# Layer 1 — YAML schema parser
+# ============================================================================
+
+
+def parse_yaml_enum(schema_path: Path) -> list[str]:
+    """Extract the optimizer.name enum from the YAML schema.
+
+    Args:
+        schema_path: Path to `configs/schemas/training.schema.yaml`.
+
+    Returns:
+        Sorted list of optimizer names declared in the schema's enum.
+
+    Raises:
+        FileNotFoundError, yaml.YAMLError, KeyError on malformed input.
+    """
+    with schema_path.open() as f:
+        schema = yaml.safe_load(f)
+    enum = schema["properties"]["optimizer"]["properties"]["name"]["enum"]
+    return sorted(enum)
+
+
+# ============================================================================
+# Layer 2 — dispatch.mojo all_supported_optimizers() parser
+# ============================================================================
+
+# Matches `String("name")` entries. Captures the optimizer name.
+# Used only within the `all_supported_optimizers()` function body —
+# see `parse_dispatch_registry` for the scoping logic.
+_DISPATCH_NAME_RE = re.compile(
+    r'String\(\s*"(?P<name>[a-z_]+)"\s*\)',
+)
+
+# Matches the `def all_supported_optimizers()` function header so we can
+# scope the name extraction to only that function's body (avoids false
+# positives from `String("...")` calls elsewhere in dispatch.mojo).
+_ALL_SUPPORTED_FN_RE = re.compile(
+    r"^def\s+all_supported_optimizers\s*\(",
+    re.MULTILINE,
+)
+
+
+def parse_dispatch_registry(dispatch_path: Path) -> set[str]:
+    """Extract optimizer names from `all_supported_optimizers()` in dispatch.mojo.
+
+    The current dispatch.mojo API (PR #5708) uses `all_supported_optimizers()`
+    returning `List[String]` with `String("name")` entries. This function
+    extracts those names by scoping the regex to the function body only —
+    `String("...")` calls elsewhere in dispatch.mojo (e.g., error messages)
+    are NOT matched. It does NOT extract buffer counts — the new API
+    delegates state allocation to `init_optimizer_state()` which dispatches
+    to per-optimizer `init_<name>_state` functions at the source level.
+
+    Args:
+        dispatch_path: Path to `src/odyssey/training/dispatch.mojo`.
+
+    Returns:
+        Set of optimizer names declared in `all_supported_optimizers()`.
+
+    Raises:
+        FileNotFoundError if the path does not exist.
+    """
+    text = dispatch_path.read_text()
+
+    # Scope to the `all_supported_optimizers()` function body only.
+    fn_match = _ALL_SUPPORTED_FN_RE.search(text)
+    if fn_match is None:
+        return set()
+
+    # The function body extends from after the signature's closing `:` line
+    # to the next top-level `def ` (column 0) or EOF.
+    pos = fn_match.end()
+    while pos < len(text):
+        nl = text.find("\n", pos)
+        if nl == -1:
+            nl = len(text)
+        line = text[pos:nl]
+        stripped = line.lstrip()
+        if stripped.startswith(")") and stripped.endswith(":"):
+            pos = nl + 1
+            break
+        pos = nl + 1
+
+    end_match = re.search(r"^def ", text[pos:], re.MULTILINE)
+    body_end = pos + end_match.start() if end_match else len(text)
+    body = text[pos:body_end]
+
+    names: set[str] = set()
+    for m in _DISPATCH_NAME_RE.finditer(body):
+        names.add(m.group("name"))
+    return names
+
+
+# ============================================================================
+# Layer 3 — per-source `init_<name>_state` buffer-count extractor
+# ============================================================================
+
+# Matches the function header for `init_<name>_state(...)`. Captures the
+# optimizer name. We then extract the function body via brace-balanced scan
+# (Mojo uses indentation rather than braces, but the function ends at the
+# next `def ` at the same indent level — see `_extract_function_body`).
+_INIT_DEF_RE = re.compile(
+    r"^def\s+init_(?P<name>[a-z_]+)_state\s*\(",
+    re.MULTILINE,
+)
+
+# Pattern A (loop-based): `for _ in range(N): per.append(...)` inside the
+# function body. Captures the integer N.
+_LOOP_BUFFER_COUNT_RE = re.compile(
+    # Use [ \t]* (NOT \s*) before \n so the greedy \s doesn't eat the newline.
+    r"for\s+_\s+in\s+range\s*\(\s*(?P<n>\d+)\s*\)[ \t]*:[ \t]*\n[ \t]*per\.append",
+    re.MULTILINE,
+)
+
+# Pattern B (append-based): every `per.append(...)` inside the function
+# body. Count these. Used as a fallback when pattern A doesn't match.
+_APPEND_COUNT_RE = re.compile(r"^\s*per\.append\s*\(", re.MULTILINE)
+
+
+def _extract_function_body(source: str, def_match: re.Match) -> str:
+    """Extract the indented body of the `def init_<name>_state(...)` block.
+
+    Mojo uses leading-whitespace indentation, not braces, so the body
+    extends from the line after the `def` header until the next
+    line at the SAME indent as `def` (or end-of-file).
+
+    Multi-line signatures (`def init_<n>_state(\\n    args\\n) raises ->
+    ...:\\n    body`) need special handling: the `):` line is at the same
+    indent as `def` (column 0), so a naive `line_indent <= def_line_indent`
+    break fires at the signature's closing paren BEFORE the body ever
+    starts. We scan forward to find that closing line, then collect the
+    body from the next line onward.
+
+    Args:
+        source: Full file text.
+        def_match: Regex match for the `def init_<name>_state(` header.
+
+    Returns:
+        The body text (everything between the signature's `):` line and
+        the next top-level `def `, or end-of-file).
+    """
+    # Step 1 — find the signature's closing `):` line. The signature is
+    # everything from the match end until a line containing `):` (possibly
+    # with `raises ->` / `-> ReturnType:` decorations). After that line,
+    # the actual function body begins.
+    pos = def_match.end()
+    while pos < len(source):
+        nl = source.find("\n", pos)
+        if nl == -1:
+            nl = len(source)
+        line = source[pos:nl]
+        # Detect the signature's closing line. Could be `):`, `) raises -> ... :`,
+        # `) -> ReturnType:`, etc. The line must (a) START with `)` after
+        # lstrip AND (b) END with `:` (the colon that introduces the body).
+        # This guards against false matches on comment lines that happen to
+        # start with `)`, e.g. `# ) foo bar baz`.
+        stripped = line.lstrip()
+        if stripped.startswith(")") and stripped.endswith(":"):
+            pos = nl + 1
+            break
+        pos = nl + 1
+
+    # Step 2 — body extends until the next top-level `def ` (column 0) or EOF.
+    end_match = re.search(r"^def ", source[pos:], re.MULTILINE)
+    body_end = pos + end_match.start() if end_match else len(source)
+    return source[pos:body_end]
+
+
+def extract_init_state_buffer_count(optimizer_source: Path, name: str) -> int | None:
+    """Return the per-parameter inner buffer count of `init_<name>_state`.
+
+    Two extraction strategies, in order of preference:
+
+    1. **Loop-based**: scan the function body for `for _ in range(N): per.append(...)`
+       and return N. Covers the canonical `init_<name>_state` template used
+       by sgd, adam, adamw, adopt, adan, sophia, rmsprop, adagrad, lars,
+       muon, normuon, mgup_muon, muon_hyperball, lion, lionmuon, sf_normuon,
+       ftrl, schedule_free, schedule_free_plus, prodigy.
+
+    2. **Append-based**: count `per.append(...)` calls in the function body.
+       Covers optimizers that allocate buffers via explicit `per.append(eye(...))`
+       etc. inside an `if <eligibility>:` branch — notably shampoo, kl_shampoo,
+       soap, splus. Counts the *matrix-eligible* path, which is what the
+       dispatch's `num_state_buffers` documents.
+
+    Args:
+        optimizer_source: Path to `src/odyssey/training/optimizers/<name>.mojo`.
+        name: Optimizer name (e.g., "shampoo").
+
+    Returns:
+        The extracted buffer count, or None if the function or pattern is
+        not found.
+    """
+    text = optimizer_source.read_text()
+    m = _INIT_DEF_RE.search(text)
+    if m is None or m.group("name") != name:
+        return None
+
+    body = _extract_function_body(text, m)
+    loop_match = _LOOP_BUFFER_COUNT_RE.search(body)
+    if loop_match is not None:
+        return int(loop_match.group("n"))
+
+    # Fallback: count `per.append(...)` calls. For eligibility-gated
+    # optimizers (shampoo family), these all live inside the same `if`
+    # branch, so a global count in the function body equals the
+    # matrix-eligible buffer count.
+    return len(_APPEND_COUNT_RE.findall(body))
+
+
+# ============================================================================
+# Consistency check + reporting
+# ============================================================================
+
+
+def check_dispatch_sync(
+    root: Path,
+    *,
+    strict: bool = False,
+    quiet: bool = False,
+) -> int:
+    """Run the consistency check.
+
+    Args:
+        root: Repository root.
+        strict: Reserved for future use (e.g., fail-on-warning). Currently
+            a no-op — any source-level mismatch is already a hard error.
+        quiet: Suppress per-optimizer informational output; print only
+            the summary + errors.
+
+    Returns:
+        Exit code: 0 on success, 1 on any inconsistency.
+    """
+    schema_path = root / "configs" / "schemas" / "training.schema.yaml"
+    dispatch_path = root / "src" / "odyssey" / "training" / "dispatch.mojo"
+    optimizers_dir = root / "src" / "odyssey" / "training" / "optimizers"
+
+    # Layer 1: YAML enum
+    try:
+        yaml_enum = parse_yaml_enum(schema_path)
+    except Exception as e:
+        print(f"ERROR: failed to parse YAML schema: {e}", file=sys.stderr)
+        return 1
+
+    # Layer 2: dispatch.mojo registry
+    if not dispatch_path.exists():
+        print(
+            f"ERROR: dispatch module not found at {dispatch_path}",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        registry = parse_dispatch_registry(dispatch_path)
+    except Exception as e:
+        print(f"ERROR: failed to parse dispatch.mojo: {e}", file=sys.stderr)
+        return 1
+
+    # Layer 3: per-source init_<name>_state existence check
+    source_exists: dict[str, bool] = {}
+    for name in sorted(registry):
+        source_path = optimizers_dir / f"{name}.mojo"
+        if not source_path.exists():
+            source_exists[name] = False
+            continue
+        try:
+            count = extract_init_state_buffer_count(source_path, name)
+            source_exists[name] = count is not None
+        except Exception:
+            source_exists[name] = False
+
+    # Layer-by-layer comparison.
+    errors: list[str] = []
+    yaml_set = set(yaml_enum)
+    reg_set = set(registry)
+
+    # 1. YAML <-> registry name set (name mismatches are always errors)
+    only_in_yaml = yaml_set - reg_set
+    only_in_reg = reg_set - yaml_set
+    for name in sorted(only_in_yaml):
+        errors.append(f"NAME MISMATCH: '{name}' is in YAML schema but NOT in dispatch.mojo")
+    for name in sorted(only_in_reg):
+        errors.append(f"NAME MISMATCH: '{name}' is in dispatch.mojo but NOT in YAML schema")
+
+    # 2. dispatch registry <-> source existence
+    if not quiet:
+        print("\nPer-optimizer source-existence check (dispatch ↔ source):\n")
+    for name in sorted(registry):
+        exists = source_exists.get(name, False)
+        if not quiet:
+            status = "found" if exists else "MISSING"
+            print(f"  {name:<22} init_{name}_state: {status}")
+        if not exists:
+            errors.append(
+                f"SOURCE MISSING: '{name}' — dispatch lists it but init_<name>_state not found or unparsable in source"
+            )
+
+    # Summary
+    print()
+    print(
+        f"YAML enum:         {len(yaml_enum)} names\n"
+        f"dispatch.mojo:     {len(registry)} optimizer names\n"
+        f"source-verified:   {sum(1 for v in source_exists.values() if v)} / "
+        f"{len(registry)} init_<name>_state functions found"
+    )
+
+    if errors:
+        print(f"\nFAIL: {len(errors)} consistency error(s):", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    print("\nOK: all optimizer names consistent across YAML enum, dispatch.mojo, and source.")
+    return 0
+
+
+# ============================================================================
+# CLI
+# ============================================================================
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Three-way consistency check across the optimizer dispatch "
+            "registry (YAML schema enum ↔ dispatch.mojo "
+            "all_supported_optimizers names ↔ per-source "
+            "init_<name>_state existence)."
+        )
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root (default: cwd).",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Reserved for future use (no effect today).",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress per-optimizer informational output.",
+    )
+    args = parser.parse_args()
+    return check_dispatch_sync(
+        args.root,
+        strict=args.strict,
+        quiet=args.quiet,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_check_dispatch_sync.py
+++ b/tests/scripts/test_check_dispatch_sync.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Tests for `scripts/check_dispatch_sync.py` — three-way dispatch sync check.
+
+Issue: #5682. Validates:
+
+1. `parse_yaml_enum` returns the canonical names from the schema.
+2. `parse_dispatch_registry` extracts every `String("name")` entry from
+   `all_supported_optimizers()`.
+3. `extract_init_state_buffer_count` returns:
+   - The integer N for loop-based `init_<name>_state` (sgd=1, adam=2).
+   - The count of `per.append(...)` calls for append-based (shampoo=3).
+4. `check_dispatch_sync` is internally consistent for a synthetic fixture.
+5. The full script runs against the live repo without errors.
+
+Usage:
+    python tests/scripts/test_check_dispatch_sync.py
+    pytest tests/scripts/test_check_dispatch_sync.py -v
+"""
+
+import importlib.util
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load `check_dispatch_sync` from scripts/ (which has no __init__.py)
+# ---------------------------------------------------------------------------
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_SPEC = importlib.util.spec_from_file_location(
+    "check_dispatch_sync",
+    _PROJECT_ROOT / "scripts" / "check_dispatch_sync.py",
+)
+_mod = importlib.util.module_from_spec(_SPEC)  # type: ignore[arg-type]
+_SPEC.loader.exec_module(_mod)  # type: ignore[union-attr]
+
+parse_yaml_enum = _mod.parse_yaml_enum
+parse_dispatch_registry = _mod.parse_dispatch_registry
+extract_init_state_buffer_count = _mod.extract_init_state_buffer_count
+check_dispatch_sync = _mod.check_dispatch_sync
+
+
+# ============================================================================
+# Layer 1 — YAML parser
+# ============================================================================
+
+
+class TestParseYamlEnum:
+    def test_extracts_all_names(self, tmp_path: Path) -> None:
+        schema = tmp_path / "training.schema.yaml"
+        schema.write_text(
+            textwrap.dedent(
+                """\
+                $schema: "http://json-schema.org/draft-07/schema#"
+                title: Training
+                type: object
+                properties:
+                  optimizer:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        enum:
+                          - sgd
+                          - adam
+                          - shampoo
+                          - prodigy
+                """
+            )
+        )
+        assert parse_yaml_enum(schema) == ["adam", "prodigy", "sgd", "shampoo"]
+
+    def test_returns_sorted(self, tmp_path: Path) -> None:
+        schema = tmp_path / "s.yaml"
+        schema.write_text(
+            textwrap.dedent(
+                """\
+                properties:
+                  optimizer:
+                    properties:
+                      name:
+                        enum:
+                          - zebra
+                          - apple
+                          - mango
+                """
+            )
+        )
+        assert parse_yaml_enum(schema) == ["apple", "mango", "zebra"]
+
+
+# ============================================================================
+# Layer 2 — dispatch.mojo parser (all_supported_optimizers)
+# ============================================================================
+
+
+class TestParseDispatchRegistry:
+    def test_single_line_entries(self, tmp_path: Path) -> None:
+        f = tmp_path / "dispatch.mojo"
+        f.write_text(
+            textwrap.dedent(
+                """\
+                def all_supported_optimizers() -> List[String]:
+                    var names: List[String] = []
+                    names.append(String("sgd"))
+                    names.append(String("adam"))
+                    return names^
+                """
+            )
+        )
+        reg = parse_dispatch_registry(f)
+        assert reg == {"sgd", "adam"}
+
+    def test_multi_line_entries(self, tmp_path: Path) -> None:
+        f = tmp_path / "dispatch.mojo"
+        f.write_text(
+            textwrap.dedent(
+                """\
+                def all_supported_optimizers() -> List[String]:
+                    var names: List[String] = []
+                    names.append(
+                        String("shampoo")
+                    )
+                    names.append(
+                        String("prodigy")
+                    )
+                    return names^
+                """
+            )
+        )
+        reg = parse_dispatch_registry(f)
+        assert reg == {"shampoo", "prodigy"}
+
+    def test_no_entries(self, tmp_path: Path) -> None:
+        f = tmp_path / "dispatch.mojo"
+        f.write_text("# no specs here\n")
+        assert parse_dispatch_registry(f) == set()
+
+    def test_duplicate_entries_collapsed(self, tmp_path: Path) -> None:
+        """Duplicate `String("name")` entries collapse into one set member."""
+        f = tmp_path / "dispatch.mojo"
+        f.write_text(
+            "def all_supported_optimizers() -> List[String]:\n"
+            "    var names: List[String] = []\n"
+            '    names.append(String("sgd"))\n'
+            '    names.append(String("sgd"))\n'
+            "    return names^\n"
+        )
+        reg = parse_dispatch_registry(f)
+        assert reg == {"sgd"}
+
+
+# ============================================================================
+# Layer 3 — per-source buffer-count extractor
+# ============================================================================
+
+
+_LOOP_BASED_OPTIMIZER = textwrap.dedent(
+    """\
+    def init_sgd_state(
+        params_list: List[AnyTensor],
+        *,
+        force_f64: Bool = False,
+    ) raises -> List[List[AnyTensor]]:
+        from odyssey.tensor.tensor_creation import zeros
+
+        var all_states: List[List[AnyTensor]] = []
+        for i in range(len(params_list)):
+            var p = params_list[i]
+            var d = p.dtype() if not force_f64 else DType.float64
+            var per: List[AnyTensor] = []
+            for _ in range(1):
+                per.append(zeros(p.shape(), d))
+            all_states.append(per^)
+        return all_states^
+
+    def other_function():
+        # This should NOT be picked up by the regex.
+        for _ in range(99):
+            pass
+    """
+)
+
+
+_APPEND_BASED_OPTIMIZER = textwrap.dedent(
+    """\
+    def is_shampoo_eligible(p) -> Bool:
+        return p.ndim() == 2 and p.shape()[0] >= 2 and p.shape()[1] >= 2
+
+
+    def init_shampoo_state(
+        params_list: List[AnyTensor],
+        *,
+        force_f64: Bool = False,
+    ) raises -> List[List[AnyTensor]]:
+        from odyssey.tensor.tensor_creation import eye, zeros_like
+
+        var all_states: List[List[AnyTensor]] = []
+        for i in range(len(params_list)):
+            var p = params_list[i]
+            var per: List[AnyTensor] = []
+            if is_shampoo_eligible(p):
+                var dtype = p.dtype() if not force_f64 else DType.float64
+                var sh = p.shape()
+                var m = sh[0]
+                var n = sh[1]
+                per.append(eye(m, m, 0, dtype))
+                per.append(eye(n, n, 0, dtype))
+                per.append(zeros_like(p))
+            all_states.append(per^)
+        return all_states^
+    """
+)
+
+
+_NO_INIT_OPTIMIZER = textwrap.dedent(
+    """\
+    # No init function defined here.
+    def step_function(p, g):
+        return p
+    """
+)
+
+
+class TestExtractInitStateBufferCount:
+    def test_loop_based_returns_range_int(self, tmp_path: Path) -> None:
+        f = tmp_path / "sgd.mojo"
+        f.write_text(_LOOP_BASED_OPTIMIZER)
+        assert extract_init_state_buffer_count(f, "sgd") == 1
+
+    def test_loop_based_ignores_other_functions(self, tmp_path: Path) -> None:
+        """The other_function's `for _ in range(99)` must not be picked up."""
+        f = tmp_path / "sgd.mojo"
+        f.write_text(_LOOP_BASED_OPTIMIZER)
+        assert extract_init_state_buffer_count(f, "sgd") == 1
+
+    def test_append_based_returns_per_append_count(self, tmp_path: Path) -> None:
+        f = tmp_path / "shampoo.mojo"
+        f.write_text(_APPEND_BASED_OPTIMIZER)
+        assert extract_init_state_buffer_count(f, "shampoo") == 3
+
+    def test_missing_init_returns_none(self, tmp_path: Path) -> None:
+        f = tmp_path / "noop.mojo"
+        f.write_text(_NO_INIT_OPTIMIZER)
+        assert extract_init_state_buffer_count(f, "noop") is None
+
+    def test_name_mismatch_returns_none(self, tmp_path: Path) -> None:
+        """Source contains init_sgd_state but caller asks for 'adam'."""
+        f = tmp_path / "sgd.mojo"
+        f.write_text(_LOOP_BASED_OPTIMIZER)
+        assert extract_init_state_buffer_count(f, "adam") is None
+
+
+# ============================================================================
+# Layer 4 — end-to-end on a synthetic repo
+# ============================================================================
+
+
+def _make_synthetic_repo(tmp_path: Path, *, mismatch: str | None = None) -> Path:
+    """Build a 3-optimizer synthetic repo for end-to-end testing.
+
+    Args:
+        tmp_path: Test temp dir.
+        mismatch: One of None, "yaml_only", "reg_only", "source_missing".
+            Each introduces a different kind of consistency error.
+    """
+    root = tmp_path
+
+    # YAML schema (3 optimizers)
+    schema_path = root / "configs" / "schemas" / "training.schema.yaml"
+    schema_path.parent.mkdir(parents=True, exist_ok=True)
+    yaml_names = ["sgd", "adam", "shampoo"]
+    if mismatch == "yaml_only":
+        yaml_names.append("phantom_optimizer")
+    yaml_text = (
+        '$schema: "http://json-schema.org/draft-07/schema#"\n'
+        "title: Training\n"
+        "type: object\n"
+        "properties:\n"
+        "  optimizer:\n"
+        "    properties:\n"
+        "      name:\n"
+        "        type: string\n"
+        "        enum:\n"
+    )
+    for n in yaml_names:
+        yaml_text += f"          - {n}\n"
+    schema_path.write_text(yaml_text)
+
+    # dispatch.mojo (all_supported_optimizers with String("name") entries)
+    dispatch_path = root / "src" / "odyssey" / "training" / "dispatch.mojo"
+    dispatch_path.parent.mkdir(parents=True, exist_ok=True)
+    reg_names = ["sgd", "adam", "shampoo"]
+    if mismatch == "reg_only":
+        reg_names.append("phantom_optimizer")
+    dispatch_text = "def all_supported_optimizers() -> List[String]:\n"
+    dispatch_text += "    var names: List[String] = []\n"
+    for n in reg_names:
+        dispatch_text += f'    names.append(String("{n}"))\n'
+    dispatch_text += "    return names^\n"
+    dispatch_path.write_text(dispatch_text)
+
+    # optimizer sources
+    opt_dir = root / "src" / "odyssey" / "training" / "optimizers"
+    opt_dir.mkdir(parents=True, exist_ok=True)
+    # sgd — loop-based, 1 buffer
+    (opt_dir / "sgd.mojo").write_text(_LOOP_BASED_OPTIMIZER)
+    # adam — loop-based with N=2 (rewrite the loop to range(2))
+    adam_src = _LOOP_BASED_OPTIMIZER.replace("for _ in range(1):", "for _ in range(2):")
+    adam_src = adam_src.replace("def init_sgd_state", "def init_adam_state")
+    (opt_dir / "adam.mojo").write_text(adam_src)
+    # shampoo — append-based, 3 buffers
+    (opt_dir / "shampoo.mojo").write_text(_APPEND_BASED_OPTIMIZER)
+    if mismatch == "reg_only":
+        # Source for phantom optimizer is missing — registry should error.
+        pass
+
+    return root
+
+
+class TestCheckDispatchSync:
+    def test_clean_synthetic_repo_passes(self, tmp_path: Path) -> None:
+        root = _make_synthetic_repo(tmp_path)
+        assert check_dispatch_sync(root, quiet=True) == 0
+
+    def test_yaml_only_optimizer_fails(self, tmp_path: Path) -> None:
+        root = _make_synthetic_repo(tmp_path, mismatch="yaml_only")
+        rc = check_dispatch_sync(root, quiet=True)
+        assert rc == 1
+
+    def test_reg_only_optimizer_fails(self, tmp_path: Path) -> None:
+        root = _make_synthetic_repo(tmp_path, mismatch="reg_only")
+        rc = check_dispatch_sync(root, quiet=True)
+        assert rc == 1
+
+
+# ============================================================================
+# Layer 5 — live-repo smoke test
+# ============================================================================
+
+
+def test_live_repo_dispatch_is_consistent(capsys: pytest.CaptureFixture[str]) -> None:
+    """Run check_dispatch_sync on the live repo.
+
+    The live repo should have a consistent dispatch registry: the YAML enum,
+    dispatch.mojo's `all_supported_optimizers()`, and each optimizer's
+    `init_<name>_state` source function should all agree on the optimizer
+    name set.
+
+    Skips if `dispatch.mojo` doesn't exist (e.g., partial checkout).
+    """
+    dispatch_path = _PROJECT_ROOT / "src" / "odyssey" / "training" / "dispatch.mojo"
+    if not dispatch_path.exists():
+        pytest.skip("dispatch.mojo not present in this checkout")
+
+    rc = check_dispatch_sync(_PROJECT_ROOT, quiet=False)
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+
+    assert rc == 0, f"check_dispatch_sync returned {rc}, expected 0 (all consistent). Output:\n{combined}"
+
+
+def test_live_repo_cli_invocation() -> None:
+    """`python scripts/check_dispatch_sync.py --help` exits 0."""
+    script = _PROJECT_ROOT / "scripts" / "check_dispatch_sync.py"
+    proc = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0
+    assert "--root" in proc.stdout
+    assert "--strict" in proc.stdout


### PR DESCRIPTION
## Summary
Closes #5682 — adds a CI gate (`check-dispatch-sync.yml`) that enforces name-set consistency between the YAML optimizer enum, `all_supported_optimizers()` in `dispatch.mojo` (PR #5708 API), and per-source `init_<name>_state` functions.

## Changes
- `scripts/check_dispatch_sync.py` — Three-way consistency check (YAML enum ↔ dispatch names ↔ source `init_<name>_state` existence). Scoped regex to `all_supported_optimizers()` function body to avoid false positives.
- `tests/scripts/test_check_dispatch_sync.py` — 16 tests covering YAML parser, dispatch parser (with function-body scoping), per-source extractor, end-to-end on synthetic repos, and live-repo smoke test. All pass.
- `.github/workflows/check-dispatch-sync.yml` — New CI gate. Triggers on PR `opened`, `synchronize`, `reopened`.

## CI Status
All dispatch-sync related checks pass:
- ✅ Three-way dispatch consistency (PASS)
- ✅ Python Tests (PASS)
- ✅ Build Validation (PASS)
- ✅ Mojo Package Compilation (PASS)

**Pre-existing CI failure (unrelated to this PR):** `Comprehensive Mojo Tests (autograd-tensor-base)` is failing on `main` and also fails on recently merged PRs #5704 and #5708. This failure is not caused by the dispatch-sync changes in this PR. The same single check fails on PRs that already landed — see #5711 for the cleanup issue.

## Test coverage
- 16/16 unit tests pass locally (`pytest tests/scripts/test_check_dispatch_sync.py`)
- Script exits 0 against live repo (24/24 optimizer names consistent across YAML ↔ dispatch ↔ source)
- All #5683 references corrected to #5682