### PR TITLE
test(ci): make dependency URL adversary version-agnostic

### DIFF
--- a/tests/scripts/test_commit_generated_dependencies.py
+++ b/tests/scripts/test_commit_generated_dependencies.py
@@ -853,10 +853,19 @@ def test_trusted_validator_rejects_candidate_project_urls_or_unrelated_changes()
     validator = getattr(PUBLISHER, "validate_canonical_dependencies", None)
     assert callable(validator), "trusted publisher must independently validate generated dependency bytes"
     trusted = (PROJECT_ROOT / "pyproject.toml").read_bytes()
+    requirement_lines = [
+        line for line in trusted.splitlines(keepends=True) if line.lstrip().startswith(b'"types-PyYAML')
+    ]
+    assert len(requirement_lines) == 1, "test fixture must contain exactly one types-PyYAML requirement"
+    requirement_line = requirement_lines[0]
+    indentation = requirement_line[: len(requirement_line) - len(requirement_line.lstrip())]
+    line_ending = b"\n" if requirement_line.endswith(b"\n") else b""
     candidate = trusted.replace(
-        b'"types-PyYAML>=6.0"',
-        b'"types-PyYAML @ https://attacker.invalid/types.whl"',
+        requirement_line,
+        indentation + b'"types-PyYAML @ https://attacker.invalid/types.whl",' + line_ending,
+        1,
     )
+    assert candidate != trusted, "adversarial dependency mutation must change the candidate"
 
     with pytest.raises(PUBLISHER.PublishError, match="dependency|URL"):
         validator(


### PR DESCRIPTION
## Summary

Make the trusted Dependabot publisher’s malicious-URL regression test independent of the currently pinned `types-PyYAML` version.

The prior test replaced only the literal `types-PyYAML>=6.0`. A legitimate version-floor update made that replacement a no-op, so the test invoked uv and failed for the wrong reason.

Closes #5750.

## Changes Made

- locate the single complete `types-PyYAML` requirement line without assuming its version or comparison operator
- replace that exact line with the malicious direct-URL requirement
- fail closed if the fixture contains zero or multiple matching requirements
- assert that the adversarial candidate bytes actually differ before invoking the trusted validator
- preserve the assertion that unsafe project metadata is rejected before any uv subprocess runs

## Files Modified

- `tests/scripts/test_commit_generated_dependencies.py`

## Verification

- reproduced the exact failure against `types-PyYAML>=6.0.12.20260724`
- fixed test passed against that same legitimate floor
- trusted publisher tests: 76 passed
- exact Workflow Smoke property suite: 146 passed
- full Python suite: 1,437 passed, 228 skipped
- Ruff check and format passed
- targeted pre-commit hooks passed
- full pre-push verification passed
- independent review found no actionable issues

The Dependabot branch is intentionally untouched; after this fix lands and main is green, #5724 will be recreated again from the new main SHA.
