### PR TITLE
feat(autograd): add DiagonalHessianEstimator trait surface for Sophia-G (Phase 1)

### DIFF
--- a/src/odyssey/autograd/DESIGN.md
+++ b/src/odyssey/autograd/DESIGN.md
@@ -141,7 +141,52 @@ tape.record_mean(z_id, loss_id)
 
 # Automatic backward
 tape.backward(loss)
-```text
+```
+
+#### Experimental Sophia curvature-estimator surface (PR #5719)
+
+PR #5719 adds `DiagonalHessianEstimator` as a narrow experimental seam for
+the remaining Sophia work in #5683. The contract accepts
+`List[Variable]`, a scalar objective `Variable`, a dedicated `GradientTape`
+that recorded the objective, its batch size, and one requested result dtype
+per parameter. This preserves parameter/objective connectivity, the scale
+needed for the GNB `batch_size * gradient^2` estimate, and the destination
+precision; detached `AnyTensor` parameters plus a detached loss value would
+contain none of those derivative relationships.
+
+The returned list is length- and shape-aligned with the parameters. Each
+output dtype comes from the corresponding entry in `result_dtypes`. Callers
+normally request float32 or the exact dtype of the Sophia Hessian-moment
+buffer, including float64 state created with `force_f64`; neither parameter
+storage nor scalar-objective precision implicitly chooses the result dtype.
+
+The estimator tape is deliberately separate from the ordinary training tape.
+At entry, the parameters and sampled objective must all be registered on the
+dedicated tape, require gradients, and its registry must contain no
+pre-existing gradients. A concrete estimator leaves only gradients from its
+own backward pass in that registry. The caller consumes the estimate and then
+clears or discards the dedicated tape, so training gradients are never
+accumulated over or destroyed. The current `Variable` stores a numeric ID but
+no owning-tape identity, so runtime validation can reject missing IDs but
+cannot distinguish colliding IDs from two tapes; same-tape construction
+remains an explicit caller precondition.
+
+The estimator families have different derivative requirements:
+
+- **Sophia-G (Gauss-Newton-Bartlett)** builds a sampled-label
+  negative-log-likelihood on the tape, takes an ordinary backward pass, and
+  uses the batch-scaled square of each parameter gradient. It does not require
+  an HVP or JVP.
+- **Sophia-H (Hutchinson)** multiplies by a Hessian and therefore does require
+  an HVP (which may be implemented with higher-order reverse mode or JVP
+  machinery).
+
+Phase 1 includes only the trait and an inner-module
+`PlaceholderDiagonalHessianEstimator`. The placeholder fails only when a
+caller explicitly constructs and invokes it; no optimizer or dispatcher is
+wired to select it. Consequently, PR #5719 does not make Sophia runnable end
+to end and must not close #5683. Implementation follow-up #5717 remains under
+that parent and is cross-referenced from `TODO.md`.
 
 ### Phase 4: Full Autograd (ASPIRATIONAL)
 

