### PR TITLE
feat(dev): add fail-closed Podman preflight

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,18 +10,31 @@
 # ---------------------------------------------------------------------------
 # These control the UID/GID inside Podman containers so that files created
 # in the container have correct ownership on the host filesystem.
-# Default: auto-detected via `id -u` / `id -g` in the justfile.
-# Set explicitly if auto-detection does not match your host user.
-USER_ID=1000
-GROUP_ID=1000
+# The justfile auto-detects these values. Keep them unset unless the container
+# must deliberately use a different numeric identity. The container account is
+# fixed to `dev` to match Dockerfile's sudo policy.
+# USER_ID=1000
+# GROUP_ID=1000
 
 # ---------------------------------------------------------------------------
-# Native vs Podman execution (used by justfile)
+# Container resources
 # ---------------------------------------------------------------------------
-# When set to "1", justfile recipes run commands directly on the host
-# instead of inside a Podman container.  Leave unset (or empty) to use
-# the default Podman-based execution.
-# NATIVE=1
+# Just loads this file and exports one resource contract to preflight and
+# Compose. Use one of the two supported profiles.
+#
+# Default profile: 6 CPUs, 16 GiB nominal runtime, 14 GiB container limit, and
+# up to four concurrent Mojo builds. The guest may reserve up to 512 MiB, so
+# preflight requires usable Podman Host.MemTotal >= 15872 MiB.
+# BUILD_PARALLELISM=4
+# ODYSSEY_MEM_LIMIT=14g
+# ODYSSEY_CPU_LIMIT=6.0
+#
+# Constrained profile: 6 CPUs, 8 GiB nominal runtime, 7 GiB container limit,
+# and one Mojo build at a time. Preflight requires usable Podman Host.MemTotal
+# >= 7680 MiB. Set all three values together.
+# ODYSSEY_MEM_LIMIT=7g
+# ODYSSEY_CPU_LIMIT=6.0
+# BUILD_PARALLELISM=1
 
 # ---------------------------------------------------------------------------
 # Mojo runtime logging (used by src/odyssey/utils/logging.mojo)

--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -755,6 +755,11 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
+      - name: Set up Just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
+        with:
+          just-version: '1.36.0'
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,38 +12,37 @@ services:
       args:
         USER_ID: ${USER_ID}
         GROUP_ID: ${GROUP_ID}
-        USER_NAME: ${USER_NAME:-dev}
+        USER_NAME: dev
     image: odyssey:dev
     volumes:
       - .:/workspace:Z
-      - uv-cache:/home/${USER_NAME:-dev}/.cache/uv
-      - pre-commit-cache:/home/${USER_NAME:-dev}/.cache/pre-commit
-      - ${HOME}/.gitconfig:/home/${USER_NAME:-dev}/.gitconfig:ro
+      - uv-cache:/home/dev/.cache/uv
+      - pre-commit-cache:/home/dev/.cache/pre-commit
+      - ${HOME}/.gitconfig:/home/dev/.gitconfig:ro
     entrypoint: ["/usr/local/bin/entrypoint.sh"]
     environment:
-      - HOME=/home/${USER_NAME:-dev}
+      - HOME=/home/dev
       - USER_ID=${USER_ID}
       - GROUP_ID=${GROUP_ID}
+      - BUILD_PARALLELISM=${BUILD_PARALLELISM:-4}
       - ENVIRONMENT=development
       - TERM=xterm-256color
-      - UV_CACHE_DIR=/home/${USER_NAME:-dev}/.cache/uv
-      - UV_PROJECT_ENVIRONMENT=/home/${USER_NAME:-dev}/.venv
+      - UV_CACHE_DIR=/home/dev/.cache/uv
+      - UV_PROJECT_ENVIRONMENT=/home/dev/.venv
     working_dir: /workspace
     stdin_open: true
     tty: true
     command: /bin/bash
     # Resource limits guard the host from runaway training jobs OOMing the box
-    # (#5313/#5317). Tunable via env vars; defaults sized for a 16-GB / 8-core
-    # developer workstation. Override per-host with:
-    #   ODYSSEY_MEM_LIMIT=8g ODYSSEY_CPU_LIMIT=4 just podman-up
-    # cgroups v1 hosts will silently ignore these — that's fine; on cgroups v2
-    # they enforce.
-    #
+    # (#5313/#5317). Just loads .env and exports the same values to preflight
+    # and every Compose service. See .env.example for the two supported
+    # profiles.
     # Sanitizer note: `just build tsan` and `just build asan` cause the Mojo
     # compiler to allocate ~3-6 GB per invocation (modular/modular#6433).
     # Build sweeps under TSAN may hit OOM if other processes are competing for
-    # memory; on memory-constrained hosts run with explicit swap or a higher
-    # limit, e.g. ODYSSEY_MEM_LIMIT=24g just podman-up.
+    # memory. Constrained hosts must keep builds serial; otherwise use the
+    # default profile on a runtime with the documented nominal and usable
+    # capacity.
     mem_limit: ${ODYSSEY_MEM_LIMIT:-14g}
     cpus: ${ODYSSEY_CPU_LIMIT:-6.0}
 
@@ -58,28 +57,24 @@ services:
       args:
         USER_ID: ${USER_ID}
         GROUP_ID: ${GROUP_ID}
-        USER_NAME: ${USER_NAME:-dev}
+        USER_NAME: dev
     image: odyssey:ci
     volumes:
       - .:/workspace
-      - uv-cache:/home/${USER_NAME:-dev}/.cache/uv
+      - uv-cache:/home/dev/.cache/uv
     entrypoint: ["/usr/local/bin/entrypoint.sh"]
     environment:
-      - HOME=/home/${USER_NAME:-dev}
+      - HOME=/home/dev
       - USER_ID=${USER_ID}
       - GROUP_ID=${GROUP_ID}
+      - BUILD_PARALLELISM=${BUILD_PARALLELISM:-4}
       - ENVIRONMENT=ci
       - CI=true
-      - UV_CACHE_DIR=/home/${USER_NAME:-dev}/.cache/uv
-      - UV_PROJECT_ENVIRONMENT=/home/${USER_NAME:-dev}/.venv
+      - UV_CACHE_DIR=/home/dev/.cache/uv
+      - UV_PROJECT_ENVIRONMENT=/home/dev/.venv
     working_dir: /workspace
-    # Resource limits guard the host from runaway CI jobs OOMing the box
-    # (#5313/#5317). Tunable via env vars; same defaults as the dev service.
-    # Override per-host with:
-    #   ODYSSEY_MEM_LIMIT=8g ODYSSEY_CPU_LIMIT=4 just podman-up
-    # cgroups v1 hosts will silently ignore these — that's fine; on cgroups v2
-    # they enforce.
-    mem_limit: ${ODYSSEY_MEM_LIMIT:-24g}
+    # Resource limits use the same preflighted contract as odyssey-dev.
+    mem_limit: ${ODYSSEY_MEM_LIMIT:-14g}
     cpus: ${ODYSSEY_CPU_LIMIT:-6.0}
     # See odyssey-dev for rationale: ulimit -c must be set on the
     # service so cores survive across `podman compose exec` invocations.
@@ -96,23 +91,19 @@ services:
       args:
         USER_ID: ${USER_ID}
         GROUP_ID: ${GROUP_ID}
-        USER_NAME: ${USER_NAME:-dev}
+        USER_NAME: dev
     image: odyssey:prod
     volumes:
       - .:/workspace:ro
     environment:
