### PR TITLE
fix(security): audit locked dependencies fail closed

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,9 +23,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  security-events: write
-  issues: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -68,6 +65,9 @@ jobs:
   sast-scan:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout code
@@ -133,7 +133,6 @@ jobs:
         with:
           fail-on-severity: high
           deny-licenses: GPL-3.0, AGPL-3.0
-          comment-summary-in-pr: always
 
   # ============================================================================
   # Security Report
@@ -144,9 +143,6 @@ jobs:
     if: always()
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
       - name: Generate security report
         run: |
           echo "# 🔐 Security Scan Results" > security-report.md
@@ -186,18 +182,17 @@ jobs:
           cat security-report.md
 
       - name: Upload security report
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: security-report
           path: security-report.md
           retention-days: 90
+          if-no-files-found: error
 
-      - name: Comment on PR
-        if: github.event_name == 'pull_request'
-        uses: ./.github/actions/pr-comment
-        with:
-          report-file: security-report.md
-          comment-marker: "\U0001F510 Security Scan Results"
+      # PR comments are intentionally omitted here. A pull_request workflow
+      # executes PR-controlled code, so it must retain the top-level read-only
+      # token rather than loading a local comment action with write authority.
 
       - name: Fail if secrets detected
         run: |
@@ -220,114 +215,63 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
-        with:
-          python-version: '3.11'
-          cache: 'pip'
+      - name: Set up uv
+        uses: ./.github/actions/setup-uv
 
-      - name: Install audit tools
-        run: |
-          python -m pip install --upgrade pip
-          pip install safety pip-audit
-
-      - name: Audit with Safety
-        id: safety
-        run: |
-          echo "## Safety Scan Results" > safety-report.md
-          echo "" >> safety-report.md
-
-          FILES_SCANNED=0
-          VULN_COUNT=0
-
-          for file in requirements.txt requirements-dev.txt; do
-            if [ -f "$file" ]; then
-              echo "### $file" >> safety-report.md
-              echo "" >> safety-report.md
-              FILES_SCANNED=$((FILES_SCANNED + 1))
-
-              if safety check --file "$file" --json > "safety-${file//\//-}.json" 2>/dev/null; then
-                echo "✅ No vulnerabilities found" >> safety-report.md
-              else
-                FOUND=$(jq '.vulnerabilities | length' "safety-${file//\//-}.json" 2>/dev/null || echo "0")
-                VULN_COUNT=$((VULN_COUNT + FOUND))
-                echo "⚠️ Found $FOUND vulnerabilities" >> safety-report.md
-                # Append advisory list when jq can parse the report; emit a
-                # placeholder line otherwise so reviewers see the malformed file.
-                if ! jq -r '.vulnerabilities[] | "- **\(.package_name)** \(.vulnerable_versions): \(.advisory)"' \
-                        "safety-${file//\//-}.json" >> safety-report.md 2>/dev/null; then
-                  echo "- (could not parse safety report for $file)" >> safety-report.md
-                fi
-              fi
-              echo "" >> safety-report.md
-            fi
-          done
-
-          echo "files_scanned=$FILES_SCANNED" >> "$GITHUB_OUTPUT"
-          echo "vulnerabilities=$VULN_COUNT" >> "$GITHUB_OUTPUT"
-        # No `continue-on-error`: the script consumes all sub-step exit codes
-        # itself (every `safety check` and `jq` is wrapped in `if`/`if !`), so
-        # the step's exit code already reflects only real script failures.
-
-      - name: Audit with pip-audit
+      - name: Audit requirements-dev.txt with pip-audit
         id: pip_audit
-        # NOTE: pip-audit ran with `continue-on-error: true` historically — that
-        # silently masked installation failures. The `if !` blocks below now
-        # log the failure as a warning but still allow downstream summary jobs
-        # to run because the step itself exits 0 when only requirements are
-        # missing (requirements*.txt is not always present in this repo).
         run: |
-          echo "## pip-audit Scan Results" > pip-audit-report.md
-          echo "" >> pip-audit-report.md
+          set -euo pipefail
 
-          # Install whichever requirements*.txt are present. These files are
-          # auto-generated stubs (essentially empty) in this repo, but we still
-          # honour them if a branch carries real deps. pip install is fail-fast:
-          # a real install error means the audit cannot trust its result, so we
-          # let the step exit non-zero and require a fix rather than emitting an
-          # advisory warning (see HomericIntelligence/Odysseus#282 Bucket F).
-          req_args=()
-          for r in requirements.txt requirements-dev.txt; do
-            [ -f "$r" ] && req_args+=("-r" "$r")
-          done
-          if [ "${#req_args[@]}" -gt 0 ]; then
-            pip install "${req_args[@]}"
-          fi
+          set +e
+          uv run --frozen pip-audit --strict --no-deps --disable-pip --requirement requirements-dev.txt \
+            --format json --output pip-audit.json
+          audit_rc=$?
+          set -e
 
-          if pip-audit --format json --output pip-audit.json 2>/dev/null; then
-            echo "✅ No vulnerabilities found" >> pip-audit-report.md
-            echo "count=0" >> "$GITHUB_OUTPUT"
-          else
-            COUNT=$(jq '. | length' pip-audit.json 2>/dev/null || echo "0")
-            echo "⚠️ Found $COUNT vulnerabilities" >> pip-audit-report.md
-            echo "count=$COUNT" >> "$GITHUB_OUTPUT"
-            if ! jq -r '.[] | "- **\(.name)** \(.version): \(.vulns[0].id // \"Unknown\")"' \
-                    pip-audit.json >> pip-audit-report.md 2>/dev/null; then
-              echo "- (could not parse pip-audit output)" >> pip-audit-report.md
-            fi
+          uv run --frozen python scripts/ci/parse_pip_audit.py \
+            --input pip-audit.json \
+            --requirements requirements-dev.txt \
+            --audit-exit-code "$audit_rc" \
+            --report pip-audit-report.md \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Write Python audit manifest
+        if: always()
+        env:
+          AUDIT_STATUS: ${{ job.status }}
+          AUDIT_VERDICT: ${{ steps.pip_audit.outputs.verdict || 'operational' }}
+          AUDIT_FINDINGS: ${{ steps.pip_audit.outputs.count || 'unknown' }}
+          AUDIT_DIAGNOSTIC: ${{ steps.pip_audit.outputs.diagnostic || 'pip-audit did not produce a verdict' }}
+        run: |
+          if [ ! -s pip-audit-report.md ]; then
+            {
+              echo "## pip-audit Scan Results"
+              echo ""
+              echo "❌ Audit failed: $AUDIT_DIAGNOSTIC"
+              echo ""
+              echo "No vulnerability verdict is available for this audit."
+            } > pip-audit-report.md
           fi
+          python scripts/ci/dependency_audit_contract.py manifest \
+            --producer python-audit \
+            --status "$AUDIT_STATUS" \
+            --verdict "$AUDIT_VERDICT" \
+            --findings "$AUDIT_FINDINGS" \
+            --report pip-audit-report.md \
+            --output python-audit-manifest.json
 
       - name: Upload Python audit results
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: python-audit-results
           path: |
-            safety-*.json
             pip-audit.json
-            safety-report.md
             pip-audit-report.md
+            python-audit-manifest.json
           retention-days: 30
-
-      - name: Set Python audit outputs
-        id: python_summary
-        run: |
-          SAFETY_VULNS="${{ steps.safety.outputs.vulnerabilities }}"
-          PIP_VULNS="${{ steps.pip_audit.outputs.count }}"
-          TOTAL=$((${SAFETY_VULNS:-0} + ${PIP_VULNS:-0}))
-          echo "total_vulnerabilities=$TOTAL" >> "$GITHUB_OUTPUT"
-
-    outputs:
-      vulnerabilities: ${{ steps.python_summary.outputs.total_vulnerabilities }}
+          if-no-files-found: error
 
   # ============================================================================
   # Pixi/Conda Dependency Audit (scheduled / workflow_dispatch only)
@@ -346,76 +290,100 @@ jobs:
 
       - name: Audit uv dependencies
         run: |
+          set -euo pipefail
           echo "## uv Dependency Audit" > pixi-audit-report.md
           echo "" >> pixi-audit-report.md
           echo "### Installed Packages" >> pixi-audit-report.md
           echo "" >> pixi-audit-report.md
           echo "\`\`\`" >> pixi-audit-report.md
-          uv tree >> pixi-audit-report.md 2>&1 || echo "Failed to list packages"
+          uv tree >> pixi-audit-report.md 2>&1
           echo "\`\`\`" >> pixi-audit-report.md
           echo "" >> pixi-audit-report.md
 
           echo "### Version Check" >> pixi-audit-report.md
           echo "" >> pixi-audit-report.md
-          echo "Mojo version: $(uv run mojo --version 2>/dev/null | head -1)" >> pixi-audit-report.md
+          uv run --frozen mojo --version >> pixi-audit-report.md
 
       - name: Audit PyPI packages from the uv lockfile
-        # pip-audit covers the PyPI-sourced packages resolved into uv.lock.
-        # No public CVE feed exists for the Mojo compiler binaries themselves;
-        # those are tracked via manual review — see SECURITY-AUDIT.md.
+        id: pip_audit
         run: |
-          pip install pip-audit 2>/dev/null
+          set -euo pipefail
 
           echo "" >> pixi-audit-report.md
-          echo "### PyPI Package CVE Scan (pip-audit)" >> pixi-audit-report.md
+          echo "### Complete lock-derived CVE Scan (pip-audit)" >> pixi-audit-report.md
           echo "" >> pixi-audit-report.md
 
-          # Export the fully-resolved, pinned dependency set from uv.lock. Skip
-          # the mojo compiler chain (from the Modular index) — pip-audit cannot
-          # resolve those against PyPI's advisory DB and they have no PyPI CVE feed.
-          if ! uv export --frozen --no-hashes --no-emit-project --all-groups \
-              > uv-requirements.txt 2>/dev/null; then
-            : > uv-requirements.txt
+          # The unfiltered export is authoritative. Do not silently exclude the
+          # compiler toolchain or any package without an advisory record.
+          uv export --frozen --no-hashes --no-emit-project --all-groups > uv-requirements.txt
+          test -s uv-requirements.txt
+
+          PKG_COUNT=$(awk '/^[A-Za-z0-9_.-]+==/ { count++ } END { print count + 0 }' uv-requirements.txt)
+          if [ "$PKG_COUNT" -eq 0 ]; then
+            echo "uv.lock export did not contain any dependencies" >&2
+            exit 1
           fi
