### PR TITLE
fix(ci): make comprehensive Test Report fail closed

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -148,12 +148,13 @@ ls .github/workflows/*.yml | wc -l
 
 - **Individual Test Execution**: Files executed one-by-one for clarity on which tests pass/fail
 
-- **Test Group Summary**: Each group generates result file with test counts and failures
+- **Producer Outcomes**: Each result-producing job emits an always-run outcome manifest
 
 - **Combined Report** (`test-report` job):
-  - Aggregates all 17 group results
-  - Calculates total statistics
-  - Comments on PRs with detailed breakdown
+  - Validates all 19 upstream job results and all 12 expected producer manifests
+  - Treats missing, malformed, duplicate, skipped, cancelled, or failed results as failures
+  - Reports job and producer outcomes without presenting partial artifacts as total test counts
+  - Comments on PRs with a fail-closed diagnostic breakdown
 
 **Cache Strategy**:
 
@@ -163,13 +164,13 @@ ls .github/workflows/*.yml | wc -l
 
 **Artifacts**:
 
-- `test-results-*` (7 days, one per group)
+- `test-results-*` (7 days, one per result producer)
 - `comprehensive-test-report` (30 days)
 
 **Failure Handling**:
 
 - `fail-fast: false` - all groups run even if one fails
-- Overall workflow fails if any tests fail
+- `Test Report` runs after all upstream jobs and fails unless the complete contract is green
 
 ---
 

--- a/.github/workflows/comprehensive-test-pr-comments.yml
+++ b/.github/workflows/comprehensive-test-pr-comments.yml
@@ -15,6 +15,9 @@ jobs:
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.pull_requests[0]
+    concurrency:
+      group: comprehensive-test-pr-comment-${{ github.event.workflow_run.pull_requests[0].number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     name: "Post Comprehensive Test PR Comments"
     permissions:
@@ -23,7 +26,34 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Discover report artifacts
+        id: discover_artifacts
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.payload.workflow_run.id,
+                per_page: 100,
+              },
+            );
+            const available = new Set(
+              artifacts
+                .filter(artifact => !artifact.expired)
+                .map(artifact => artifact.name),
+            );
+            core.setOutput('has_metrics', String(available.has('test-metrics')));
+            core.setOutput(
+              'has_report',
+              String(available.has('comprehensive-test-report')),
+            );
+
       - name: Download test metrics report
+        id: download-metrics
+        if: steps.discover_artifacts.outputs.has_metrics == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: test-metrics
@@ -32,6 +62,8 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Download comprehensive test report
+        id: download-report
+        if: always() && steps.discover_artifacts.outputs.has_report == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: comprehensive-test-report
@@ -40,23 +72,52 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Post or update PR comments
+        if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          REPORT_AVAILABLE: ${{ steps.discover_artifacts.outputs.has_report }}
+          METRICS_AVAILABLE: ${{ steps.discover_artifacts.outputs.has_metrics }}
+          REPORT_DOWNLOAD_OUTCOME: ${{ steps.download-report.outcome }}
+          METRICS_DOWNLOAD_OUTCOME: ${{ steps.download-metrics.outcome }}
+          WORKFLOW_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          WORKFLOW_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         with:
           script: |
             const fs = require('fs');
             const issue_number = Number(process.env.PR_NUMBER);
-            const reports = [
-              {
-                marker: 'Test Metrics Report',
-                path: 'reports/metrics/metrics-pr-comment.md',
-              },
-              {
-                marker: '🧪 Comprehensive Test Results',
-                path: 'reports/comprehensive/test-report.md',
-              },
-            ];
+            const metricsPath = 'reports/metrics/metrics-pr-comment.md';
+            const reportPath = 'reports/comprehensive/test-report.md';
+            const sourceHeadSha =
+              context.payload.workflow_run.pull_requests[0]?.head?.sha;
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: issue_number,
+            });
+            if (!sourceHeadSha || pullRequest.head.sha !== sourceHeadSha) {
+              core.info(
+                `Stale workflow run for ${sourceHeadSha || 'unknown head'}; ` +
+                `current PR head is ${pullRequest.head.sha}. No comment updated.`,
+              );
+              return;
+            }
+
+            const readDownloadedFile = (available, outcome, path) => {
+              if (available !== 'true' || outcome !== 'success') {
+                return null;
+              }
+              try {
+                const stat = fs.statSync(path);
+                if (!stat.isFile() || stat.size === 0) {
+                  return null;
+                }
+                return fs.readFileSync(path, 'utf8');
+              } catch (error) {
+                core.info(`Unable to read ${path}: ${error.message}`);
+                return null;
+              }
+            };
 
             const comments = await github.paginate(
               github.rest.issues.listComments,
@@ -68,10 +129,9 @@ jobs:
               },
             );
 
-            for (const report of reports) {
-              const body = fs.readFileSync(report.path, 'utf8');
+            const upsertComment = async (marker, body) => {
               const existing = comments.find(comment =>
-                comment.user.type === 'Bot' && comment.body.includes(report.marker)
+                comment.user.type === 'Bot' && comment.body.includes(marker)
               );
 
               if (existing) {
@@ -89,4 +149,53 @@ jobs:
                   body,
                 });
               }
+            };
+
+            const metricsBody = readDownloadedFile(
+              process.env.METRICS_AVAILABLE,
+              process.env.METRICS_DOWNLOAD_OUTCOME,
+              metricsPath,
+            );
+            if (metricsBody !== null) {
+              await upsertComment(
+                'Test Metrics Report',
+                metricsBody,
+              );
             }
+
+            const downloadedReport = readDownloadedFile(
+              process.env.REPORT_AVAILABLE,
+              process.env.REPORT_DOWNLOAD_OUTCOME,
+              reportPath,
+            );
+            const conclusion = process.env.WORKFLOW_CONCLUSION || 'unknown';
+            const expectedVerdict =
+              conclusion === 'success' ? '✅ PASS —' : '❌ FAIL —';
+            const oppositeVerdict =
+              conclusion === 'success' ? '❌ FAIL —' : '✅ PASS —';
+            const reportMatchesConclusion =
+              downloadedReport !== null &&
+              downloadedReport.includes(expectedVerdict) &&
+              !downloadedReport.includes(oppositeVerdict);
+
+            let reportBody = downloadedReport;
+            if (!reportMatchesConclusion) {
+              const runUrl = process.env.WORKFLOW_RUN_URL;
+              const reason = downloadedReport === null
+                ? 'The workflow did not publish a readable comprehensive report.'
+                : 'The downloaded report verdict does not match the workflow conclusion.';
+              reportBody = [
+                '# 🧪 Comprehensive Test Results',
+                '',
+                '❌ **Comprehensive test report unavailable.**',
+                '',
+                reason,
+                'so this result must be treated as a failure.',
+                '',
+                `- Workflow conclusion: \`${conclusion}\``,
+                `- [Workflow run](${runUrl})`,
+                '',
+              ].join('\n');
+            }
+
+            await upsertComment('🧪 Comprehensive Test Results', reportBody);

--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -553,12 +553,29 @@ jobs:
         if: matrix.group == 'integration-bench'
         run: just test-group "tests/odyssey/integration" "test_*.mojo"
 
+      - name: Record test producer outcome
+        if: always()
+        env:
+          producer: comprehensive-${{ matrix.group }}
+          job_id: test-mojo-comprehensive
+          status: ${{ job.status }}
+        run: |
+          mkdir -p test-results
+          cat > test-results/outcome-manifest.json <<EOF
+          {
+            "producer": "$producer",
+            "job_id": "$job_id",
+            "status": "$status"
+          }
+          EOF
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: test-results-comprehensive-${{ matrix.group }}
           path: test-results/
+          if-no-files-found: error
           retention-days: 7
 
   # ============================================================================
@@ -591,12 +608,29 @@ jobs:
       - name: Run Configs tests
         run: just test-group tests/configs "test_*.mojo"
 
+      - name: Record test producer outcome
+        if: always()
+        env:
+          producer: configs
+          job_id: test-configs
+          status: ${{ job.status }}
+        run: |
+          mkdir -p test-results
+          cat > test-results/outcome-manifest.json <<EOF
+          {
+            "producer": "$producer",
+            "job_id": "$job_id",
+            "status": "$status"
+          }
+          EOF
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: test-results-Configs
           path: test-results/
+          if-no-files-found: error
           retention-days: 7
 
   # ============================================================================
@@ -628,12 +662,29 @@ jobs:
       - name: Run Benchmarks tests
         run: just test-group tests/odyssey/benchmarks "bench_*.mojo"
 
+      - name: Record test producer outcome
+        if: always()
+        env:
+          producer: benchmarks
+          job_id: test-benchmarks
+          status: ${{ job.status }}
+        run: |
+          mkdir -p test-results
+          cat > test-results/outcome-manifest.json <<EOF
+          {
+            "producer": "$producer",
+            "job_id": "$job_id",
+            "status": "$status"
+          }
+          EOF
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: test-results-Benchmarks
           path: test-results/
+          if-no-files-found: error
           retention-days: 7
 
   # ============================================================================
@@ -661,12 +712,29 @@ jobs:
       - name: Run Core Layers tests
         run: just test-group tests/odyssey/core/layers "test_*.mojo"
 
+      - name: Record test producer outcome
+        if: always()
+        env:
+          producer: core-layers
+          job_id: test-core-layers
+          status: ${{ job.status }}
+        run: |
+          mkdir -p test-results
+          cat > test-results/outcome-manifest.json <<EOF
+          {
+            "producer": "$producer",
+            "job_id": "$job_id",
+            "status": "$status"
+          }
+          EOF
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: test-results-Core-Layers
           path: test-results/
+          if-no-files-found: error
           retention-days: 7
 
   # ============================================================================
@@ -719,12 +787,29 @@ jobs:
             exit 1
           fi
 
+      - name: Record test producer outcome
+        if: always()
+        env:
+          producer: python-tests
+          job_id: test-python
+          status: ${{ job.status }}
+        run: |
+          mkdir -p test-results
+          cat > test-results/outcome-manifest.json <<EOF
+          {
+            "producer": "$producer",
+            "job_id": "$job_id",
+            "status": "$status"
+          }
+          EOF
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: test-results-Python-Tests
           path: test-results/
+          if-no-files-found: error
           retention-days: 7
 
   # ============================================================================
@@ -939,12 +1024,29 @@ jobs:
 
           exit $exit_code
 
+      - name: Record test producer outcome
+        if: always()
+        env:
+          producer: gradient-checking
+          job_id: gradient-tests
+          status: ${{ job.status }}
+        run: |
+          mkdir -p test-results
+          cat > test-results/outcome-manifest.json <<EOF
+          {
+            "producer": "$producer",
+            "job_id": "$job_id",
+            "status": "$status"
+          }
+          EOF
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: test-results-Gradient-Checking-Tests
           path: test-results/
+          if-no-files-found: error
           retention-days: 7
 
       - name: Check test results
@@ -1102,12 +1204,29 @@ jobs:
             echo "This workflow will run once tests/odyssey/data/ tests are created"
           fi
 
+      - name: Record test producer outcome
+        if: always()
+        env:
+          producer: data-utilities
+          job_id: test-data-utilities
+          status: ${{ job.status }}
+        run: |
+          mkdir -p test-results
+          cat > test-results/outcome-manifest.json <<EOF
+          {
+            "producer": "$producer",
+            "job_id": "$job_id",
+            "status": "$status"
+          }
+          EOF
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: test-results-Data-Utilities
           path: test-results/
+          if-no-files-found: error
           retention-days: 7
 
   # ============================================================================
@@ -1158,7 +1277,26 @@ jobs:
   # Combined Test Report with Metrics
   # ============================================================================
   test-report:
-    needs: [mojo-compilation, validate-test-coverage, audit-shared-links, test-mojo-comprehensive, test-configs, test-benchmarks, test-core-layers, test-python, code-quality, build-validation, gradient-tests, test-data-utilities, test-metrics]
+    needs:
+      - mojo-syntax-check
+      - mojo-compilation
+      - example-backward-tests
+      - training-smoke
+      - validate-test-coverage
+      - audit-shared-links
+      - validate-dep-sync
+      - test-mojo-comprehensive
+      - test-configs
+      - test-benchmarks
+      - test-core-layers
+      - test-python
+      - code-quality
+      - simd-analysis
+      - build-validation
+      - gradient-tests
+      - gradient-coverage
+      - test-data-utilities
+      - test-metrics
     runs-on: ubuntu-latest
     if: always()
     name: "Test Report"
@@ -1175,127 +1313,25 @@ jobs:
           merge-multiple: false
           run-id: ${{ github.run_id }}  # Only artifacts from this specific run
 
-      - name: Generate combined report
+      - name: Generate and enforce combined report
+        if: always()
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_EXTENDED: ${{ github.event_name == 'workflow_dispatch' && inputs.run_extended || false }}
         run: |
-          echo "# 🧪 Comprehensive Test Results" > test-report.md
-          echo "" >> test-report.md
-          echo "**Workflow Run**: [\`${{ github.run_number }}\`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> test-report.md
-          echo "**Commit**: \`${{ github.sha }}\`" >> test-report.md
-          echo "**Date**: $(date -Iseconds)" >> test-report.md
-          echo "" >> test-report.md
-
-          total_groups=0
-          passed_groups=0
-          failed_groups=0
-          total_tests=0
-          total_passed=0
-          total_failed=0
-          total_duration=0
-
-          echo "## Test Groups" >> test-report.md
-          echo "" >> test-report.md
-          echo "| Group | Tests | Passed | Failed | Duration |" >> test-report.md
-          echo "|-------|-------|--------|--------|----------|" >> test-report.md
-
-          # Process each result file
-          for result_dir in all-results/test-results-*; do
-            if [ -d "$result_dir" ]; then
-              for json_file in "$result_dir"/*.json; do
-                if [ -f "$json_file" ]; then
-                  total_groups=$((total_groups + 1))
-
-                  group=$(jq -r '.group' "$json_file" 2>/dev/null || echo "Unknown")
-                  tests=$(jq -r '.tests' "$json_file" 2>/dev/null || echo "0")
-                  passed=$(jq -r '.passed' "$json_file" 2>/dev/null || echo "0")
-                  failed=$(jq -r '.failed' "$json_file" 2>/dev/null || echo "0")
-                  duration=$(jq -r '.duration' "$json_file" 2>/dev/null || echo "0")
-
-                  total_tests=$((total_tests + tests))
-                  total_passed=$((total_passed + passed))
-                  total_failed=$((total_failed + failed))
-                  total_duration=$((total_duration + duration))
-
-                  if [ "$failed" -gt 0 ]; then
-                    failed_groups=$((failed_groups + 1))
-                    status="❌"
-                  else
-                    passed_groups=$((passed_groups + 1))
-                    status="✅"
-                  fi
-
-                  echo "| $status $group | $tests | $passed | $failed | ${duration}s |" >> test-report.md
-                fi
-              done
-            fi
-          done
-
-          echo "" >> test-report.md
-          echo "## Summary" >> test-report.md
-          echo "" >> test-report.md
-          echo "| Metric | Value |" >> test-report.md
-          echo "|--------|-------|" >> test-report.md
-          echo "| Total Test Groups | $total_groups |" >> test-report.md
-          echo "| Passed Groups | $passed_groups |" >> test-report.md
-          echo "| Failed Groups | $failed_groups |" >> test-report.md
-          echo "| Total Tests | $total_tests |" >> test-report.md
-          echo "| Passed Tests | $total_passed |" >> test-report.md
-          echo "| Failed Tests | $total_failed |" >> test-report.md
-          echo "| Total Duration | ${total_duration}s |" >> test-report.md
-
-          if [ $total_tests -gt 0 ]; then
-            pass_rate=$(echo "scale=1; $total_passed * 100 / $total_tests" | bc 2>/dev/null || echo "0")
-            echo "| Pass Rate | ${pass_rate}% |" >> test-report.md
-          fi
-
-          echo "" >> test-report.md
-
-          if [ $total_failed -eq 0 ]; then
-            echo "✅ **All tests passed!**" >> test-report.md
-          else
-            echo "❌ **Some tests failed. See details above.**" >> test-report.md
-          fi
-
-          # Include code quality if available
-          if [ -f "all-results/code-quality-reports/complexity.md" ]; then
-            echo "" >> test-report.md
-            echo "---" >> test-report.md
-            echo "" >> test-report.md
-            echo "## 📈 Code Quality" >> test-report.md
-            cat "all-results/code-quality-reports/complexity.md" >> test-report.md
-          fi
-
-          # Display report
-          cat test-report.md
+          mkdir -p all-results
+          python scripts/ci/comprehensive_report.py \
+            --artifacts-dir all-results \
+            --output test-report.md \
+            --event-name "$EVENT_NAME" \
+            --run-extended "$RUN_EXTENDED"
 
       - name: Upload combined report
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: comprehensive-test-report
           path: test-report.md
+          if-no-files-found: error
           retention-days: 30
-
-      - name: Fail if any tests failed
-        run: |
-          # Check if any test groups failed
-          failed=0
-          for result_dir in all-results/test-results-*; do
-            if [ -d "$result_dir" ]; then
-              for json_file in "$result_dir"/*.json; do
-                if [ -f "$json_file" ]; then
-                  failed_count=$(jq -r '.failed' "$json_file" 2>/dev/null || echo "0")
-                  if [ "$failed_count" -gt 0 ]; then
-                    failed=1
-                    break
-                  fi
-                fi
-              done
-            fi
-          done
-
-          if [ $failed -eq 1 ]; then
-            echo "❌ FAIL: Some tests failed. See test report for details."
-            exit 1
-          else
-            echo "✅ All tests passed!"
-            exit 0
-          fi

--- a/.github/workflows/workflow-smoke-test.yml
+++ b/.github/workflows/workflow-smoke-test.yml
@@ -30,6 +30,8 @@ on:
       - 'tests/smoke/test_pre_commit_workflow_properties.py'
       - '.github/workflows/comprehensive-tests.yml'
       - 'tests/smoke/test_comprehensive_tests_workflow_properties.py'
+      - 'tests/smoke/test_comprehensive_report_workflow_properties.py'
+      - 'tests/smoke/test_comprehensive_pr_comments_workflow_properties.py'
       - '.github/workflows/validate-configs.yml'
       - 'tests/smoke/test_validate_configs_workflow_properties.py'
       - '.github/actions/setup-container/action.yml'
@@ -208,6 +210,8 @@ jobs:
             tests/smoke/test_merge_queue_workflow_properties.py \
             tests/smoke/test_pre_commit_workflow_properties.py \
             tests/smoke/test_comprehensive_tests_workflow_properties.py \
+            tests/smoke/test_comprehensive_report_workflow_properties.py \
+            tests/smoke/test_comprehensive_pr_comments_workflow_properties.py \
             tests/smoke/test_validate_configs_workflow_properties.py \
             tests/smoke/test_container_runtime_workflow_properties.py \
             -v

--- a/scripts/ci/comprehensive_report.py
+++ b/scripts/ci/comprehensive_report.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""Build the fail-closed comprehensive CI report.
+
+ADR-001 Justification: Python is required for CI automation that parses JSON,
+walks downloaded artifact trees, and returns a reliable process exit status.
+Mojo's subprocess support cannot provide the exit-code guarantees needed for
+this gate. See: docs/adr/ADR-001-language-selection-tooling.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+REQUIRED_JOB_IDS = (
+    "mojo-syntax-check",
+    "mojo-compilation",
+    "example-backward-tests",
+    "training-smoke",
+    "validate-test-coverage",
+    "audit-shared-links",
+    "validate-dep-sync",
+    "test-mojo-comprehensive",
+    "test-configs",
+    "test-benchmarks",
+    "test-core-layers",
+    "test-python",
+    "code-quality",
+    "simd-analysis",
+    "build-validation",
+    "gradient-tests",
+    "gradient-coverage",
+    "test-data-utilities",
+    "test-metrics",
+)
+
+EXPECTED_PRODUCERS = {
+    "comprehensive-core-tensors-loss": "test-mojo-comprehensive",
+    "comprehensive-core-gradient-utils": "test-mojo-comprehensive",
+    "comprehensive-data": "test-mojo-comprehensive",
+    "comprehensive-autograd-tensor-base": "test-mojo-comprehensive",
+    "comprehensive-models-misc": "test-mojo-comprehensive",
+    "comprehensive-integration-bench": "test-mojo-comprehensive",
+    "configs": "test-configs",
+    "benchmarks": "test-benchmarks",
+    "core-layers": "test-core-layers",
+    "python-tests": "test-python",
+    "gradient-checking": "gradient-tests",
+    "data-utilities": "test-data-utilities",
+}
+
+_VALID_STATUSES = frozenset({"success", "failure", "cancelled", "skipped"})
+_SIMD_SKIP_EVENTS = frozenset({"pull_request", "push", "workflow_dispatch"})
+
+
+@dataclass(frozen=True)
+class EvaluationResult:
+    """The report text and its fail-closed verdict."""
+
+    passed: bool
+    errors: tuple[str, ...]
+    markdown: str
+
+
+@dataclass(frozen=True)
+class _Manifest:
+    producer: str
+    job_id: str
+    status: str
+    path: Path
+
+
+def _display(value: object) -> str:
+    """Render untrusted values safely inside a Markdown table cell."""
+    return str(value).replace("|", r"\|").replace("\n", " ")
+
+
+def _simd_skip_allowed(event_name: str, run_extended: bool) -> bool:
+    return event_name in _SIMD_SKIP_EVENTS and not (event_name == "workflow_dispatch" and run_extended)
+
+
+def _validate_needs(
+    needs: Mapping[str, object],
+    *,
+    event_name: str,
+    run_extended: bool,
+) -> tuple[dict[str, str], list[str]]:
+    statuses: dict[str, str] = {}
+    errors: list[str] = []
+
+    missing_jobs = [job_id for job_id in REQUIRED_JOB_IDS if job_id not in needs]
+    for job_id in missing_jobs:
+        errors.append(f"Required upstream job {job_id!r} is missing from needs.")
+
+    unexpected_jobs = sorted(set(needs) - set(REQUIRED_JOB_IDS))
+    for job_id in unexpected_jobs:
+        record = needs[job_id]
+        result = record.get("result") if isinstance(record, Mapping) else None
+        status = result if isinstance(result, str) and result else "invalid"
+        statuses[job_id] = status
+        errors.append(f"Unexpected upstream job {job_id!r} is present in needs with result {status!r}.")
+
+    for job_id in REQUIRED_JOB_IDS:
+        record = needs.get(job_id)
+        if not isinstance(record, Mapping):
+            statuses[job_id] = "missing" if record is None else "invalid"
+            if job_id in needs:
+                errors.append(f"Upstream job {job_id!r} has an invalid needs record.")
+            continue
+
+        result = record.get("result")
+        if not isinstance(result, str) or not result:
+            statuses[job_id] = "invalid"
+            errors.append(f"Upstream job {job_id!r} has no valid result in needs.")
+            continue
+
+        statuses[job_id] = result
+        if result == "success":
+            continue
+        if job_id == "simd-analysis" and result == "skipped" and _simd_skip_allowed(event_name, run_extended):
+            continue
+        errors.append(f"Required upstream job {job_id!r} concluded with {result!r}, not success.")
+
+    return statuses, errors
+
+
+def _load_manifest(path: Path) -> tuple[_Manifest | None, str | None]:
+    try:
+        contents = path.read_text(encoding="utf-8")
+        payload: Any = json.loads(contents)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        return None, f"Manifest {path} could not be read as JSON: {exc}."
+
+    if not isinstance(payload, dict):
+        return None, f"Manifest {path} must contain a JSON object."
+
+    required_fields = ("producer", "job_id", "status")
+    invalid_fields = [
+        field for field in required_fields if not isinstance(payload.get(field), str) or not payload[field]
+    ]
+    if invalid_fields:
+        fields = ", ".join(invalid_fields)
+        return None, f"Manifest {path} has missing or invalid fields: {fields}."
+
+    status = payload["status"]
+    if status not in _VALID_STATUSES:
+        return None, f"Manifest {path} has unsupported status {status!r}."
+
+    return (
+        _Manifest(
+            producer=payload["producer"],
+            job_id=payload["job_id"],
+            status=status,
+            path=path,
+        ),
+        None,
+    )
+
+
+def _validate_manifests(
+    artifacts_dir: Path,
+    job_statuses: Mapping[str, str],
+) -> tuple[dict[str, list[_Manifest]], list[str]]:
+    manifests: dict[str, list[_Manifest]] = {producer: [] for producer in EXPECTED_PRODUCERS}
+    errors: list[str] = []
+
+    if not artifacts_dir.is_dir():
+        errors.append(f"Artifacts directory {artifacts_dir} does not exist or is not a directory.")
+        paths: Sequence[Path] = ()
+    else:
+        paths = sorted(artifacts_dir.rglob("outcome-manifest.json"))
+
+    for path in paths:
+        manifest, error = _load_manifest(path)
+        if error is not None:
+            errors.append(error)
+            continue
+        assert manifest is not None
+
+        if manifest.producer not in EXPECTED_PRODUCERS:
+            errors.append(f"Manifest {path} names unexpected producer {manifest.producer!r}.")
+            continue
+
+        manifests[manifest.producer].append(manifest)
+
+    for producer, expected_job_id in EXPECTED_PRODUCERS.items():
+        producer_manifests = manifests[producer]
+        if not producer_manifests:
+            errors.append(f"Expected producer {producer!r} has no outcome manifest.")
+            continue
+        if len(producer_manifests) > 1:
+            locations = ", ".join(str(item.path) for item in producer_manifests)
+            errors.append(f"Expected producer {producer!r} has duplicate outcome manifests: {locations}.")
+            continue
+
+        manifest = producer_manifests[0]
+        if manifest.job_id != expected_job_id:
+            errors.append(
+                f"Producer {producer!r} names job {manifest.job_id!r}; the contract requires {expected_job_id!r}."
+            )
+
+        if manifest.status != "success":
+            errors.append(
+                f"Producer {producer!r} for job {expected_job_id!r} concluded with {manifest.status!r}, not success."
+            )
+
+        upstream_status = job_statuses.get(expected_job_id)
+        if (
+            expected_job_id != "test-mojo-comprehensive"
+            and upstream_status in _VALID_STATUSES
+            and manifest.status != upstream_status
+        ):
+            errors.append(
+                f"Producer {producer!r} status {manifest.status!r} "
+                f"contradicts upstream job {expected_job_id!r} status "
+                f"{upstream_status!r}."
+            )
+
+    return manifests, errors
+
+
+def _build_markdown(
+    *,
+    passed: bool,
+    errors: Sequence[str],
+    job_statuses: Mapping[str, str],
+    manifests: Mapping[str, Sequence[_Manifest]],
+) -> str:
+    verdict = (
+        "✅ PASS — upstream jobs and producer manifests are complete and successful."
+        if passed
+        else "❌ FAIL — the comprehensive CI contract is incomplete or unsuccessful."
+    )
+    lines = [
+        "# 🧪 Comprehensive Test Results",
+        "",
+        verdict,
+        "",
+        "## Upstream jobs",
+        "",
+        "| Job | Result |",
+        "| --- | --- |",
+    ]
+    reported_job_ids = (
+        *REQUIRED_JOB_IDS,
+        *sorted(set(job_statuses) - set(REQUIRED_JOB_IDS)),
+    )
+    for job_id in reported_job_ids:
+        lines.append(f"| `{_display(job_id)}` | `{_display(job_statuses.get(job_id, 'missing'))}` |")
+
+    lines.extend(
+        [
+            "",
+            "## Result producers",
+            "",
+            "| Producer | Expected job | Manifest status |",
+            "| --- | --- | --- |",
+        ]
+    )
+    for producer, job_id in EXPECTED_PRODUCERS.items():
+        producer_manifests = manifests.get(producer, ())
+        if len(producer_manifests) == 1:
+            status = producer_manifests[0].status
+        elif len(producer_manifests) > 1:
+            status = "duplicate"
+        else:
+            status = "missing"
+        lines.append(f"| `{_display(producer)}` | `{_display(job_id)}` | `{_display(status)}` |")
+
+    lines.extend(["", "## Diagnostics", ""])
+    if errors:
+        lines.extend(f"- {_display(error)}" for error in errors)
+    else:
+        lines.append("- No contract violations detected.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def evaluate_report(
+    *,
+    needs: Mapping[str, object],
+    artifacts_dir: Path | str,
+    event_name: str,
+    run_extended: bool,
+) -> EvaluationResult:
+    """Validate upstream job results and recursively discovered manifests."""
+    if not isinstance(needs, Mapping):
+        needs = {}
+        initial_errors: list[str] = ["The needs payload must be a JSON object."]
+    else:
+        initial_errors = []
+
+    job_statuses, needs_errors = _validate_needs(
+        needs,
+        event_name=event_name,
+        run_extended=run_extended,
+    )
+    manifests, manifest_errors = _validate_manifests(
+        Path(artifacts_dir),
+        job_statuses,
+    )
+    errors = tuple((*initial_errors, *needs_errors, *manifest_errors))
+    passed = not errors
+    markdown = _build_markdown(
+        passed=passed,
+        errors=errors,
+        job_statuses=job_statuses,
+        manifests=manifests,
+    )
+    return EvaluationResult(passed=passed, errors=errors, markdown=markdown)
+
+
+def _parse_bool(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off", ""}:
+        return False
+    raise argparse.ArgumentTypeError(f"invalid boolean value: {value!r}")
+
+
+def _argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate the fail-closed comprehensive CI report.")
+    needs_group = parser.add_mutually_exclusive_group()
+    needs_group.add_argument(
+        "--needs-json",
+        help="GitHub Actions needs context as inline JSON.",
+    )
+    needs_group.add_argument(
+        "--needs-file",
+        type=Path,
+        help="Path containing the GitHub Actions needs context as JSON.",
+    )
+    parser.add_argument(
+        "--artifacts-dir",
+        type=Path,
+        default=Path(os.environ.get("ARTIFACTS_DIR", "test-results")),
+        help="Directory containing downloaded result artifacts.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path(
+            os.environ.get(
+                "REPORT_OUTPUT",
+                "comprehensive-test-report.md",
+            )
+        ),
+        help="Markdown report destination.",
+    )
+    parser.add_argument(
+        "--event-name",
+        default=os.environ.get("GITHUB_EVENT_NAME", "pull_request"),
+        help="GitHub event name.",
+    )
+    parser.add_argument(
+        "--run-extended",
+        nargs="?",
+        const=True,
+        type=_parse_bool,
+        default=_parse_bool(os.environ.get("RUN_EXTENDED", "false")),
+        help="Whether extended SIMD analysis was requested.",
+    )
+    return parser
+
+
+def _read_needs(args: argparse.Namespace) -> Mapping[str, object]:
+    if args.needs_file is not None:
+        payload = json.loads(args.needs_file.read_text(encoding="utf-8"))
+    else:
+        raw_needs = (
+            args.needs_json
+            if args.needs_json is not None
+            else os.environ.get("CI_NEEDS_JSON", os.environ.get("NEEDS_JSON"))
+        )
+        if raw_needs is None:
+            raise ValueError("needs JSON is required via --needs-json, --needs-file, CI_NEEDS_JSON, or NEEDS_JSON")
+        payload = json.loads(raw_needs)
+
+    if not isinstance(payload, dict):
+        raise ValueError("needs JSON must contain an object")
+    return payload
+
+
+def _input_failure(message: str) -> EvaluationResult:
+    errors = (message,)
+    markdown = _build_markdown(
+        passed=False,
+        errors=errors,
+        job_statuses={},
+        manifests={},
+    )
+    return EvaluationResult(passed=False, errors=errors, markdown=markdown)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _argument_parser().parse_args(argv)
+    try:
+        needs = _read_needs(args)
+        result = evaluate_report(
+            needs=needs,
+            artifacts_dir=args.artifacts_dir,
+            event_name=args.event_name,
+            run_extended=args.run_extended,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+        result = _input_failure(f"Unable to load report inputs: {exc}.")
+    except Exception as exc:  # pragma: no cover - last-resort CI fail-closed path
+        result = _input_failure(f"Report aggregation crashed with {type(exc).__name__}: {exc}.")
+
+    try:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(result.markdown, encoding="utf-8")
+    except OSError as exc:
+        print(f"Unable to write report to {args.output}: {exc}", file=sys.stderr)
+        return 1
+
+    print(result.markdown)
+    return 0 if result.passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_comprehensive_report.py
+++ b/tests/scripts/test_comprehensive_report.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""Fail-closed regression tests for the comprehensive CI report.
+
+Issue #5731: the historical report could claim success after discovering zero
+test groups, even when upstream jobs had failed during setup.  These tests
+define the stdlib-only report evaluator contract before its implementation.
+"""
+
+import importlib.util
+import json
+import sys
+from functools import lru_cache
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+REPORT_SCRIPT = REPO_ROOT / "scripts" / "ci" / "comprehensive_report.py"
+
+REQUIRED_JOB_IDS = (
+    "mojo-syntax-check",
+    "mojo-compilation",
+    "example-backward-tests",
+    "training-smoke",
+    "validate-test-coverage",
+    "audit-shared-links",
+    "validate-dep-sync",
+    "test-mojo-comprehensive",
+    "test-configs",
+    "test-benchmarks",
+    "test-core-layers",
+    "test-python",
+    "code-quality",
+    "simd-analysis",
+    "build-validation",
+    "gradient-tests",
+    "gradient-coverage",
+    "test-data-utilities",
+    "test-metrics",
+)
+
+EXPECTED_PRODUCERS = {
+    "comprehensive-core-tensors-loss": "test-mojo-comprehensive",
+    "comprehensive-core-gradient-utils": "test-mojo-comprehensive",
+    "comprehensive-data": "test-mojo-comprehensive",
+    "comprehensive-autograd-tensor-base": "test-mojo-comprehensive",
+    "comprehensive-models-misc": "test-mojo-comprehensive",
+    "comprehensive-integration-bench": "test-mojo-comprehensive",
+    "configs": "test-configs",
+    "benchmarks": "test-benchmarks",
+    "core-layers": "test-core-layers",
+    "python-tests": "test-python",
+    "gradient-checking": "gradient-tests",
+    "data-utilities": "test-data-utilities",
+}
+
+
+@lru_cache(maxsize=1)
+def _load_report_module() -> ModuleType:
+    """Load the planned script lazily so a missing script is a RED assertion."""
+    assert REPORT_SCRIPT.exists(), (
+        "Issue #5731 requires scripts/ci/comprehensive_report.py; "
+        "the fail-closed report evaluator has not been implemented yet."
+    )
+    spec = importlib.util.spec_from_file_location("comprehensive_report", REPORT_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _successful_needs(**overrides: str) -> dict[str, dict[str, str]]:
+    statuses = {job_id: "success" for job_id in REQUIRED_JOB_IDS}
+    statuses.update(overrides)
+    return {job_id: {"result": status} for job_id, status in statuses.items()}
+
+
+def _write_manifest(
+    artifacts_dir: Path,
+    producer: str,
+    *,
+    status: str = "success",
+    location: str | None = None,
+) -> Path:
+    manifest_dir = artifacts_dir / (location or producer)
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = manifest_dir / "outcome-manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "producer": producer,
+                "job_id": EXPECTED_PRODUCERS[producer],
+                "status": status,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def _write_all_successful_manifests(artifacts_dir: Path) -> None:
+    for producer in EXPECTED_PRODUCERS:
+        _write_manifest(artifacts_dir, producer)
+
+
+def _evaluate(
+    *,
+    needs: dict[str, dict[str, str]],
+    artifacts_dir: Path,
+    event_name: str = "pull_request",
+    run_extended: bool = False,
+) -> Any:
+    report = _load_report_module()
+    assert tuple(report.REQUIRED_JOB_IDS) == REQUIRED_JOB_IDS
+    assert dict(report.EXPECTED_PRODUCERS) == EXPECTED_PRODUCERS
+    return report.evaluate_report(
+        needs=needs,
+        artifacts_dir=artifacts_dir,
+        event_name=event_name,
+        run_extended=run_extended,
+    )
+
+
+def test_zero_artifacts_is_a_failure(tmp_path: Path) -> None:
+    result = _evaluate(needs=_successful_needs(), artifacts_dir=tmp_path)
+
+    assert result.passed is False
+    diagnostics = "\n".join(result.errors)
+    for producer in EXPECTED_PRODUCERS:
+        assert producer in diagnostics
+
+
+def test_upstream_failure_cannot_be_hidden_by_passing_manifests(tmp_path: Path) -> None:
+    _write_all_successful_manifests(tmp_path)
+
+    result = _evaluate(
+        needs=_successful_needs(**{"mojo-compilation": "failure"}),
+        artifacts_dir=tmp_path,
+    )
+
+    assert result.passed is False
+    assert any("mojo-compilation" in diagnostic for diagnostic in result.errors)
+    assert "mojo-compilation" in result.markdown
+
+
+def test_unexpected_upstream_job_and_result_are_reported(tmp_path: Path) -> None:
+    _write_all_successful_manifests(tmp_path)
+    needs = _successful_needs()
+    needs["unexpected-setup"] = {"result": "failure"}
+
+    result = _evaluate(needs=needs, artifacts_dir=tmp_path)
+
+    assert result.passed is False
+    assert "unexpected-setup" in result.markdown
+    assert "failure" in result.markdown
+
+
+def test_missing_manifest_is_a_failure(tmp_path: Path) -> None:
+    missing_producer = "python-tests"
+    for producer in EXPECTED_PRODUCERS:
+        if producer != missing_producer:
+            _write_manifest(tmp_path, producer)
+
+    result = _evaluate(needs=_successful_needs(), artifacts_dir=tmp_path)
+
+    assert result.passed is False
+    assert any(missing_producer in diagnostic for diagnostic in result.errors)
+
+
+def test_duplicate_manifest_is_a_failure(tmp_path: Path) -> None:
+    _write_all_successful_manifests(tmp_path)
+    duplicated_producer = "configs"
+    _write_manifest(tmp_path, duplicated_producer, location="duplicate-configs")
+
+    result = _evaluate(needs=_successful_needs(), artifacts_dir=tmp_path)
+
+    assert result.passed is False
+    assert any(duplicated_producer in diagnostic and "duplicate" in diagnostic.lower() for diagnostic in result.errors)
+
+
+@pytest.mark.parametrize(
+    "contents",
+    [
+        "",
+        "not JSON",
+        "[]",
+        '{"producer": "configs"}',
+    ],
+    ids=["empty", "invalid-json", "wrong-json-type", "missing-fields"],
+)
+def test_malformed_manifest_is_a_failure(tmp_path: Path, contents: str) -> None:
+    _write_all_successful_manifests(tmp_path)
+    malformed = tmp_path / "configs" / "outcome-manifest.json"
+    malformed.write_text(contents, encoding="utf-8")
+
+    result = _evaluate(needs=_successful_needs(), artifacts_dir=tmp_path)
+
+    assert result.passed is False
+    assert any("manifest" in diagnostic.lower() for diagnostic in result.errors)
+
+
+def test_unexpected_manifest_is_a_failure(tmp_path: Path) -> None:
+    _write_all_successful_manifests(tmp_path)
+    unexpected_dir = tmp_path / "unexpected"
+    unexpected_dir.mkdir()
+    (unexpected_dir / "outcome-manifest.json").write_text(
+        json.dumps(
+            {
+                "producer": "unexpected-producer",
+                "job_id": "test-python",
+                "status": "success",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _evaluate(needs=_successful_needs(), artifacts_dir=tmp_path)
+
+    assert result.passed is False
+    assert any("unexpected-producer" in diagnostic for diagnostic in result.errors)
+
+
+def test_manifest_status_cannot_contradict_non_matrix_job(tmp_path: Path) -> None:
+    _write_all_successful_manifests(tmp_path)
+    _write_manifest(tmp_path, "configs", status="failure")
+
+    result = _evaluate(needs=_successful_needs(), artifacts_dir=tmp_path)
+
+    assert result.passed is False
+    diagnostics = "\n".join(result.errors)
+    assert "configs" in diagnostics
+    assert "test-configs" in diagnostics
+
+
+def test_manifest_job_mapping_cannot_contradict_contract(tmp_path: Path) -> None:
+    _write_all_successful_manifests(tmp_path)
+    configs_manifest = tmp_path / "configs" / "outcome-manifest.json"
+    configs_manifest.write_text(
+        json.dumps(
+            {
+                "producer": "configs",
+                "job_id": "test-python",
+                "status": "success",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _evaluate(needs=_successful_needs(), artifacts_dir=tmp_path)
+
+    assert result.passed is False
+    diagnostics = "\n".join(result.errors)
+    assert "configs" in diagnostics
+    assert "test-python" in diagnostics
+    assert "test-configs" in diagnostics
+
+
+def test_manifest_at_download_root_is_discovered(tmp_path: Path) -> None:
+    root_level_producer = "configs"
+    for producer in EXPECTED_PRODUCERS:
+        _write_manifest(
+            tmp_path,
+            producer,
+            location="." if producer == root_level_producer else producer,
+        )
+
+    result = _evaluate(needs=_successful_needs(), artifacts_dir=tmp_path)
+
+    assert result.passed is True
+    assert result.errors == () or result.errors == []
+    assert root_level_producer in result.markdown
+
+
+@pytest.mark.parametrize("status", ["skipped", "cancelled"])
+def test_required_job_that_did_not_succeed_is_a_failure(tmp_path: Path, status: str) -> None:
+    _write_all_successful_manifests(tmp_path)
+
+    result = _evaluate(
+        needs=_successful_needs(**{"mojo-compilation": status}),
+        artifacts_dir=tmp_path,
+    )
+
+    assert result.passed is False
+    assert any("mojo-compilation" in diagnostic and status in diagnostic for diagnostic in result.errors)
+
+
+@pytest.mark.parametrize(
+    ("event_name", "run_extended"),
+    [
+        ("pull_request", False),
+        ("push", False),
+        ("workflow_dispatch", False),
+    ],
+)
+def test_simd_skip_is_allowed_when_extended_analysis_is_not_requested(
+    tmp_path: Path,
+    event_name: str,
+    run_extended: bool,
+) -> None:
+    _write_all_successful_manifests(tmp_path)
+
+    result = _evaluate(
+        needs=_successful_needs(**{"simd-analysis": "skipped"}),
+        artifacts_dir=tmp_path,
+        event_name=event_name,
+        run_extended=run_extended,
+    )
+
+    assert result.passed is True
+    assert result.errors == () or result.errors == []
+
+
+def test_extended_dispatch_requires_simd_success(tmp_path: Path) -> None:
+    _write_all_successful_manifests(tmp_path)
+
+    result = _evaluate(
+        needs=_successful_needs(**{"simd-analysis": "skipped"}),
+        artifacts_dir=tmp_path,
+        event_name="workflow_dispatch",
+        run_extended=True,
+    )
+
+    assert result.passed is False
+    assert any("simd-analysis" in diagnostic and "skipped" in diagnostic for diagnostic in result.errors)
+
+
+def test_one_failed_matrix_shard_fails_the_aggregate(tmp_path: Path) -> None:
+    failed_producer = "comprehensive-autograd-tensor-base"
+    _write_all_successful_manifests(tmp_path)
+    _write_manifest(tmp_path, failed_producer, status="failure")
+
+    result = _evaluate(
+        needs=_successful_needs(**{"test-mojo-comprehensive": "failure"}),
+        artifacts_dir=tmp_path,
+    )
+
+    assert result.passed is False
+    evidence = "\n".join((*result.errors, result.markdown))
+    assert failed_producer in evidence
+    assert "test-mojo-comprehensive" in evidence
+
+
+def test_complete_green_contract_passes_and_reports_every_input(tmp_path: Path) -> None:
+    _write_all_successful_manifests(tmp_path)
+
+    result = _evaluate(needs=_successful_needs(), artifacts_dir=tmp_path)
+
+    assert result.passed is True
+    assert result.errors == () or result.errors == []
+    for job_id in REQUIRED_JOB_IDS:
+        assert job_id in result.markdown
+    for producer in EXPECTED_PRODUCERS:
+        assert producer in result.markdown
+    assert "pass rate" not in result.markdown.lower()
+    assert "total tests" not in result.markdown.lower()
+
+
+def test_cli_malformed_input_writes_red_report_before_failing(tmp_path: Path) -> None:
+    report = _load_report_module()
+    output = tmp_path / "report.md"
+
+    return_code = report.main(
+        [
+            "--needs-json",
+            "not-json",
+            "--artifacts-dir",
+            str(tmp_path / "artifacts"),
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert return_code == 1
+    assert output.is_file()
+    contents = output.read_text(encoding="utf-8")
+    assert "❌ FAIL —" in contents
+    assert "Unable to load report inputs" in contents
+
+
+def test_cli_aggregation_crash_writes_red_report_before_failing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    report = _load_report_module()
+    output = tmp_path / "report.md"
+
+    def crash(**_kwargs: object) -> None:
+        raise RuntimeError("simulated aggregation crash")
+
+    monkeypatch.setattr(report, "evaluate_report", crash)
+    return_code = report.main(
+        [
+            "--needs-json",
+            "{}",
+            "--artifacts-dir",
+            str(tmp_path / "artifacts"),
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert return_code == 1
+    assert output.is_file()
+    contents = output.read_text(encoding="utf-8")
+    assert "❌ FAIL —" in contents
+    assert "simulated aggregation crash" in contents

--- a/tests/smoke/test_comprehensive_pr_comments_workflow_properties.py
+++ b/tests/smoke/test_comprehensive_pr_comments_workflow_properties.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Fail-closed properties for the trusted comprehensive PR commenter."""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "comprehensive-test-pr-comments.yml"
+
+
+def _load_job() -> dict[str, Any]:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    job = workflow["jobs"]["post-pr-comments"]
+    assert isinstance(job, dict)
+    return job
+
+
+def test_missing_report_replaces_stale_green_comment_with_failure_fallback() -> None:
+    job = _load_job()
+    steps = job["steps"]
+
+    downloads = {
+        str(step.get("id", "")): step
+        for step in steps
+        if str(step.get("uses", "")).startswith("actions/download-artifact@")
+    }
+    assert set(downloads) == {"download-metrics", "download-report"}
+    assert downloads["download-metrics"].get("continue-on-error") is not True
+    assert downloads["download-report"].get("continue-on-error") is not True
+    assert "discover_artifacts.outputs.has_metrics" in downloads["download-metrics"]["if"]
+    assert "always()" in downloads["download-report"]["if"]
+    assert "discover_artifacts.outputs.has_report" in downloads["download-report"]["if"]
+
+    discovery_step = next(step for step in steps if step.get("id") == "discover_artifacts")
+    assert "actions/github-script@" in discovery_step["uses"]
+    discovery_script = discovery_step["with"]["script"]
+    assert "listWorkflowRunArtifacts" in discovery_script
+    assert "has_metrics" in discovery_script
+    assert "has_report" in discovery_script
+
+    post_step = next(step for step in steps if step.get("name") == "Post or update PR comments")
+    assert post_step.get("if") == "always()"
+
+    environment = post_step.get("env", {})
+    assert environment["REPORT_AVAILABLE"] == ("${{ steps.discover_artifacts.outputs.has_report }}")
+    assert environment["METRICS_AVAILABLE"] == ("${{ steps.discover_artifacts.outputs.has_metrics }}")
+    assert environment["REPORT_DOWNLOAD_OUTCOME"] == ("${{ steps.download-report.outcome }}")
+    assert environment["METRICS_DOWNLOAD_OUTCOME"] == ("${{ steps.download-metrics.outcome }}")
+    assert environment["WORKFLOW_RUN_URL"] == ("${{ github.event.workflow_run.html_url }}")
+    assert environment["WORKFLOW_CONCLUSION"] == ("${{ github.event.workflow_run.conclusion }}")
+
+    script = post_step["with"]["script"]
+    assert "REPORT_DOWNLOAD_OUTCOME" in script
+    assert "WORKFLOW_RUN_URL" in script
+    assert "WORKFLOW_CONCLUSION" in script
+    assert "🧪 Comprehensive Test Results" in script
+    assert "report unavailable" in script.lower()
+
+
+def test_commenter_rejects_stale_runs_and_verdict_mismatches() -> None:
+    job = _load_job()
+    concurrency = job.get("concurrency", {})
+    assert "pull_requests[0].number" in str(concurrency.get("group", ""))
+    assert concurrency.get("cancel-in-progress") is True
+
+    post_step = next(step for step in job["steps"] if step.get("name") == "Post or update PR comments")
+    script = post_step["with"]["script"]
+
+    assert "github.rest.pulls.get" in script
+    assert "workflow_run.pull_requests[0]" in script
+    assert "head?.sha" in script
+    assert "pullRequest.head.sha" in script
+    assert "Stale workflow run" in script
+
+    assert "WORKFLOW_CONCLUSION" in script
+    assert "✅ PASS —" in script
+    assert "❌ FAIL —" in script
+    assert "does not match the workflow conclusion" in script
+    assert "try {" in script
+    assert "catch" in script

--- a/tests/smoke/test_comprehensive_report_workflow_properties.py
+++ b/tests/smoke/test_comprehensive_report_workflow_properties.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Workflow contracts for the fail-closed comprehensive Test Report.
+
+These tests intentionally inspect behavior-bearing workflow structure rather
+than report prose.  They prevent a newly added job or a setup-time artifact
+failure from silently escaping the aggregate gate.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "comprehensive-tests.yml"
+WORKFLOW_SMOKE_PATH = REPO_ROOT / ".github" / "workflows" / "workflow-smoke-test.yml"
+
+EXPECTED_UPSTREAM_JOB_IDS = {
+    "mojo-syntax-check",
+    "mojo-compilation",
+    "example-backward-tests",
+    "training-smoke",
+    "validate-test-coverage",
+    "audit-shared-links",
+    "validate-dep-sync",
+    "test-mojo-comprehensive",
+    "test-configs",
+    "test-benchmarks",
+    "test-core-layers",
+    "test-python",
+    "code-quality",
+    "simd-analysis",
+    "build-validation",
+    "gradient-tests",
+    "gradient-coverage",
+    "test-data-utilities",
+    "test-metrics",
+}
+
+EXPECTED_PRODUCERS_BY_JOB = {
+    "test-mojo-comprehensive": {
+        "comprehensive-core-tensors-loss",
+        "comprehensive-core-gradient-utils",
+        "comprehensive-data",
+        "comprehensive-autograd-tensor-base",
+        "comprehensive-models-misc",
+        "comprehensive-integration-bench",
+    },
+    "test-configs": {"configs"},
+    "test-benchmarks": {"benchmarks"},
+    "test-core-layers": {"core-layers"},
+    "test-python": {"python-tests"},
+    "gradient-tests": {"gradient-checking"},
+    "test-data-utilities": {"data-utilities"},
+}
+
+
+def _load_workflow() -> dict[str, Any]:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+    assert isinstance(workflow.get("jobs"), dict)
+    return workflow
+
+
+def _steps_for(job: dict[str, Any]) -> list[dict[str, Any]]:
+    steps = job.get("steps")
+    assert isinstance(steps, list)
+    assert all(isinstance(step, dict) for step in steps)
+    return steps
+
+
+def _serialized(value: object) -> str:
+    return json.dumps(value, sort_keys=True)
+
+
+def test_test_report_needs_exactly_every_other_top_level_job() -> None:
+    jobs = _load_workflow()["jobs"]
+    assert set(jobs) - {"test-report"} == EXPECTED_UPSTREAM_JOB_IDS
+
+    needs = jobs["test-report"].get("needs")
+    assert isinstance(needs, list)
+    assert len(needs) == len(set(needs)), "test-report.needs must not contain duplicate job IDs"
+    assert set(needs) == EXPECTED_UPSTREAM_JOB_IDS
+    assert set(needs) == set(jobs) - {"test-report"}
+
+
+def test_each_result_producer_writes_an_always_run_outcome_manifest() -> None:
+    jobs = _load_workflow()["jobs"]
+
+    for job_id, producers in EXPECTED_PRODUCERS_BY_JOB.items():
+        manifest_steps = [step for step in _steps_for(jobs[job_id]) if "outcome-manifest.json" in _serialized(step)]
+        assert len(manifest_steps) == 1, f"{job_id} must have exactly one step that writes outcome-manifest.json"
+
+        manifest_step = manifest_steps[0]
+        serialized = _serialized(manifest_step)
+        assert manifest_step.get("if") == "always()"
+        assert "${{ job.status }}" in serialized
+        assert "mkdir -p test-results" in serialized
+        assert '"producer"' in serialized
+        assert '"job_id"' in serialized
+        assert '"status"' in serialized
+
+        if job_id == "test-mojo-comprehensive":
+            assert "${{ matrix.group }}" in serialized
+            assert "comprehensive-" in serialized
+        else:
+            producer = next(iter(producers))
+            assert producer in serialized
+            assert job_id in serialized
+
+
+def test_each_result_producer_upload_is_fail_closed_and_always_runs() -> None:
+    jobs = _load_workflow()["jobs"]
+
+    for job_id in EXPECTED_PRODUCERS_BY_JOB:
+        uploads = [
+            step
+            for step in _steps_for(jobs[job_id])
+            if "actions/upload-artifact@" in str(step.get("uses", ""))
+            and str(step.get("with", {}).get("name", "")).startswith("test-results-")
+        ]
+        assert len(uploads) == 1, f"{job_id} must upload exactly one test-results artifact"
+
+        upload = uploads[0]
+        assert upload.get("if") == "always()"
+        assert upload.get("with", {}).get("if-no-files-found") == "error"
+        assert "test-results" in str(upload.get("with", {}).get("path", ""))
+
+
+def test_report_job_passes_needs_json_to_the_stdlib_validator() -> None:
+    report_job = _load_workflow()["jobs"]["test-report"]
+    serialized = _serialized(report_job)
+
+    assert "${{ toJSON(needs) }}" in serialized
+    assert "scripts/ci/comprehensive_report.py" in serialized
+    validator_step = next(
+        step for step in _steps_for(report_job) if "scripts/ci/comprehensive_report.py" in str(step.get("run", ""))
+    )
+    validator_command = validator_step["run"]
+    assert "--artifacts-dir all-results" in validator_command
+    assert "--output test-report.md" in validator_command
+    assert '--event-name "$EVENT_NAME"' in validator_command
+    assert '--run-extended "$RUN_EXTENDED"' in validator_command
+
+    report_uploads = [
+        step
+        for step in _steps_for(report_job)
+        if "actions/upload-artifact@" in str(step.get("uses", ""))
+        and step.get("with", {}).get("name") == "comprehensive-test-report"
+    ]
+    assert len(report_uploads) == 1
+    upload = report_uploads[0]
+    assert upload.get("if") == "always()"
+    assert upload.get("with", {}).get("path") == "test-report.md"
+    assert upload.get("with", {}).get("if-no-files-found") == "error"
+
+
+def test_result_download_preserves_artifact_directories_for_recursive_discovery() -> None:
+    report_job = _load_workflow()["jobs"]["test-report"]
+    downloads = [step for step in _steps_for(report_job) if "actions/download-artifact@" in str(step.get("uses", ""))]
+    assert len(downloads) == 1
+    assert downloads[0].get("with", {}).get("merge-multiple") is False
+
+
+def test_workflow_smoke_job_runs_report_property_suites() -> None:
+    smoke_workflow = WORKFLOW_SMOKE_PATH.read_text(encoding="utf-8")
+    assert "test_comprehensive_report_workflow_properties.py" in smoke_workflow
+    assert "test_comprehensive_pr_comments_workflow_properties.py" in smoke_workflow

--- a/tests/smoke/test_merge_queue_workflow_properties.py
+++ b/tests/smoke/test_merge_queue_workflow_properties.py
@@ -184,6 +184,8 @@ def test_existing_pull_request_and_push_triggers_are_preserved() -> None:
         "docker-compose.yml",
         "justfile",
         "scripts/ci/ensure-podman-runtime.sh",
+        "tests/smoke/test_comprehensive_pr_comments_workflow_properties.py",
+        "tests/smoke/test_comprehensive_report_workflow_properties.py",
         "tests/smoke/test_comprehensive_tests_workflow_properties.py",
         "tests/smoke/test_container_runtime_workflow_properties.py",
         "tests/smoke/test_merge_queue_workflow_properties.py",


### PR DESCRIPTION
## Summary

Replaces the false-green Comprehensive Test Report with a fail-closed gate while preserving the test-report job ID, Test Report check name, report artifact, and PR comment marker.

## Changes Made

- Treats all 19 upstream job results as authoritative, with only the intentional non-extended SIMD skip allowed.
- Requires 12 complete, valid, recursively discovered producer manifests.
- Rejects missing, duplicate, malformed, unexpected, contradictory, failed, cancelled, and required skipped inputs.
- Removes synthetic global test counts and pass-rate claims.
- Always writes and uploads a diagnostic report before returning the verdict.
- Makes PR comments resilient to missing metrics/reports, conclusion mismatches, and stale workflow runs.
- Adds unit, CLI, workflow-property, artifact-layout, and exact job-inventory regression coverage.

## Verification

- 1,228 Python tests passed; 228 skipped in the signed pre-push suite.
- 133 focused report, workflow-property, and action-pin tests passed.
- Required pre-commit hooks passed.
- Commit signature verified locally.

Closes #5731