-      - HOME=/home/${USER_NAME:-dev}
+      - HOME=/home/dev
       - USER_ID=${USER_ID}
       - GROUP_ID=${GROUP_ID}
+      - BUILD_PARALLELISM=${BUILD_PARALLELISM:-4}
       - ENVIRONMENT=production
     working_dir: /workspace
-    # Resource limits guard the host from runaway training jobs OOMing the box
-    # (#5313/#5317). Tunable via env vars; same defaults as the dev service.
-    # Override per-host with:
-    #   ODYSSEY_MEM_LIMIT=8g ODYSSEY_CPU_LIMIT=4 just podman-up
-    # cgroups v1 hosts will silently ignore these — that's fine; on cgroups v2
-    # they enforce.
-    mem_limit: ${ODYSSEY_MEM_LIMIT:-24g}
+    # Resource limits use the same preflighted contract as odyssey-dev.
+    mem_limit: ${ODYSSEY_MEM_LIMIT:-14g}
     cpus: ${ODYSSEY_CPU_LIMIT:-6.0}
 
 volumes:

--- a/justfile
+++ b/justfile
@@ -1,6 +1,9 @@
 # ML Odyssey Build System
 # Unified build/test/lint interface for Podman containers
 
+# Load the repository .env once, before evaluating exported container values.
+set dotenv-load
+
 # Default recipe - show help
 default: help
 
@@ -16,14 +19,19 @@ BUILD_ROOT := env_var_or_default("BUILD_ROOT", repo_root / "build")
 
 
 # ==============================================================================
-# Automatically detect host UID/GID if not set
+# Shared container identity and bounded build concurrency
 # ==============================================================================
-USER_ID := `sh -c 'echo ${USER_ID:-$(id -u)}'`
-GROUP_ID := `sh -c 'echo ${GROUP_ID:-$(id -g)}'`
+export USER_ID := env_var_or_default("USER_ID", `id -u`)
+export GROUP_ID := env_var_or_default("GROUP_ID", `id -g`)
+export USER_NAME := "dev"
+export BUILD_PARALLELISM := env_var_or_default("BUILD_PARALLELISM", "4")
+export ODYSSEY_MEM_LIMIT := env_var_or_default("ODYSSEY_MEM_LIMIT", "14g")
+export ODYSSEY_CPU_LIMIT := env_var_or_default("ODYSSEY_CPU_LIMIT", "6.0")
 
 show-user:
 	@echo "USER_ID = {{USER_ID}}"
 	@echo "GROUP_ID = {{GROUP_ID}}"
+	@echo "USER_NAME = {{USER_NAME}}"
 
 # ==============================================================================
 # Mojo Compiler Flags
@@ -76,7 +84,6 @@ _run cmd:
 			ORIGINAL_CMD='{{cmd}}'
 			REWRITTEN_CMD="${ORIGINAL_CMD//$BUILD_ROOT/\/ext-build}"
 			podman compose run --rm \
-				-e USER_ID={{USER_ID}} -e GROUP_ID={{GROUP_ID}} \
 				-v "$BUILD_ROOT":/ext-build:Z \
 				{{podman_service}} bash -c "$REWRITTEN_CMD"
 		else
@@ -87,7 +94,6 @@ _run cmd:
 			# does not propagate through `podman compose exec` invocations.
 			HOME_FIXUP='if [ ! -w "$HOME" ]; then export HOME="/tmp/mojo-home-$(id -u)"; mkdir -p "$HOME/.modular" "$HOME/.cache/uv"; fi; ulimit -c unlimited 2>/dev/null || echo "warn: ulimit -c rejected" >&2;'
 			podman compose exec \
-				-e USER_ID={{USER_ID}} -e GROUP_ID={{GROUP_ID}} \
 				-T {{podman_service}} bash -c "$HOME_FIXUP {{cmd}}"
 		fi
 	else
@@ -105,6 +111,10 @@ _ensure_build_dir mode:
 # Podman Management
 # ==============================================================================
 
+# Validate Podman availability, engine reachability, and runtime resources
+podman-preflight:
+    @scripts/podman-preflight.sh
+
 # Start Podman development environment
 #
 # If a container already exists but is bind-mounted to a different clone
@@ -113,15 +123,11 @@ _ensure_build_dir mode:
 # lets the same dev work seamlessly across multiple clones without
 # manually running `podman compose down` from the old clone first.
 #
-# docker-compose substitutes ${USER_ID}/${GROUP_ID} in docker-compose.yml from
-# its OWN environment, not from just's template vars. Without explicit
-# `USER_ID=... GROUP_ID=...` exports on the same line, the variables expand to
-# empty strings and the container would get `user: ":"` (invalid), causing
-# the compose call to fail or create a stuck container in an invalid state.
-podman-up:
+# The shared exported values at the top of this file are inherited by every
+# Compose command, so build args, runtime user mapping, and caches agree.
+podman-up: podman-preflight
     #!/usr/bin/env bash
     set -euo pipefail
-    export USER_ID="{{USER_ID}}" GROUP_ID="{{GROUP_ID}}" USER_NAME="${USER_NAME:-dev}"
     EXPECTED="{{repo_root}}"
     EXISTING=$(podman inspect odyssey-{{podman_service}}-1 \
         --format '{{{{range .Mounts}}{{{{if eq .Destination "/workspace"}}{{{{.Source}}{{{{end}}{{{{end}}' 2>/dev/null || echo "")
@@ -135,22 +141,15 @@ podman-up:
 
 # Stop Podman development environment
 podman-down:
-    @USER_ID={{USER_ID}} GROUP_ID={{GROUP_ID}} USER_NAME=${USER_NAME:-dev} \
-        podman compose down
+    @podman compose down
 
 # Build Podman images
-podman-build:
-    @podman compose build \
-        --build-arg USER_ID={{USER_ID}} \
-        --build-arg GROUP_ID={{GROUP_ID}} \
-        --build-arg USER_NAME=dev
+podman-build: podman-preflight
+    @podman compose build
 
 # Rebuild Podman images (no cache)
-podman-rebuild:
-    @podman compose build --no-cache \
-        --build-arg USER_ID={{USER_ID}} \
-        --build-arg GROUP_ID={{GROUP_ID}} \
-        --build-arg USER_NAME=dev
+podman-rebuild: podman-preflight
+    @podman compose build --no-cache
 
 # View Podman container logs
 podman-logs:
@@ -173,7 +172,7 @@ REGISTRY := "ghcr.io"
 REPO_NAME := "homericintelligence/odyssey"
 
 # Build CI-optimized container image
-podman-build-ci target="runtime":
+podman-build-ci target="runtime": podman-preflight
     @podman build --format docker -f Dockerfile.ci --target {{target}} \
         -t {{REGISTRY}}/{{REPO_NAME}}:{{target}} \
         -t {{REGISTRY}}/{{REPO_NAME}}:{{target}}-$(git rev-parse --short HEAD) \
@@ -202,18 +201,29 @@ podman-release target="runtime":
     @just podman-push {{target}}
 
 # Test container image locally
-podman-test-image target="runtime":
+podman-test-image target="runtime": podman-preflight
     @echo "Testing {{target}} image..."
-    @podman run --rm {{REGISTRY}}/{{REPO_NAME}}:{{target}} uv run mojo --version
+    @podman run --rm {{REGISTRY}}/{{REPO_NAME}}:{{target}} mojo --version
     @echo "✅ Image {{target}} is working"
 
 # Run tests in container image