--- a/src/odyssey/autograd/TODO.md
+++ b/src/odyssey/autograd/TODO.md
@@ -125,6 +125,33 @@ The autograd module follows **YAGNI** (You Aren't Gonna Need It) and **KISS** (K
 
 ### Phase 3: Advanced Features
 
+- [x] **Experimental Sophia estimator trait surface (PR #5719)**
+  - Accepts derivative-connected parameter `Variable` objects, a scalar
+    objective `Variable`, a dedicated mutable `GradientTape`, the batch size
+    needed to scale the GNB gradient square, and one requested result dtype
+    per parameter.
+  - Requires scalar objective, positive batch size, `requires_grad`, observable
+    same-registry IDs, matching result-dtype count, and no pre-existing
+    gradients on the dedicated tape.
+  - Returns one finite, shape-matched tensor per parameter in its requested
+    dtype; callers normally choose float32 or the Hessian-moment state dtype.
+  - Leaves estimator-backward gradients only on the dedicated tape, which the
+    caller clears or discards without touching ordinary training gradients.
+  - Includes an inner-module placeholder whose explicit invocation raises;
+    no Sophia optimizer/dispatch path selects it.
+  - This Phase-1 seam does not close parent #5683; implementation follow-up
+    #5717 remains under that parent.
+- [ ] **Sophia-G Gauss-Newton-Bartlett estimator and wiring (#5717, under #5683)**
+  - Build the sampled-label negative-log-likelihood objective from model
+    outputs on the same tape as the parameters.
+  - Use one ordinary backward pass and return the batch-scaled squared
+    parameter gradients; Sophia-G does not require an HVP or JVP.
+  - Wire the real estimator into the higher-level Sophia training path and
+    add numerical plus end-to-end convergence tests.
+- [ ] **Sophia-H Hutchinson estimator**
+  - Add the HVP/higher-order-autograd substrate required for
+    `u * (H * u)`.
+  - Keep this dependency separate from the first-order Sophia-G path.
 - [ ] **Higher-order gradients** - Compute gradients of gradients
   - Hessian computation
   - Laplacian computation

--- a/src/odyssey/autograd/__init__.mojo
+++ b/src/odyssey/autograd/__init__.mojo
@@ -171,6 +171,12 @@ from odyssey.autograd.schedulers import (
     ExponentialLR,
 )
 
+# Experimental public trait.  The Phase-1 placeholder stays intentionally
+# available only from ``odyssey.autograd.sophia_g``.
+from odyssey.autograd.sophia_g import (
+    DiagonalHessianEstimator,
+)
+
 from odyssey.autograd.functional import (
     LossAndGrad,
     mse_loss_and_grad,

--- a/src/odyssey/autograd/sophia_g.mojo
+++ b/src/odyssey/autograd/sophia_g.mojo
@@ -1,0 +1,202 @@
+"""Experimental diagonal-curvature estimator contract for Sophia.
+
+The contract is derivative-context aware: callers provide parameter
+``Variable`` objects, a scalar objective ``Variable`` built from those
+parameters, a dedicated ``GradientTape`` that recorded that objective, the
+objective's batch size, and one requested result dtype per parameter.
+Detached ``AnyTensor`` values are insufficient because they do not retain the
+graph needed to differentiate with respect to the parameters.
+
+Sophia has two distinct estimator families:
+
+* Sophia-G uses the Gauss-Newton-Bartlett (GNB) estimator.  The caller builds
+  the sampled-label negative-log-likelihood objective on the supplied tape;
+  the estimator takes one ordinary backward pass and returns the batch-scaled
+  squared parameter gradients.  Sophia-G does not require an HVP or JVP.
+* Sophia-H uses Hutchinson's estimator and does require a Hessian-vector
+  product.  That backend remains dependent on higher-order autograd support.
+
+Phase 1, PR #5719, exposes only this experimental trait and an inner-module
+placeholder.  It does not wire an estimator into the Sophia optimizer and
+does not close the end-to-end work in #5683.
+"""
+
+from std.collections import List
+
+from odyssey.autograd.tape import GradientTape
+from odyssey.autograd.variable import Variable
+from odyssey.tensor.any_tensor import AnyTensor
+
+
+def _validate_estimator_context(
+    parameters: List[Variable],
+    objective: Variable,
+    estimator_tape: GradientTape,
+    batch_size: Int,
+    result_dtypes: List[DType],
+) raises:
+    """Validate the Phase-1 preconditions observable through today's tape API.
+    """
+    if batch_size <= 0:
+        raise Error("batch_size must be positive")
+    if len(result_dtypes) != len(parameters):
+        raise Error("result_dtypes length must match parameters")
+    if objective.data.numel() != 1:
+        raise Error("objective must be scalar")
+
+    for i in range(len(parameters)):
+        ref parameter = parameters[i]
+        if not parameter.requires_grad:
+            raise Error("parameter[" + String(i) + "] must require gradients")
+        if (
+            parameter.id < 0
+            or parameter.id >= estimator_tape.registry.next_id
+            or not estimator_tape.registry.requires_grad[parameter.id]
+        ):
+            raise Error(
+                "parameter["
+                + String(i)
+                + "] is not registered on estimator_tape"
+            )
+
+    if not objective.requires_grad:
+        raise Error("objective must require gradients")
+    if (
+        objective.id < 0
+        or objective.id >= estimator_tape.registry.next_id
+        or not estimator_tape.registry.requires_grad[objective.id]
+    ):
+        raise Error("objective is not registered on estimator_tape")
+
+    for variable_id in range(estimator_tape.registry.next_id):
+        if estimator_tape.registry.has_gradient(variable_id):
+            raise Error(
+                "dedicated estimator tape must not contain pre-existing "
+                "gradients"
+            )
+
+
+trait DiagonalHessianEstimator:
+    """Estimate one diagonal curvature tensor for each parameter.
+
+    The input context preserves the derivative relationship, scaling, result
+    precision, and gradient lifecycle that a concrete implementation needs:
+
+    * ``parameters`` contains the differentiable ``Variable`` objects.
+    * ``objective`` is a scalar ``Variable`` derived from those parameters.
+    * ``estimator_tape`` is a dedicated tape that registered the parameters
+      and recorded the operations producing ``objective``.
+    * ``batch_size`` is the number of samples reduced into ``objective``.
+    * ``result_dtypes`` has one requested output dtype per parameter.  It is
+      normally ``DType.float32`` or the exact dtype of the corresponding
+      Sophia Hessian-moment buffer, including ``DType.float64`` when
+      ``force_f64`` state is active.
+
+    Preconditions:
+
+    1. ``batch_size > 0``.
+    2. ``objective.data.numel() == 1``.
+    3. Every parameter and the objective has ``requires_grad=True``.
+    4. Every parameter and the objective was registered on
+       ``estimator_tape``.
+    5. ``len(result_dtypes) == len(parameters)``.
+    6. The dedicated tape has no pre-existing gradients.  It must not be the
+       ordinary training tape.
+
+    ``Variable`` currently stores a numeric registry ID but no owning-tape
+    identity.  Runtime validation can therefore check that each ID exists in
+    the supplied registry and agrees on ``requires_grad``, but cannot detect a
+    colliding ID from another tape.  Constructing all supplied Variables on
+    ``estimator_tape`` remains a caller precondition until tape ownership is
+    represented in the API.
+
+    For Sophia-G, ``objective`` is the mean negative log-likelihood formed
+    with labels sampled from the model distribution.  A concrete GNB
+    implementation may run ``objective.backward(estimator_tape)``, read each
+    parameter gradient from the tape, square it element-wise, and apply the
+    batch-size scale ``batch_size * gradient^2`` from the Sophia paper.  For a
+    future Sophia-H implementation, ``objective`` is the ordinary mini-batch
+    loss and the tape must support the required Hessian-vector product.
+
+    Result invariants:
+
+    1. ``len(result) == len(parameters)``.
+    2. ``result[i].shape() == parameters[i].data.shape()``.
+    3. ``result[i].dtype() == result_dtypes[i]``.
+    4. Every result value is finite.
+    5. Implementations do not mutate parameter or objective data.  They may
+       mutate their own estimator state and the tape's gradient registry.
+    6. At return, the dedicated registry contains only gradients produced by
+       the estimator backward pass.  The caller consumes the estimates and
+       then clears or discards this tape.  Ordinary training gradients live on
+       a different tape, so they are neither accumulated over nor destroyed.
+
+    This surface is experimental until a real #5683 estimator and optimizer
+    wiring exercise it end to end.
+    """
+
+    def estimate_diag_hessian(
+        mut self,
+        parameters: List[Variable],
+        objective: Variable,
+        mut estimator_tape: GradientTape,
+        batch_size: Int,
+        result_dtypes: List[DType],
+    ) raises -> List[AnyTensor]:
+        """Return derivative-connected diagonal curvature estimates."""
+        ...
+
+
+struct PlaceholderDiagonalHessianEstimator(DiagonalHessianEstimator):
+    """Inner-module-only Phase-1 stub that always fails when invoked.
+
+    The stub demonstrates trait conformance and provides an executable
+    diagnostic for explicit experiments.  Nothing in Odyssey's Sophia
+    dispatch selects this type in Phase 1.
+    """
+
+    var estimator_kind: String
+
+    def __init__(out self):
+        self.estimator_kind = "PlaceholderDiagonalHessianEstimator"
+
+    def estimate_diag_hessian(
+        mut self,
+        parameters: List[Variable],
+        objective: Variable,
+        mut estimator_tape: GradientTape,
+        batch_size: Int,
+        result_dtypes: List[DType],
+    ) raises -> List[AnyTensor]:
+        """Fail because Phase 1 contains no Sophia-G implementation."""
+        _validate_estimator_context(
+            parameters,
+            objective,
+            estimator_tape,
+            batch_size,
+            result_dtypes,
+        )
+        var tape_state = "enabled" if estimator_tape.enabled else "disabled"
+        raise Error(
+            self.estimator_kind
+            + ".estimate_diag_hessian called, but Sophia-G is not implemented. "
+            "PR #5719 exposes only an experimental derivative-context-aware "
+            "trait; follow #5717 under parent #5683 and "
+            "src/odyssey/autograd/TODO.md for sampled-label objective "
+            "plumbing, the GNB gradient-square estimator, optimizer wiring, "
+            "and end-to-end tests. (parameters="
+            + String(len(parameters))
+            + ", objective_id="
+            + String(objective.id)
+            + ", tape="
+            + tape_state
+            + ", batch_size="
+            + String(batch_size)
+            + ", result_dtypes="
+            + String(len(result_dtypes))
+            + ")"
+        )
+
+    def name(self) -> String:
+        """Return the concrete placeholder identifier."""
+        return self.estimator_kind

--- a/tests/odyssey/autograd/test_sophia_g.mojo
+++ b/tests/odyssey/autograd/test_sophia_g.mojo
@@ -1,0 +1,284 @@
+"""Behavioral tests for the experimental Sophia curvature-estimator surface.
+
+Phase 1 exposes the experimental trait from ``odyssey.autograd`` while keeping
+the temporary fail-fast implementation at ``odyssey.autograd.sophia_g``.
+The estimator receives derivative-connected ``Variable`` objects and the
+dedicated ``GradientTape`` that recorded the scalar objective, plus its batch
+size and requested result dtypes.
+"""
+
+from std.collections import List
+
+from odyssey.autograd import (
+    DiagonalHessianEstimator,
+    GradientTape,
+    Variable,
+    variable_sum,
+)
+from odyssey.autograd.sophia_g import (
+    PlaceholderDiagonalHessianEstimator,
+)
+from odyssey.tensor.tensor_creation import zeros
+
+
+def _accept_as_estimator[
+    Estimator: DiagonalHessianEstimator
+](mut estimator: Estimator):
+    """Require concrete conformance to the public trait at compile time."""
+    _ = estimator
+
+
+def test_public_trait_and_inner_placeholder_imports() raises:
+    """The public trait and inner-only temporary stub use their intended paths.
+    """
+    var estimator = PlaceholderDiagonalHessianEstimator()
+    _accept_as_estimator[PlaceholderDiagonalHessianEstimator](estimator)
+
+    if estimator.name() != "PlaceholderDiagonalHessianEstimator":
+        raise Error("unexpected placeholder estimator name")
+
+
+def _one_result_dtype(dtype: DType) -> List[DType]:
+    var result = List[DType]()
+    result.append(dtype)
+    return result^
+
+
+def _expect_context_error(
+    parameters: List[Variable],
+    objective: Variable,
+    mut estimator_tape: GradientTape,
+    batch_size: Int,
+    result_dtypes: List[DType],
+    expected: String,
+) raises:
+    var estimator = PlaceholderDiagonalHessianEstimator()
+    var raised = False
+    try:
+        _ = estimator.estimate_diag_hessian(
+            parameters,
+            objective,
+            estimator_tape,
+            batch_size,
+            result_dtypes,
+        )
+    except error:
+        raised = True
+        var message = String(error)
+        if expected not in message:
+            raise Error(
+                "expected placeholder error containing '"
+                + expected
+                + "'; got: "
+                + message
+            )
+    if not raised:
+        raise Error("placeholder estimate_diag_hessian must fail")
+
+
+def test_placeholder_failure_is_observable() raises:
+    """A valid context reaches the actionable not-implemented diagnostic."""
+    var estimator_tape = GradientTape()
+    estimator_tape.enable()
+
+    var parameter = Variable(zeros([2], DType.float32), True, estimator_tape)
+    var objective = variable_sum(parameter, estimator_tape)
+    var parameters = List[Variable]()
+    parameters.append(parameter^)
+    # The requested result precision is independent of parameter precision.
+    var result_dtypes = _one_result_dtype(DType.float64)
+
+    var estimator = PlaceholderDiagonalHessianEstimator()
+    var raised = False
+    try:
+        _ = estimator.estimate_diag_hessian(
+            parameters,
+            objective,
+            estimator_tape,
+            batch_size=2,
+            result_dtypes=result_dtypes,
+        )
+    except error:
+        raised = True
+        var message = String(error)
+        if (
+            "Sophia-G" not in message
+            or "not implemented" not in message
+            or "#5717" not in message
+            or "autograd/TODO.md" not in message
+        ):
+            raise Error(
+                "placeholder error must identify the unavailable Sophia-G "
+                "implementation and its TODO; got: "
+                + message
+            )
+
+    if not raised:
+        raise Error("placeholder estimate_diag_hessian must fail")
+
+
+def test_batch_size_must_be_positive() raises:
+    var tape = GradientTape()
+    tape.enable()
+    var parameter = Variable(zeros([1], DType.float32), True, tape)
+    var objective = variable_sum(parameter, tape)
+    var parameters = List[Variable]()
+    parameters.append(parameter^)
+    _expect_context_error(
+        parameters,
+        objective,
+        tape,
+        0,
+        _one_result_dtype(DType.float32),
+        "batch_size must be positive",
+    )
+
+
+def test_result_dtype_count_must_match_parameters() raises:
+    var tape = GradientTape()
+    tape.enable()
+    var parameter = Variable(zeros([1], DType.float32), True, tape)
+    var objective = variable_sum(parameter, tape)
+    var parameters = List[Variable]()
+    parameters.append(parameter^)
+    _expect_context_error(
+        parameters,
+        objective,
+        tape,
+        1,
+        List[DType](),
+        "result_dtypes length must match parameters",
+    )
+
+
+def test_objective_must_be_scalar() raises:
+    var tape = GradientTape()
+    tape.enable()
+    var parameter = Variable(zeros([2], DType.float32), True, tape)
+    var objective = Variable(zeros([2], DType.float32), True, tape)
+    var parameters = List[Variable]()
+    parameters.append(parameter^)
+    _expect_context_error(
+        parameters,
+        objective,
+        tape,
+        2,
+        _one_result_dtype(DType.float32),
+        "objective must be scalar",
+    )
+
+
+def test_parameters_must_require_grad() raises:
+    var tape = GradientTape()
+    tape.enable()
+    var parameter = Variable(zeros([1], DType.float32), False, tape)
+    var objective = variable_sum(parameter, tape)
+    var parameters = List[Variable]()
+    parameters.append(parameter^)
+    _expect_context_error(
+        parameters,
+        objective,
+        tape,
+        1,
+        _one_result_dtype(DType.float32),
+        "parameter[0] must require gradients",
+    )
+
+
+def test_objective_must_require_grad() raises:
+    var tape = GradientTape()
+    tape.enable()
+    var parameter = Variable(zeros([1], DType.float32), True, tape)
+    var objective = Variable(zeros([1], DType.float32), False, tape)
+    var parameters = List[Variable]()
+    parameters.append(parameter^)
+    _expect_context_error(
+        parameters,
+        objective,
+        tape,
+        1,
+        _one_result_dtype(DType.float32),
+        "objective must require gradients",
+    )
+
+
+def test_estimator_tape_must_have_clean_gradient_registry() raises:
+    var tape = GradientTape()
+    tape.enable()
+    var parameter = Variable(zeros([1], DType.float32), True, tape)
+    var objective = variable_sum(parameter, tape)
+    tape.registry.set_grad(parameter.id, zeros([1], DType.float32))
+    var parameters = List[Variable]()
+    parameters.append(parameter^)
+    _expect_context_error(
+        parameters,
+        objective,
+        tape,
+        1,
+        _one_result_dtype(DType.float32),
+        "dedicated estimator tape must not contain pre-existing gradients",
+    )
+
+
+def test_parameters_must_be_registered_on_estimator_tape() raises:
+    var estimator_tape = GradientTape()
+    estimator_tape.enable()
+    var local_parameter = Variable(
+        zeros([1], DType.float32), True, estimator_tape
+    )
+    var objective = variable_sum(local_parameter, estimator_tape)
+
+    var foreign_tape = GradientTape()
+    _ = foreign_tape.register_variable(True)
+    _ = foreign_tape.register_variable(True)
+    var foreign_parameter = Variable(
+        zeros([1], DType.float32), True, foreign_tape
+    )
+    var parameters = List[Variable]()
+    parameters.append(foreign_parameter^)
+    _expect_context_error(
+        parameters,
+        objective,
+        estimator_tape,
+        1,
+        _one_result_dtype(DType.float32),
+        "parameter[0] is not registered on estimator_tape",
+    )
+
+
+def test_objective_must_be_registered_on_estimator_tape() raises:
+    var estimator_tape = GradientTape()
+    estimator_tape.enable()
+    var parameter = Variable(zeros([1], DType.float32), True, estimator_tape)
+
+    var foreign_tape = GradientTape()
+    _ = foreign_tape.register_variable(True)
+    var foreign_parameter = Variable(
+        zeros([1], DType.float32), True, foreign_tape
+    )
+    var foreign_objective = variable_sum(foreign_parameter, foreign_tape)
+
+    var parameters = List[Variable]()
+    parameters.append(parameter^)
+    _expect_context_error(
+        parameters,
+        foreign_objective,
+        estimator_tape,
+        1,
+        _one_result_dtype(DType.float32),
+        "objective is not registered on estimator_tape",
+    )
+
+
+def main() raises:
+    test_public_trait_and_inner_placeholder_imports()
+    test_placeholder_failure_is_observable()
+    test_batch_size_must_be_positive()
+    test_result_dtype_count_must_match_parameters()
+    test_objective_must_be_scalar()
+    test_parameters_must_require_grad()
+    test_objective_must_require_grad()
+    test_estimator_tape_must_have_clean_gradient_registry()
+    test_parameters_must_be_registered_on_estimator_tape()
+    test_objective_must_be_registered_on_estimator_tape()
+    print("Sophia curvature-estimator Phase-1 tests PASSED")


### PR DESCRIPTION
## Summary

Recover the Sophia curvature-estimator Phase 1 as a clean five-file change on the trustworthy green main branch.

This PR defines only the experimental derivative-connected `DiagonalHessianEstimator` contract and an inner-module fail-fast placeholder. It does not implement Sophia-G estimator math or wire Sophia into a training path.

## Changes Made

- add `DiagonalHessianEstimator` with derivative-connected parameters, a scalar objective, a dedicated estimator tape, batch size, and one requested result dtype per parameter
- document length, shape, dtype, finiteness, tape-lifecycle, and training-gradient-isolation invariants
- add `PlaceholderDiagonalHessianEstimator`, which validates the observable context and then raises an actionable diagnostic
- document the current numeric registry-ID ownership limitation
- re-export only the permanent trait from `odyssey.autograd`
- add behavioral coverage for public conformance, fail-fast behavior, scalar/batch/dtype/gradient preconditions, registration checks, and clean estimator gradients
- update the autograd design and TODO documentation without marking Sophia-G complete

## Files Modified

- `src/odyssey/autograd/DESIGN.md`
- `src/odyssey/autograd/TODO.md`
- `src/odyssey/autograd/__init__.mojo`
- `src/odyssey/autograd/sophia_g.mojo`
- `tests/odyssey/autograd/test_sophia_g.mojo`

## Scope Boundaries

- no JVP implementation from #5718 or PR #5721
- no historical PR #5722 estimator payload
- no real GNB or Hutchinson estimator
- no optimizer wiring
- parent #5683 and implementation follow-up #5717 remain open

## Verification

- exact signed+DCO head: `7dacf2b39e5ff033dc73b864030249eaaa4721c5`
- exact fully green base: `f4a1887e0684ace8d71e5f54d0b31c5f3e7fbff3`
- focused Sophia test passed
- all 11 autograd test files passed with warnings fatal
- Mojo package compilation passed with `--Werror`
- formatting and static checks passed
- full Python suite: 1,437 passed and 228 expected skips, including the pre-push gate
- exact five-file issue-specific diff; all five payload blobs match the audited recovery commit
- no JVP/#5722 ancestry or payload; no reversal of trusted-writer files
- base Comprehensive run 30520008006 and report artifact 8751047500: 19 upstream rows, 12 successful producer manifests, no violations

Closes #5741

Related: #5683, #5717, #5718
