### PR TITLE
fix(ci): dispatch trusted Test Report monitor

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -178,11 +178,16 @@ ls .github/workflows/*.yml | wc -l
 
 **File**: `comprehensive-test-pr-comments.yml`
 
-**Triggers**: Completed `Comprehensive Tests` runs whose source event is `pull_request`
+**Triggers**: Completed `Comprehensive Tests` runs whose source event is `pull_request`, or a
+trusted default-branch dispatch bound to an exact same-repository Dependabot head
 
 **Purpose**: Post or update the test-metrics and comprehensive-test reports on the pull request.
 The workflow runs from the trusted default branch, downloads reports as data, and never checks out
-or executes pull-request code with its narrowly scoped `pull-requests: write` token.
+or executes pull-request code with its narrowly scoped `pull-requests: write` token. For Dependabot,
+the trusted dependency writer dispatches this workflow as a sibling monitor. The monitor polls the
+single exact Comprehensive dispatch because its completion does not create the downstream
+`workflow_run` consumer in this GitHub Actions event chain, then validates the current PR/head before
+consuming its artifacts.
 
 **Artifacts**: Consumes `test-metrics` and `comprehensive-test-report`; creates none
 

--- a/.github/workflows/comprehensive-test-pr-comments.yml
+++ b/.github/workflows/comprehensive-test-pr-comments.yml
@@ -6,6 +6,16 @@ on:
   workflow_run:
     workflows: ["Comprehensive Tests"]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      source_head_sha:
+        description: Exact Dependabot head whose Comprehensive run must be reported
+        required: true
+        type: string
+      source_head_branch:
+        description: Exact same-repository Dependabot branch
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -13,15 +23,13 @@ permissions:
 jobs:
   post-pr-comments:
     if: >-
-      github.event.workflow_run.event == 'pull_request' ||
-      (
-        github.event.workflow_run.event == 'workflow_dispatch' &&
-        startsWith(github.event.workflow_run.head_branch, 'dependabot/')
-      )
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.event == 'pull_request'
     concurrency:
-      group: comprehensive-test-pr-comment-${{ github.event.workflow_run.head_sha }}
+      group: comprehensive-test-pr-comment-${{ inputs.source_head_sha || github.event.workflow_run.head_sha }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
+    timeout-minutes: 130
     name: "Post Comprehensive Test PR Comments"
     permissions:
       actions: read
@@ -29,13 +37,83 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Resolve exactly one current pull request for the run head
-        id: resolve-pr
+      - name: Resolve trusted source run and exactly one current pull request
+        id: resolve-context
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          SOURCE_HEAD_SHA: ${{ inputs.source_head_sha }}
+          SOURCE_HEAD_BRANCH: ${{ inputs.source_head_branch }}
         with:
           script: |
-            const run = context.payload.workflow_run;
-            const sourceHeadSha = run.head_sha;
+            const expectedRepository =
+              `${context.repo.owner}/${context.repo.repo}`;
+            const comprehensiveWorkflowUrl =
+              `https://github.com/${expectedRepository}/actions/workflows/` +
+              `comprehensive-tests.yml`;
+            const isTrustedDispatch =
+              context.eventName === 'workflow_dispatch';
+            let run = context.payload.workflow_run;
+            let sourceHeadSha;
+            let sourceHeadBranch;
+
+            const setSourceFailure = (message) => {
+              core.setOutput('source_ready', 'false');
+              core.setOutput('source_error', message);
+              core.setOutput(
+                'source_run_url',
+                run?.html_url || comprehensiveWorkflowUrl,
+              );
+              core.setOutput(
+                'source_run_conclusion',
+                run?.conclusion || run?.status || 'unknown',
+              );
+              if (run?.id) {
+                core.setOutput('source_run_id', String(run.id));
+              }
+            };
+
+            const setSourceReady = () => {
+              core.setOutput('source_ready', 'true');
+              core.setOutput('source_error', '');
+              core.setOutput('source_run_id', String(run.id));
+              core.setOutput('source_run_url', run.html_url);
+              core.setOutput('source_run_conclusion', run.conclusion);
+            };
+
+            if (isTrustedDispatch) {
+              const requestedHeadSha = process.env.SOURCE_HEAD_SHA;
+              const requestedHeadBranch = process.env.SOURCE_HEAD_BRANCH;
+              if (
+                typeof requestedHeadSha !== 'string' ||
+                typeof requestedHeadBranch !== 'string' ||
+                !/^[0-9a-f]{40}$/.test(requestedHeadSha) ||
+                !requestedHeadBranch.startsWith('dependabot/')
+              ) {
+                core.setFailed(
+                  'Comment workflow dispatch inputs are not an exact Dependabot head.',
+                );
+                return;
+              }
+              sourceHeadSha = requestedHeadSha;
+              sourceHeadBranch = requestedHeadBranch;
+            } else {
+              if (
+                !run ||
+                run.name !== 'Comprehensive Tests' ||
+                run.path !== '.github/workflows/comprehensive-tests.yml' ||
+                run.event !== 'pull_request' ||
+                run.status !== 'completed' ||
+                typeof run.conclusion !== 'string'
+              ) {
+                core.setFailed(
+                  'Source run is not a completed pull-request Comprehensive workflow.',
+                );
+                return;
+              }
+              sourceHeadSha = run.head_sha;
+              sourceHeadBranch = run.head_branch;
+            }
+
             const associated = await github.paginate(
               github.rest.repos.listPullRequestsAssociatedWithCommit,
               {
@@ -72,28 +150,129 @@ jobs:
               return;
             }
 
-            if (run.event === 'workflow_dispatch') {
-              const expectedRepository =
-                `${context.repo.owner}/${context.repo.repo}`;
+            if (isTrustedDispatch) {
               if (
-                !run.head_branch.startsWith('dependabot/') ||
                 pullRequest.user.login !== 'dependabot[bot]' ||
-                pullRequest.head.ref !== run.head_branch ||
+                pullRequest.head.ref !== sourceHeadBranch ||
                 pullRequest.head.repo.full_name !== expectedRepository
               ) {
                 core.setFailed(
-                  'Dispatched Comprehensive run is not bound to a current ' +
-                  'same-repository Dependabot PR.',
+                  'Comment dispatch is not bound to a current same-repository ' +
+                  'Dependabot PR.',
                 );
                 return;
               }
             }
             core.setOutput('pr_number', String(pullRequest.number));
+            core.setOutput('source_head_sha', sourceHeadSha);
+
+            if (!isTrustedDispatch) {
+              setSourceReady();
+              return;
+            }
+
+            let runs;
+            try {
+              runs = await github.paginate(
+                github.rest.actions.listWorkflowRuns,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: 'comprehensive-tests.yml',
+                  branch: sourceHeadBranch,
+                  event: 'workflow_dispatch',
+                  per_page: 100,
+                },
+              );
+            } catch (error) {
+              setSourceFailure(
+                `Unable to locate the exact Comprehensive run: ${error.message}`,
+              );
+              return;
+            }
+
+            const matches = runs.filter(
+              candidateRun =>
+                candidateRun.head_sha === sourceHeadSha &&
+                candidateRun.head_branch === sourceHeadBranch &&
+                candidateRun.head_repository?.full_name === expectedRepository,
+            );
+            if (matches.length !== 1) {
+              setSourceFailure(
+                `Expected exactly one dispatched Comprehensive run for ` +
+                `${sourceHeadSha}; found ${matches.length}.`,
+              );
+              return;
+            }
+
+            run = matches[0];
+            if (
+              run.name !== 'Comprehensive Tests' ||
+              run.path !== '.github/workflows/comprehensive-tests.yml' ||
+              run.event !== 'workflow_dispatch'
+            ) {
+              setSourceFailure(
+                'Located run is not the trusted Comprehensive workflow dispatch.',
+              );
+              return;
+            }
+
+            const sourceRunId = run.id;
+            try {
+              for (
+                let attempt = 0;
+                attempt < 120 && run.status !== 'completed';
+                attempt += 1
+              ) {
+                await new Promise(resolve => setTimeout(resolve, 60000));
+                const response = await github.rest.actions.getWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: sourceRunId,
+                });
+                run = response.data;
+                if (
+                  run.id !== sourceRunId ||
+                  run.head_sha !== sourceHeadSha ||
+                  run.head_branch !== sourceHeadBranch ||
+                  run.head_repository?.full_name !== expectedRepository ||
+                  run.path !== '.github/workflows/comprehensive-tests.yml' ||
+                  run.event !== 'workflow_dispatch'
+                ) {
+                  setSourceFailure(
+                    'Comprehensive run identity changed while it was monitored.',
+                  );
+                  return;
+                }
+              }
+            } catch (error) {
+              setSourceFailure(
+                `Unable to monitor the exact Comprehensive run: ${error.message}`,
+              );
+              return;
+            }
+            if (run.status !== 'completed') {
+              setSourceFailure(
+                'Comprehensive run did not complete within 120 minutes.',
+              );
+              return;
+            }
+            if (typeof run.conclusion !== 'string') {
+              setSourceFailure(
+                'Completed Comprehensive run has no authoritative conclusion.',
+              );
+              return;
+            }
+            setSourceReady();
 
       - name: Discover report artifacts
         id: discover_artifacts
-        if: steps.resolve-pr.outcome == 'success'
+        if: >-
+          steps.resolve-context.outcome == 'success' &&
+          steps.resolve-context.outputs.source_ready == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          SOURCE_RUN_ID: ${{ steps.resolve-context.outputs.source_run_id }}
         with:
           script: |
             const artifacts = await github.paginate(
@@ -101,7 +280,7 @@ jobs:
               {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                run_id: context.payload.workflow_run.id,
+                run_id: Number(process.env.SOURCE_RUN_ID),
                 per_page: 100,
               },
             );
@@ -119,46 +298,50 @@ jobs:
       - name: Download test metrics report
         id: download-metrics
         if: >-
-          steps.resolve-pr.outcome == 'success' &&
+          steps.resolve-context.outcome == 'success' &&
+          steps.resolve-context.outputs.source_ready == 'true' &&
           steps.discover_artifacts.outputs.has_metrics == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: test-metrics
           path: reports/metrics
           github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ steps.resolve-context.outputs.source_run_id }}
 
       - name: Download comprehensive test report
         id: download-report
         if: >-
           always() &&
-          steps.resolve-pr.outcome == 'success' &&
+          steps.resolve-context.outcome == 'success' &&
+          steps.resolve-context.outputs.source_ready == 'true' &&
           steps.discover_artifacts.outputs.has_report == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: comprehensive-test-report
           path: reports/comprehensive
           github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ steps.resolve-context.outputs.source_run_id }}
 
       - name: Post or update PR comments
-        if: always() && steps.resolve-pr.outcome == 'success'
+        if: always() && steps.resolve-context.outcome == 'success'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
-          PR_NUMBER: ${{ steps.resolve-pr.outputs.pr_number }}
+          PR_NUMBER: ${{ steps.resolve-context.outputs.pr_number }}
           REPORT_AVAILABLE: ${{ steps.discover_artifacts.outputs.has_report }}
           METRICS_AVAILABLE: ${{ steps.discover_artifacts.outputs.has_metrics }}
           REPORT_DOWNLOAD_OUTCOME: ${{ steps.download-report.outcome }}
           METRICS_DOWNLOAD_OUTCOME: ${{ steps.download-metrics.outcome }}
-          WORKFLOW_RUN_URL: ${{ github.event.workflow_run.html_url }}
-          WORKFLOW_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          WORKFLOW_RUN_URL: ${{ steps.resolve-context.outputs.source_run_url }}
+          WORKFLOW_CONCLUSION: ${{ steps.resolve-context.outputs.source_run_conclusion }}
+          SOURCE_HEAD_SHA: ${{ steps.resolve-context.outputs.source_head_sha }}
+          SOURCE_RESOLUTION_ERROR: ${{ steps.resolve-context.outputs.source_error }}
         with:
           script: |
             const fs = require('fs');
             const issue_number = Number(process.env.PR_NUMBER);
             const metricsPath = 'reports/metrics/metrics-pr-comment.md';
             const reportPath = 'reports/comprehensive/test-report.md';
-            const sourceHeadSha = context.payload.workflow_run.head_sha;
+            const sourceHeadSha = process.env.SOURCE_HEAD_SHA;
             const { data: pullRequest } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -250,9 +433,11 @@ jobs:
             let reportBody = downloadedReport;
             if (!reportMatchesConclusion) {
               const runUrl = process.env.WORKFLOW_RUN_URL;
-              const reason = downloadedReport === null
-                ? 'The workflow did not publish a readable comprehensive report.'
-                : 'The downloaded report verdict does not match the workflow conclusion.';
+              const reason = process.env.SOURCE_RESOLUTION_ERROR || (
+                downloadedReport === null
+                  ? 'The workflow did not publish a readable comprehensive report.'
+                  : 'The downloaded report verdict does not match the workflow conclusion.'
+              );
               reportBody = [
                 '# 🧪 Comprehensive Test Results',
                 '',
@@ -268,3 +453,14 @@ jobs:
             }
 
             await upsertComment('🧪 Comprehensive Test Results', reportBody);
+
+      - name: Enforce trusted source resolution
+        if: >-
+          always() &&
+          steps.resolve-context.outcome == 'success' &&
+          steps.resolve-context.outputs.source_ready != 'true'
+        env:
+          SOURCE_RESOLUTION_ERROR: ${{ steps.resolve-context.outputs.source_error }}
+        run: |
+          echo "ERROR: ${SOURCE_RESOLUTION_ERROR:-trusted source run was not resolved}"
+          exit 1

--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -1078,6 +1078,7 @@ jobs:
   gradient-coverage:
     needs: [gradient-tests]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: always()  # Run even when gradient-tests fails/skips — required status check must complete
     name: "Gradient Coverage Report"
 
@@ -1307,6 +1308,7 @@ jobs:
       - test-data-utilities
       - test-metrics
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: always()
     name: "Test Report"
 

--- a/.github/workflows/dependabot-uv-lock-writer.yml
+++ b/.github/workflows/dependabot-uv-lock-writer.yml
@@ -55,5 +55,8 @@ jobs:
           python scripts/ci/commit_generated_dependencies.py publish
           --event-path "$GITHUB_EVENT_PATH"
 
-# Comprehensive Test's trusted comment consumer now supports the explicitly
-# dispatched Dependabot run. No PR-code checkout is added to either consumer.
+# The trusted publisher also dispatches the default-branch comment monitor as
+# a sibling workflow. The monitor waits for the exact Comprehensive run because
+# that dispatched run does not create the downstream workflow_run consumer in
+# this GitHub Actions event chain.
+# No PR-code checkout is added to either privileged workflow.

--- a/scripts/ci/commit_generated_dependencies.py
+++ b/scripts/ci/commit_generated_dependencies.py
@@ -53,6 +53,7 @@ REQUIRED_WORKFLOWS = (
     "pre-commit.yml",
     "workflow-smoke-test.yml",
 )
+COMMENT_WORKFLOW = "comprehensive-test-pr-comments.yml"
 REQUIRED_WORKFLOW_PATHS = tuple(f".github/workflows/{workflow}" for workflow in REQUIRED_WORKFLOWS)
 PROJECT_METADATA_PATH = "pyproject.toml"
 PYTHON_VERSION_PATH = ".python-version"
@@ -1690,11 +1691,23 @@ def _dispatch_workflow(
     *,
     token: str,
     opener: UrlOpener,
+    inputs: Mapping[str, str] | None = None,
 ) -> None:
+    payload: dict[str, object] = {"ref": branch}
+    if inputs is not None:
+        if not isinstance(inputs, Mapping):
+            raise PublishError("workflow dispatch inputs must be a string mapping")
+        normalized_inputs: dict[str, str] = {}
+        for key, value in inputs.items():
+            if not isinstance(key, str) or not key or not isinstance(value, str) or not value:
+                raise PublishError("workflow dispatch inputs must be non-empty strings")
+            normalized_inputs[key] = value
+        payload["inputs"] = normalized_inputs
+
     encoded_workflow = urllib.parse.quote(workflow, safe="")
     request = urllib.request.Request(
         f"{_api_root(repository)}/actions/workflows/{encoded_workflow}/dispatches",
-        data=json.dumps({"ref": branch}, separators=(",", ":")).encode(),
+        data=json.dumps(payload, separators=(",", ":")).encode(),
         headers={
             "Accept": "application/vnd.github+json",
             "Authorization": f"Bearer {token}",
@@ -1714,6 +1727,35 @@ def _dispatch_workflow(
         raise PublishError(f"workflow dispatch for {workflow} failed: {error}") from error
     if status_code != 204:
         raise PublishError(f"workflow dispatch for {workflow} failed with HTTP {status_code}")
+
+
+def dispatch_comment_workflow(
+    *,
+    repository: str,
+    default_branch: str,
+    head_ref: str,
+    commit_oid: str,
+    token: str,
+    opener: UrlOpener = urllib.request.urlopen,
+) -> None:
+    """Dispatch the trusted commenter beside the required Dependabot checks."""
+    _validate_repository(repository)
+    _validate_branch(default_branch)
+    _validate_branch(head_ref)
+    _validate_oid(commit_oid, "published GraphQL commit OID")
+    if not head_ref.startswith("dependabot/"):
+        raise PublishError("comment workflow requires a Dependabot branch")
+    _dispatch_workflow(
+        repository,
+        COMMENT_WORKFLOW,
+        default_branch,
+        token=token,
+        opener=opener,
+        inputs={
+            "source_head_sha": commit_oid,
+            "source_head_branch": head_ref,
+        },
+    )
 
 
 def authenticate_required_workflows(
@@ -1958,6 +2000,14 @@ def publish_dependencies(
         token=token,
         opener=opener,
         sleeper=sleeper,
+    )
+    dispatch_comment_workflow(
+        repository=context.repository,
+        default_branch=context.default_branch,
+        head_ref=context.head_ref,
+        commit_oid=verified.oid,
+        token=token,
+        opener=opener,
     )
     return PublishResult("published", verified.oid, dispatched)
 

--- a/tests/scripts/test_commit_generated_dependencies.py
+++ b/tests/scripts/test_commit_generated_dependencies.py
@@ -1244,6 +1244,7 @@ def test_retry_after_partial_commit_verifies_existing_child_and_resumes_dispatch
 
     monkeypatch.setattr(PUBLISHER, "verify_exact_child", verify_existing)
     monkeypatch.setattr(PUBLISHER, "dispatch_required_workflows", resume_dispatches)
+    monkeypatch.setattr(PUBLISHER, "dispatch_comment_workflow", lambda **_kwargs: None)
 
     result = PUBLISHER.publish_dependencies(
         context=_context(),
@@ -1301,6 +1302,7 @@ def test_retry_reconciles_split_parent_child_visibility_before_dispatch(
     monkeypatch.setattr(PUBLISHER, "verify_exact_child", verify_existing)
     monkeypatch.setattr(PUBLISHER, "wait_for_published_head", wait_for_child)
     monkeypatch.setattr(PUBLISHER, "dispatch_required_workflows", resume_dispatches)
+    monkeypatch.setattr(PUBLISHER, "dispatch_comment_workflow", lambda **_kwargs: None)
 
     result = PUBLISHER.publish_dependencies(
         context=_context(),
@@ -1453,6 +1455,167 @@ def test_dispatch_allowlist_skips_existing_oid_runs_and_polls_new_ones(
     assert authenticated == [(CHILD_SHA, HEAD_SHA)]
     assert dispatched == list(PUBLISHER.REQUIRED_WORKFLOWS[2:])
     assert count == 2
+
+
+def test_commenter_dispatch_binds_default_branch_and_exact_dependabot_head(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dispatch_commenter = getattr(PUBLISHER, "dispatch_comment_workflow", None)
+    assert callable(dispatch_commenter), "trusted writer must dispatch the commenter as a sibling workflow"
+    calls: list[dict[str, Any]] = []
+
+    def dispatch(
+        repository: str,
+        workflow: str,
+        branch: str,
+        **kwargs: Any,
+    ) -> None:
+        calls.append(
+            {
+                "repository": repository,
+                "workflow": workflow,
+                "branch": branch,
+                "inputs": kwargs.get("inputs"),
+            }
+        )
+
+    monkeypatch.setattr(PUBLISHER, "_dispatch_workflow", dispatch)
+
+    dispatch_commenter(
+        repository=REPOSITORY,
+        default_branch="main",
+        head_ref=BRANCH,
+        commit_oid=CHILD_SHA,
+        token="token",
+    )
+
+    assert calls == [
+        {
+            "repository": REPOSITORY,
+            "workflow": "comprehensive-test-pr-comments.yml",
+            "branch": "main",
+            "inputs": {
+                "source_head_sha": CHILD_SHA,
+                "source_head_branch": BRANCH,
+            },
+        }
+    ]
+
+
+def test_workflow_dispatch_serializes_exact_string_inputs() -> None:
+    recorded: dict[str, Any] = {}
+
+    class FakeResponse:
+        status = 204
+
+        def __enter__(self) -> FakeResponse:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b""
+
+    def opener(request: Any, *, timeout: int) -> FakeResponse:
+        recorded["url"] = request.full_url
+        recorded["payload"] = json.loads(request.data)
+        recorded["timeout"] = timeout
+        return FakeResponse()
+
+    PUBLISHER._dispatch_workflow(
+        REPOSITORY,
+        "comprehensive-test-pr-comments.yml",
+        "main",
+        token="token",
+        opener=opener,
+        inputs={
+            "source_head_sha": CHILD_SHA,
+            "source_head_branch": BRANCH,
+        },
+    )
+
+    assert recorded == {
+        "url": (
+            "https://api.github.com/repos/HomericIntelligence/Odyssey/actions/"
+            "workflows/comprehensive-test-pr-comments.yml/dispatches"
+        ),
+        "payload": {
+            "ref": "main",
+            "inputs": {
+                "source_head_sha": CHILD_SHA,
+                "source_head_branch": BRANCH,
+            },
+        },
+        "timeout": 30,
+    }
+
+
+@pytest.mark.parametrize(
+    "inputs",
+    [
+        {"source_head_sha": ""},
+        {"source_head_sha": CHILD_SHA, 1: BRANCH},
+        {"source_head_sha": CHILD_SHA, "source_head_branch": 1},
+    ],
+)
+def test_workflow_dispatch_rejects_non_string_or_empty_inputs(inputs: Any) -> None:
+    with pytest.raises(PUBLISHER.PublishError, match="inputs"):
+        PUBLISHER._dispatch_workflow(
+            REPOSITORY,
+            "comprehensive-test-pr-comments.yml",
+            "main",
+            token="token",
+            opener=lambda *_args, **_kwargs: pytest.fail("invalid input must not dispatch"),
+            inputs=inputs,
+        )
+
+
+def test_publisher_dispatches_commenter_after_exact_required_runs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _artifact_root, bundle = _package(tmp_path)
+    commenter_calls: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(PUBLISHER, "get_pull_request_head", lambda *_args, **_kwargs: CHILD_SHA)
+    monkeypatch.setattr(PUBLISHER, "get_branch_head", lambda *_args, **_kwargs: CHILD_SHA)
+    monkeypatch.setattr(PUBLISHER, "validate_published_dependency_candidate", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(PUBLISHER, "compare_artifact_to_source", lambda *_args, **_kwargs: ("uv.lock",))
+    monkeypatch.setattr(
+        PUBLISHER,
+        "verify_exact_child",
+        lambda **_kwargs: PUBLISHER.CommitResult(
+            CHILD_SHA,
+            f"https://github.com/{REPOSITORY}/commit/{CHILD_SHA}",
+        ),
+    )
+    monkeypatch.setattr(PUBLISHER, "dispatch_required_workflows", lambda **_kwargs: 4)
+    monkeypatch.setattr(
+        PUBLISHER,
+        "dispatch_comment_workflow",
+        lambda **kwargs: commenter_calls.append(kwargs),
+        raising=False,
+    )
+
+    result = PUBLISHER.publish_dependencies(
+        context=_context(),
+        bundle=bundle,
+        trusted_default_oid=HEAD_SHA,
+        token="token",
+    )
+
+    assert result == PUBLISHER.PublishResult("published", CHILD_SHA, 4)
+    assert commenter_calls == [
+        {
+            "repository": REPOSITORY,
+            "default_branch": "main",
+            "head_ref": BRANCH,
+            "commit_oid": CHILD_SHA,
+            "token": "token",
+            "opener": PUBLISHER.urllib.request.urlopen,
+        }
+    ]
 
 
 def test_required_workflow_definitions_are_authenticated_at_child_oid(

--- a/tests/smoke/test_comprehensive_pr_comments_workflow_properties.py
+++ b/tests/smoke/test_comprehensive_pr_comments_workflow_properties.py
@@ -2,6 +2,7 @@
 """Fail-closed properties for the trusted comprehensive PR commenter."""
 
 from pathlib import Path
+import re
 from typing import Any
 
 import yaml
@@ -9,10 +10,23 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "comprehensive-test-pr-comments.yml"
+COMPREHENSIVE_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "comprehensive-tests.yml"
+
+
+def _load_workflow() -> dict[Any, Any]:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+    return workflow
+
+
+def _on_block(workflow: dict[Any, Any]) -> dict[str, Any]:
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict)
+    return triggers
 
 
 def _load_job() -> dict[str, Any]:
-    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    workflow = _load_workflow()
     job = workflow["jobs"]["post-pr-comments"]
     assert isinstance(job, dict)
     return job
@@ -42,15 +56,16 @@ def test_missing_report_replaces_stale_green_comment_with_failure_fallback() -> 
     assert "has_report" in discovery_script
 
     post_step = next(step for step in steps if step.get("name") == "Post or update PR comments")
-    assert post_step.get("if") == "always() && steps.resolve-pr.outcome == 'success'"
+    assert post_step.get("if") == "always() && steps.resolve-context.outcome == 'success'"
 
     environment = post_step.get("env", {})
     assert environment["REPORT_AVAILABLE"] == ("${{ steps.discover_artifacts.outputs.has_report }}")
     assert environment["METRICS_AVAILABLE"] == ("${{ steps.discover_artifacts.outputs.has_metrics }}")
     assert environment["REPORT_DOWNLOAD_OUTCOME"] == ("${{ steps.download-report.outcome }}")
     assert environment["METRICS_DOWNLOAD_OUTCOME"] == ("${{ steps.download-metrics.outcome }}")
-    assert environment["WORKFLOW_RUN_URL"] == ("${{ github.event.workflow_run.html_url }}")
-    assert environment["WORKFLOW_CONCLUSION"] == ("${{ github.event.workflow_run.conclusion }}")
+    assert environment["WORKFLOW_RUN_URL"] == ("${{ steps.resolve-context.outputs.source_run_url }}")
+    assert environment["WORKFLOW_CONCLUSION"] == ("${{ steps.resolve-context.outputs.source_run_conclusion }}")
+    assert environment["SOURCE_HEAD_SHA"] == ("${{ steps.resolve-context.outputs.source_head_sha }}")
 
     script = post_step["with"]["script"]
     assert "REPORT_DOWNLOAD_OUTCOME" in script
@@ -71,7 +86,7 @@ def test_commenter_rejects_stale_runs_and_verdict_mismatches() -> None:
     script = post_step["with"]["script"]
 
     assert "github.rest.pulls.get" in script
-    assert "workflow_run.head_sha" in script
+    assert "SOURCE_HEAD_SHA" in script
     assert "workflow_run.pull_requests[0]" not in script
     assert "pullRequest.head.sha" in script
     assert "Stale workflow run" in script
@@ -84,15 +99,56 @@ def test_commenter_rejects_stale_runs_and_verdict_mismatches() -> None:
     assert "catch" in script
 
 
-def test_dispatch_commenter_resolves_one_exact_current_dependabot_pr() -> None:
+def test_writer_dispatches_commenter_as_a_sibling_bound_to_the_exact_comprehensive_run() -> None:
+    workflow = _load_workflow()
+    triggers = _on_block(workflow)
+    dispatch = triggers.get("workflow_dispatch")
+    assert dispatch == {
+        "inputs": {
+            "source_head_sha": {
+                "description": "Exact Dependabot head whose Comprehensive run must be reported",
+                "required": True,
+                "type": "string",
+            },
+            "source_head_branch": {
+                "description": "Exact same-repository Dependabot branch",
+                "required": True,
+                "type": "string",
+            },
+        }
+    }
+
     job = _load_job()
     condition = str(job["if"])
+    assert "github.event_name == 'workflow_dispatch'" in condition
     assert "github.event.workflow_run.event == 'pull_request'" in condition
-    assert "github.event.workflow_run.event == 'workflow_dispatch'" in condition
-    assert "startsWith(github.event.workflow_run.head_branch, 'dependabot/')" in condition
+    assert "github.event.workflow_run.event == 'workflow_dispatch'" not in condition
 
-    resolve = next(step for step in job["steps"] if step.get("id") == "resolve-pr")
+    concurrency = str(job["concurrency"]["group"])
+    assert "inputs.source_head_sha" in concurrency
+    assert "github.event.workflow_run.head_sha" in concurrency
+
+    resolve = next(step for step in job["steps"] if step.get("id") == "resolve-context")
+    assert resolve["env"] == {
+        "SOURCE_HEAD_SHA": "${{ inputs.source_head_sha }}",
+        "SOURCE_HEAD_BRANCH": "${{ inputs.source_head_branch }}",
+    }
     script = resolve["with"]["script"]
+    assert "context.eventName === 'workflow_dispatch'" in script
+    assert "listWorkflowRuns" in script
+    assert "workflow_id: 'comprehensive-tests.yml'" in script
+    assert "candidateRun.head_sha === sourceHeadSha" in script
+    assert "candidateRun.head_branch === sourceHeadBranch" in script
+    assert "matches.length !== 1" in script
+    assert "github.rest.actions.getWorkflowRun" in script
+    assert "run.status !== 'completed'" in script
+    assert "Comprehensive run did not complete" in script
+    assert "run.path !== '.github/workflows/comprehensive-tests.yml'" in script
+    assert "run.event !== 'workflow_dispatch'" in script
+    assert "setSourceFailure" in script
+    assert "core.setOutput('source_ready', 'false')" in script
+    assert "core.setOutput('source_error', message)" in script
+
     assert "listPullRequestsAssociatedWithCommit" in script
     assert "commit_sha: sourceHeadSha" in script
     assert "pullRequest.state === 'open'" in script
@@ -100,15 +156,69 @@ def test_dispatch_commenter_resolves_one_exact_current_dependabot_pr() -> None:
     assert "candidates.length !== 1" in script
     assert "github.rest.pulls.get" in script
     assert "pullRequest.head.sha !== sourceHeadSha" in script
-    assert "run.event === 'workflow_dispatch'" in script
+    assert "context.eventName === 'workflow_dispatch'" in script
     assert "pullRequest.user.login !== 'dependabot[bot]'" in script
-    assert "pullRequest.head.ref !== run.head_branch" in script
+    assert "pullRequest.head.ref !== sourceHeadBranch" in script
     assert "pullRequest.head.repo.full_name !== expectedRepository" in script
     assert "core.setFailed" in script
     assert "core.setOutput('pr_number'" in script
+    assert "core.setOutput('source_run_id'" in script
+    assert "core.setOutput('source_run_url'" in script
+    assert "core.setOutput('source_run_conclusion'" in script
 
     for step in job["steps"][1:]:
-        assert "steps.resolve-pr.outcome == 'success'" in str(step.get("if", ""))
+        assert "steps.resolve-context.outcome == 'success'" in str(step.get("if", ""))
+
+    discovery = next(step for step in job["steps"] if step.get("id") == "discover_artifacts")
+    assert "steps.resolve-context.outputs.source_run_id" in discovery["env"]["SOURCE_RUN_ID"]
+    assert "run_id: Number(process.env.SOURCE_RUN_ID)" in discovery["with"]["script"]
+
+    post = next(step for step in job["steps"] if step.get("name") == "Post or update PR comments")
+    assert post["env"]["PR_NUMBER"] == "${{ steps.resolve-context.outputs.pr_number }}"
+    assert post["env"]["WORKFLOW_RUN_URL"] == "${{ steps.resolve-context.outputs.source_run_url }}"
+    assert post["env"]["WORKFLOW_CONCLUSION"] == ("${{ steps.resolve-context.outputs.source_run_conclusion }}")
+    assert post["env"]["SOURCE_RESOLUTION_ERROR"] == ("${{ steps.resolve-context.outputs.source_error }}")
+    assert "source_ready" not in str(post["if"])
+    assert "SOURCE_RESOLUTION_ERROR" in post["with"]["script"]
+
+    enforcement = next(step for step in job["steps"] if step.get("name") == "Enforce trusted source resolution")
+    assert "always()" in enforcement["if"]
+    assert "outputs.source_ready != 'true'" in enforcement["if"]
+    assert "exit 1" in enforcement["run"]
+
+
+def test_comment_monitor_budget_exceeds_the_declared_comprehensive_needs_dag() -> None:
+    job = _load_job()
+    resolve = next(step for step in job["steps"] if step.get("id") == "resolve-context")
+    script = resolve["with"]["script"]
+    attempt_match = re.search(r"attempt < (\d+)", script)
+    interval_match = re.search(r"setTimeout\(resolve, (\d+)\)", script)
+    assert attempt_match is not None
+    assert interval_match is not None
+
+    poll_minutes = int(attempt_match.group(1)) * int(interval_match.group(1)) / 1000 / 60
+    comprehensive = yaml.safe_load(COMPREHENSIVE_WORKFLOW_PATH.read_text(encoding="utf-8"))
+    jobs = comprehensive["jobs"]
+    assert all("timeout-minutes" in candidate for candidate in jobs.values())
+
+    bounds: dict[str, int] = {}
+
+    def declared_path_minutes(job_id: str) -> int:
+        if job_id in bounds:
+            return bounds[job_id]
+        candidate = jobs[job_id]
+        raw_needs = candidate.get("needs", [])
+        needs = [raw_needs] if isinstance(raw_needs, str) else raw_needs
+        upstream = max(
+            (declared_path_minutes(dependency) for dependency in needs),
+            default=0,
+        )
+        bounds[job_id] = upstream + candidate["timeout-minutes"]
+        return bounds[job_id]
+
+    comprehensive_bound = declared_path_minutes("test-report")
+    assert poll_minutes >= comprehensive_bound + 10
+    assert job["timeout-minutes"] >= poll_minutes + 10
 
 
 def test_trusted_commenter_never_checks_out_or_executes_pr_code() -> None:

--- a/tests/smoke/test_dependabot_uv_lock_workflow_properties.py
+++ b/tests/smoke/test_dependabot_uv_lock_workflow_properties.py
@@ -230,6 +230,19 @@ def test_dispatch_allowlist_is_literal_exact_and_every_target_is_read_only() -> 
             assert "write" not in job.get("permissions", {}).values()
 
 
+def test_writer_dispatches_the_comment_monitor_beside_required_checks() -> None:
+    source = PUBLISHER_SCRIPT.read_text(encoding="utf-8")
+
+    assert 'COMMENT_WORKFLOW = "comprehensive-test-pr-comments.yml"' in source
+    assert "def dispatch_comment_workflow(" in source
+    assert '"source_head_sha": commit_oid' in source
+    assert '"source_head_branch": head_ref' in source
+    assert source.index("dispatched = dispatch_required_workflows(") < source.index(
+        "dispatch_comment_workflow(\n        repository=context.repository,"
+    )
+    assert "comprehensive-test-pr-comments.yml" not in ALLOWLIST
+
+
 def test_dependency_generation_uses_one_pinned_uv_version() -> None:
     setup_action = _load(SETUP_UV_ACTION)
     assert setup_action["inputs"]["uv-version"]["default"] == UV_VERSION

--- a/tests/smoke/test_merge_queue_workflow_properties.py
+++ b/tests/smoke/test_merge_queue_workflow_properties.py
@@ -260,7 +260,21 @@ def test_merge_group_cannot_receive_write_scope() -> None:
         "workflow_run": {
             "workflows": ["Comprehensive Tests"],
             "types": ["completed"],
-        }
+        },
+        "workflow_dispatch": {
+            "inputs": {
+                "source_head_sha": {
+                    "description": "Exact Dependabot head whose Comprehensive run must be reported",
+                    "required": True,
+                    "type": "string",
+                },
+                "source_head_branch": {
+                    "description": "Exact same-repository Dependabot branch",
+                    "required": True,
+                    "type": "string",
+                },
+            }
+        },
     }
     assert comment_workflow.get("permissions") == {"contents": "read"}
 
@@ -269,9 +283,9 @@ def test_merge_group_cannot_receive_write_scope() -> None:
     assert set(comment_jobs) == {"post-pr-comments"}
     comment_job = comment_jobs["post-pr-comments"]
     comment_condition = str(comment_job.get("if"))
+    assert "github.event_name == 'workflow_dispatch'" in comment_condition
     assert "github.event.workflow_run.event == 'pull_request'" in comment_condition
-    assert "github.event.workflow_run.event == 'workflow_dispatch'" in comment_condition
-    assert "startsWith(github.event.workflow_run.head_branch, 'dependabot/')" in comment_condition
+    assert "github.event.workflow_run.event == 'workflow_dispatch'" not in comment_condition
     assert "workflow_run.head_sha" in str(comment_job.get("concurrency", {}).get("group"))
     assert comment_job.get("permissions") == {
         "actions": "read",


### PR DESCRIPTION
## Summary

Restore Dependabot Test Report comment delivery across the trusted workflow-dispatch boundary. The default-branch publisher now starts the commenter as a sibling monitor, bound to the exact generated head SHA and branch, instead of depending on a downstream `workflow_run` that was never created.

Closes #5752

## Changes Made

- dispatch the trusted default-branch commenter after all exact-head required workflows are created
- resolve exactly one current same-repository Dependabot PR and one matching Comprehensive dispatch
- poll and re-authenticate run identity without checking out or executing PR code
- preserve PR/run outputs on lookup, API, duplicate-run, and timeout failures so stale green comments are replaced by a red fallback before enforcement fails
- bound monitoring from the declared Comprehensive `needs` DAG: 105-minute source bound, 120-minute poll, 130-minute job timeout
- add explicit timeouts to every Comprehensive job and rate-limit-safe 60-second polling
- retain the ordinary pull-request `workflow_run` commenter path

## Files Modified

- trusted Dependabot publisher and PR-comment workflows
- Comprehensive workflow timeout contract
- publisher implementation and unit tests
- workflow security/property tests and workflow documentation

## Verification

- TDD RED: direct commenter dispatch property failed before implementation
- Workflow Smoke property suite: 154 passed
- full pre-push Python suite: 1445 passed, 228 skipped
- mypy: 80 source files clean
- Ruff check and format: passed
- all modified-file pre-commit hooks: passed
- two independent reviews: no remaining findings
- signed commit with DCO; direct parent is current main `6a744f16c969b2c97a588f0770f7ab6a74b89b4b`

## Security

The write-scoped commenter executes only trusted default-branch workflow code, treats artifacts as data, validates exact run/PR/head/branch/repository identity, and never checks out pull-request code.