-podman-run-tests target="runtime":
-    @podman run --rm {{REGISTRY}}/{{REPO_NAME}}:{{target}} \
-        uv run mojo test {{MOJO_TARGET_CPU}} -I . tests/
+podman-run-tests target="runtime": podman-preflight
+    #!/usr/bin/env bash
+    set -euo pipefail
+    podman run --rm {{REGISTRY}}/{{REPO_NAME}}:{{target}} bash -ceu '
+        mapfile -t test_files < <(find tests -type f -name "test_*.mojo" -print | sort)
+        if [ "${#test_files[@]}" -eq 0 ]; then
+            echo "ERROR: No Mojo test files found in tests/" >&2
+            exit 1
+        fi
+        for test_file in "${test_files[@]}"; do
+            echo "Testing: $test_file"
+            mojo --Werror -I src -I . "$test_file"
+        done
+    '
 
 # Interactive shell in container image
-podman-run-shell target="runtime":
+podman-run-shell target="runtime": podman-preflight
     @podman run -it --rm {{REGISTRY}}/{{REPO_NAME}}:{{target}} bash
 
 # ==============================================================================
@@ -221,7 +231,7 @@ podman-run-shell target="runtime":
 # ==============================================================================
 
 # Build container image exactly as CI does
-ci-podman-build:
+ci-podman-build: podman-preflight
     @podman build --format docker \
         --file Dockerfile.ci \
         --target runtime \
@@ -230,7 +240,7 @@ ci-podman-build:
         .
 
 # Validate container build without pushing
-ci-podman-validate:
+ci-podman-validate: podman-preflight
     @echo "Validating Dockerfile.ci..."
     @podman build -f Dockerfile.ci --target runtime . >/dev/null
     @echo "✅ Dockerfile.ci is valid"
@@ -367,9 +377,10 @@ _build-inner mode="debug":
     # timeout once the autograd example ports landed (#5454); bounded parallelism
     # keeps every mode's build under budget without OOMing the runner.
     #
-    # BUILD_PARALLELISM: number of concurrent `mojo build` jobs. Defaults to 4
-    # (fits a standard 4-core/16 GB CI runner); override via env for tighter or
-    # looser hosts. TSAN forces serial (JOBS=-j1 already; keep 1 worker too).
+    # BUILD_PARALLELISM: number of concurrent `mojo build` jobs. Defaults to 4,
+    # leaving headroom on the preflighted 6-CPU/16-GiB local runtime. Override
+    # via env for tighter or looser hosts. TSAN forces serial (JOBS=-j1 already;
+    # keep 1 worker too).
     # ------------------------------------------------------------
     if [ "$MODE" = "tsan" ]; then
         BUILD_PARALLELISM=1
@@ -816,14 +827,14 @@ bootstrap:
 
 # Open development shell. Auto-starts the container if it isn't running, so
 # new developers don't need to remember to `just podman-up` first (#5329).
-shell:
+shell: podman-preflight
     #!/usr/bin/env bash
     set -euo pipefail
     if ! podman compose ps --services --filter "status=running" 2>/dev/null | grep -q "^{{podman_service}}$"; then
         echo "Container '{{podman_service}}' is not running — starting it now (just podman-up)..."
         just podman-up
     fi
-    podman compose exec -it -e USER_ID={{USER_ID}} -e GROUP_ID={{GROUP_ID}} {{podman_service}} bash
+    podman compose exec -it {{podman_service}} bash
 
 # Serve documentation
 docs-serve:
@@ -1308,7 +1319,7 @@ help:
     @echo "Package:   package [mode], package-debug, package-release"
     @echo "Test:      test, test-python, test-group, test-group-asan, test-mojo"
     @echo "Jupyter:   jupyter, jupyter-notebook, jupyter-validate, jupyter-clear"
-    @echo "Podman:    podman-up, podman-down, podman-build, podman-logs, podman-status"
+    @echo "Podman:    podman-preflight, podman-up, podman-down, podman-build, podman-logs, podman-status"
     @echo "Dev:       bootstrap, shell, docs, docs-serve, pre-commit, validate"
     @echo "Utility:   help, status, clean, clean-all"
     @echo ""

