### PR TITLE
feat(autograd): add jvp / jvp_only forward-mode submodule (#5718)

### DIFF
--- a/src/odyssey/autograd/DESIGN.md
+++ b/src/odyssey/autograd/DESIGN.md
@@ -188,6 +188,50 @@ wired to select it. Consequently, PR #5719 does not make Sophia runnable end
 to end and must not close #5683. Implementation follow-up #5717 remains under
 that parent and is cross-referenced from `TODO.md`.
 
+#### Forward-mode JVP substrate ✅ (DONE — #5718)
+
+Forward-mode differentiation is implemented independently from the reverse-mode
+tape in `jvp.mojo`. A `DualTensor` owns a dynamic `AnyTensor` primal and tangent,
+validates that their shapes and supported dtypes match, and propagates them
+through explicit primitive rules. The supported dtypes are float16, float32,
+and float64. BF16 is rejected at construction until every downstream primitive
+dispatcher used by the JVP rules supports it.
+
+- add and subtract
+- elementwise product
+- matrix multiplication (`A_dot @ B + A @ B_dot`)
+- ReLU (zero tangent at the kink, matching Odyssey's existing convention)
+- linear composition (`input @ weight + bias`)
+
+Callers implement `JVPFunction` on a concrete, copyable struct. This supports
+deterministic model state without escaping closures or bare function-value
+annotations:
+
+```mojo
+@fieldwise_init
+struct Model(JVPFunction):
+    var weight: DualTensor
+    var bias: DualTensor
+
+    def __call__(self, input: DualTensor) raises -> DualTensor:
+        return dual_linear(input, self.weight, self.bias)
+
+var result = jvp(model, input, seed)
+var tangent = jvp_only(model, input, seed)
+```
+
+`jvp` returns both the primal result and `J(model)(input) @ seed`. `jvp_only`
+provides the same numerical tangent while retaining a smaller return payload,
+but it still computes the primal intermediates required by forward mode. This
+is not a claim about peak memory or allocation count.
+
+This substrate completes issue #5718 as independent forward-mode
+infrastructure. The first-order Sophia-G path in #5717 uses an ordinary
+reverse-mode backward pass and does not depend on it. The substrate does
+**not** implement a Sophia estimator, an optimizer, general higher-order
+differentiation, or automatic rules for operations beyond the primitives
+listed above.
+
 ### Phase 4: Full Autograd (ASPIRATIONAL)
 
 - Automatic operation recording via operator overloading

--- a/src/odyssey/autograd/TODO.md
+++ b/src/odyssey/autograd/TODO.md
@@ -141,6 +141,19 @@ The autograd module follows **YAGNI** (You Aren't Gonna Need It) and **KISS** (K
     no Sophia optimizer/dispatch path selects it.
   - This Phase-1 seam does not close parent #5683; implementation follow-up
     #5717 remains under that parent.
+- [x] **Forward-mode JVP substrate** - `jvp.mojo` (#5718)
+  - Dynamic `DualTensor` with matching shape/dtype validation; supported dtypes
+    are float16, float32, and float64 (BF16 remains rejected until all invoked
+    primitive dispatchers support it)
+  - Rules for add, subtract, elementwise product, matmul, ReLU, and linear
+    composition
+  - `jvp` returns primal and tangent; `jvp_only` provides numerical tangent
+    parity and a smaller retained return payload while still computing required
+    primal intermediates (no peak-memory or allocation-count claim)
+  - Publicly exported from `odyssey.autograd`
+  - This is independent forward-mode infrastructure; the first-order Sophia-G
+    path in #5717 uses an ordinary reverse-mode backward pass and does not
+    depend on it.
 - [ ] **Sophia-G Gauss-Newton-Bartlett estimator and wiring (#5717, under #5683)**
   - Build the sampled-label negative-log-likelihood objective from model
     outputs on the same tape as the parameters.

--- a/src/odyssey/autograd/__init__.mojo
+++ b/src/odyssey/autograd/__init__.mojo
@@ -17,6 +17,7 @@ Core Components:
 - StepLR, ExponentialLR: Learning rate schedulers for adaptive decay
 - Variable operations: Tape-integrated ops (add, multiply, matmul, etc.)
 - Functional helpers: Practical gradient computation for common patterns
+- Forward-mode JVP: DualTensor rules for vector-valued directional derivatives
 
 Tape-Based Autograd API (Recommended for full automatic differentiation):
     from odyssey.autograd import Variable, GradientTape
@@ -66,6 +67,12 @@ Available Loss+Grad Helpers:
 - bce_loss_and_grad: Binary cross-entropy (binary classification)
 - ce_loss_and_grad: Cross-entropy with softmax (multi-class classification)
 
+Forward-Mode JVP API:
+- DualTensor, JVPFunction
+- dual_add, dual_subtract, dual_multiply, dual_matmul, dual_relu, dual_linear
+- jvp: Return primal result and Jacobian-vector product
+- jvp_only: Return the same numerical tangent with a smaller retained payload
+
 Gradient Clipping Utilities:
 - clip_grad_value_: Clip each gradient element to [-max_value, max_value]
 - clip_grad_norm_: Clip gradient L2 norm per parameter
@@ -87,6 +94,7 @@ Status:
     ✅ AdamW optimizer (decoupled weight decay)
     ✅ RMSprop optimizer
     ✅ Gradient clipping utilities (value, norm, global norm)
+    ✅ Forward-mode JVP substrate
 
 References:
     - Tape implementation: tape.mojo
@@ -189,6 +197,20 @@ from odyssey.autograd.functional import (
     divide_scalar,
     apply_gradient,
     apply_gradients,
+)
+
+from odyssey.autograd.jvp import (
+    DualTensor,
+    JVPFunction,
+    dual_constant,
+    dual_add,
+    dual_subtract,
+    dual_multiply,
+    dual_matmul,
+    dual_relu,
+    dual_linear,
+    jvp,
+    jvp_only,
 )
 
 # ============================================================================

--- a/src/odyssey/autograd/jvp.mojo
+++ b/src/odyssey/autograd/jvp.mojo
@@ -1,0 +1,176 @@
+"""Forward-mode Jacobian-vector products for dynamic tensors.
+
+This module represents a forward-mode value as a ``DualTensor``:
+
+    primal + epsilon * tangent
+
+The primitive rules propagate both components through a computation.  A
+``JVPFunction`` is a concrete, copyable struct rather than a bare function
+value.  That pattern supports deterministic captured model state on Mojo 1.0
+without relying on escaping closures or error-prone ``thin`` annotations.
+
+Only float16, float32, and float64 ``AnyTensor`` values are accepted.  A primal
+and its tangent must have exactly the same shape and dtype.  BF16 is rejected
+until every downstream primitive dispatcher used here supports it.
+"""
+
+from odyssey.core.activation import relu, relu_backward
+from odyssey.core.arithmetic import add, multiply, subtract
+from odyssey.core.matrix import matmul
+from odyssey.core.validation import validate_matching_tensors
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros_like
+
+
+def _validate_jvp_dtype(tensor: AnyTensor, name: String) raises:
+    var dtype = tensor.dtype()
+    if (
+        dtype != DType.float16
+        and dtype != DType.float32
+        and dtype != DType.float64
+    ):
+        raise Error(
+            name
+            + ": JVP supports only float16, float32, and float64; got "
+            + String(dtype)
+        )
+
+
+struct DualTensor(Copyable, Movable):
+    """A dynamic tensor value and its forward-mode tangent.
+
+    ``primal`` and ``tangent`` are owned, reference-counted ``AnyTensor``
+    handles.  The constructor consumes its local arguments into the fields and
+    validates shape and supported dtype before any rule can observe the pair.
+    """
+
+    var primal: AnyTensor
+    var tangent: AnyTensor
+
+    def __init__(
+        out self, var primal: AnyTensor, var tangent: AnyTensor
+    ) raises:
+        validate_matching_tensors(
+            primal, tangent, "DualTensor.primal", "DualTensor.tangent"
+        )
+        _validate_jvp_dtype(primal, "DualTensor.primal")
+        _validate_jvp_dtype(tangent, "DualTensor.tangent")
+        self.primal = primal^
+        self.tangent = tangent^
+
+
+trait JVPFunction(Copyable, Movable):
+    """Callable model interface consumed by :func:`jvp`.
+
+    Implement this trait on a struct and store deterministic weights or other
+    model state in its fields.  Using a trait-bound concrete type keeps state
+    available to the compiler and avoids escaping-closure/function-value
+    lifetime constraints in Mojo 1.0.
+    """
+
+    def __call__(self, input: DualTensor) raises -> DualTensor:
+        ...
+
+
+def dual_constant(var primal: AnyTensor) raises -> DualTensor:
+    """Lift a floating tensor into forward mode with an all-zero tangent."""
+    var tangent = zeros_like(primal)
+    return DualTensor(primal^, tangent^)
+
+
+def dual_add(lhs: DualTensor, rhs: DualTensor) raises -> DualTensor:
+    """Forward rule for elementwise addition."""
+    var primal = add(lhs.primal, rhs.primal)
+    var tangent = add(lhs.tangent, rhs.tangent)
+    return DualTensor(primal^, tangent^)
+
+
+def dual_subtract(lhs: DualTensor, rhs: DualTensor) raises -> DualTensor:
+    """Forward rule for elementwise subtraction."""
+    var primal = subtract(lhs.primal, rhs.primal)
+    var tangent = subtract(lhs.tangent, rhs.tangent)
+    return DualTensor(primal^, tangent^)
+
+
+def dual_multiply(lhs: DualTensor, rhs: DualTensor) raises -> DualTensor:
+    """Forward rule for an elementwise product.
+
+    ``(lhs * rhs)_dot = lhs_dot * rhs + lhs * rhs_dot``.
+    """
+    var primal = multiply(lhs.primal, rhs.primal)
+    var lhs_term = multiply(lhs.tangent, rhs.primal)
+    var rhs_term = multiply(lhs.primal, rhs.tangent)
+    var tangent = add(lhs_term, rhs_term)
+    return DualTensor(primal^, tangent^)
+
+
+def dual_matmul(lhs: DualTensor, rhs: DualTensor) raises -> DualTensor:
+    """Forward rule for matrix multiplication.
+
+    ``(A @ B)_dot = A_dot @ B + A @ B_dot``.
+    """
+    var primal = matmul(lhs.primal, rhs.primal)
+    var lhs_term = matmul(lhs.tangent, rhs.primal)
+    var rhs_term = matmul(lhs.primal, rhs.tangent)
+    var tangent = add(lhs_term, rhs_term)
+    return DualTensor(primal^, tangent^)
+
+
+def dual_relu(input: DualTensor) raises -> DualTensor:
+    """Forward rule for ReLU.
+
+    The tangent is masked by ``input.primal > 0``.  At the non-differentiable
+    kink (zero), Odyssey follows its existing ReLU backward convention and
+    chooses a tangent of zero.
+    """
+    var primal = relu(input.primal)
+    var tangent = relu_backward(input.tangent, input.primal)
+    return DualTensor(primal^, tangent^)
+
+
+def dual_linear(
+    input: DualTensor, weight: DualTensor, bias: DualTensor
+) raises -> DualTensor:
+    """Compose matmul and addition for ``input @ weight + bias``.
+
+    Weight and bias may themselves carry tangents.  Use :func:`dual_constant`
+    for ordinary fixed model parameters.
+    """
+    var projected = dual_matmul(input, weight)
+    var output = dual_add(projected, bias)
+    return output^
+
+
+def jvp[
+    F: JVPFunction
+](forward: F, primal: AnyTensor, tangent: AnyTensor) raises -> DualTensor:
+    """Evaluate ``forward`` and its Jacobian-vector product at ``primal``.
+
+    Args:
+        forward: Concrete callable struct implementing ``JVPFunction``.
+        primal: Floating input tensor ``x``.
+        tangent: Floating seed vector ``v`` with the same shape/dtype as ``x``.
+
+    Returns:
+        ``DualTensor`` containing ``forward(x)`` and ``J(forward)(x) @ v``.
+    """
+    # AnyTensor copies are reference-counted owned handles.  Constructing the
+    # seed this way keeps the caller's handles valid while the local DualTensor
+    # has explicit ownership of its two fields.
+    var seed = DualTensor(primal.copy(), tangent.copy())
+    var result = forward(seed)
+    return result^
+
+
+def jvp_only[
+    F: JVPFunction
+](forward: F, primal: AnyTensor, tangent: AnyTensor) raises -> AnyTensor:
+    """Return only ``J(forward)(primal) @ tangent``.
+
+    The returned tangent is numerically identical to ``jvp(...).tangent`` and
+    has a smaller retained return payload because the primal is not returned.
+    This variant still computes the same primal intermediates required by the
+    forward-mode rules; it makes no claim about peak memory or allocation count.
+    """
+    var result = jvp(forward, primal, tangent)
+    return result.tangent.copy()

--- a/tests/odyssey/autograd/test_jvp.mojo
+++ b/tests/odyssey/autograd/test_jvp.mojo
@@ -1,0 +1,331 @@
+"""Forward-mode Jacobian-vector product tests.
+
+The fixtures are intentionally vector-valued and asymmetric.  They exercise
+both terms of the matrix-product rule and a deterministic two-layer model
+rather than accepting a scalar directional-derivative shortcut.
+"""
+
+from odyssey.autograd import (
+    DualTensor,
+    JVPFunction,
+    dual_add,
+    dual_constant,
+    dual_linear,
+    dual_matmul,
+    dual_multiply,
+    dual_relu,
+    dual_subtract,
+    jvp,
+    jvp_only,
+)
+from odyssey.tensor.any_tensor import AnyTensor
+from odyssey.tensor.tensor_creation import zeros
+
+
+def _tensor(shape: List[Int], values: List[Float64]) raises -> AnyTensor:
+    if len(values) == 0:
+        raise Error("test fixture values must not be empty")
+    var result = zeros(shape, DType.float32)
+    if result.numel() != len(values):
+        raise Error("test fixture shape/value count mismatch")
+    for i in range(len(values)):
+        result._set_float64(i, values[i])
+    return result^
+
+
+def _abs(value: Float64) -> Float64:
+    return value if value >= 0.0 else -value
+
+
+def _assert_tensor_close(
+    label: String,
+    actual: AnyTensor,
+    expected: List[Float64],
+    tolerance: Float64 = 1e-5,
+) raises:
+    if actual.numel() != len(expected):
+        raise Error(label + ": element-count mismatch")
+    for i in range(len(expected)):
+        var got = actual._get_float64(i)
+        if _abs(got - expected[i]) > tolerance:
+            raise Error(
+                label
+                + "["
+                + String(i)
+                + "]: expected "
+                + String(expected[i])
+                + ", got "
+                + String(got)
+            )
+
+
+struct IdentityFn(JVPFunction):
+    def __init__(out self):
+        pass
+
+    def __call__(self, input: DualTensor) raises -> DualTensor:
+        return input.copy()
+
+
+struct PolynomialFn(JVPFunction):
+    """Elementwise polynomial f(x) = x² + x."""
+
+    def __init__(out self):
+        pass
+
+    def __call__(self, input: DualTensor) raises -> DualTensor:
+        var squared = dual_multiply(input, input)
+        return dual_add(squared, input)
+
+
+struct CompositionFn(JVPFunction):
+    """Composition f(g(x)) with g(x) = x² and f(g) = g²."""
+
+    def __init__(out self):
+        pass
+
+    def __call__(self, input: DualTensor) raises -> DualTensor:
+        var squared = dual_multiply(input, input)
+        return dual_multiply(squared, squared)
+
+
+@fieldwise_init
+struct BilinearMatmulFn(JVPFunction):
+    var rhs: DualTensor
+
+    def __call__(self, lhs: DualTensor) raises -> DualTensor:
+        return dual_matmul(lhs, self.rhs)
+
+
+struct ReluFn(JVPFunction):
+    def __init__(out self):
+        pass
+
+    def __call__(self, input: DualTensor) raises -> DualTensor:
+        return dual_relu(input)
+
+
+@fieldwise_init
+struct TwoLayerMLP(JVPFunction):
+    var weight1: DualTensor
+    var bias1: DualTensor
+    var weight2: DualTensor
+    var bias2: DualTensor
+
+    def __call__(self, input: DualTensor) raises -> DualTensor:
+        var hidden_pre = dual_linear(input, self.weight1, self.bias1)
+        var hidden = dual_relu(hidden_pre)
+        return dual_linear(hidden, self.weight2, self.bias2)
+
+
+def test_public_import_identity_polynomial_and_composition() raises:
+    var shape: List[Int] = [3]
+    var x_values: List[Float64] = [-2.0, 0.5, 3.0]
+    var v_values: List[Float64] = [0.25, -2.0, 1.5]
+
+    var identity = jvp(
+        IdentityFn(), _tensor(shape, x_values), _tensor(shape, v_values)
+    )
+    _assert_tensor_close("identity primal", identity.primal, x_values)
+    _assert_tensor_close("identity tangent", identity.tangent, v_values)
+
+    var polynomial = jvp(
+        PolynomialFn(), _tensor(shape, x_values), _tensor(shape, v_values)
+    )
+    var polynomial_primal: List[Float64] = [2.0, 0.75, 12.0]
+    var polynomial_tangent: List[Float64] = [-0.75, -4.0, 10.5]
+    _assert_tensor_close(
+        "polynomial primal", polynomial.primal, polynomial_primal
+    )
+    _assert_tensor_close(
+        "polynomial tangent", polynomial.tangent, polynomial_tangent
+    )
+
+    var composed = jvp(
+        CompositionFn(), _tensor(shape, x_values), _tensor(shape, v_values)
+    )
+    var composed_primal: List[Float64] = [16.0, 0.0625, 81.0]
+    var composed_tangent: List[Float64] = [-8.0, -1.0, 162.0]
+    _assert_tensor_close("composition primal", composed.primal, composed_primal)
+    _assert_tensor_close(
+        "composition tangent", composed.tangent, composed_tangent
+    )
+
+    # Exercise the public constant/subtraction rules as part of the import test.
+    var constant = dual_constant(_tensor(shape, x_values))
+    var difference = dual_subtract(constant, constant)
+    var zero_values: List[Float64] = [0.0, 0.0, 0.0]
+    _assert_tensor_close("constant subtraction", difference.primal, zero_values)
+    _assert_tensor_close("constant tangent", difference.tangent, zero_values)
+
+
+def test_matmul_uses_both_product_rule_terms() raises:
+    var matrix_shape: List[Int] = [2, 2]
+    var a_values: List[Float64] = [1.0, 2.0, 3.0, 4.0]
+    var a_dot_values: List[Float64] = [0.5, -1.0, 2.0, 0.25]
+    var b_values: List[Float64] = [2.0, -1.0, 0.5, 3.0]
+    var b_dot_values: List[Float64] = [-2.0, 1.0, 4.0, -0.5]
+    var rhs = DualTensor(
+        _tensor(matrix_shape, b_values), _tensor(matrix_shape, b_dot_values)
+    )
+    var result = jvp(
+        BilinearMatmulFn(rhs^),
+        _tensor(matrix_shape, a_values),
+        _tensor(matrix_shape, a_dot_values),
+    )
+
+    var expected_primal: List[Float64] = [3.0, 5.0, 8.0, 9.0]
+    # A_dot @ B + A @ B_dot.  Neither term alone equals this fixture.
+    var expected_tangent: List[Float64] = [6.5, -3.5, 14.125, -0.25]
+    _assert_tensor_close("matmul primal", result.primal, expected_primal)
+    _assert_tensor_close("matmul tangent", result.tangent, expected_tangent)
+
+
+def test_relu_tangent_mask_away_from_kink() raises:
+    var shape: List[Int] = [4]
+    var primal_values: List[Float64] = [-2.0, -0.5, 0.25, 3.0]
+    var tangent_values: List[Float64] = [1.0, 2.0, -3.0, 4.0]
+    var result = jvp(
+        ReluFn(),
+        _tensor(shape, primal_values),
+        _tensor(shape, tangent_values),
+    )
+    var expected_primal: List[Float64] = [0.0, 0.0, 0.25, 3.0]
+    var expected_tangent: List[Float64] = [0.0, 0.0, -3.0, 4.0]
+    _assert_tensor_close("relu primal", result.primal, expected_primal)
+    _assert_tensor_close("relu tangent", result.tangent, expected_tangent)
+
+
+def test_relu_at_zero_uses_zero_tangent() raises:
+    var shape: List[Int] = [1]
+    var primal_values: List[Float64] = [0.0]
+    var tangent_values: List[Float64] = [7.5]
+    var result = jvp(
+        ReluFn(),
+        _tensor(shape, primal_values),
+        _tensor(shape, tangent_values),
+    )
+    var expected: List[Float64] = [0.0]
+    _assert_tensor_close("relu-at-zero primal", result.primal, expected)
+    _assert_tensor_close("relu-at-zero tangent", result.tangent, expected)
+
+
+def test_asymmetric_seed_42_two_layer_mlp_formula_parity() raises:
+    # Fixed seed-42 fixture, recorded explicitly so model state cannot vary with
+    # global RNG state.  Shapes are x:[1,2], W1:[2,3], W2:[3,2].
+    var input_shape: List[Int] = [1, 2]
+    var hidden_weight_shape: List[Int] = [2, 3]
+    var hidden_bias_shape: List[Int] = [3]
+    var output_weight_shape: List[Int] = [3, 2]
+    var output_bias_shape: List[Int] = [2]
+    var x_values: List[Float64] = [0.75, -1.25]
+    var v_values: List[Float64] = [0.2, -0.4]
+    var w1_values: List[Float64] = [0.8, -0.3, 0.5, -0.2, 0.7, -0.6]
+    var b1_values: List[Float64] = [0.1, -0.2, 0.05]
+    var w2_values: List[Float64] = [-0.4, 0.9, 0.3, -0.5, 0.8, 0.2]
+    var b2_values: List[Float64] = [-0.15, 0.4]
+
+    var model = TwoLayerMLP(
+        dual_constant(_tensor(hidden_weight_shape, w1_values)),
+        dual_constant(_tensor(hidden_bias_shape, b1_values)),
+        dual_constant(_tensor(output_weight_shape, w2_values)),
+        dual_constant(_tensor(output_bias_shape, b2_values)),
+    )
+    var result = jvp(
+        model, _tensor(input_shape, x_values), _tensor(input_shape, v_values)
+    )
+
+    # Analytic formula:
+    # h = relu(x @ W1 + b1), h_dot = (v @ W1) * 1[h_pre > 0]
+    # y = h @ W2 + b2,          y_dot = h_dot @ W2
+    var expected_primal: List[Float64] = [0.41, 1.49]
+    var expected_tangent: List[Float64] = [0.176, 0.284]
+    _assert_tensor_close("two-layer MLP primal", result.primal, expected_primal)
+    _assert_tensor_close(
+        "two-layer MLP tangent", result.tangent, expected_tangent
+    )
+
+
+def test_jvp_only_parity_and_lower_retained_payload() raises:
+    var shape: List[Int] = [3]
+    var x_values: List[Float64] = [-1.5, 0.25, 2.0]
+    var v_values: List[Float64] = [0.5, -3.0, 1.25]
+    var pair = jvp(
+        PolynomialFn(), _tensor(shape, x_values), _tensor(shape, v_values)
+    )
+    var tangent_only = jvp_only(
+        PolynomialFn(), _tensor(shape, x_values), _tensor(shape, v_values)
+    )
+    for i in range(tangent_only.numel()):
+        if (
+            _abs(tangent_only._get_float64(i) - pair.tangent._get_float64(i))
+            > 1e-5
+        ):
+            raise Error("jvp_only tangent differs from jvp")
+
+    # This checks numerical parity and the smaller retained return payload.
+    # jvp_only still computes primal intermediates; this is not a claim about
+    # peak memory or allocation count.
+    if tangent_only.numel() >= pair.primal.numel() + pair.tangent.numel():
+        raise Error("jvp_only did not reduce the retained output payload")
+
+
+def _expect_invalid_pair(
+    label: String, var primal: AnyTensor, var tangent: AnyTensor
+) raises:
+    var did_raise = False
+    try:
+        _ = DualTensor(primal^, tangent^)
+    except:
+        did_raise = True
+    if not did_raise:
+        raise Error(label + ": expected DualTensor validation to fail")
+
+
+def test_shape_dtype_integer_and_bfloat16_validation() raises:
+    var vector_shape: List[Int] = [2]
+    var matrix_shape: List[Int] = [1, 2]
+    var pair_values: List[Float64] = [1.0, 2.0]
+    _expect_invalid_pair(
+        "shape mismatch",
+        _tensor(vector_shape, pair_values),
+        _tensor(matrix_shape, pair_values),
+    )
+
+    var float_seed = _tensor(vector_shape, pair_values)
+    var float64_tangent = zeros(vector_shape, DType.float64)
+    _expect_invalid_pair("dtype mismatch", float_seed^, float64_tangent^)
+
+    var integer_primal = zeros(vector_shape, DType.int32)
+    var integer_tangent = zeros(vector_shape, DType.int32)
+    _expect_invalid_pair("integer pair", integer_primal^, integer_tangent^)
+
+    # BF16 is floating-point, but the arithmetic/matmul dispatchers used by
+    # these forward rules do not all support it yet.  Reject it at the seed
+    # boundary instead of allowing a later, operation-dependent failure.
+    var bf16_primal = zeros(vector_shape, DType.bfloat16)
+    var bf16_tangent = zeros(vector_shape, DType.bfloat16)
+    var bf16_did_raise = False
+    try:
+        _ = DualTensor(bf16_primal^, bf16_tangent^)
+    except error:
+        bf16_did_raise = True
+        var message = String(error)
+        if (
+            "supports only float16, float32, and float64" not in message
+            or "bfloat16" not in message
+        ):
+            raise Error("bfloat16 rejection diagnostic is unclear: " + message)
+    if not bf16_did_raise:
+        raise Error("bfloat16 pair: expected DualTensor validation to fail")
+
+
+def main() raises:
+    test_public_import_identity_polynomial_and_composition()
+    test_matmul_uses_both_product_rule_terms()
+    test_relu_tangent_mask_away_from_kink()
+    test_relu_at_zero_uses_zero_tangent()
+    test_asymmetric_seed_42_two_layer_mlp_formula_parity()
+    test_jvp_only_parity_and_lower_retained_payload()
+    test_shape_dtype_integer_and_bfloat16_validation()
+    print("All vector JVP tests passed")


### PR DESCRIPTION
## Summary

Recover PR #5721 as a clean, one-commit vector forward-mode JVP implementation on the current green main branch containing Sophia Phase 1.

This is independent forward-mode infrastructure. It does not implement a Sophia estimator, optimizer wiring, HVP, or higher-order reverse mode, and it contains no payload or ancestry from PR #5722.

## Changes Made

- add `DualTensor`, carrying same-shape and same-dtype `AnyTensor` primal and tangent handles
- accept float16, float32, and float64 while explicitly rejecting integer and BF16 inputs
- add forward rules for constants, addition, subtraction, elementwise multiplication, full two-term matrix multiplication, ReLU, and linear composition
- add the trait-bound `JVPFunction` callable surface for deterministic retained model state under Mojo 1.0
- add `jvp`, returning the primal and tangent in a `DualTensor`
- add `jvp_only`, returning the numerically identical tangent with a smaller retained return payload
- publicly re-export `DualTensor`, `JVPFunction`, all forward rules, `jvp`, and `jvp_only`
- document JVP as infrastructure independent of Sophia-G’s ordinary-backward implementation path

## Files Modified

- `src/odyssey/autograd/DESIGN.md`
- `src/odyssey/autograd/TODO.md`
- `src/odyssey/autograd/__init__.mojo`
- `src/odyssey/autograd/jvp.mojo`
- `tests/odyssey/autograd/test_jvp.mojo`

## Test Coverage

- public imports plus identity, polynomial, and composition cases
- elementwise product and full two-term matrix-product derivatives
- ReLU behavior for negative, positive, and exactly-zero primals
- deterministic asymmetric two-layer MLP analytic parity within `1e-5`
- `jvp_only` numerical parity and smaller retained return payload
- shape, dtype, integer, and BF16 rejection behavior

## Scope Boundaries

- no `sophia_g.mojo` or Sophia test changes
- no estimator or optimizer implementation from #5717
- no PR #5722 history or payload
- no stale scalar/SIMD `Dual` API from the prior #5721 head
- no VJP, HVP, or higher-order reverse-mode implementation
- no claim that `jvp_only` reduces peak allocation or avoids required primal computation

## Verification

- exact signed+DCO head: `a6f45df45275f3a0ba6bae7e7b8ac4f84bda6ee4`
- exact fully green base containing merged #5719: `6d8a7d70021d0aab2f4d41c91c5534c93c6c93d8`
- one commit, no merges, exact five-file issue-specific diff
- all five resulting payload blobs match the audited recovery commit
- vector JVP test passed
- all 12 autograd tests passed with warnings fatal
- shared package compilation passed with `--Werror`
- formatting and static analysis passed
- full Python/pre-push validation: 1,437 passed, 228 expected skips
- no stale #5721/#5722 ancestry, merge commits, writer changes, or Sophia implementation payload
- base Comprehensive run 30524132756 and report artifact 8753022944: 19 upstream rows, 12 successful producer manifests, no violations
- base image pipeline built, scanned, and smoke-tested `ci`, `production`, and `runtime`

Closes #5718

Related: #5719, #5741, #5717