-          # grep -v exits 1 when it filters out every line; guard with `set +e`
-          # so an all-filtered result is not treated as a pipeline failure.
-          set +e
-          grep -viE '^(mojo|mojo-compiler|mojo-compiler-mojo-libs|mojo-lldb-libs|mblack)==' \
-            uv-requirements.txt > pypi-from-uv.txt
-          PKG_COUNT=$(grep -cE '==' pypi-from-uv.txt)
-          set -e
-          [ -z "$PKG_COUNT" ] && PKG_COUNT=0
           echo "Packages extracted from uv.lock: $PKG_COUNT" >> pixi-audit-report.md
           echo "" >> pixi-audit-report.md
 
-          if [ "$PKG_COUNT" -gt 0 ]; then
-            if pip-audit --requirement pypi-from-uv.txt \
-                --format json --output pixi-pypi-audit.json 2>/dev/null; then
-              echo "No CVEs found in PyPI packages from uv.lock" >> pixi-audit-report.md
-            else
-              COUNT=$(python3 -c "import json,sys; d=json.load(open('pixi-pypi-audit.json')); print(len(d))" 2>/dev/null || echo "?")
-              echo "WARNING: $COUNT vulnerable PyPI package(s) found — review pixi-pypi-audit.json" >> pixi-audit-report.md
-            fi
-          else
-            echo "No PyPI packages found in uv.lock — skipping pip-audit." >> pixi-audit-report.md
-          fi
+          set +e
+          uv run --frozen pip-audit --strict --no-deps --disable-pip --requirement uv-requirements.txt \
+            --format json --output pixi-pypi-audit.json
+          audit_rc=$?
+          set -e
+
+          set +e
+          uv run --frozen python scripts/ci/parse_pip_audit.py \
+            --input pixi-pypi-audit.json \
+            --requirements uv-requirements.txt \
+            --audit-exit-code "$audit_rc" \
+            --report pixi-pip-audit-report.md \
+            --github-output "$GITHUB_OUTPUT"
+          parser_rc=$?
+          set -e
+          cat pixi-pip-audit-report.md >> pixi-audit-report.md
 
           echo "" >> pixi-audit-report.md
-          echo "### Conda-Native Package Gap" >> pixi-audit-report.md
-          echo "" >> pixi-audit-report.md
-          echo "No automated CVE feed covers conda-forge packages (including the Mojo" >> pixi-audit-report.md
-          echo "runtime). These are reviewed manually per .github/SECURITY-AUDIT.md." >> pixi-audit-report.md
+          exit "$parser_rc"
+
+      - name: Write Pixi audit manifest
+        if: always()
+        env:
+          AUDIT_STATUS: ${{ job.status }}
+          AUDIT_VERDICT: ${{ steps.pip_audit.outputs.verdict || 'operational' }}
+          AUDIT_FINDINGS: ${{ steps.pip_audit.outputs.count || 'unknown' }}
+          AUDIT_DIAGNOSTIC: ${{ steps.pip_audit.outputs.diagnostic || 'lock-derived audit did not produce a verdict' }}
+        run: |
+          if [ ! -s pixi-audit-report.md ]; then
+            {
+              echo "## uv Dependency Audit"
+              echo ""
+              echo "❌ Audit failed: $AUDIT_DIAGNOSTIC"
+              echo ""
+              echo "No vulnerability verdict is available for this audit."
+            } > pixi-audit-report.md
+          fi
+          python scripts/ci/dependency_audit_contract.py manifest \
+            --producer pixi-audit \
+            --status "$AUDIT_STATUS" \
+            --verdict "$AUDIT_VERDICT" \
+            --findings "$AUDIT_FINDINGS" \
+            --report pixi-audit-report.md \
+            --output pixi-audit-manifest.json
 
       - name: Upload Pixi audit results
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: pixi-audit-results
           path: |
             pixi-audit-report.md
             uv-requirements.txt
-            pypi-from-uv.txt
             pixi-pypi-audit.json
+            pixi-pip-audit-report.md
+            pixi-audit-manifest.json
           retention-days: 30
+          if-no-files-found: error
 
   # ============================================================================
   # License Compliance Audit (scheduled / workflow_dispatch only)
@@ -429,58 +397,99 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-
-      - name: Install license checker
-        run: pip install pip-licenses
+      - name: Set up uv
+        uses: ./.github/actions/setup-uv
 
       - name: Check licenses
+        id: license
         run: |
-          # Install whichever requirements*.txt are present. pip install runs
-          # fail-fast: a real install failure means the license report would be
-          # incomplete, so we require a real fix rather than an advisory warning
-          # (see HomericIntelligence/Odysseus#282 Bucket F).
-          req_args=()
-          for r in requirements.txt requirements-dev.txt; do
-            [ -f "$r" ] && req_args+=("-r" "$r")
-          done
-          if [ "${#req_args[@]}" -gt 0 ]; then
-            pip install "${req_args[@]}"
-          fi
-
+          set -euo pipefail
           echo "## License Audit Report" > license-report.md
           echo "" >> license-report.md
           echo "### All Package Licenses" >> license-report.md
           echo "" >> license-report.md
-          if ! pip-licenses --format=markdown >> license-report.md 2>/dev/null; then
-            echo "Failed to generate license report" >> license-report.md
+
+          set +e
+          uv run --frozen pip-licenses --format=markdown > license-table.md 2>license-error.txt
+          license_rc=$?
+          set -e
+          if [ "$license_rc" -ne 0 ]; then
+            echo "❌ License inventory failed (exit code $license_rc)" >> license-report.md
+            cat license-error.txt >> license-report.md
+            echo "count=unknown" >> "$GITHUB_OUTPUT"
+            echo "verdict=operational" >> "$GITHUB_OUTPUT"
+            echo "diagnostic=license inventory failed with exit code $license_rc" >> "$GITHUB_OUTPUT"
+            exit "$license_rc"
           fi
+          cat license-table.md >> license-report.md
 
           echo "" >> license-report.md
           echo "### License Compliance" >> license-report.md
           echo "" >> license-report.md
 
-          # `pip-licenses --fail-on` exits non-zero when a problematic license
-          # is detected — that's the signal we want, not an error condition.
           set +e
-          PROBLEMATIC=$(pip-licenses --fail-on="GPL-3.0;AGPL-3.0" 2>&1)
+          uv run --frozen pip-licenses --format=markdown \
+            --fail-on="GPL-3.0;AGPL-3.0" > license-compliance.md 2>license-error.txt
+          license_rc=$?
           set -e
-          if echo "$PROBLEMATIC" | grep -q "fail"; then
-            echo "⚠️ Potentially problematic licenses detected" >> license-report.md
-          else
+
+          cat license-compliance.md >> license-report.md
+          if [ "$license_rc" -eq 0 ]; then
             echo "✅ No problematic licenses (GPL-3.0, AGPL-3.0) found" >> license-report.md
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            echo "verdict=success" >> "$GITHUB_OUTPUT"
+            echo "diagnostic=No denied licenses found" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          cat license-error.txt >> license-report.md
+          echo "❌ Denied license finding or license checker failure (exit code $license_rc)" >> license-report.md
+          echo "count=unknown" >> "$GITHUB_OUTPUT"
+          if [ "$license_rc" -eq 1 ]; then
+            echo "verdict=findings" >> "$GITHUB_OUTPUT"
+          else
+            echo "verdict=operational" >> "$GITHUB_OUTPUT"
+          fi
+          echo "diagnostic=license compliance failed with exit code $license_rc" >> "$GITHUB_OUTPUT"
+          exit "$license_rc"
+
+      - name: Write License audit manifest
+        if: always()
+        env:
+          AUDIT_STATUS: ${{ job.status }}
+          AUDIT_VERDICT: ${{ steps.license.outputs.verdict || 'operational' }}
+          AUDIT_FINDINGS: ${{ steps.license.outputs.count || 'unknown' }}
+          AUDIT_DIAGNOSTIC: ${{ steps.license.outputs.diagnostic || 'license audit did not produce a verdict' }}
+        run: |
+          if [ ! -s license-report.md ]; then
+            {
+              echo "## License Audit Report"
+              echo ""
+              echo "❌ Audit failed: $AUDIT_DIAGNOSTIC"
+              echo ""
+              echo "No license verdict is available for this audit."
+            } > license-report.md
+          fi
+          python scripts/ci/dependency_audit_contract.py manifest \
+            --producer license-audit \
+            --status "$AUDIT_STATUS" \
+            --verdict "$AUDIT_VERDICT" \
+            --findings "$AUDIT_FINDINGS" \
+            --report license-report.md \
+            --output license-audit-manifest.json
 
       - name: Upload license audit
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: license-audit-results
-          path: license-report.md
+          path: |
+            license-report.md
+            license-table.md
+            license-compliance.md
+            license-error.txt
+            license-audit-manifest.json
           retention-days: 30
+          if-no-files-found: error
 
   # ============================================================================
   # Dependency Audit Report (scheduled / workflow_dispatch only)
@@ -488,83 +497,89 @@ jobs:
   audit-report:
     needs: [python-audit, pixi-audit, license-audit]
     runs-on: ubuntu-latest
-    if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    if: >-
+      always() &&
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    permissions:
+      contents: read
+      issues: write
 
     steps:
-      - name: Checkout code
+      - name: Checkout trusted report validator
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
 
-      - name: Download all artifacts
+      - name: Download Python audit artifact
+        if: always()
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
-          path: audit-results/
+          name: python-audit-results
+          path: audit-results/python-audit-results
 
