### PR TITLE
fix(tests): align main CI test_MoJo suite with Muon paper defaults

### DIFF
--- a/tests/odyssey/training/test_dispatch.mojo
+++ b/tests/odyssey/training/test_dispatch.mojo
@@ -143,7 +143,7 @@ def test_loop_all_24_known() raises:
     print("  ok all 24 names return non-empty defaults")
 
 
-def _make_dummy_params() -> List[AnyTensor]:
+def _make_dummy_params() raises -> List[AnyTensor]:
     """Build a small 2-parameter list for state allocation tests.
 
     Both params are rank-2 with both dims >= 4 — large enough to satisfy
@@ -153,6 +153,9 @@ def _make_dummy_params() -> List[AnyTensor]:
     lists that would false-positive the loop test.
     """
     var params: List[AnyTensor] = []
+    # zeros([a, b], ...) is documented as raising on bad shapes; mark
+    # _make_dummy_params raises too so the append chain is type-correct.
+    # (Mojo 1.0: callers of zeros() must propagate errors.)
     params.append(zeros([4, 4], DType.float32))
     params.append(zeros([4, 8], DType.float32))
     return params^

--- a/tests/odyssey/training/test_muon.mojo
+++ b/tests/odyssey/training/test_muon.mojo
@@ -536,8 +536,8 @@ def test_muon_step_simple() raises:
         pass). This upgrade replaces the smoke check with element-wise parity
         on `new_params` AND `new_momentum` across two paths: zero-grad
         (exercises the orthogonalized-momentum init) and non-zero-grad
-        (exercises the actual Muon update). Defaults match muon.mojo:
-        momentum_beta=0.95, weight_decay=0.0, nesterov=True, ns_steps=5.
+        (exercises the actual Muon update).        Defaults match muon.mojo:
+        momentum_beta=0.95, weight_decay=0.01, nesterov=True, ns_steps=5.
     """
     # --- Pass 1: zero gradients ---
     var shape: List[Int] = [4, 4]
@@ -546,13 +546,15 @@ def test_muon_step_simple() raises:
     var mom_f1 = zeros_like(params_zi)
     var mom_s1 = zeros_like(params_zi)
 
+    # weight_decay=0.01 here MUST match `muon_step_simple`'s internal default;
+    # otherwise the zero-grad pass shows a spurious lr*wd*p = 1e-4 * p drift.
     var full_p1 = muon_step(
         params_zi,
         grads_zi,
         mom_f1,
         learning_rate=0.01,
         momentum_beta=0.95,
-        weight_decay=0.0,
+        weight_decay=0.01,
         nesterov=True,
         ns_steps=5,
     )
@@ -597,7 +599,7 @@ def test_muon_step_simple() raises:
         mom_full,
         learning_rate=0.01,
         momentum_beta=0.95,
-        weight_decay=0.0,
+        weight_decay=0.01,
         nesterov=True,
         ns_steps=5,
     )


### PR DESCRIPTION
## Summary

Main branch CI is failing the `Comprehensive Mojo Tests (autograd-tensor-base)` matrix job on **only** 2 of 101 tests:

1. `tests/odyssey/training/test_dispatch.mojo:156` — `_make_dummy_params` calls `zeros([a, b], ...)` (which can raise on bad shape in Mojo 1.0) without declaring `raises`. Compiler error in Mojo 1.0 because `zeros` is documented as a raising function.
2. `tests/odyssey/training/test_muon.mojo` — `test_muon_step_simple` (cache-bust `20260727-32a8f6d6`) compares `muon_step(weight_decay=0.0)` vs `muon_step_simple(...)` which internally uses `weight_decay=0.01` (Jordan et al. 2024). At zero-grad the divergence is exactly `lr*wd*p = 0.01*0.01*1.0 = 0.0001`, matching the observed `diff=0.00010001659393310547`.

## Fix

Both fixes are **test-only** (`tests/odyssey/...`); no production source code is touched:

- `test_dispatch.mojo:146`: marked `_make_dummy_params() raises` so the `zeros([4, 4], …)` / `zeros([4, 8], …)` append-chain type-checks.
- `test_muon.mojo:541`: updated test docstring bullet + the two explicit `muon_step(...)` calls inside `test_muon_step_simple` to use `weight_decay=0.01` so the parity assertion actually compares the same underlying formula as `muon_step_simple`'s documented default.

## Other failing jobs on sha 93cfd4b3 (NOT addressed by this PR)

Three other jobs in run 30468494041 fail with `crun: unknown version specified: OCI runtime error` at the `podman compose up -d odyssey-dev` step **before any Mojo is compiled**:

- `Comprehensive Mojo Tests (core-gradient-utils)` — job 90636522166
- `Training Smoke (resnet18_cifar10/train_autograd.mojo)` — job 90636522208
- `Training Smoke (vgg16_cifar10/train.mojo)` — job 90636522296

These are pre-existing runner-infra flakes in `.github/actions/setup-container/action.yml` (Podman rootless race) and are tracked separately. Build Validation, Pre-commit, Mojo Syntax, Mojo Package Compilation + 12 other matrix entries on the SAME sha passed ("runner is healthy"). Same-flake failure observed on PRs #5704 / #5706 / #5708 / #5718 / #5719 across multiple worktrees; not specific to this PR.

## Diff stat

```
 tests/odyssey/training/test_dispatch.mojo |  5 ++++- 
 tests/odyssey/training/test_muon.mojo     | 10 ++++++----
 2 files changed, 10 insertions(+), 5 deletions(-)
```

## Verification commands (post-merge)

```bash
# Should pass on sha post-merge:
gh pr checks <this-pr-number> --repo HomericIntelligence/Odyssey --watch

# Replay failing matrix locally:
just test-group "tests/odyssey/training" "test_*.mojo"
```

## Related

Historical context: `gh pr list --head fix-main-ci-failures` shows 7 previous MERGED PRs that used the same branch name across Odyssey's history. This PR is a fresh attempt against the current failure each prior attempt landed before subsequent regressions appeared.
