### PR TITLE
fix(tests): align Muon delegation with documented defaults

### DIFF
--- a/tests/odyssey/training/test_dispatch.mojo
+++ b/tests/odyssey/training/test_dispatch.mojo
@@ -143,7 +143,7 @@ def test_loop_all_24_known() raises:
     print("  ok all 24 names return non-empty defaults")
 
 
-def _make_dummy_params() -> List[AnyTensor]:
+def _make_dummy_params() raises -> List[AnyTensor]:
     """Build a small 2-parameter list for state allocation tests.
 
     Both params are rank-2 with both dims >= 4 — large enough to satisfy

--- a/tests/odyssey/training/test_muon.mojo
+++ b/tests/odyssey/training/test_muon.mojo
@@ -537,7 +537,7 @@ def test_muon_step_simple() raises:
         on `new_params` AND `new_momentum` across two paths: zero-grad
         (exercises the orthogonalized-momentum init) and non-zero-grad
         (exercises the actual Muon update). Defaults match muon.mojo:
-        momentum_beta=0.95, weight_decay=0.0, nesterov=True, ns_steps=5.
+        momentum_beta=0.95, weight_decay=0.01, nesterov=True, ns_steps=5.
     """
     # --- Pass 1: zero gradients ---
     var shape: List[Int] = [4, 4]
@@ -552,7 +552,7 @@ def test_muon_step_simple() raises:
         mom_f1,
         learning_rate=0.01,
         momentum_beta=0.95,
-        weight_decay=0.0,
+        weight_decay=0.01,
         nesterov=True,
         ns_steps=5,
     )
@@ -597,7 +597,7 @@ def test_muon_step_simple() raises:
         mom_full,
         learning_rate=0.01,
         momentum_beta=0.95,
-        weight_decay=0.0,
+        weight_decay=0.01,
         nesterov=True,
         ns_steps=5,
     )


### PR DESCRIPTION
## Summary

Repairs the two deterministic failures in main's
`Comprehensive Mojo Tests (autograd-tensor-base)` job without changing
production code.

## Changes Made

- Marks `_make_dummy_params()` as `raises` because its `zeros()` calls use the
  documented raising API.
- Compares `muon_step_simple()` with `muon_step()` using the same documented
  `weight_decay=0.01` delegation default in both zero- and non-zero-gradient
  paths.
- Retains only the two issue-specific test-file edits on top of the repaired
  container main SHA.

## Verification

- Reproduced the dispatch compiler error and exact Muon divergence
  `0.00010001659393310547` before the changes.
- Both focused Mojo test executables pass after the changes.
- Mojo formatting, pre-commit, test coverage validation, and `git diff --check`
  pass.
- The replacement commit is signed and will be GitHub-verified before merge.

Closes #5727