-      - name: Generate combined report
+      - name: Download Pixi audit artifact
+        if: always()
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          name: pixi-audit-results
+          path: audit-results/pixi-audit-results
+
+      - name: Download license audit artifact
+        if: always()
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          name: license-audit-results
+          path: audit-results/license-audit-results
+
+      - name: Generate and validate combined report
+        id: aggregate
+        if: always()
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
-          echo "# 🔍 Dependency Audit Report" > combined-report.md
-          echo "" >> combined-report.md
-          echo "**Generated**: $(date -u +%Y-%m-%d)" >> combined-report.md
-          echo "**Workflow Run**: [${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> combined-report.md
-          echo "" >> combined-report.md
-
-          echo "## Summary" >> combined-report.md
-          echo "" >> combined-report.md
-          echo "| Audit Type | Status |" >> combined-report.md
-          echo "|------------|--------|" >> combined-report.md
-          echo "| Python Dependencies | ${{ needs.python-audit.result }} |" >> combined-report.md
-          echo "| Pixi/Conda Dependencies | ${{ needs.pixi-audit.result }} |" >> combined-report.md
-          echo "| License Compliance | ${{ needs.license-audit.result }} |" >> combined-report.md
-          echo "" >> combined-report.md
-
-          VULNS="${{ needs.python-audit.outputs.vulnerabilities }}"
-          if [ "${VULNS:-0}" -gt 0 ]; then
-            echo "⚠️ **$VULNS Python vulnerabilities found** - Review required" >> combined-report.md
-          else
-            echo "✅ No Python vulnerabilities detected" >> combined-report.md
-          fi
-          echo "" >> combined-report.md
-
-          echo "---" >> combined-report.md
-          echo "" >> combined-report.md
-
-          for report in audit-results/**/*.md; do
-            if [ -f "$report" ]; then
-              echo "" >> combined-report.md
-              cat "$report" >> combined-report.md
-              echo "" >> combined-report.md
-            fi
-          done
+          python scripts/ci/dependency_audit_contract.py aggregate \
+            --artifacts audit-results \
+            --needs-json "$NEEDS_JSON" \
+            --report combined-report.md
 
       - name: Upload combined report
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: dependency-audit-report
           path: combined-report.md
           retention-days: 90
+          if-no-files-found: error
 
-      - name: Create issue for vulnerabilities
-        if: needs.python-audit.outputs.vulnerabilities > 0
+      - name: Create issue for failed dependency audit
+        if: always() && steps.aggregate.outcome == 'failure'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          VULNS="${{ needs.python-audit.outputs.vulnerabilities }}"
           WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          EXISTING=$(gh issue list --search "Security vulnerabilities found in:dependencies" --state open --json number --jq '.[0].number // ""')
+          EXISTING=$(gh issue list --search "Dependency security audit failed in:title" --state open --json number --jq '.[0].number // ""')
 
           if [ -n "$EXISTING" ]; then
-            gh issue comment "$EXISTING" --body "Audit update ($(date -u +%Y-%m-%d)): Found $VULNS vulnerabilities. See workflow run at $WORKFLOW_URL for details."
+            gh issue comment "$EXISTING" --body "Audit update ($(date -u +%Y-%m-%d)): the dependency audit failed closed. See $WORKFLOW_URL and its combined report artifact."
           else
             gh issue create \
-              --title "Security vulnerabilities found in dependencies" \
-              --body "## Summary\n\nFound $VULNS vulnerabilities. Review the audit at $WORKFLOW_URL" \
+              --title "Dependency security audit failed" \
+              --body "## Summary\n\nA dependency audit reported findings, failed operationally, or produced incomplete evidence. Review $WORKFLOW_URL and its combined report artifact." \
               --label "security" \
               --label "dependencies" \
               --label "automated"
           fi
 
       - name: Write summary
+        if: always()
         run: |
           echo "## Dependency Audit Complete" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          cat combined-report.md >> "$GITHUB_STEP_SUMMARY"
+          if [ -s combined-report.md ]; then
+            cat combined-report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "❌ Combined report was not generated." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi

--- a/.github/workflows/workflow-smoke-test.yml
+++ b/.github/workflows/workflow-smoke-test.yml
@@ -2,7 +2,7 @@ name: Workflow Smoke Tests
 
 # Fast-fail gate that validates workflow properties without heavy setup.
 # Guards against regression of gaps fixed in #3143 and #3318:
-#   - security.yml: pull_request trigger, Semgrep setup, Gitleaks flags
+#   - security.yml: pull_request trigger, scanners, deterministic dependency audit
 #   - pre-commit.yml: pull_request trigger present
 #   - comprehensive-tests.yml: matrix coverage maintained
 #   - validate-configs.yml: agent config validation on PRs
@@ -27,6 +27,11 @@ on:
       - 'configs/github/merge-queue-policy.json'
       - 'tests/smoke/test_merge_queue_workflow_properties.py'
       - 'tests/smoke/test_security_workflow_properties.py'
+      - 'tests/workflows/test_security_dependency_audit.py'
+      - 'tests/scripts/test_parse_pip_audit.py'
+      - 'tests/scripts/test_dependency_audit_contract.py'
+      - 'scripts/ci/parse_pip_audit.py'
+      - 'scripts/ci/dependency_audit_contract.py'
       - '.github/workflows/pre-commit.yml'
       - 'tests/smoke/test_pre_commit_workflow_properties.py'
       - '.github/workflows/comprehensive-tests.yml'
@@ -117,7 +122,13 @@ jobs:
         uses: ./.github/actions/setup-uv
 
       - name: Run security workflow smoke tests
-        run: uv run python -m pytest tests/smoke/test_security_workflow_properties.py -v
+        run: |
+          uv run python -m pytest \
+            tests/smoke/test_security_workflow_properties.py \
+            tests/workflows/test_security_dependency_audit.py \
+            tests/scripts/test_parse_pip_audit.py \
+            tests/scripts/test_dependency_audit_contract.py \
+            -v
 
   smoke-test-other-workflows:
     name: Other Workflow Property Checks