--- a/scripts/podman-preflight.sh
+++ b/scripts/podman-preflight.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+#
+# Validate the local Podman runtime without changing machine state.
+#
+# Mojo compilation is memory intensive. The default and constrained profiles
+# target nominal 16-GiB and 8-GiB runtimes, respectively. Podman Host.MemTotal
+# may be at most 512 MiB lower because the guest reserves memory for itself.
+# The rendered Compose model and active engine are authoritative; this script
+# never guesses which Podman machine is in use.
+
+set -euo pipefail
+
+fail() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+require_positive_integer() {
+    local name="$1"
+    local value="$2"
+    if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+        fail "$name must be a positive integer (received '$value')."
+    fi
+}
+
+normalize_memory_bytes() {
+    python3 - "$1" <<'PY' 2>/dev/null
+from decimal import Decimal, InvalidOperation
+import re
+import sys
+
+value = sys.argv[1]
+match = re.fullmatch(
+    r"(?i)([0-9]+(?:\.[0-9]+)?|\.[0-9]+)(b|k|kb|ki|kib|m|mb|mi|mib|g|gb|gi|gib)?",
+    value,
+)
+if match is None:
+    raise SystemExit(1)
+
+try:
+    number = Decimal(match.group(1))
+except InvalidOperation:
+    raise SystemExit(1)
+if number <= 0:
+    raise SystemExit(1)
+
+unit = (match.group(2) or "b").lower()
+power = {
+    "b": 0,
+    "k": 1,
+    "kb": 1,
+    "ki": 1,
+    "kib": 1,
+    "m": 2,
+    "mb": 2,
+    "mi": 2,
+    "mib": 2,
+    "g": 3,
+    "gb": 3,
+    "gi": 3,
+    "gib": 3,
+}[unit]
+byte_count = number * (Decimal(1024) ** power)
+if byte_count != byte_count.to_integral_value():
+    raise SystemExit(1)
+print(int(byte_count))
+PY
+}
+
+normalize_cpu_micros() {
+    python3 - "$1" <<'PY' 2>/dev/null
+from decimal import Decimal, InvalidOperation
+import re
+import sys
+
+value = sys.argv[1]
+if re.fullmatch(r"(?:[0-9]+(?:\.[0-9]+)?|\.[0-9]+)", value) is None:
+    raise SystemExit(1)
+try:
+    cpus = Decimal(value)
+except InvalidOperation:
+    raise SystemExit(1)
+micros = cpus * 1_000_000
+if cpus <= 0 or micros != micros.to_integral_value():
+    raise SystemExit(1)
+print(int(micros))
+PY
+}
+
+resource_remediation() {
+    printf 'Increase resources for the host or machine selected by the active '
+    printf 'Podman connection, then restart Podman as needed.\n'
+    printf 'Inspect the active connection with: podman system connection list\n'
+    printf 'Supported profiles:\n'
+    printf '  default:     ODYSSEY_MEM_LIMIT=14g ODYSSEY_CPU_LIMIT=6.0 '
+    printf 'BUILD_PARALLELISM=1..4 (16-GiB nominal; Host.MemTotal >=15872 MiB)\n'
+    printf '  constrained: ODYSSEY_MEM_LIMIT=7g ODYSSEY_CPU_LIMIT=6.0 '
+    printf 'BUILD_PARALLELISM=1 (8-GiB nominal; Host.MemTotal >=7680 MiB)\n'
+}
+
+if ! command -v podman >/dev/null 2>&1; then
+    fail "Podman is not installed. Install Podman before running container recipes."
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+    fail "python3 is required to validate Podman and Compose resources."
+fi
+
+user_id="${USER_ID:-$(id -u)}"
+group_id="${GROUP_ID:-$(id -g)}"
+build_parallelism="${BUILD_PARALLELISM:-4}"
+compose_memory_limit="${ODYSSEY_MEM_LIMIT:-14g}"
+compose_cpu_limit="${ODYSSEY_CPU_LIMIT:-6.0}"
+
+require_positive_integer "USER_ID" "$user_id"
+require_positive_integer "GROUP_ID" "$group_id"
+require_positive_integer "BUILD_PARALLELISM" "$build_parallelism"
+if ! compose_memory_bytes="$(normalize_memory_bytes "$compose_memory_limit")"; then
+    fail "ODYSSEY_MEM_LIMIT must be a positive Compose byte value (received '$compose_memory_limit')."
+fi
+if ! compose_cpu_micros="$(normalize_cpu_micros "$compose_cpu_limit")"; then
+    fail "ODYSSEY_CPU_LIMIT must be a positive number (received '$compose_cpu_limit')."
+fi
+
+# Compose requires these substitutions even when the caller invokes the script
+# directly instead of through Just. Just exports the same values after loading
+# .env, so preflight and all subsequent Compose commands share one contract.
+export USER_ID="$user_id"
+export GROUP_ID="$group_id"
+export BUILD_PARALLELISM="$build_parallelism"
+export USER_NAME="dev"
+export ODYSSEY_MEM_LIMIT="$compose_memory_limit"
+export ODYSSEY_CPU_LIMIT="$compose_cpu_limit"
+
+# Query the engine selected by the active connection before inspecting or
+# assuming anything about locally configured machines. podman info reports the
+# capacity of that reachable engine for both native and machine-backed setups.
+if ! podman_info="$(podman info --format json 2>/dev/null)"; then
+    {
+        printf 'ERROR: Podman engine is not reachable for the active connection.\n'
+        printf 'Start that Podman machine or rootless service.\n'
+        printf 'Inspect the active connection with: podman system connection list\n'
+    } >&2
+    exit 1
+fi
+
+if ! host_resources="$(
+    python3 -c '
+import json
+import sys
+
+info = json.load(sys.stdin)
+host = info.get("host", info.get("Host", {}))
+cpus = host.get("cpus", host.get("CPUs"))
+memory = host.get("memTotal", host.get("MemTotal"))
+if not isinstance(cpus, int) or not isinstance(memory, int):
+    raise SystemExit("Podman info omitted host CPU or memory data")
+if cpus <= 0 or memory <= 0:
+    raise SystemExit("Podman info reported non-positive host resources")
+print(f"{cpus}|{memory}")
+' <<<"$podman_info"
+)"; then
+    fail "Could not read CPU and memory capacity from podman info."
+fi
+IFS='|' read -r runtime_cpus runtime_memory_bytes <<<"$host_resources"
+require_positive_integer "Podman host CPU count" "$runtime_cpus"
+require_positive_integer "Podman host memory" "$runtime_memory_bytes"
+runtime_memory_mib=$((runtime_memory_bytes / 1024 / 1024))
+runtime_cpu_micros=$((runtime_cpus * 1000000))
+
+if ! podman compose version >/dev/null 2>&1; then
+    fail "Podman Compose is unavailable. Install a Podman Compose provider."
+fi
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+if ! compose_config="$(
+    cd "$repo_root"
+    podman compose config
+)" 2>/dev/null; then
+    fail "Podman Compose configuration is invalid. Check container identity and resource settings."
+fi
+
+# Parse only the stable Compose surface needed here. This deliberately avoids a
+# PyYAML dependency in the bootstrap path while still validating the rendered
+# model produced by the installed Compose provider.
+if ! rendered_limits="$(
+    printf '%s\n' "$compose_config" | python3 -c '
+import re
+import sys
+
+expected = {"odyssey-dev", "odyssey-ci", "odyssey-prod"}
+services = {}
+current = None
+in_services = False
+for raw_line in sys.stdin:
+    line = raw_line.rstrip()
+    if not line or line.lstrip().startswith("#"):
+        continue
+    indent = len(line) - len(line.lstrip())
+    stripped = line.strip()
+    if indent == 0:
+        in_services = stripped == "services:"
+        current = None
+        continue
+    if not in_services:
+        continue
+    if indent == 2 and stripped.endswith(":"):
+        current = stripped[:-1].strip("\"'\''")
+        if current in services:
+            raise SystemExit("duplicate rendered Compose service")
+        services[current] = {}
+        continue
+    if current is None or indent != 4:
+        continue
+    match = re.fullmatch(r"(cpus|mem_limit):\s*(.*)", stripped)
+    if match is None:
+        continue
+    key, value = match.groups()
+    if key in services[current]:
+        raise SystemExit("duplicate rendered Compose resource")
+    services[current][key] = value.strip().strip("\"'\''")
+
+if set(services) != expected:
+    raise SystemExit("unexpected or missing rendered Compose services")
+for service in sorted(expected):
+    resources = services[service]
+    if set(resources) != {"cpus", "mem_limit"}:
+        raise SystemExit("missing rendered Compose resource")
+    print(f"{service}|{resources['\''mem_limit'\'']}|{resources['\''cpus'\'']}")
+'
+)"; then
+    fail "Could not read the rendered Compose resource limits for all services."
+fi
+
+rendered_count=0
+while IFS='|' read -r service rendered_memory rendered_cpu; do
+    [[ -n "$service" ]] || continue
+    rendered_count=$((rendered_count + 1))
+    if ! rendered_memory_bytes="$(normalize_memory_bytes "$rendered_memory")"; then
+        fail "$service rendered Compose memory limit is invalid ('$rendered_memory')."
+    fi
+    if ! rendered_cpu_micros="$(normalize_cpu_micros "$rendered_cpu")"; then
+        fail "$service rendered Compose CPU limit is invalid ('$rendered_cpu')."
+    fi
+    if ((rendered_memory_bytes != compose_memory_bytes)); then
+        fail "$service rendered Compose memory limit contradicts ODYSSEY_MEM_LIMIT."
+    fi
+    if ((rendered_cpu_micros != compose_cpu_micros)); then
+        fail "$service rendered Compose CPU limit contradicts ODYSSEY_CPU_LIMIT."
+    fi
+done <<<"$rendered_limits"
+if ((rendered_count != 3)); then
+    fail "Could not read the rendered Compose resource limits for all services."
+fi
+
+if ((build_parallelism * 1000000 > compose_cpu_micros)); then
+    fail "BUILD_PARALLELISM ($build_parallelism) cannot exceed the effective Compose CPU limit ($compose_cpu_limit)."
+fi
+
+gib=$((1024 * 1024 * 1024))
+default_memory_bytes=$((14 * gib))
+constrained_memory_bytes=$((7 * gib))
+required_cpu_micros=6000000
+if ((compose_memory_bytes == default_memory_bytes)) \
+    && ((compose_cpu_micros == required_cpu_micros)) \
+    && ((build_parallelism <= 4)); then
+    profile_name="default"
+    nominal_memory_gib=16
+    minimum_usable_memory_mib=15872
+elif ((compose_memory_bytes == constrained_memory_bytes)) \
+    && ((compose_cpu_micros == required_cpu_micros)) \
+    && ((build_parallelism == 1)); then
+    profile_name="constrained"
+    nominal_memory_gib=8
+    minimum_usable_memory_mib=7680
+else
+    {
+        printf 'ERROR: Resource settings do not match a supported resource profile.\n'
+        resource_remediation
+    } >&2
+    exit 1
+fi
+minimum_cpus=6
+minimum_usable_memory_bytes=$((minimum_usable_memory_mib * 1024 * 1024))
+
+if ((compose_memory_bytes > runtime_memory_bytes)); then
+    {
+        printf 'ERROR: Compose memory limit (%s bytes) exceeds active Podman engine memory (%s bytes).\n' \
+            "$compose_memory_bytes" "$runtime_memory_bytes"
+        resource_remediation
+    } >&2
+    exit 1
+fi
+if ((compose_cpu_micros > runtime_cpu_micros)); then
+    {
+        printf 'ERROR: Compose CPU limit (%s) exceeds active Podman engine CPUs (%s).\n' \
+            "$compose_cpu_limit" "$runtime_cpus"
+        resource_remediation
+    } >&2
+    exit 1
+fi
+if ((runtime_cpus < minimum_cpus)) || ((runtime_memory_bytes < minimum_usable_memory_bytes)); then
+    {
+        printf 'ERROR: The active Podman engine has %s CPUs and %s MiB memory; ' \
+            "$runtime_cpus" "$runtime_memory_mib"
+        printf 'the %s profile targets %s GiB nominal configured capacity, ' \
+            "$profile_name" "$nominal_memory_gib"
+        printf 'requires at least %s CPUs, and requires Host.MemTotal of at least %s MiB ' \
+            "$minimum_cpus" "$minimum_usable_memory_mib"
+        printf '(allowing up to 512 MiB for the Podman guest reservation).\n'
+        resource_remediation
+    } >&2
+    exit 1
+fi
+
+printf 'Podman preflight passed (%s CPUs, %s MiB memory, %s build jobs, %s profile).\n' \
+    "$runtime_cpus" "$runtime_memory_mib" "$build_parallelism" "$profile_name"

