### PR TITLE
fix(tests): correct zeros() shape API + capitalize docstring in test_dispatch.mojo

### DIFF
--- a/tests/odyssey/training/test_dispatch.mojo
+++ b/tests/odyssey/training/test_dispatch.mojo
@@ -153,13 +153,13 @@ def _make_dummy_params() -> List[AnyTensor]:
     lists that would false-positive the loop test.
     """
     var params: List[AnyTensor] = []
-    params.append(zeros(4, 4))
-    params.append(zeros(4, 8))
+    params.append(zeros([4, 4], DType.float32))
+    params.append(zeros([4, 8], DType.float32))
     return params^
 
 
 def test_init_state_unknown_name_raises() raises:
-    """init_optimizer_state must raise for an unknown optimizer name.
+    """The init_optimizer_state must raise for an unknown optimizer name.
 
     Mirrors the strict-routing contract of get_default_hyperparams: no
     silent fallback. An unknown name is a caller bug, not a recoverable


### PR DESCRIPTION
## Summary

Fixes the pre-existing compile/lint bug in `tests/odyssey/training/test_dispatch.mojo` that was blocking PRs #5715 and #5716 from going green (via the `Comprehensive Mojo Tests (autograd-tensor-base)` CI matrix job).

Both PRs were failing on the **same** pre-existing bug, in a file neither PR modifies. The clean minimum-friction path is a single-source-of-truth fix on main; both PR branches will pick this up automatically on next rebase.

Closes #5711.

## Bug 1: `zeros()` shape API mismatch (lines 156-157)

**Before**

```mojo
params.append(zeros(4, 4))
params.append(zeros(4, 8))
```

**After**

```mojo
params.append(zeros([4, 4], DType.float32))
params.append(zeros([4, 8], DType.float32))
```

`zeros()` in `src/odyssey/tensor/tensor_creation.mojo` is defined as `def zeros(shape: List[Int], dtype: DType) raises -> AnyTensor`. The bare-int form passes `IntLiteral` arguments where a `List[Int]` is expected; Mojo rejects with:

```
invalid call to 'zeros': value passed to 'shape' cannot be converted from 'IntLiteral[...]'
```

## Bug 2: docstring lint (line 162)

**Before**

```mojo
def test_init_state_unknown_name_raises() raises:
    """init_optimizer_state must raise for an unknown optimizer name.
```

**After**

```mojo
def test_init_state_unknown_name_raises() raises:
    """The init_optimizer_state must raise for an unknown optimizer name.
```

Mojo's lexer requires the first alphabetic character of a def-level docstring summary to be a capital letter; the original summary line's leading "i" tripped the lint rule.

## Why a separate PR (not fix-on-top-of-either-PR)

| PR | Scope |
| --- | --- |
| #5715 | `test_optimizer_utils.mojo` bug + cache-bust stamps |
| #5716 | Retire legacy `initialize_shampoo_state` (delete + doc fixes) |

Neither PR touches `tests/odyssey/training/test_dispatch.mojo`; both were just unlucky enough to surface the bug via their respective CI matrices. Attaching the fix to either PR would mean scope creep; a separate single-source-of-truth fix is the minimum-friction path.

## Verification

- 3-line diff (2 `zeros()` API fixes + 1 docstring capitalization).
- Both PRs #5715 and #5716 will pick up the fix on next rebase; their `Comprehensive Mojo Tests (autograd-tensor-base)` job should go from FAIL → CLEAN.
- No new imports needed: `DType` is a Mojo builtin.