--- a/scripts/ci/dependency_audit_contract.py
+++ b/scripts/ci/dependency_audit_contract.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Write and validate fail-closed dependency-audit outcome artifacts.
+
+ADR-001 justification: Python is used because this CI helper requires recursive
+artifact discovery and strict JSON validation that Mojo's automation APIs do
+not currently provide.
+
+See docs/adr/ADR-001-language-selection-tooling.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+EXPECTED_PRODUCERS = {
+    "python-audit": ("python-audit-manifest.json", "pip-audit-report.md"),
+    "pixi-audit": ("pixi-audit-manifest.json", "pixi-audit-report.md"),
+    "license-audit": ("license-audit-manifest.json", "license-report.md"),
+}
+EXPECTED_MANIFEST_KEYS = {
+    "schema_version",
+    "producer",
+    "status",
+    "verdict",
+    "findings",
+    "report",
+}
+ALLOWED_JOB_RESULTS = {"success", "failure", "cancelled", "skipped"}
+ALLOWED_VERDICTS = {"success", "findings", "malformed", "operational", "contradictory"}
+
+
+class ContractError(ValueError):
+    """Raised when a manifest cannot be written safely."""
+
+
+@dataclass(frozen=True)
+class Manifest:
+    """One validated producer outcome."""
+
+    producer: str
+    status: str
+    verdict: str
+    findings: int | None
+    report_path: Path
+
+
+def _parse_findings(raw: str) -> int | None:
+    if raw == "unknown":
+        return None
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ContractError("findings must be a non-negative integer or 'unknown'") from exc
+    if value < 0:
+        raise ContractError("findings must be a non-negative integer or 'unknown'")
+    return value
+
+
+def write_manifest(args: argparse.Namespace) -> int:
+    """Write a producer manifest after checking its diagnostic report exists."""
+
+    if args.producer not in EXPECTED_PRODUCERS:
+        raise ContractError(f"unexpected producer: {args.producer}")
+    if args.status not in ALLOWED_JOB_RESULTS:
+        raise ContractError(f"invalid job status: {args.status}")
+    if args.verdict not in ALLOWED_VERDICTS:
+        raise ContractError(f"invalid audit verdict: {args.verdict}")
+    if not args.report.is_file() or not args.report.read_text(encoding="utf-8").strip():
+        raise ContractError(f"report is missing or empty: {args.report}")
+
+    findings = _parse_findings(args.findings)
+    payload = {
+        "schema_version": 1,
+        "producer": args.producer,
+        "status": args.status,
+        "verdict": args.verdict,
+        "findings": findings,
+        "report": args.report.name,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+def _read_needs(raw: str, diagnostics: list[str]) -> dict[str, str]:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        diagnostics.append(f"needs JSON is malformed: {exc}")
+        return {}
+    if not isinstance(payload, dict):
+        diagnostics.append("needs JSON must be an object")
+        return {}
+
+    results: dict[str, str] = {}
+    expected = set(EXPECTED_PRODUCERS)
+    actual = set(payload)
+    for missing in sorted(expected - actual):
+        diagnostics.append(f"missing upstream result for {missing}")
+    for unexpected in sorted(actual - expected):
+        diagnostics.append(f"unexpected upstream result for {unexpected}")
+
+    for producer, value in sorted(payload.items()):
+        if not isinstance(value, dict):
+            diagnostics.append(f"upstream {producer} metadata must be an object")
+            results[producer] = "invalid"
+            continue
+        result = value.get("result")
+        if result not in ALLOWED_JOB_RESULTS:
+            diagnostics.append(f"upstream {producer} has invalid result {result!r}")
+            results[producer] = "invalid"
+            continue
+        results[producer] = result
+        if producer in expected and result != "success":
+            diagnostics.append(f"upstream {producer} result is {result}")
+    return results
+
+
+def _load_manifest(path: Path, producer: str) -> Manifest:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise ContractError("manifest is not valid UTF-8") from exc
+    except OSError as exc:
+        raise ContractError(f"could not read manifest: {exc}") from exc
+    if not raw.strip():
+        raise ContractError("manifest is empty")
+    try:
+        payload: Any = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ContractError(f"manifest is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ContractError("manifest top level must be an object")
+    if set(payload) != EXPECTED_MANIFEST_KEYS:
+        missing = sorted(EXPECTED_MANIFEST_KEYS - set(payload))
+        unexpected = sorted(set(payload) - EXPECTED_MANIFEST_KEYS)
+        details = []
+        if missing:
+            details.append(f"missing keys {', '.join(missing)}")
+        if unexpected:
+            details.append(f"unexpected keys {', '.join(unexpected)}")
+        raise ContractError("; ".join(details))
+    if payload["schema_version"] != 1:
+        raise ContractError("schema_version must be 1")
+    if payload["producer"] != producer:
+        raise ContractError(f"producer must be {producer!r}")
+
+    status = payload["status"]
+    verdict = payload["verdict"]
+    findings = payload["findings"]
+    expected_report = EXPECTED_PRODUCERS[producer][1]
+    if status not in ALLOWED_JOB_RESULTS:
+        raise ContractError(f"invalid status {status!r}")
+    if verdict not in ALLOWED_VERDICTS:
+        raise ContractError(f"invalid verdict {verdict!r}")
+    if findings is not None and (isinstance(findings, bool) or not isinstance(findings, int) or findings < 0):
+        raise ContractError("findings must be a non-negative integer or null")
+    if payload["report"] != expected_report:
+        raise ContractError(f"report must be {expected_report!r}")
+
+    report_path = path.parent / expected_report
+    try:
+        report_text = report_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise ContractError("report is not valid UTF-8") from exc
+    except OSError as exc:
+        raise ContractError(f"report is missing: {exc}") from exc
+    if not report_text.strip():
+        raise ContractError("report is empty")
+    return Manifest(producer, status, verdict, findings, report_path)
+
+
+def _discover_manifests(root: Path, diagnostics: list[str]) -> dict[str, Manifest]:
+    manifests: dict[str, Manifest] = {}
+    if not root.is_dir():
+        diagnostics.append(f"artifact root is missing: {root}")
+        return manifests
+
+    expected_names = {details[0]: producer for producer, details in EXPECTED_PRODUCERS.items()}
+    candidates = sorted(path for path in root.rglob("*-audit-manifest.json") if path.is_file())
+    grouped: dict[str, list[Path]] = {}
+    for path in candidates:
+        producer = expected_names.get(path.name)
+        if producer is None:
+            diagnostics.append(f"unexpected manifest: {path.relative_to(root)}")
+            continue
+        grouped.setdefault(producer, []).append(path)
+
+    for producer in EXPECTED_PRODUCERS:
+        paths = grouped.get(producer, [])
+        if not paths:
+            diagnostics.append(f"missing manifest for {producer}")
+            continue
+        if len(paths) > 1:
+            diagnostics.append(f"duplicate manifest for {producer}: {len(paths)} copies")
+            continue
+        try:
+            manifests[producer] = _load_manifest(paths[0], producer)
+        except ContractError as exc:
+            diagnostics.append(f"invalid manifest for {producer}: {exc}")
+    return manifests
+
+
+def _validate_consistency(
+    needs: dict[str, str],
+    manifests: dict[str, Manifest],
+    diagnostics: list[str],
+) -> None:
+    for producer, manifest in manifests.items():
+        result = needs.get(producer)
+        if result in ALLOWED_JOB_RESULTS and manifest.status != result:
+            diagnostics.append(f"{producer} manifest status {manifest.status} contradicts upstream result {result}")
+        if manifest.status != "success":
+            diagnostics.append(f"{producer} manifest status is {manifest.status}")
+        if manifest.verdict != "success":
+            diagnostics.append(f"{producer} manifest verdict is {manifest.verdict}")
+        if manifest.verdict == "success" and manifest.findings != 0:
+            diagnostics.append(f"{producer} success manifest has nonzero findings")
+
+
+def _render_report(
+    needs: dict[str, str],
+    manifests: dict[str, Manifest],
+    diagnostics: list[str],
+) -> str:
+    passing = not diagnostics
+    lines = [
+        "# Dependency Audit Report",
+        "",
+        "✅ PASS — all dependency audits and artifacts are complete and successful."
+        if passing
+        else "❌ FAIL — dependency audit evidence is incomplete or unsuccessful.",
+        "",
+        "## Upstream jobs",
+        "",
+        "| Job | Result |",
+        "| --- | --- |",
+    ]
+    for producer in sorted(set(EXPECTED_PRODUCERS) | set(needs)):
+        lines.append(f"| `{producer}` | {needs.get(producer, 'missing')} |")
+
+    lines.extend(
+        [
+            "",
+            "## Producer artifacts",
+            "",
+            "| Producer | Manifest status | Verdict | Findings |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    for producer in EXPECTED_PRODUCERS:
+        manifest = manifests.get(producer)
+        if manifest is None:
+            lines.append(f"| `{producer}` | missing/invalid | unavailable | unavailable |")
+        else:
+            findings = manifest.findings if manifest.findings is not None else "unknown"
+            lines.append(f"| `{producer}` | {manifest.status} | {manifest.verdict} | {findings} |")
+
+    lines.extend(["", "## Diagnostics", ""])
+    if diagnostics:
+        lines.extend(f"- ❌ {diagnostic}" for diagnostic in diagnostics)
+    else:
+        lines.append("- No contract violations.")
+
+    for producer in EXPECTED_PRODUCERS:
+        manifest = manifests.get(producer)
+        if manifest is None:
+            continue
+        lines.extend(
+            [
+                "",
+                "---",
+                "",
+                f"## {producer} diagnostic report",
+                "",
+                manifest.report_path.read_text(encoding="utf-8").rstrip(),
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def aggregate(args: argparse.Namespace) -> int:
+    """Generate the combined report, then enforce the complete contract."""
+
+    diagnostics: list[str] = []
+    needs = _read_needs(args.needs_json, diagnostics)
+    manifests = _discover_manifests(args.artifacts, diagnostics)
+    _validate_consistency(needs, manifests, diagnostics)
+    args.report.write_text(_render_report(needs, manifests, diagnostics), encoding="utf-8")
+    if diagnostics:
+        for diagnostic in diagnostics:
+            print(diagnostic, file=sys.stderr)
+        return 1
+    return 0
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    manifest = subparsers.add_parser("manifest", help="write one producer outcome manifest")
+    manifest.add_argument("--producer", required=True)
+    manifest.add_argument("--status", required=True)
+    manifest.add_argument("--verdict", required=True)
+    manifest.add_argument("--findings", required=True)
+    manifest.add_argument("--report", type=Path, required=True)
+    manifest.add_argument("--output", type=Path, required=True)
+
+    report = subparsers.add_parser("aggregate", help="validate artifacts and write the combined report")
+    report.add_argument("--artifacts", type=Path, required=True)
+    report.add_argument("--needs-json", required=True)
+    report.add_argument("--report", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        if args.command == "manifest":
+            return write_manifest(args)
+        return aggregate(args)
+    except (ContractError, OSError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/parse_pip_audit.py
+++ b/scripts/ci/parse_pip_audit.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Validate and summarize modern pip-audit JSON without false-green fallbacks.
+
+ADR-001 justification: Python is used because this CI helper requires JSON
+schema validation and structured subprocess-output handling that Mojo's
+automation APIs do not currently provide.
+
+See docs/adr/ADR-001-language-selection-tooling.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import InvalidName, canonicalize_name
+from packaging.version import InvalidVersion, Version
+
+
+class AuditError(ValueError):
+    """Raised when pip-audit output cannot establish a trustworthy result."""
+
+
+class MalformedAuditError(AuditError):
+    """Raised when the JSON payload does not satisfy the audit schema."""
+
+
+class OperationalAuditError(AuditError):
+    """Raised when pip-audit or its output transport did not complete."""
+
+
+class ContradictoryAuditError(AuditError):
+    """Raised when independently reported audit outcomes disagree."""
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One vulnerability reported for a resolved dependency."""
+
+    package: str
+    version: str
+    vulnerability_id: str
+    fix_versions: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ResolvedDependency:
+    """One normalized name/version pair covered by the audit."""
+
+    name: str
+    version: Version
+
+
+@dataclass(frozen=True)
+class AuditResult:
+    """Validated audit contents used by the report and workflow outputs."""
+
+    dependencies: tuple[ResolvedDependency, ...]
+    findings: tuple[Finding, ...]
+
+
+def _require_nonempty_string(value: object, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise MalformedAuditError(f"{path} must be a non-empty string")
+    return value
+
+
+def _require_string_list(value: object, path: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise MalformedAuditError(f"{path} must be a list of strings")
+    return tuple(value)
+
+
+def parse_requirements(path: Path) -> dict[str, Version]:
+    """Load the exact applicable pinned dependency set passed to pip-audit."""
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise MalformedAuditError("requirements input is not valid UTF-8") from exc
+    except OSError as exc:
+        raise OperationalAuditError(f"could not read requirements input: {exc}") from exc
+
+    if not raw.strip():
+        raise MalformedAuditError("requirements input is empty")
+
+    dependencies: dict[str, Version] = {}
+    ignored_option_prefixes = (
+        "--index-url ",
+        "--extra-index-url ",
+        "--find-links ",
+        "--trusted-host ",
+    )
+    for line_number, line in enumerate(raw.splitlines(), start=1):
+        text = line.strip()
+        if not text or text.startswith("#"):
+            continue
+        if text.startswith(ignored_option_prefixes):
+            continue
+        if text.startswith("-"):
+            raise MalformedAuditError(
+                f"requirements input line {line_number} uses unsupported include or option syntax"
+            )
+        try:
+            requirement = Requirement(text)
+        except InvalidRequirement as exc:
+            raise MalformedAuditError(f"requirements input line {line_number} is invalid: {exc}") from exc
+        if requirement.marker is not None and not requirement.marker.evaluate():
+            continue
+        if requirement.url is not None:
+            raise MalformedAuditError(f"requirements input line {line_number} is not an exactly pinned name/version")
+
+        specifiers = list(requirement.specifier)
+        if len(specifiers) != 1 or specifiers[0].operator != "==" or "*" in specifiers[0].version:
+            raise MalformedAuditError(f"requirements input line {line_number} is not an exactly pinned name/version")
+        try:
+            version = Version(specifiers[0].version)
+        except InvalidVersion as exc:
+            raise MalformedAuditError(f"requirements input line {line_number} has an invalid pinned version") from exc
+
+        name = canonicalize_name(requirement.name)
+        if name in dependencies:
+            raise MalformedAuditError(f"duplicate applicable requirement: {name}")
+        dependencies[name] = version
+
+    if not dependencies:
+        raise MalformedAuditError("requirements input contains no applicable pinned dependencies")
+    return dependencies
+
+
+def parse_manifest(path: Path) -> AuditResult:
+    """Load and validate pip-audit's modern ``dependencies``/``fixes`` schema."""
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise MalformedAuditError("pip-audit output is not valid UTF-8") from exc
+    except OSError as exc:
+        raise OperationalAuditError(f"could not read pip-audit output: {exc}") from exc
+
+    if not raw.strip():
+        raise MalformedAuditError("pip-audit output is empty")
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise MalformedAuditError(f"pip-audit output is not valid JSON: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise MalformedAuditError("pip-audit JSON top level must be an object")
+
+    missing_keys = {"dependencies", "fixes"} - payload.keys()
+    if missing_keys:
+        raise MalformedAuditError(f"pip-audit JSON is missing required key(s): {', '.join(sorted(missing_keys))}")
+
+    dependencies = payload["dependencies"]
+    fixes = payload["fixes"]
+    if not isinstance(dependencies, list):
+        raise MalformedAuditError("pip-audit JSON dependencies must be a list")
+    if not isinstance(fixes, list):
+        raise MalformedAuditError("pip-audit JSON fixes must be a list")
+    if fixes:
+        raise ContradictoryAuditError("non-fix pip-audit run returned non-empty fixes")
+
+    findings: list[Finding] = []
+    resolved_dependencies: list[ResolvedDependency] = []
+    package_names: set[str] = set()
+    for dependency_index, dependency in enumerate(dependencies):
+        path_prefix = f"dependencies[{dependency_index}]"
+        if not isinstance(dependency, dict):
+            raise MalformedAuditError(f"{path_prefix} must be an object")
+
+        package_value = _require_nonempty_string(dependency.get("name"), f"{path_prefix}.name")
+        try:
+            package = canonicalize_name(package_value, validate=True)
+        except InvalidName as exc:
+            raise MalformedAuditError(f"{path_prefix}.name must be a valid package name") from exc
+        if package in package_names:
+            raise MalformedAuditError(f"duplicate dependency in pip-audit JSON: {package}")
+        package_names.add(package)
+
+        if "skip_reason" in dependency:
+            reason = _require_nonempty_string(dependency["skip_reason"], f"{path_prefix}.skip_reason")
+            raise MalformedAuditError(f"pip-audit reported skipped dependency {package}: {reason}")
+
+        version_value = _require_nonempty_string(dependency.get("version"), f"{path_prefix}.version")
+        try:
+            version = Version(version_value)
+        except InvalidVersion as exc:
+            raise MalformedAuditError(f"{path_prefix}.version must be a valid version") from exc
+        resolved_dependencies.append(ResolvedDependency(package, version))
+        vulnerabilities = dependency.get("vulns")
+        if not isinstance(vulnerabilities, list):
+            raise MalformedAuditError(f"{path_prefix}.vulns must be a list")
+
+        for vulnerability_index, vulnerability in enumerate(vulnerabilities):
+            vulnerability_path = f"{path_prefix}.vulns[{vulnerability_index}]"
+            if not isinstance(vulnerability, dict):
+                raise MalformedAuditError(f"{vulnerability_path} must be an object")
+            vulnerability_id = _require_nonempty_string(vulnerability.get("id"), f"{vulnerability_path}.id")
+            fix_versions = _require_string_list(vulnerability.get("fix_versions"), f"{vulnerability_path}.fix_versions")
+            if "aliases" in vulnerability:
+                _require_string_list(vulnerability["aliases"], f"{vulnerability_path}.aliases")
+            if "description" in vulnerability and not isinstance(vulnerability["description"], str):
+                raise MalformedAuditError(f"{vulnerability_path}.description must be a string")
+
+            findings.append(Finding(package, str(version), vulnerability_id, fix_versions))
+
+    return AuditResult(tuple(resolved_dependencies), tuple(findings))
+
+
+def validate_dependency_set(requirements: dict[str, Version], result: AuditResult) -> None:
+    """Require pip-audit JSON to cover exactly the requested applicable pins."""
+
+    audited = {dependency.name: dependency.version for dependency in result.dependencies}
+    diagnostics: list[str] = []
+    for name in sorted(requirements.keys() - audited.keys()):
+        diagnostics.append(f"missing audited dependency {name}=={requirements[name]}")
+    for name in sorted(audited.keys() - requirements.keys()):
+        diagnostics.append(f"unexpected audited dependency {name}=={audited[name]}")
+    for name in sorted(requirements.keys() & audited.keys()):
+        if requirements[name] != audited[name]:
+            diagnostics.append(f"version mismatch for {name}: requirements={requirements[name]}, audit={audited[name]}")
+    if diagnostics:
+        raise ContradictoryAuditError("; ".join(diagnostics))
+
+
+def validate_exit_code(result: AuditResult, audit_exit_code: int) -> None:
+    """Require the subprocess exit code to agree with the validated manifest."""
+
+    if audit_exit_code not in (0, 1):
+        raise OperationalAuditError(f"pip-audit operational failure (exit code {audit_exit_code})")
+    if audit_exit_code == 0 and result.findings:
+        raise ContradictoryAuditError("pip-audit reported success despite vulnerability findings")
+    if audit_exit_code == 1 and not result.findings:
+        raise ContradictoryAuditError("pip-audit reported failure without vulnerability findings")
+
+
+def render_report(result: AuditResult) -> str:
+    """Render a diagnostic report from a validated audit result."""
+
+    lines = [
+        "## pip-audit Scan Results",
+        "",
+        f"Dependencies audited: {len(result.dependencies)}",
+        "",
+    ]
+    if not result.findings:
+        lines.append("✅ No known vulnerabilities found")
+    else:
+        lines.extend(
+            [
+                f"⚠️ Found {len(result.findings)} known vulnerabilities",
+                "",
+                "| Package | Version | Advisory | Fix versions |",
+                "| --- | --- | --- | --- |",
+            ]
+        )
+        for finding in result.findings:
+            fixes = ", ".join(finding.fix_versions) or "None published"
+            lines.append(f"| {finding.package} | {finding.version} | {finding.vulnerability_id} | {fixes} |")
+    return "\n".join(lines) + "\n"
+
+
+def render_error(message: str) -> str:
+    """Render a report that clearly distinguishes an incomplete audit."""
+
+    return "\n".join(
+        [
+            "## pip-audit Scan Results",
+            "",
+            f"❌ Audit failed: {message}",
+            "",
+            "No vulnerability verdict is available for this audit.",
+            "",
+        ]
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, required=True, help="pip-audit JSON manifest")
+    parser.add_argument("--requirements", type=Path, required=True, help="exact requirements input audited")
+    parser.add_argument("--audit-exit-code", type=int, required=True, help="pip-audit subprocess exit code")
+    parser.add_argument("--report", type=Path, required=True, help="Markdown report output")
+    parser.add_argument("--github-output", type=Path, help="Optional GitHub Actions output file")
+    return parser.parse_args(argv)
+
+
+def write_outputs(path: Path | None, count: int | None, verdict: str, diagnostic: str) -> None:
+    """Append a complete, single-line-safe GitHub Actions result contract."""
+
+    if path is None:
+        return
+    safe_diagnostic = " ".join(diagnostic.splitlines()).strip()
+    with path.open("a", encoding="utf-8") as output:
+        output.write(f"count={count if count is not None else 'unknown'}\n")
+        output.write(f"verdict={verdict}\n")
+        output.write(f"diagnostic={safe_diagnostic}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        if args.audit_exit_code not in (0, 1):
+            raise OperationalAuditError(f"pip-audit operational failure (exit code {args.audit_exit_code})")
+        requirements = parse_requirements(args.requirements)
+        result = parse_manifest(args.input)
+        validate_dependency_set(requirements, result)
+        validate_exit_code(result, args.audit_exit_code)
+    except AuditError as exc:
+        args.report.write_text(render_error(str(exc)), encoding="utf-8")
+        if isinstance(exc, OperationalAuditError):
+            exit_code, verdict = 3, "operational"
+        elif isinstance(exc, ContradictoryAuditError):
+            exit_code, verdict = 4, "contradictory"
+        else:
+            exit_code, verdict = 2, "malformed"
+        write_outputs(args.github_output, None, verdict, str(exc))
+        print(str(exc), file=sys.stderr)
+        return exit_code
+
+    args.report.write_text(render_report(result), encoding="utf-8")
+    finding_count = len(result.findings)
+    if finding_count:
+        diagnostic = f"{finding_count} known vulnerabilities found"
+        write_outputs(args.github_output, finding_count, "findings", diagnostic)
+        return 1
+    write_outputs(args.github_output, 0, "success", "No known vulnerabilities found")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_dependency_audit_contract.py
+++ b/tests/scripts/test_dependency_audit_contract.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Behavioral tests for the fail-closed dependency-audit artifact contract."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "ci" / "dependency_audit_contract.py"
+
+PRODUCERS = {
+    "python-audit": ("python-audit-manifest.json", "pip-audit-report.md"),
+    "pixi-audit": ("pixi-audit-manifest.json", "pixi-audit-report.md"),
+    "license-audit": ("license-audit-manifest.json", "license-report.md"),
+}
+
+
+def _write_artifact(
+    root: Path,
+    producer: str,
+    *,
+    status: str = "success",
+    verdict: str = "success",
+    findings: int | None = 0,
+    nested: bool = True,
+) -> None:
+    manifest_name, report_name = PRODUCERS[producer]
+    destination = root / producer / "nested" if nested else root
+    destination.mkdir(parents=True, exist_ok=True)
+    (destination / report_name).write_text(f"# {producer} report\n", encoding="utf-8")
+    (destination / manifest_name).write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "producer": producer,
+                "status": status,
+                "verdict": verdict,
+                "findings": findings,
+                "report": report_name,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _run_aggregate(
+    tmp_path: Path,
+    *,
+    needs: dict[str, dict[str, str]],
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir(exist_ok=True)
+    report = tmp_path / "combined-report.md"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "aggregate",
+            "--artifacts",
+            str(artifacts),
+            "--needs-json",
+            json.dumps(needs),
+            "--report",
+            str(report),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result, report
+
+
+def _successful_needs() -> dict[str, dict[str, str]]:
+    return {producer: {"result": "success"} for producer in PRODUCERS}
+
+
+def test_complete_successful_artifacts_are_green_even_when_nested(tmp_path: Path) -> None:
+    artifacts = tmp_path / "artifacts"
+    for producer in PRODUCERS:
+        _write_artifact(artifacts, producer)
+
+    result, report = _run_aggregate(tmp_path, needs=_successful_needs())
+
+    assert result.returncode == 0, result.stderr
+    content = report.read_text(encoding="utf-8")
+    assert "✅ PASS" in content
+    for producer in PRODUCERS:
+        assert f"| `{producer}` | success |" in content
+
+
+@pytest.mark.parametrize("missing", list(PRODUCERS))
+def test_missing_artifact_fails_and_names_the_producer(tmp_path: Path, missing: str) -> None:
+    artifacts = tmp_path / "artifacts"
+    for producer in PRODUCERS:
+        if producer != missing:
+            _write_artifact(artifacts, producer)
+
+    result, report = _run_aggregate(tmp_path, needs=_successful_needs())
+
+    assert result.returncode != 0
+    content = report.read_text(encoding="utf-8")
+    assert "❌ FAIL" in content
+    assert f"missing manifest for {missing}" in content
+
+
+def test_duplicate_manifest_fails_closed(tmp_path: Path) -> None:
+    artifacts = tmp_path / "artifacts"
+    for producer in PRODUCERS:
+        _write_artifact(artifacts, producer)
+    duplicate = artifacts / "duplicate"
+    duplicate.mkdir(parents=True)
+    source = next(artifacts.rglob("python-audit-manifest.json"))
+    (duplicate / source.name).write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+    result, report = _run_aggregate(tmp_path, needs=_successful_needs())
+
+    assert result.returncode != 0
+    assert "duplicate manifest for python-audit" in report.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("payload", ["", "{not json", "[]"])
+def test_malformed_manifest_fails_closed(tmp_path: Path, payload: str) -> None:
+    artifacts = tmp_path / "artifacts"
+    for producer in PRODUCERS:
+        _write_artifact(artifacts, producer)
+    manifest = next(artifacts.rglob("pixi-audit-manifest.json"))
+    manifest.write_text(payload, encoding="utf-8")
+
+    result, report = _run_aggregate(tmp_path, needs=_successful_needs())
+
+    assert result.returncode != 0
+    content = report.read_text(encoding="utf-8")
+    assert "invalid manifest for pixi-audit" in content
+
+
+def test_binary_malformed_manifest_is_reported_without_crashing_aggregate(tmp_path: Path) -> None:
+    artifacts = tmp_path / "artifacts"
+    for producer in PRODUCERS:
+        _write_artifact(artifacts, producer)
+    manifest = next(artifacts.rglob("pixi-audit-manifest.json"))
+    manifest.write_bytes(b"\xff\xfe\x00")
+
+    result, report = _run_aggregate(tmp_path, needs=_successful_needs())
+
+    assert result.returncode != 0
+    assert "Traceback" not in result.stderr
+    content = report.read_text(encoding="utf-8")
+    assert "❌ FAIL" in content
+    assert "invalid manifest for pixi-audit: manifest is not valid UTF-8" in content
+
+
+def test_binary_malformed_report_is_reported_without_crashing_aggregate(tmp_path: Path) -> None:
+    artifacts = tmp_path / "artifacts"
+    for producer in PRODUCERS:
+        _write_artifact(artifacts, producer)
+    report_artifact = next(artifacts.rglob("pixi-audit-report.md"))
+    report_artifact.write_bytes(b"\xff\xfe\x00")
+
+    result, report = _run_aggregate(tmp_path, needs=_successful_needs())
+
+    assert result.returncode != 0
+    assert "Traceback" not in result.stderr
+    content = report.read_text(encoding="utf-8")
+    assert "❌ FAIL" in content
+    assert "invalid manifest for pixi-audit: report is not valid UTF-8" in content
+
+
+@pytest.mark.parametrize("result_name", ["failure", "cancelled", "skipped"])
+def test_non_successful_upstream_result_is_red(tmp_path: Path, result_name: str) -> None:
+    artifacts = tmp_path / "artifacts"
+    for producer in PRODUCERS:
+        _write_artifact(artifacts, producer)
+    needs = _successful_needs()
+    needs["python-audit"]["result"] = result_name
+
+    result, report = _run_aggregate(tmp_path, needs=needs)
+
+    assert result.returncode != 0
+    content = report.read_text(encoding="utf-8")
+    assert f"| `python-audit` | {result_name} |" in content
+    assert f"upstream python-audit result is {result_name}" in content
+
+
+def test_finding_or_operational_manifest_cannot_be_green(tmp_path: Path) -> None:
+    artifacts = tmp_path / "artifacts"
+    _write_artifact(artifacts, "python-audit", status="failure", verdict="findings", findings=2)
+    _write_artifact(artifacts, "pixi-audit", status="failure", verdict="operational", findings=None)
+    _write_artifact(artifacts, "license-audit")
+    needs = _successful_needs()
+    needs["python-audit"]["result"] = "failure"
+    needs["pixi-audit"]["result"] = "failure"
+
+    result, report = _run_aggregate(tmp_path, needs=needs)
+
+    assert result.returncode != 0
+    content = report.read_text(encoding="utf-8")
+    assert "python-audit manifest verdict is findings" in content
+    assert "pixi-audit manifest verdict is operational" in content
+
+
+def test_contradictory_success_manifest_with_findings_fails(tmp_path: Path) -> None:
+    artifacts = tmp_path / "artifacts"
+    _write_artifact(artifacts, "python-audit", findings=3)
+    _write_artifact(artifacts, "pixi-audit")
+    _write_artifact(artifacts, "license-audit")
+
+    result, report = _run_aggregate(tmp_path, needs=_successful_needs())
+
+    assert result.returncode != 0
+    assert "success manifest has nonzero findings" in report.read_text(encoding="utf-8")
+
+
+def test_manifest_writer_creates_strict_json_contract(tmp_path: Path) -> None:
+    report = tmp_path / "pip-audit-report.md"
+    report.write_text("# report\n", encoding="utf-8")
+    manifest = tmp_path / "python-audit-manifest.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "manifest",
+            "--producer",
+            "python-audit",
+            "--status",
+            "success",
+            "--verdict",
+            "success",
+            "--findings",
+            "0",
+            "--report",
+            str(report),
+            "--output",
+            str(manifest),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(manifest.read_text(encoding="utf-8")) == {
+        "schema_version": 1,
+        "producer": "python-audit",
+        "status": "success",
+        "verdict": "success",
+        "findings": 0,
+        "report": "pip-audit-report.md",
+    }

--- a/tests/scripts/test_parse_pip_audit.py
+++ b/tests/scripts/test_parse_pip_audit.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Unit tests for fail-closed parsing of pip-audit JSON output."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "ci" / "parse_pip_audit.py"
+
+
+def _dependency(name: str, version: str, vulns: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"name": name, "version": version, "vulns": vulns}
+
+
+def _vulnerability(vulnerability_id: str) -> dict[str, Any]:
+    return {
+        "id": vulnerability_id,
+        "fix_versions": ["9.9.9"],
+        "aliases": [f"CVE-{vulnerability_id[-4:]}"],
+        "description": "A test advisory",
+    }
+
+
+def _run_parser(
+    tmp_path: Path,
+    payload: object,
+    *,
+    audit_exit_code: int,
+    requirements: str | None = None,
+) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
+    input_path = tmp_path / "pip-audit.json"
+    requirements_path = tmp_path / "requirements.txt"
+    report_path = tmp_path / "pip-audit-report.md"
+    output_path = tmp_path / "github-output.txt"
+
+    if isinstance(payload, bytes):
+        input_path.write_bytes(payload)
+    elif isinstance(payload, str):
+        input_path.write_text(payload, encoding="utf-8")
+    else:
+        input_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    if requirements is None:
+        requirement_lines = []
+        if isinstance(payload, dict) and isinstance(payload.get("dependencies"), list):
+            for dependency in payload["dependencies"]:
+                if (
+                    isinstance(dependency, dict)
+                    and isinstance(dependency.get("name"), str)
+                    and isinstance(dependency.get("version"), str)
+                ):
+                    requirement_lines.append(f"{dependency['name']}=={dependency['version']}")
+        requirements = "\n".join(requirement_lines or ["safe==1.0"]) + "\n"
+    requirements_path.write_text(requirements, encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--input",
+            str(input_path),
+            "--requirements",
+            str(requirements_path),
+            "--audit-exit-code",
+            str(audit_exit_code),
+            "--report",
+            str(report_path),
+            "--github-output",
+            str(output_path),
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result, report_path, output_path
+
+
+def test_modern_manifest_counts_vulnerabilities_and_writes_findings(tmp_path: Path) -> None:
+    payload = {
+        "dependencies": [
+            _dependency("safe", "1.0", []),
+            _dependency("affected", "2.0", [_vulnerability("PYSEC-1000"), _vulnerability("GHSA-2000")]),
+        ],
+        "fixes": [],
+    }
+
+    result, report_path, output_path = _run_parser(tmp_path, payload, audit_exit_code=1)
+
+    assert result.returncode == 1, result.stderr
+    assert output_path.read_text(encoding="utf-8") == (
+        "count=2\nverdict=findings\ndiagnostic=2 known vulnerabilities found\n"
+    )
+    report = report_path.read_text(encoding="utf-8")
+    assert "PYSEC-1000" in report
+    assert "GHSA-2000" in report
+    assert "affected" in report
+
+
+def test_modern_manifest_without_findings_is_successful(tmp_path: Path) -> None:
+    payload = {
+        "dependencies": [_dependency("safe", "1.0", [])],
+        "fixes": [],
+    }
+
+    result, report_path, output_path = _run_parser(tmp_path, payload, audit_exit_code=0)
+
+    assert result.returncode == 0, result.stderr
+    assert output_path.read_text(encoding="utf-8") == (
+        "count=0\nverdict=success\ndiagnostic=No known vulnerabilities found\n"
+    )
+    assert "No known vulnerabilities found" in report_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_error"),
+    [
+        ({"dependencies": [_dependency("safe", "1.0", [])]}, "missing required key"),
+        ([], "top level must be an object"),
+        ("", "empty"),
+        ("not-json", "valid JSON"),
+    ],
+)
+def test_empty_or_malformed_output_fails_closed(
+    tmp_path: Path,
+    payload: object,
+    expected_error: str,
+) -> None:
+    result, report_path, output_path = _run_parser(tmp_path, payload, audit_exit_code=0)
+
+    assert result.returncode == 2
+    assert expected_error in result.stderr
+    assert "Audit failed" in report_path.read_text(encoding="utf-8")
+    output = output_path.read_text(encoding="utf-8")
+    assert "count=unknown\n" in output
+    assert "verdict=malformed\n" in output
+    assert expected_error in output
+
+
+@pytest.mark.parametrize(
+    ("payload", "audit_exit_code", "expected_error", "expected_code", "expected_verdict"),
+    [
+        (
+            {"dependencies": [_dependency("safe", "1.0", [])], "fixes": []},
+            1,
+            "reported failure without vulnerability findings",
+            4,
+            "contradictory",
+        ),
+        (
+            {"dependencies": [_dependency("affected", "2.0", [_vulnerability("PYSEC-1000")])], "fixes": []},
+            0,
+            "reported success despite vulnerability findings",
+            4,
+            "contradictory",
+        ),
+        (
+            {"dependencies": [_dependency("affected", "2.0", [_vulnerability("PYSEC-1000")])], "fixes": []},
+            2,
+            "operational failure",
+            3,
+            "operational",
+        ),
+    ],
+)
+def test_exit_code_and_manifest_must_describe_the_same_outcome(
+    tmp_path: Path,
+    payload: object,
+    audit_exit_code: int,
+    expected_error: str,
+    expected_code: int,
+    expected_verdict: str,
+) -> None:
+    result, report_path, output_path = _run_parser(tmp_path, payload, audit_exit_code=audit_exit_code)
+
+    assert result.returncode == expected_code
+    assert expected_error in result.stderr
+    assert "Audit failed" in report_path.read_text(encoding="utf-8")
+    output = output_path.read_text(encoding="utf-8")
+    assert "count=unknown\n" in output
+    assert f"verdict={expected_verdict}\n" in output
+    assert "diagnostic=" in output
+    assert expected_error in output
+
+
+def test_skipped_dependency_is_an_incomplete_audit(tmp_path: Path) -> None:
+    payload = {
+        "dependencies": [{"name": "unknown", "skip_reason": "could not resolve"}],
+        "fixes": [],
+    }
+
+    result, report_path, output_path = _run_parser(tmp_path, payload, audit_exit_code=0)
+
+    assert result.returncode == 2
+    assert "skipped dependency" in result.stderr
+    assert "Audit failed" in report_path.read_text(encoding="utf-8")
+    output = output_path.read_text(encoding="utf-8")
+    assert "count=unknown\n" in output
+    assert "verdict=malformed\n" in output
+
+
+def test_non_fix_audit_rejects_nonempty_fixes_as_contradictory(tmp_path: Path) -> None:
+    payload = {
+        "dependencies": [_dependency("safe", "1.0", [])],
+        "fixes": [{"name": "safe", "version": "2.0"}],
+    }
+
+    result, report_path, output_path = _run_parser(tmp_path, payload, audit_exit_code=0)
+
+    assert result.returncode == 4
+    assert "non-empty fixes" in result.stderr
+    assert "Audit failed" in report_path.read_text(encoding="utf-8")
+    output = output_path.read_text(encoding="utf-8")
+    assert "verdict=contradictory\n" in output
+    assert "count=unknown\n" in output
+
+
+def test_operational_exit_code_is_authoritative_when_output_is_malformed(tmp_path: Path) -> None:
+    result, report_path, output_path = _run_parser(tmp_path, "not-json", audit_exit_code=2)
+
+    assert result.returncode == 3
+    assert "operational failure" in result.stderr
+    assert "Audit failed" in report_path.read_text(encoding="utf-8")
+    output = output_path.read_text(encoding="utf-8")
+    assert "count=unknown\n" in output
+    assert "verdict=operational\n" in output
+
+
+def test_unrelated_clean_dependency_cannot_replace_the_requested_audit_set(tmp_path: Path) -> None:
+    payload = {
+        "dependencies": [_dependency("unrelated-clean", "9.0", [])],
+        "fixes": [],
+    }
+
+    result, report_path, output_path = _run_parser(
+        tmp_path,
+        payload,
+        audit_exit_code=0,
+        requirements="expected-vulnerable==1.0\n",
+    )
+
+    assert result.returncode == 4
+    assert "missing audited dependency expected-vulnerable==1.0" in result.stderr
+    assert "unexpected audited dependency unrelated-clean==9.0" in result.stderr
+    assert "Audit failed" in report_path.read_text(encoding="utf-8")
+    assert "verdict=contradictory\n" in output_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("requirements", "payload", "expected_error"),
+    [
+        (
+            "expected==1.0\n",
+            {"dependencies": [], "fixes": []},
+            "missing audited dependency expected==1.0",
+        ),
+        (
+            "expected==1.0\n",
+            {
+                "dependencies": [
+                    _dependency("expected", "1.0", []),
+                    _dependency("unexpected", "2.0", []),
+                ],
+                "fixes": [],
+            },
+            "unexpected audited dependency unexpected==2.0",
+        ),
+        (
+            "expected==1.0\n",
+            {"dependencies": [_dependency("expected", "2.0", [])], "fixes": []},
+            "version mismatch for expected: requirements=1.0, audit=2.0",
+        ),
+    ],
+)
+def test_requirements_and_json_must_have_exact_name_version_equality(
+    tmp_path: Path,
+    requirements: str,
+    payload: object,
+    expected_error: str,
+) -> None:
+    result, report_path, output_path = _run_parser(
+        tmp_path,
+        payload,
+        audit_exit_code=0,
+        requirements=requirements,
+    )
+
+    assert result.returncode == 4
+    assert expected_error in result.stderr
+    assert "Audit failed" in report_path.read_text(encoding="utf-8")
+    assert "verdict=contradictory\n" in output_path.read_text(encoding="utf-8")
+
+
+def test_names_versions_and_applicable_markers_are_normalized(tmp_path: Path) -> None:
+    payload = {
+        "dependencies": [_dependency("my-package", "1.0", [])],
+        "fixes": [],
+    }
+
+    result, report_path, output_path = _run_parser(
+        tmp_path,
+        payload,
+        audit_exit_code=0,
+        requirements=('My_Package==1.0.0\nnot-applicable==7.0 ; python_version < "1"\n'),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Dependencies audited: 1" in report_path.read_text(encoding="utf-8")
+    assert "verdict=success\n" in output_path.read_text(encoding="utf-8")
+
+
+def test_duplicate_normalized_requirement_is_malformed(tmp_path: Path) -> None:
+    payload = {
+        "dependencies": [_dependency("my-package", "1.0", [])],
+        "fixes": [],
+    }
+
+    result, report_path, output_path = _run_parser(
+        tmp_path,
+        payload,
+        audit_exit_code=0,
+        requirements="My_Package==1.0\nmy-package==1.0.0\n",
+    )
+
+    assert result.returncode == 2
+    assert "duplicate applicable requirement: my-package" in result.stderr
+    assert "Audit failed" in report_path.read_text(encoding="utf-8")
+    assert "verdict=malformed\n" in output_path.read_text(encoding="utf-8")
+
+
+def test_duplicate_normalized_json_dependency_is_malformed(tmp_path: Path) -> None:
+    payload = {
+        "dependencies": [
+            _dependency("My_Package", "1.0", []),
+            _dependency("my-package", "1.0.0", []),
+        ],
+        "fixes": [],
+    }
+
+    result, report_path, output_path = _run_parser(
+        tmp_path,
+        payload,
+        audit_exit_code=0,
+        requirements="my-package==1.0\n",
+    )
+
+    assert result.returncode == 2
+    assert "duplicate dependency in pip-audit JSON: my-package" in result.stderr
+    assert "Audit failed" in report_path.read_text(encoding="utf-8")
+    assert "verdict=malformed\n" in output_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "requirements",
+    [
+        "not-pinned>=1.0\n",
+        "wildcard==1.*\n",
+        "-r other-requirements.txt\n",
+        "not a valid requirement\n",
+    ],
+)
+def test_unverifiable_requirement_input_is_malformed(tmp_path: Path, requirements: str) -> None:
+    payload = {
+        "dependencies": [_dependency("safe", "1.0", [])],
+        "fixes": [],
+    }
+
+    result, report_path, output_path = _run_parser(
+        tmp_path,
+        payload,
+        audit_exit_code=0,
+        requirements=requirements,
+    )
+
+    assert result.returncode == 2
+    assert "requirements input" in result.stderr
+    assert "Audit failed" in report_path.read_text(encoding="utf-8")
+    assert "verdict=malformed\n" in output_path.read_text(encoding="utf-8")
+
+
+def test_invalid_json_dependency_name_is_malformed(tmp_path: Path) -> None:
+    payload = {
+        "dependencies": [_dependency("invalid name!", "1.0", [])],
+        "fixes": [],
+    }
+
+    result, report_path, output_path = _run_parser(
+        tmp_path,
+        payload,
+        audit_exit_code=0,
+        requirements="safe==1.0\n",
+    )
+
+    assert result.returncode == 2
+    assert "dependencies[0].name must be a valid package name" in result.stderr
+    assert "Audit failed" in report_path.read_text(encoding="utf-8")
+    assert "verdict=malformed\n" in output_path.read_text(encoding="utf-8")
+
+
+def test_binary_malformed_audit_json_writes_diagnostics_without_traceback(tmp_path: Path) -> None:
+    result, report_path, output_path = _run_parser(
+        tmp_path,
+        b"\xff\xfe\x00",
+        audit_exit_code=0,
+        requirements="safe==1.0\n",
+    )
+
+    assert result.returncode == 2
+    assert "Traceback" not in result.stderr
+    assert "pip-audit output is not valid UTF-8" in result.stderr
+    assert "Audit failed" in report_path.read_text(encoding="utf-8")
+    assert "verdict=malformed\n" in output_path.read_text(encoding="utf-8")

--- a/tests/smoke/test_merge_queue_workflow_properties.py
+++ b/tests/smoke/test_merge_queue_workflow_properties.py
@@ -184,7 +184,11 @@ def test_existing_pull_request_and_push_triggers_are_preserved() -> None:
         "configs/github/merge-queue-policy.json",
         "docker-compose.yml",
         "justfile",
+        "scripts/ci/dependency_audit_contract.py",
         "scripts/ci/ensure-podman-runtime.sh",
+        "scripts/ci/parse_pip_audit.py",
+        "tests/scripts/test_dependency_audit_contract.py",
+        "tests/scripts/test_parse_pip_audit.py",
         "tests/smoke/test_comprehensive_pr_comments_workflow_properties.py",
         "tests/smoke/test_comprehensive_report_workflow_properties.py",
         "tests/smoke/test_comprehensive_tests_workflow_properties.py",
@@ -194,6 +198,7 @@ def test_existing_pull_request_and_push_triggers_are_preserved() -> None:
         "tests/smoke/test_pre_commit_workflow_properties.py",
         "tests/smoke/test_security_workflow_properties.py",
         "tests/smoke/test_validate_configs_workflow_properties.py",
+        "tests/workflows/test_security_dependency_audit.py",
     }
 
 

--- a/tests/workflows/test_security_dependency_audit.py
+++ b/tests/workflows/test_security_dependency_audit.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Behavioral properties for deterministic dependency auditing in security.yml."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+WORKFLOW = Path(__file__).parents[2] / ".github" / "workflows" / "security.yml"
+WORKFLOW_SMOKE = Path(__file__).parents[2] / ".github" / "workflows" / "workflow-smoke-test.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow_content() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _step(workflow_content: str, name: str) -> str:
+    match = re.search(
+        rf"(?ms)^      - name: {re.escape(name)}\n(?P<body>.*?)(?=^      - name: |\Z)",
+        workflow_content,
+    )
+    assert match is not None, f"Could not find workflow step {name!r}"
+    return match.group("body")
+
+
+def test_python_audit_targets_requirements_dev_from_locked_environment(workflow_content: str) -> None:
+    step = _step(workflow_content, "Audit requirements-dev.txt with pip-audit")
+
+    assert re.search(r"uv run --frozen pip-audit\b.*--requirement requirements-dev\.txt", step)
+    assert "--strict" in step
+    assert "--no-deps" in step
+    assert re.search(r"(?m)^\s*pip-audit\s+--format json", step) is None
+    assert "pip install requirements-dev.txt" not in step
+
+
+def test_python_audit_preserves_exit_code_for_validated_parsing(workflow_content: str) -> None:
+    step = _step(workflow_content, "Audit requirements-dev.txt with pip-audit")
+
+    assert re.search(r"(?m)^\s*audit_rc=\$\?", step)
+    assert "scripts/ci/parse_pip_audit.py" in step
+    assert "--requirements requirements-dev.txt" in step
+    assert '--audit-exit-code "$audit_rc"' in step
+    assert '--github-output "$GITHUB_OUTPUT"' in step
+
+
+def test_uv_lock_export_cannot_fall_back_to_an_empty_audit(workflow_content: str) -> None:
+    step = _step(workflow_content, "Audit PyPI packages from the uv lockfile")
+
+    assert "uv export --frozen" in step
+    assert ": > uv-requirements.txt" not in step
+    assert "No PyPI packages found in uv.lock — skipping pip-audit." not in step
+    assert "test -s uv-requirements.txt" in step
+    assert "grep -viE" not in step
+    assert "pypi-from-uv.txt" not in step
+    assert "--no-emit-project --all-groups > uv-requirements.txt" in step
+
+
+def test_uv_lock_audit_uses_same_validated_parser(workflow_content: str) -> None:
+    step = _step(workflow_content, "Audit PyPI packages from the uv lockfile")
+
+    assert re.search(r"uv run --frozen pip-audit\b.*--requirement uv-requirements\.txt", step)
+    assert "--strict" in step
+    assert "--no-deps" in step
+    assert "scripts/ci/parse_pip_audit.py" in step
+    assert "--requirements uv-requirements.txt" in step
+    assert '--audit-exit-code "$audit_rc"' in step
+    assert '|| echo "?"' not in step
+    assert '|| echo "0"' not in step
+
+
+def test_redundant_safety_scan_and_mutable_tool_installs_are_removed(workflow_content: str) -> None:
+    assert "Audit with Safety" not in workflow_content
+    assert re.search(r"(?m)^\s+(?:python -m )?pip install .*pip-audit", workflow_content) is None
+    assert re.search(r"(?m)^\s+(?:python -m )?pip install .*pip-licenses", workflow_content) is None
+    assert "uses: ./.github/actions/setup-uv" in workflow_content
+    assert "uv run --frozen pip-licenses" in workflow_content
+
+
+def test_audit_jobs_emit_always_uploaded_manifests(workflow_content: str) -> None:
+    for producer, manifest in {
+        "Python": "python-audit-manifest.json",
+        "Pixi": "pixi-audit-manifest.json",
+        "License": "license-audit-manifest.json",
+    }.items():
+        manifest_step = _step(workflow_content, f"Write {producer} audit manifest")
+        assert "if: always()" in manifest_step
+        assert "scripts/ci/dependency_audit_contract.py manifest" in manifest_step
+        assert manifest in manifest_step
+
+    for upload_step in (
+        "Upload Python audit results",
+        "Upload Pixi audit results",
+        "Upload license audit",
+    ):
+        step = _step(workflow_content, upload_step)
+        assert "if: always()" in step
+        assert "if-no-files-found: error" in step
+
+
+def test_license_audit_fails_on_findings_or_tool_failure(workflow_content: str) -> None:
+    step = _step(workflow_content, "Check licenses")
+
+    assert "uv run --frozen pip-licenses" in step
+    assert '--fail-on="GPL-3.0;AGPL-3.0"' in step
+    assert 'exit "$license_rc"' in step
+    assert "Failed to generate license report" not in step
+
+
+def test_aggregate_uses_exact_named_downloads_and_fail_closed_validator(workflow_content: str) -> None:
+    for artifact in (
+        "python-audit-results",
+        "pixi-audit-results",
+        "license-audit-results",
+    ):
+        assert f"name: {artifact}" in workflow_content
+        assert f"path: audit-results/{artifact}" in workflow_content
+
+    aggregate = _step(workflow_content, "Generate and validate combined report")
+    assert "scripts/ci/dependency_audit_contract.py aggregate" in aggregate
+    assert "NEEDS_JSON" in aggregate
+    assert "${{ toJSON(needs) }}" in aggregate
+    assert "audit-results/**/*.md" not in workflow_content
+    assert "${VULNS:-0}" not in workflow_content
+
+
+def test_permissions_are_minimal_and_pr_code_has_no_write_token(workflow_content: str) -> None:
+    assert re.search(r"(?m)^permissions:\n  contents: read\n\nconcurrency:", workflow_content)
+    assert "uses: ./.github/actions/pr-comment" not in workflow_content
+    assert sorted(re.findall(r"(?m)^      ([a-z-]+): write$", workflow_content)) == [
+        "issues",
+        "security-events",
+    ]
+
+    sast_job = re.search(r"(?ms)^  sast-scan:\n(?P<body>.*?)(?=^  [a-z].*:\n)", workflow_content)
+    assert sast_job is not None
+    assert "permissions:\n      contents: read\n      security-events: write" in sast_job.group("body")
+
+    report_job = re.search(r"(?ms)^  audit-report:\n(?P<body>.*?)(?=^  [a-z].*:\n|\Z)", workflow_content)
+    assert report_job is not None
+    assert "permissions:\n      contents: read\n      issues: write" in report_job.group("body")
+    assert "github.ref == format('refs/heads/{0}', github.event.repository.default_branch)" in report_job.group("body")
+    assert "ref: ${{ github.event.repository.default_branch }}" in report_job.group("body")
+    assert "uses: ./" not in report_job.group("body")
+
+
+@pytest.mark.parametrize("step_name", ["Upload Python audit results", "Upload Pixi audit results"])
+def test_audit_artifacts_upload_even_when_validation_fails(workflow_content: str, step_name: str) -> None:
+    step = _step(workflow_content, step_name)
+
+    assert "if: always()" in step
+    assert "if-no-files-found: error" in step
+
+
+def test_workflow_smoke_runs_dependency_audit_regressions() -> None:
+    smoke = WORKFLOW_SMOKE.read_text(encoding="utf-8")
+    test_step = _step(smoke, "Run security workflow smoke tests")
+
+    assert "tests/workflows/test_security_dependency_audit.py" in smoke
+    assert "scripts/ci/parse_pip_audit.py" in smoke
+    assert "scripts/ci/dependency_audit_contract.py" in smoke
+    assert "tests/workflows/test_security_dependency_audit.py" in test_step
+    assert "tests/scripts/test_parse_pip_audit.py" in test_step
+    assert "tests/scripts/test_dependency_audit_contract.py" in test_step


### PR DESCRIPTION
## Summary

Replace the mutable-environment Security audit with locked, reconciled dependency inputs and fail-closed report aggregation.

## Changes Made

- Audit `requirements-dev.txt` directly and an unfiltered export derived from `uv.lock`.
- Parse modern pip-audit dependency/vulnerability JSON and distinguish findings, malformed output, operational errors, and exit-code contradictions.
- Reconcile every normalized package and exact version between the audited requirements and pip-audit JSON.
- Emit always-run outcome manifests and aggregate them recursively with exact `needs`, artifact, and status contracts.
- Generate and upload the comprehensive report before enforcing the verdict, including invalid-UTF-8 and missing-artifact paths.
- Remove Safety and minimize workflow token permissions.

## Files Modified

- Security and workflow-smoke workflows.
- Two standard-library CI validators.
- Focused parser, reconciliation, workflow, and merge-queue regression tests.

## Verification

- Post-rebase pre-push suite: 1,304 passed, 228 expected skips.
- Focused Security suites: 61 passed; broader workflow/contract suite: 247 passed.
- Two real frozen pip-audit executions reconciled exactly: 202 applicable development packages and 207 lock-export packages.
- Ruff, mypy, Bandit, YAML, pre-commit, and diff checks passed.
- Commit is signed and contains a matching DCO trailer.

Closes #5736