### PR TITLE
refactor(check_dispatch_sync): simplify Layer 3 + remove dead strict flag (Closes #5712)

### DIFF
--- a/scripts/check_dispatch_sync.py
+++ b/scripts/check_dispatch_sync.py
@@ -2,7 +2,7 @@
 """
 Three-way consistency check for the optimizer dispatch registry.
 
-Issue: #5682 (closes the TODO documented in PR #5682).
+Issue: #5682 (the 3-way dispatch consistency requirement, closed by PR #5706).
 
 Validates that two sources of truth agree on the 24 functional optimizers
 shipped under `odyssey.training.optimizers`:
@@ -23,7 +23,7 @@ trust that any name from the YAML enum will route to a registered optimizer,
 and each registered optimizer has a matching `init_<name>_state` in source.
 
 Usage:
-    python scripts/check_dispatch_sync.py [--root PATH] [--strict] [--quiet]
+    python scripts/check_dispatch_sync.py [--root PATH] [--quiet]
 
 Exit codes:
     0 — all three sources agree (24 optimizers × 3 layers)
@@ -140,120 +140,39 @@ def parse_dispatch_registry(dispatch_path: Path) -> set[str]:
 
 
 # ============================================================================
-# Layer 3 — per-source `init_<name>_state` buffer-count extractor
+# Layer 3 — per-source `init_<name>_state` existence check
 # ============================================================================
 
 # Matches the function header for `init_<name>_state(...)`. Captures the
-# optimizer name. We then extract the function body via brace-balanced scan
-# (Mojo uses indentation rather than braces, but the function ends at the
-# next `def ` at the same indent level — see `_extract_function_body`).
+# optimizer name. We use this for a pure existence check (`has_init_state`).
+# Buffer counts are NOT verified here — the dispatch itself does not declare
+# them (post #5708 the dispatch API delegates state allocation to
+# `init_optimizer_state()` at runtime), so a buffer-count comparison would
+# be comparing across a layer that no longer exists.
 _INIT_DEF_RE = re.compile(
     r"^def\s+init_(?P<name>[a-z_]+)_state\s*\(",
     re.MULTILINE,
 )
 
-# Pattern A (loop-based): `for _ in range(N): per.append(...)` inside the
-# function body. Captures the integer N.
-_LOOP_BUFFER_COUNT_RE = re.compile(
-    # Use [ \t]* (NOT \s*) before \n so the greedy \s doesn't eat the newline.
-    r"for\s+_\s+in\s+range\s*\(\s*(?P<n>\d+)\s*\)[ \t]*:[ \t]*\n[ \t]*per\.append",
-    re.MULTILINE,
-)
 
-# Pattern B (append-based): every `per.append(...)` inside the function
-# body. Count these. Used as a fallback when pattern A doesn't match.
-_APPEND_COUNT_RE = re.compile(r"^\s*per\.append\s*\(", re.MULTILINE)
-
-
-def _extract_function_body(source: str, def_match: re.Match) -> str:
-    """Extract the indented body of the `def init_<name>_state(...)` block.
-
-    Mojo uses leading-whitespace indentation, not braces, so the body
-    extends from the line after the `def` header until the next
-    line at the SAME indent as `def` (or end-of-file).
-
-    Multi-line signatures (`def init_<n>_state(\\n    args\\n) raises ->
-    ...:\\n    body`) need special handling: the `):` line is at the same
-    indent as `def` (column 0), so a naive `line_indent <= def_line_indent`
-    break fires at the signature's closing paren BEFORE the body ever
-    starts. We scan forward to find that closing line, then collect the
-    body from the next line onward.
-
-    Args:
-        source: Full file text.
-        def_match: Regex match for the `def init_<name>_state(` header.
-
-    Returns:
-        The body text (everything between the signature's `):` line and
-        the next top-level `def `, or end-of-file).
-    """
-    # Step 1 — find the signature's closing `):` line. The signature is
-    # everything from the match end until a line containing `):` (possibly
-    # with `raises ->` / `-> ReturnType:` decorations). After that line,
-    # the actual function body begins.
-    pos = def_match.end()
-    while pos < len(source):
-        nl = source.find("\n", pos)
-        if nl == -1:
-            nl = len(source)
-        line = source[pos:nl]
-        # Detect the signature's closing line. Could be `):`, `) raises -> ... :`,
-        # `) -> ReturnType:`, etc. The line must (a) START with `)` after
-        # lstrip AND (b) END with `:` (the colon that introduces the body).
-        # This guards against false matches on comment lines that happen to
-        # start with `)`, e.g. `# ) foo bar baz`.
-        stripped = line.lstrip()
-        if stripped.startswith(")") and stripped.endswith(":"):
-            pos = nl + 1
-            break
-        pos = nl + 1
-
-    # Step 2 — body extends until the next top-level `def ` (column 0) or EOF.
-    end_match = re.search(r"^def ", source[pos:], re.MULTILINE)
-    body_end = pos + end_match.start() if end_match else len(source)
-    return source[pos:body_end]
-
-
-def extract_init_state_buffer_count(optimizer_source: Path, name: str) -> int | None:
-    """Return the per-parameter inner buffer count of `init_<name>_state`.
-
-    Two extraction strategies, in order of preference:
-
-    1. **Loop-based**: scan the function body for `for _ in range(N): per.append(...)`
-       and return N. Covers the canonical `init_<name>_state` template used
-       by sgd, adam, adamw, adopt, adan, sophia, rmsprop, adagrad, lars,
-       muon, normuon, mgup_muon, muon_hyperball, lion, lionmuon, sf_normuon,
-       ftrl, schedule_free, schedule_free_plus, prodigy.
-
-    2. **Append-based**: count `per.append(...)` calls in the function body.
-       Covers optimizers that allocate buffers via explicit `per.append(eye(...))`
-       etc. inside an `if <eligibility>:` branch — notably shampoo, kl_shampoo,
-       soap, splus. Counts the *matrix-eligible* path, which is what the
-       dispatch's `num_state_buffers` documents.
+def has_init_state(optimizer_source: Path, name: str) -> bool:
+    """Return True if `init_<name>_state(...)` is defined in the source file.
 
     Args:
         optimizer_source: Path to `src/odyssey/training/optimizers/<name>.mojo`.
         name: Optimizer name (e.g., "shampoo").
 
     Returns:
-        The extracted buffer count, or None if the function or pattern is
-        not found.
+        True if a `def init_<name>_state(` header is present in the file,
+        False otherwise (missing function or wrong name).
+
+    Note:
+        Caller is expected to handle I/O errors (FileNotFoundError, OSError,
+        UnicodeDecodeError) by treating them as "not found".
     """
     text = optimizer_source.read_text()
     m = _INIT_DEF_RE.search(text)
-    if m is None or m.group("name") != name:
-        return None
-
-    body = _extract_function_body(text, m)
-    loop_match = _LOOP_BUFFER_COUNT_RE.search(body)
-    if loop_match is not None:
-        return int(loop_match.group("n"))
-
-    # Fallback: count `per.append(...)` calls. For eligibility-gated
-    # optimizers (shampoo family), these all live inside the same `if`
-    # branch, so a global count in the function body equals the
-    # matrix-eligible buffer count.
-    return len(_APPEND_COUNT_RE.findall(body))
+    return m is not None and m.group("name") == name
 
 
 # ============================================================================
@@ -264,15 +183,12 @@ def extract_init_state_buffer_count(optimizer_source: Path, name: str) -> int | 
 def check_dispatch_sync(
     root: Path,
     *,
-    strict: bool = False,
     quiet: bool = False,
 ) -> int:
     """Run the consistency check.
 
     Args:
         root: Repository root.
-        strict: Reserved for future use (e.g., fail-on-warning). Currently
-            a no-op — any source-level mismatch is already a hard error.
         quiet: Suppress per-optimizer informational output; print only
             the summary + errors.
 
@@ -311,9 +227,13 @@ def check_dispatch_sync(
             source_exists[name] = False
             continue
         try:
-            count = extract_init_state_buffer_count(source_path, name)
-            source_exists[name] = count is not None
-        except Exception:
+            source_exists[name] = has_init_state(source_path, name)
+        except (OSError, UnicodeDecodeError):
+            # I/O errors (file deleted between .exists() and read_text,
+            # permission denied, or a binary source file) → treat as
+            # "not found". Other exceptions would indicate a genuine bug
+            # in `has_init_state` or the regex — let those propagate so
+            # CI fails fast rather than silently masking regressions.
             source_exists[name] = False
 
     # Layer-by-layer comparison.
@@ -382,11 +302,6 @@ def main() -> int:
         help="Repository root (default: cwd).",
     )
     parser.add_argument(
-        "--strict",
-        action="store_true",
-        help="Reserved for future use (no effect today).",
-    )
-    parser.add_argument(
         "--quiet",
         action="store_true",
         help="Suppress per-optimizer informational output.",
@@ -394,7 +309,6 @@ def main() -> int:
     args = parser.parse_args()
     return check_dispatch_sync(
         args.root,
-        strict=args.strict,
         quiet=args.quiet,
     )
 

--- a/tests/scripts/test_check_dispatch_sync.py
+++ b/tests/scripts/test_check_dispatch_sync.py
@@ -5,10 +5,8 @@ Issue: #5682. Validates:
 
 1. `parse_yaml_enum` returns the canonical names from the schema.
 2. `parse_dispatch_registry` extracts every `String("name")` entry from
-   `all_supported_optimizers()`.
-3. `extract_init_state_buffer_count` returns:
-   - The integer N for loop-based `init_<name>_state` (sgd=1, adam=2).
-   - The count of `per.append(...)` calls for append-based (shampoo=3).
+   `all_supported_optimizers()` (scoped to function body only).
+3. `has_init_state` returns True if `def init_<name>_state(` is defined.
 4. `check_dispatch_sync` is internally consistent for a synthetic fixture.
 5. The full script runs against the live repo without errors.
 
@@ -39,7 +37,7 @@ _SPEC.loader.exec_module(_mod)  # type: ignore[union-attr]
 
 parse_yaml_enum = _mod.parse_yaml_enum
 parse_dispatch_registry = _mod.parse_dispatch_registry
-extract_init_state_buffer_count = _mod.extract_init_state_buffer_count
+has_init_state = _mod.has_init_state
 check_dispatch_sync = _mod.check_dispatch_sync
 
 
@@ -154,104 +152,50 @@ class TestParseDispatchRegistry:
 
 
 # ============================================================================
-# Layer 3 — per-source buffer-count extractor
+# Layer 3 — per-source existence check
 # ============================================================================
 
 
-_LOOP_BASED_OPTIMIZER = textwrap.dedent(
+_INIT_STATE_FIXTURE = textwrap.dedent(
     """\
-    def init_sgd_state(
+    def init_{name}_state(
         params_list: List[AnyTensor],
         *,
         force_f64: Bool = False,
     ) raises -> List[List[AnyTensor]]:
         from odyssey.tensor.tensor_creation import zeros
-
-        var all_states: List[List[AnyTensor]] = []
-        for i in range(len(params_list)):
-            var p = params_list[i]
-            var d = p.dtype() if not force_f64 else DType.float64
-            var per: List[AnyTensor] = []
-            for _ in range(1):
-                per.append(zeros(p.shape(), d))
-            all_states.append(per^)
-        return all_states^
-
-    def other_function():
-        # This should NOT be picked up by the regex.
-        for _ in range(99):
-            pass
+        return [list[zeros(p.shape(), p.dtype())] for p in params_list]
     """
 )
 
 
-_APPEND_BASED_OPTIMIZER = textwrap.dedent(
-    """\
-    def is_shampoo_eligible(p) -> Bool:
-        return p.ndim() == 2 and p.shape()[0] >= 2 and p.shape()[1] >= 2
-
-
-    def init_shampoo_state(
-        params_list: List[AnyTensor],
-        *,
-        force_f64: Bool = False,
-    ) raises -> List[List[AnyTensor]]:
-        from odyssey.tensor.tensor_creation import eye, zeros_like
-
-        var all_states: List[List[AnyTensor]] = []
-        for i in range(len(params_list)):
-            var p = params_list[i]
-            var per: List[AnyTensor] = []
-            if is_shampoo_eligible(p):
-                var dtype = p.dtype() if not force_f64 else DType.float64
-                var sh = p.shape()
-                var m = sh[0]
-                var n = sh[1]
-                per.append(eye(m, m, 0, dtype))
-                per.append(eye(n, n, 0, dtype))
-                per.append(zeros_like(p))
-            all_states.append(per^)
-        return all_states^
-    """
-)
-
-
-_NO_INIT_OPTIMIZER = textwrap.dedent(
+_NO_INIT_SOURCE = textwrap.dedent(
     """\
     # No init function defined here.
-    def step_function(p, g):
+    def another_function(p, g):
         return p
     """
 )
 
 
-class TestExtractInitStateBufferCount:
-    def test_loop_based_returns_range_int(self, tmp_path: Path) -> None:
+class TestHasInitState:
+    def test_init_state_present(self, tmp_path: Path) -> None:
+        """Source with matching `init_<name>_state` header returns True."""
         f = tmp_path / "sgd.mojo"
-        f.write_text(_LOOP_BASED_OPTIMIZER)
-        assert extract_init_state_buffer_count(f, "sgd") == 1
+        f.write_text(_INIT_STATE_FIXTURE.replace("{name}", "sgd"))
+        assert has_init_state(f, "sgd") is True
 
-    def test_loop_based_ignores_other_functions(self, tmp_path: Path) -> None:
-        """The other_function's `for _ in range(99)` must not be picked up."""
-        f = tmp_path / "sgd.mojo"
-        f.write_text(_LOOP_BASED_OPTIMIZER)
-        assert extract_init_state_buffer_count(f, "sgd") == 1
-
-    def test_append_based_returns_per_append_count(self, tmp_path: Path) -> None:
-        f = tmp_path / "shampoo.mojo"
-        f.write_text(_APPEND_BASED_OPTIMIZER)
-        assert extract_init_state_buffer_count(f, "shampoo") == 3
-
-    def test_missing_init_returns_none(self, tmp_path: Path) -> None:
+    def test_missing_function_returns_false(self, tmp_path: Path) -> None:
+        """Source without any `init_*_state` returns False."""
         f = tmp_path / "noop.mojo"
-        f.write_text(_NO_INIT_OPTIMIZER)
-        assert extract_init_state_buffer_count(f, "noop") is None
+        f.write_text(_NO_INIT_SOURCE)
+        assert has_init_state(f, "noop") is False
 
-    def test_name_mismatch_returns_none(self, tmp_path: Path) -> None:
-        """Source contains init_sgd_state but caller asks for 'adam'."""
+    def test_wrong_name_returns_false(self, tmp_path: Path) -> None:
+        """Source contains `init_sgd_state` but caller asks for 'adam'."""
         f = tmp_path / "sgd.mojo"
-        f.write_text(_LOOP_BASED_OPTIMIZER)
-        assert extract_init_state_buffer_count(f, "adam") is None
+        f.write_text(_INIT_STATE_FIXTURE.replace("{name}", "sgd"))
+        assert has_init_state(f, "adam") is False
 
 
 # ============================================================================
@@ -303,20 +247,15 @@ def _make_synthetic_repo(tmp_path: Path, *, mismatch: str | None = None) -> Path
     dispatch_text += "    return names^\n"
     dispatch_path.write_text(dispatch_text)
 
-    # optimizer sources
+    # optimizer sources — one per NAME in the canonical set (sgd, adam, shampoo).
+    # Phantom optimizers added by mismatch cases intentionally have NO source
+    # file generated, so the SOURCE MISSING code path is exercised alongside
+    # the NAME MISMATCH detection.
     opt_dir = root / "src" / "odyssey" / "training" / "optimizers"
     opt_dir.mkdir(parents=True, exist_ok=True)
-    # sgd — loop-based, 1 buffer
-    (opt_dir / "sgd.mojo").write_text(_LOOP_BASED_OPTIMIZER)
-    # adam — loop-based with N=2 (rewrite the loop to range(2))
-    adam_src = _LOOP_BASED_OPTIMIZER.replace("for _ in range(1):", "for _ in range(2):")
-    adam_src = adam_src.replace("def init_sgd_state", "def init_adam_state")
-    (opt_dir / "adam.mojo").write_text(adam_src)
-    # shampoo — append-based, 3 buffers
-    (opt_dir / "shampoo.mojo").write_text(_APPEND_BASED_OPTIMIZER)
-    if mismatch == "reg_only":
-        # Source for phantom optimizer is missing — registry should error.
-        pass
+    canonical_names = ["sgd", "adam", "shampoo"]
+    for n in canonical_names:
+        (opt_dir / f"{n}.mojo").write_text(_INIT_STATE_FIXTURE.format(name=n))
 
     return root
 
@@ -343,12 +282,21 @@ class TestCheckDispatchSync:
 
 
 def test_live_repo_dispatch_is_consistent(capsys: pytest.CaptureFixture[str]) -> None:
-    """Run check_dispatch_sync on the live repo.
+    """STRICT live-repo check: any inconsistency fails this test.
 
-    The live repo should have a consistent dispatch registry: the YAML enum,
-    dispatch.mojo's `all_supported_optimizers()`, and each optimizer's
-    `init_<name>_state` source function should all agree on the optimizer
-    name set.
+    This test runs `check_dispatch_sync` against the live repository and
+    asserts `rc == 0`. There is **no EXPECTED_DRIFT safety net** — any
+    mismatch between the YAML enum, `dispatch.mojo`'s
+    `all_supported_optimizers()`, and per-source `init_<name>_state`
+    functions will fail this test.
+
+    If the test fails:
+    - A new optimizer was added without updating all three sources.
+    - An optimizer was renamed/removed without updating all three sources.
+    - The YAML enum, dispatch roster, or source files have diverged.
+
+    The fix is to reconcile the three sources, NOT to add the divergence
+    to an allowed-drift set (no such safety net exists in this codebase).
 
     Skips if `dispatch.mojo` doesn't exist (e.g., partial checkout).
     """
@@ -360,11 +308,16 @@ def test_live_repo_dispatch_is_consistent(capsys: pytest.CaptureFixture[str]) ->
     captured = capsys.readouterr()
     combined = captured.out + captured.err
 
-    assert rc == 0, f"check_dispatch_sync returned {rc}, expected 0 (all consistent). Output:\n{combined}"
+    assert rc == 0, (
+        f"check_dispatch_sync returned {rc}, expected 0 (all consistent). "
+        f"This is a STRICT check — reconcile the YAML enum, "
+        f"`all_supported_optimizers()`, and per-source `init_<name>_state` "
+        f"function names. Output:\n{combined}"
+    )
 
 
 def test_live_repo_cli_invocation() -> None:
-    """`python scripts/check_dispatch_sync.py --help` exits 0."""
+    """`python scripts/check_dispatch_sync.py --help` exits 0 and shows expected flags."""
     script = _PROJECT_ROOT / "scripts" / "check_dispatch_sync.py"
     proc = subprocess.run(
         [sys.executable, str(script), "--help"],
@@ -374,4 +327,4 @@ def test_live_repo_cli_invocation() -> None:
     )
     assert proc.returncode == 0
     assert "--root" in proc.stdout
-    assert "--strict" in proc.stdout
+    assert "--quiet" in proc.stdout


### PR DESCRIPTION
## Summary
Closes #5712 — implements the cleanup tracked in issue #5712: removes three pieces of dead/over-engineered code that became orphaned when `scripts/check_dispatch_sync.py` was rewritten to consume the new `all_supported_optimizers()` API (post PR #5708).

## Cleanup Items

### 1. Dead code: ~115 LOC reduction in Layer 3
- `extract_init_state_buffer_count()` → `has_init_state()` boolean check (~10 LOC).
- Removed `_LOOP_BUFFER_COUNT_RE`, `_APPEND_COUNT_RE`, `_extract_function_body` regex machinery.
- Buffer counts are no longer verified because the dispatch itself does not declare them — the new API delegates state allocation to `init_optimizer_state()` at runtime.

### 2. Dead parameter: `strict: bool = False` + `--strict` CLI flag
- Removed the no-op `strict` parameter from `check_dispatch_sync()`.
- Removed the `--strict` argparse argument.
- Updated Usage block in module docstring.

### 3. Brittle live-repo smoke test docstring
- Strengthened `test_live_repo_dispatch_is_consistent` docstring to explicitly state this is a STRICT check with **no EXPECTED_DRIFT safety net**.
- If the test fails, the underlying sources must be reconciled (NOT added to an allowed-drift set).

## Test impact
- 16 → 14 tests (removed 5 buffer-count tests, added 3 `has_init_state` tests).
- All 14 pass locally and against live repo.
- `check_dispatch_sync.py` reduces from 403 → 311 lines (-92 LOC, -23%).
- Total diff: +67 / -206 lines across the two files.

## CI impact
Three newly-affected CI checks all PASS on this branch:
- ✅ Three-way dispatch consistency
- ✅ Python Tests
- ✅ Build Validation

## Files Changed
- `scripts/check_dispatch_sync.py` — Layer 3 simplified, strict removed.
- `tests/scripts/test_check_dispatch_sync.py` — Removed buffer-count tests/fixtures, strengthened live-repo docstring.

## References
- Issue: #5712 (the cleanup tracking issue)
- Parent PRs: #5705 and #5706 (already merged — added the dispatch sync infrastructure)
- Underlying issue: #5682 (the original 3-way dispatch consistency requirement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>