### PR TITLE
fix(tests): remove undefined test_main() + cache-bust preambles (#5714)

### DIFF
--- a/tests/odyssey/core/test_dtype_dispatch.mojo
+++ b/tests/odyssey/core/test_dtype_dispatch.mojo
@@ -416,7 +416,9 @@ def test_dispatch_binary_2d_tensor() raises:
 
 def main() raises:
     """Run all test_dtype_dispatch tests."""
-    print("Running test_dtype_dispatch tests...")
+    print(
+        "Running test_dtype_dispatch tests (cache-bust: 20260727-32a8f6d6)..."
+    )
 
     test_dispatch_unary_float32_identity()
     print("✓ test_dispatch_unary_float32_identity")

--- a/tests/odyssey/training/test_muon.mojo
+++ b/tests/odyssey/training/test_muon.mojo
@@ -672,7 +672,7 @@ def test_muon_step_pure_functional() raises:
 def main() raises:
     """Run all Muon optimizer tests."""
     print("=" * 60)
-    print("Muon Optimizer Test Suite")
+    print("Muon Optimizer Test Suite (cache-bust: 20260727-32a8f6d6)")
     print("=" * 60)
 
     test_is_muon_eligible_rank_1()

--- a/tests/odyssey/training/test_optimizer_utils.mojo
+++ b/tests/odyssey/training/test_optimizer_utils.mojo
@@ -213,6 +213,10 @@ def main() raises:
     """Run all test_optimizer_utils tests."""
     print("Running test_optimizer_utils tests...")
 
+    print(
+        "Running test_optimizer_utils tests (cache-bust: 20260727-32a8f6d6)..."
+    )
+
     test_scale_tensor()
     print("✓ test_scale_tensor")
 
@@ -230,9 +234,6 @@ def main() raises:
 
     test_clip_tensor_norm()
     print("✓ test_clip_tensor_norm")
-
-    test_main()
-    print("✓ test_main")
 
     test_clip_tensor_norm_no_clip()
     print("✓ test_clip_tensor_norm_no_clip")


### PR DESCRIPTION
Closes #5714

## Summary
Three phantom failures were blocking the `autograd-tensor-base` CI check on multiple recent PRs. Investigation in #5714 traced them to one real bug plus two stale-cache artifacts. This PR resolves both.

## Change 1 (real bug fix): `tests/odyssey/training/test_optimizer_utils.mojo`
`main()` was calling `test_main()` followed by `print("\u2713 test_main")`, but no `test_main` function is defined anywhere in the file. This produced the CI error `test_optimizer_utils.mojo:234:5: use of unknown declaration 'test_main'`. Removed the two spurious lines and verified `grep -c test_main` returns 0.

## Changes 2 and 3 (cache-bust for stale compiled objects)
The other two reported errors (`muon_step_simple diff=0.0001` and `zeros(IntLiteral) shape cast`) reference code paths that no longer exist in the current source - verified by reading the files fresh. They are stale compiled artifacts in the CI cache.

Each of the three test files gets a static date+SHA stamp string added to its `main()` preamble:
- `tests/odyssey/training/test_optimizer_utils.mojo`
- `tests/odyssey/training/test_muon.mojo`
- `tests/odyssey/core/test_dtype_dispatch.mojo`

The mechanism is honest: **file content hash changes => CI object-file cache key invalidates => next CI run rebuilds from source**. Mojo does NOT expand shell variables, so the literal stamp IS the cache-bust, not a template. Maintainers bump the stamp on subsequent bust cycles.

## Verification
- Local `grep` for `test_main` returns 0 hits in `tests/`.
- Stamp pattern consistent across all 3 files: `(cache-bust: YYYYMMDD-shortsha)`.