--- a/tests/scripts/test_podman_preflight.py
+++ b/tests/scripts/test_podman_preflight.py
@@ -1,0 +1,730 @@
+"""Regression tests for the local Podman development contract.
+
+The executable tests use a stub ``podman`` binary, so they never inspect or
+modify a developer's real Podman machine.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).parents[2]
+PREFLIGHT = REPO_ROOT / "scripts" / "podman-preflight.sh"
+JUSTFILE = REPO_ROOT / "justfile"
+COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
+ENV_EXAMPLE = REPO_ROOT / ".env.example"
+COMPREHENSIVE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "comprehensive-tests.yml"
+SETUP_JUST_ACTION = "extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3"
+SETUP_JUST_VERSION = "1.36.0"
+
+
+def _write_podman_stub(tmp_path: Path) -> Path:
+    """Create a configurable Podman CLI double and return its bin directory."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    podman = bin_dir / "podman"
+    podman.write_text(
+        f"""#!{sys.executable}
+import json
+import os
+import sys
+
+args = sys.argv[1:]
+if call_log := os.environ.get("STUB_CALL_LOG"):
+    with open(call_log, "a", encoding="utf-8") as stream:
+        stream.write(" ".join(args) + "\\n")
+
+if args == ["--version"]:
+    print("podman version 5.6.0")
+elif args == ["compose", "version"]:
+    if os.environ.get("STUB_COMPOSE_OK", "1") == "1":
+        print("podman-compose version 1.4.0")
+    else:
+        raise SystemExit(125)
+elif args == ["compose", "config"]:
+    if os.environ.get("STUB_COMPOSE_CONFIG_OK", "1") != "1":
+        raise SystemExit(125)
+    memory = os.environ.get(
+        "STUB_RENDERED_MEM_LIMIT", os.environ.get("ODYSSEY_MEM_LIMIT", "14g")
+    )
+    cpus = os.environ.get(
+        "STUB_RENDERED_CPU_LIMIT", os.environ.get("ODYSSEY_CPU_LIMIT", "6.0")
+    )
+    for service in ("odyssey-dev", "odyssey-ci", "odyssey-prod"):
+        key = service.upper().replace("-", "_")
+        service_memory = os.environ.get(
+            f"STUB_RENDERED_{{key}}_MEM_LIMIT", memory
+        )
+        service_cpus = os.environ.get(
+            f"STUB_RENDERED_{{key}}_CPU_LIMIT", cpus
+        )
+        if service == "odyssey-dev":
+            print("services:")
+        print(f"  {{service}}:")
+        print(f"    cpus: '{{service_cpus}}'")
+        print(f"    mem_limit: '{{service_memory}}'")
+    if env_log := os.environ.get("STUB_ENV_LOG"):
+        with open(env_log, "a", encoding="utf-8") as stream:
+            stream.write(
+                "|".join(
+                    [
+                        os.environ.get("USER_ID", ""),
+                        os.environ.get("GROUP_ID", ""),
+                        os.environ.get("BUILD_PARALLELISM", ""),
+                        os.environ.get("ODYSSEY_MEM_LIMIT", ""),
+                        os.environ.get("ODYSSEY_CPU_LIMIT", ""),
+                    ]
+                )
+                + "\\n"
+            )
+elif args[:2] == ["machine", "inspect"]:
+    if os.environ.get("STUB_MACHINE_PRESENT", "1") != "1":
+        raise SystemExit(125)
+    print(
+        "|".join(
+            [
+                os.environ.get("STUB_MACHINE_NAME", "podman-machine-default"),
+                os.environ.get("STUB_MACHINE_STATE", "running"),
+                os.environ.get("STUB_MACHINE_CPUS", "6"),
+                os.environ.get("STUB_MACHINE_MEMORY_MIB", "16384"),
+            ]
+        )
+    )
+elif args == ["info", "--format", "json"]:
+    if os.environ.get("STUB_INFO_OK", "1") != "1":
+        raise SystemExit(125)
+    print(
+        json.dumps(
+            {{
+                "host": {{
+                    "cpus": int(os.environ.get("STUB_HOST_CPUS", "6")),
+                    "memTotal": int(
+                        os.environ.get("STUB_HOST_MEMORY_BYTES", str(16 * 1024**3))
+                    ),
+                }}
+            }}
+        )
+    )
+elif args == ["info"]:
+    if os.environ.get("STUB_INFO_OK", "1") != "1":
+        raise SystemExit(125)
+    print("host: stub")
+else:
+    print(f"unexpected podman arguments: {{args!r}}", file=sys.stderr)
+    raise SystemExit(64)
+""",
+        encoding="utf-8",
+    )
+    podman.chmod(podman.stat().st_mode | stat.S_IXUSR)
+    return bin_dir
+
+
+def _run_preflight(
+    tmp_path: Path,
+    *,
+    include_podman: bool = True,
+    overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run the real preflight script against a configurable Podman stub."""
+    bin_dir = _write_podman_stub(tmp_path) if include_podman else tmp_path / "empty-bin"
+    bin_dir.mkdir(exist_ok=True)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}" if include_podman else str(bin_dir)
+    env.pop("ODYSSEY_MEM_LIMIT", None)
+    env.pop("BUILD_PARALLELISM", None)
+    env.pop("ODYSSEY_PODMAN_MIN_CPUS", None)
+    env.pop("ODYSSEY_PODMAN_MIN_MEMORY_GIB", None)
+    env.pop("ODYSSEY_CPU_LIMIT", None)
+    env.pop("USER_ID", None)
+    env.pop("GROUP_ID", None)
+    env.pop("USER_NAME", None)
+    env["USER_ID"] = "1000"
+    env["GROUP_ID"] = "1000"
+    if overrides:
+        env.update(overrides)
+
+    return subprocess.run(
+        ["/bin/bash", str(PREFLIGHT)],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _run_just_preflight(
+    tmp_path: Path,
+    *,
+    dotenv: str,
+    overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``just podman-preflight`` from a copied project with a real .env."""
+    project = tmp_path / "project"
+    scripts = project / "scripts"
+    scripts.mkdir(parents=True)
+    shutil.copy2(JUSTFILE, project / "justfile")
+    shutil.copy2(COMPOSE_FILE, project / "docker-compose.yml")
+    shutil.copy2(PREFLIGHT, scripts / PREFLIGHT.name)
+    (project / ".env").write_text(dotenv, encoding="utf-8")
+
+    bin_dir = _write_podman_stub(tmp_path)
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    for variable in (
+        "USER_ID",
+        "GROUP_ID",
+        "BUILD_PARALLELISM",
+        "ODYSSEY_MEM_LIMIT",
+        "ODYSSEY_CPU_LIMIT",
+    ):
+        env.pop(variable, None)
+    if overrides:
+        env.update(overrides)
+
+    return subprocess.run(
+        ["just", "podman-preflight"],
+        cwd=project,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _recipe_header(justfile: str, recipe: str) -> str:
+    """Return the header line for one public Just recipe."""
+    match = re.search(rf"^{re.escape(recipe)}(?: [^:]*)?:[^\n]*$", justfile, re.MULTILINE)
+    assert match is not None, f"missing Just recipe: {recipe}"
+    return match.group(0)
+
+
+def test_preflight_is_an_executable_script() -> None:
+    """The public Just recipe must delegate to a checked-in executable."""
+    assert PREFLIGHT.is_file()
+    assert PREFLIGHT.stat().st_mode & stat.S_IXUSR
+
+
+def test_preflight_fails_when_podman_is_missing(tmp_path: Path) -> None:
+    """A missing runtime must fail before a container command is attempted."""
+    result = _run_preflight(tmp_path, include_podman=False)
+
+    assert result.returncode != 0
+    assert "Podman is not installed" in result.stderr
+
+
+def test_preflight_fails_when_compose_provider_is_missing(tmp_path: Path) -> None:
+    """Podman without a Compose provider cannot run the development recipes."""
+    result = _run_preflight(
+        tmp_path,
+        overrides={"STUB_COMPOSE_OK": "0"},
+    )
+
+    assert result.returncode != 0
+    assert "Podman Compose is unavailable" in result.stderr
+
+
+def test_stopped_default_machine_does_not_mask_reachable_active_engine(
+    tmp_path: Path,
+) -> None:
+    """Resources come from the reachable connection, not a stopped default VM."""
+    call_log = tmp_path / "podman-calls.log"
+    result = _run_preflight(
+        tmp_path,
+        overrides={
+            "STUB_MACHINE_STATE": "stopped",
+            "STUB_MACHINE_CPUS": "1",
+            "STUB_MACHINE_MEMORY_MIB": "1024",
+            "STUB_CALL_LOG": str(call_log),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    calls = call_log.read_text(encoding="utf-8").splitlines()
+    assert "info --format json" in calls
+    assert not any(call.startswith("machine inspect") for call in calls)
+
+
+@pytest.mark.parametrize(
+    ("cpus", "memory_mib"),
+    [
+        ("5", "16384"),
+        ("6", "8192"),
+    ],
+)
+def test_preflight_fails_when_active_engine_is_below_default_resources(
+    tmp_path: Path,
+    cpus: str,
+    memory_mib: str,
+) -> None:
+    """The default profile requires the Compose-aligned 6 CPU / 16 GiB VM."""
+    result = _run_preflight(
+        tmp_path,
+        overrides={
+            "STUB_HOST_CPUS": cpus,
+            "STUB_HOST_MEMORY_BYTES": str(int(memory_mib) * 1024**2),
+        },
+    )
+
+    assert result.returncode != 0
+    assert "active Podman engine" in result.stderr
+    assert "podman system connection list" in result.stderr
+
+
+def test_preflight_rejects_implicit_low_memory_profile(tmp_path: Path) -> None:
+    """An 8 GiB VM is unsafe unless both constrained-profile knobs are explicit."""
+    result = _run_preflight(
+        tmp_path,
+        overrides={
+            "STUB_HOST_MEMORY_BYTES": str(8 * 1024**3),
+            "BUILD_PARALLELISM": "1",
+        },
+    )
+
+    assert result.returncode != 0
+    assert "ODYSSEY_MEM_LIMIT=7g" in result.stderr
+    assert "BUILD_PARALLELISM=1" in result.stderr
+
+
+def test_preflight_accepts_explicit_constrained_profile(tmp_path: Path) -> None:
+    """The documented serial 7 GiB Compose limit may run on an 8 GiB VM."""
+    result = _run_preflight(
+        tmp_path,
+        overrides={
+            "STUB_HOST_MEMORY_BYTES": str(8 * 1024**3),
+            "ODYSSEY_MEM_LIMIT": "7g",
+            "BUILD_PARALLELISM": "1",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("usable_memory_mib", [7907, 7680])
+def test_constrained_profile_accepts_bounded_guest_reservation(
+    tmp_path: Path,
+    usable_memory_mib: int,
+) -> None:
+    """An 8-GiB nominal VM may reserve at most 512 MiB from Host.MemTotal."""
+    result = _run_preflight(
+        tmp_path,
+        overrides={
+            "STUB_HOST_MEMORY_BYTES": str(usable_memory_mib * 1024**2),
+            "ODYSSEY_MEM_LIMIT": "7g",
+            "BUILD_PARALLELISM": "1",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_constrained_profile_rejects_excess_guest_reservation(
+    tmp_path: Path,
+) -> None:
+    """A usable Host.MemTotal below 7680 MiB exceeds the reservation budget."""
+    result = _run_preflight(
+        tmp_path,
+        overrides={
+            "STUB_HOST_MEMORY_BYTES": str(7679 * 1024**2),
+            "ODYSSEY_MEM_LIMIT": "7g",
+            "BUILD_PARALLELISM": "1",
+        },
+    )
+
+    assert result.returncode != 0
+    assert "8 GiB nominal configured capacity" in result.stderr
+    assert "Host.MemTotal of at least 7680 MiB" in result.stderr
+
+
+def test_default_profile_accepts_usable_memory_boundary(tmp_path: Path) -> None:
+    """A 16-GiB nominal VM may reserve exactly 512 MiB from Host.MemTotal."""
+    result = _run_preflight(
+        tmp_path,
+        overrides={"STUB_HOST_MEMORY_BYTES": str(15872 * 1024**2)},
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_default_profile_rejects_below_usable_memory_boundary(
+    tmp_path: Path,
+) -> None:
+    """A default profile below 15872 MiB usable memory fails closed."""
+    result = _run_preflight(
+        tmp_path,
+        overrides={"STUB_HOST_MEMORY_BYTES": str(15871 * 1024**2)},
+    )
+
+    assert result.returncode != 0
+    assert "16 GiB nominal configured capacity" in result.stderr
+    assert "Host.MemTotal of at least 15872 MiB" in result.stderr
+
+
+def test_preflight_rejects_undocumented_resource_profile(tmp_path: Path) -> None:
+    """Only the reviewed default and constrained resource profiles are valid."""
+    result = _run_preflight(
+        tmp_path,
+        overrides={
+            "ODYSSEY_MEM_LIMIT": "10g",
+            "BUILD_PARALLELISM": "2",
+        },
+    )
+
+    assert result.returncode != 0
+    assert "supported resource profile" in result.stderr
+
+
+@pytest.mark.parametrize("memory", ["7g", "7G", "7gb", "7168m", "7516192768"])
+def test_preflight_normalizes_equivalent_constrained_memory_units(
+    tmp_path: Path,
+    memory: str,
+) -> None:
+    """Compose-equivalent memory spellings select the same safe profile."""
+    result = _run_preflight(
+        tmp_path,
+        overrides={
+            "STUB_HOST_MEMORY_BYTES": str(8 * 1024**3),
+            "ODYSSEY_MEM_LIMIT": memory,
+            "BUILD_PARALLELISM": "1",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "constrained profile" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("parallelism", "diagnostic"),
+    [
+        ("0", "BUILD_PARALLELISM must be a positive integer"),
+        ("many", "BUILD_PARALLELISM must be a positive integer"),
+        ("7", "cannot exceed the effective Compose CPU limit"),
+    ],
+)
+def test_preflight_rejects_invalid_or_oversized_build_parallelism(
+    tmp_path: Path,
+    parallelism: str,
+    diagnostic: str,
+) -> None:
+    """Build concurrency must be positive and fit the checked runtime."""
+    result = _run_preflight(
+        tmp_path,
+        overrides={"BUILD_PARALLELISM": parallelism},
+    )
+
+    assert result.returncode != 0
+    assert diagnostic in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("overrides", "diagnostic"),
+    [
+        ({"USER_ID": "0"}, "USER_ID must be a positive integer"),
+        ({"GROUP_ID": "staff"}, "GROUP_ID must be a positive integer"),
+        (
+            {"ODYSSEY_MEM_LIMIT": "a-lot"},
+            "ODYSSEY_MEM_LIMIT must be a positive Compose byte value",
+        ),
+        (
+            {"ODYSSEY_CPU_LIMIT": "0"},
+            "ODYSSEY_CPU_LIMIT must be a positive number",
+        ),
+    ],
+)
+def test_preflight_rejects_invalid_identity_and_compose_resource_values(
+    tmp_path: Path,
+    overrides: dict[str, str],
+    diagnostic: str,
+) -> None:
+    """Invalid interpolation values fail before Compose consumes them."""
+    result = _run_preflight(tmp_path, overrides=overrides)
+
+    assert result.returncode != 0
+    assert diagnostic in result.stderr
+
+
+def test_preflight_requires_reachable_engine(tmp_path: Path) -> None:
+    """A correctly sized VM does not pass when its engine is unreachable."""
+    result = _run_preflight(
+        tmp_path,
+        overrides={"STUB_INFO_OK": "0"},
+    )
+
+    assert result.returncode != 0
+    assert "Podman engine is not reachable" in result.stderr
+    assert "podman system connection list" in result.stderr
+
+
+def test_preflight_rejects_compose_memory_quota_above_active_runtime(
+    tmp_path: Path,
+) -> None:
+    """The effective container memory quota must fit the connected engine."""
+    result = _run_preflight(
+        tmp_path,
+        overrides={"STUB_HOST_MEMORY_BYTES": str(13 * 1024**3)},
+    )
+
+    assert result.returncode != 0
+    assert "Compose memory limit" in result.stderr
+    assert "exceeds active Podman engine memory" in result.stderr
+
+
+def test_preflight_rejects_compose_cpu_quota_above_active_runtime(
+    tmp_path: Path,
+) -> None:
+    """The effective container CPU quota must fit the connected engine."""
+    result = _run_preflight(
+        tmp_path,
+        overrides={"STUB_HOST_CPUS": "5"},
+    )
+
+    assert result.returncode != 0
+    assert "Compose CPU limit" in result.stderr
+    assert "exceeds active Podman engine CPUs" in result.stderr
+
+
+def test_preflight_validates_compose_config_after_engine_readiness(
+    tmp_path: Path,
+) -> None:
+    """The resolved Compose model is checked only after the engine responds."""
+    call_log = tmp_path / "podman-calls.log"
+    result = _run_preflight(
+        tmp_path,
+        overrides={
+            "STUB_CALL_LOG": str(call_log),
+            "STUB_COMPOSE_CONFIG_OK": "0",
+        },
+    )
+
+    assert result.returncode != 0
+    assert "Podman Compose configuration is invalid" in result.stderr
+    calls = call_log.read_text(encoding="utf-8").splitlines()
+    assert calls.index("info --format json") < calls.index("compose config")
+
+
+@pytest.mark.parametrize(
+    ("overrides", "diagnostic"),
+    [
+        (
+            {"STUB_RENDERED_MEM_LIMIT": "7g"},
+            "rendered Compose memory limit",
+        ),
+        (
+            {"STUB_RENDERED_ODYSSEY_CI_CPU_LIMIT": "5"},
+            "rendered Compose CPU limit",
+        ),
+        (
+            {"STUB_RENDERED_ODYSSEY_PROD_MEM_LIMIT": ""},
+            "rendered Compose memory limit",
+        ),
+    ],
+)
+def test_preflight_fails_when_rendered_compose_resources_contradict_environment(
+    tmp_path: Path,
+    overrides: dict[str, str],
+    diagnostic: str,
+) -> None:
+    """The rendered service model, not source-text assumptions, is enforced."""
+    result = _run_preflight(tmp_path, overrides=overrides)
+
+    assert result.returncode != 0
+    assert diagnostic in result.stderr
+
+
+def test_preflight_checks_native_linux_host_resources(tmp_path: Path) -> None:
+    """Hosts without a Podman VM use engine-reported CPU and memory capacity."""
+    result = _run_preflight(
+        tmp_path,
+        overrides={
+            "STUB_MACHINE_PRESENT": "0",
+            "STUB_HOST_CPUS": "4",
+            "STUB_HOST_MEMORY_BYTES": str(32 * 1024**3),
+        },
+    )
+
+    assert result.returncode != 0
+    assert "exceeds active Podman engine CPUs" in result.stderr
+
+
+def test_preflight_passes_for_default_resources(tmp_path: Path) -> None:
+    """A reachable engine with the default resource profile passes."""
+    result = _run_preflight(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert "Podman preflight passed" in result.stdout
+
+
+def test_just_loads_dotenv_once_for_preflight_and_compose(tmp_path: Path) -> None:
+    """Just exports one .env-derived contract to preflight and Compose."""
+    env_log = tmp_path / "compose-environment.log"
+    result = _run_just_preflight(
+        tmp_path,
+        dotenv=("USER_ID=1234\nGROUP_ID=2345\nBUILD_PARALLELISM=1\nODYSSEY_MEM_LIMIT=7168m\nODYSSEY_CPU_LIMIT=6\n"),
+        overrides={
+            "STUB_ENV_LOG": str(env_log),
+            "STUB_HOST_MEMORY_BYTES": str(8 * 1024**3),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert env_log.read_text(encoding="utf-8") == "1234|2345|1|7168m|6\n"
+    assert "constrained profile" in result.stdout
+
+
+def test_python_ci_installs_pinned_just_before_running_integration_tests() -> None:
+    """The Python producer must provide the CLI exercised by its test suite."""
+    workflow = yaml.safe_load(COMPREHENSIVE_WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["test-python"]["steps"]
+    setup_index = next(index for index, step in enumerate(steps) if step.get("uses") == SETUP_JUST_ACTION)
+    test_index = next(index for index, step in enumerate(steps) if step.get("name") == "Run Python tests")
+
+    assert setup_index < test_index
+    assert steps[setup_index].get("with", {}).get("just-version") == SETUP_JUST_VERSION
+
+
+def test_just_container_entry_recipes_depend_on_preflight() -> None:
+    """Every local entry point must fail fast through the shared preflight."""
+    justfile = JUSTFILE.read_text(encoding="utf-8")
+
+    recipes = (
+        "podman-up",
+        "podman-build",
+        "podman-rebuild",
+        "podman-build-ci",
+        "podman-test-image",
+        "podman-run-tests",
+        "podman-run-shell",
+        "ci-podman-build",
+        "ci-podman-validate",
+        "shell",
+    )
+    for recipe in recipes:
+        assert "podman-preflight" in _recipe_header(justfile, recipe)
+
+
+def test_non_compute_podman_recipes_are_not_needlessly_gated() -> None:
+    """Inspection, shutdown, and publishing controls stay independently usable."""
+    justfile = JUSTFILE.read_text(encoding="utf-8")
+
+    for recipe in (
+        "podman-down",
+        "podman-logs",
+        "podman-status",
+        "podman-push",
+    ):
+        assert "podman-preflight" not in _recipe_header(justfile, recipe)
+
+
+def test_just_exports_one_shared_container_identity() -> None:
+    """Compose calls consume globally exported identity values, not local copies."""
+    justfile = JUSTFILE.read_text(encoding="utf-8")
+
+    assert re.search(r"^set dotenv-load$", justfile, re.MULTILINE)
+    for variable in (
+        "USER_ID",
+        "GROUP_ID",
+        "USER_NAME",
+        "BUILD_PARALLELISM",
+        "ODYSSEY_MEM_LIMIT",
+        "ODYSSEY_CPU_LIMIT",
+    ):
+        assert re.search(rf"^export {variable} :=", justfile, re.MULTILINE)
+
+    assert 'export USER_ID="' not in justfile
+    assert "USER_ID={{USER_ID}}" not in justfile
+    assert "-e USER_ID=" not in justfile
+
+
+def test_local_container_username_is_fixed_to_dev() -> None:
+    """The hard-coded Dockerfile sudo policy cannot drift from Compose."""
+    justfile = JUSTFILE.read_text(encoding="utf-8")
+    compose = COMPOSE_FILE.read_text(encoding="utf-8")
+    env_example = ENV_EXAMPLE.read_text(encoding="utf-8")
+
+    assert re.search(r'^export USER_NAME := "dev"$', justfile, re.MULTILINE)
+    assert 'env_var_or_default("USER_NAME"' not in justfile
+    assert "${USER_NAME" not in compose
+    assert "USER_NAME" not in env_example
+
+
+def test_image_test_recipe_uses_sorted_per_file_mojo_execution() -> None:
+    """Container image tests use Mojo 1.0's executable-file interface."""
+    justfile = JUSTFILE.read_text(encoding="utf-8")
+    start = justfile.index("podman-run-tests target=")
+    end = justfile.index("\n# Interactive shell in container image", start)
+    recipe = justfile[start:end]
+
+    assert "mojo test" not in recipe
+    assert "find tests" in recipe
+    assert "| sort" in recipe
+    assert "No Mojo test files found" in recipe
+    assert "uv run mojo" not in recipe
+    assert 'mojo --Werror -I src -I . "$test_file"' in recipe
+
+
+def test_image_smoke_invokes_the_installed_mojo_directly() -> None:
+    """Published images expose Mojo on PATH without depending on uv at runtime."""
+    justfile = JUSTFILE.read_text(encoding="utf-8")
+    start = justfile.index("podman-test-image target=")
+    end = justfile.index("\n# Run tests in container image", start)
+    recipe = justfile[start:end]
+
+    assert "uv run mojo" not in recipe
+    assert " mojo --version" in recipe
+
+
+def test_compose_propagates_build_parallelism_to_all_build_services() -> None:
+    """Every Compose service receives the bounded build concurrency setting."""
+    compose = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+    services = compose["services"]
+
+    for service_name in ("odyssey-dev", "odyssey-ci", "odyssey-prod"):
+        environment = services[service_name]["environment"]
+        assert "BUILD_PARALLELISM=${BUILD_PARALLELISM:-4}" in environment
+
+
+def test_compose_services_share_the_preflighted_resource_contract() -> None:
+    """Every service uses the same Just-exported CPU and memory limits."""
+    compose = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+
+    for service_name in ("odyssey-dev", "odyssey-ci", "odyssey-prod"):
+        service = compose["services"][service_name]
+        assert service["mem_limit"] == "${ODYSSEY_MEM_LIMIT:-14g}"
+        assert service["cpus"] == "${ODYSSEY_CPU_LIMIT:-6.0}"
+
+
+def test_example_environment_exposes_only_supported_resource_profiles() -> None:
+    """The template gives complete, internally consistent profile selections."""
+    env_example = ENV_EXAMPLE.read_text(encoding="utf-8")
+    assignments = set(re.findall(r"^# ([A-Z_]+=\S+)$", env_example, re.MULTILINE))
+
+    assert {
+        "BUILD_PARALLELISM=4",
+        "ODYSSEY_MEM_LIMIT=14g",
+        "ODYSSEY_CPU_LIMIT=6.0",
+    } <= assignments
+    assert {
+        "BUILD_PARALLELISM=1",
+        "ODYSSEY_MEM_LIMIT=7g",
+        "ODYSSEY_CPU_LIMIT=6.0",
+    } <= assignments
+    assert "ODYSSEY_PODMAN_MIN_CPUS" not in env_example
+    assert "ODYSSEY_PODMAN_MIN_MEMORY_GIB" not in env_example
+
+
+def test_example_environment_does_not_override_host_identity_or_advertise_native() -> None:
+    """Copying the example file preserves auto-detection and Podman-only routing."""
+    env_example = ENV_EXAMPLE.read_text(encoding="utf-8")
+
+    assert not re.search(r"^(?:USER_ID|GROUP_ID)=\d+$", env_example, re.MULTILINE)
+    assert "NATIVE" not in env_example


### PR DESCRIPTION
## Summary

Make local Podman workflows fail early on incompatible runtime, socket, resource, and user-mapping conditions, then use one deterministic container contract throughout the Just recipes.

## Changes Made

- add `just podman-preflight` with runtime, socket, memory, CPU, build-parallelism, workspace, and real container smoke checks
- centralize UID/GID and constrained-resource settings across Compose and Just
- remove broad workspace chmod behavior
- execute Mojo test files deterministically instead of calling the removed `mojo test` command
- add fail-closed unit coverage for the preflight contract
- install SHA-pinned Just 1.36.0 in the Python producer before its dynamic Just/Podman integration test

## Files Modified

- `.env.example`
- `.github/workflows/comprehensive-tests.yml`
- `docker-compose.yml`
- `justfile`
- `scripts/podman-preflight.sh`
- `tests/scripts/test_podman_preflight.py`

## Verification

- exact signed head: `60c50d4f2d78bf0eafeaf4f613c67d20d9c6a31a` over main `39a9e9e5d3129583eed07304dc7a4a604c7ad96e`
- first exact-head CI correctly failed closed when the Python producer lacked Just; the producer manifest reported failure and the replacement fixes that prerequisite deterministically
- 47 focused tests passed; Bash syntax, ShellCheck, Ruff check/format, YAML, and diff checks passed
- final-head pre-push suite: 1,351 passed and 228 expected skips
- live constrained preflight passed with 6 CPUs, 7,905 MiB engine memory, and one build job
- the container patch built the runtime image, reported Mojo 1.0.0b2, started Compose, verified 7 GiB memory, 6 CPUs, UID:GID 506:20, workspace writes, clean shutdown, and clean storage state

Closes #5737