### PR TITLE
test(ci): make trusted dependency fixtures version-agnostic

### DIFF
--- a/tests/scripts/test_commit_generated_dependencies.py
+++ b/tests/scripts/test_commit_generated_dependencies.py
@@ -48,6 +48,46 @@ def _real_generated_contents() -> dict[str, bytes]:
     return {path: (PROJECT_ROOT / path).read_bytes() for path in PUBLISHER.GENERATED_PATHS}
 
 
+def _replace_dependency_declaration(
+    content: bytes,
+    name: str,
+    replacement: str,
+) -> bytes:
+    marker = f'"{name}'.encode()
+    assert content.count(marker) == 1
+    start = content.index(marker)
+    end = content.index(b'"', start + 1) + 1
+    replacement_bytes = f'"{replacement}"'.encode()
+    assert content[start:end] != replacement_bytes
+    return content[:start] + replacement_bytes + content[end:]
+
+
+def _replace_locked_version(
+    content: bytes,
+    name: str,
+    replacement: str,
+) -> bytes:
+    marker = f'name = "{name}"\nversion = "'.encode()
+    assert content.count(marker) == 1
+    start = content.index(marker) + len(marker)
+    end = content.index(b'"', start)
+    replacement_bytes = replacement.encode()
+    assert content[start:end] != replacement_bytes
+    return content[:start] + replacement_bytes + content[end:]
+
+
+def _replace_dependency_name(
+    content: bytes,
+    name: str,
+    replacement: str,
+) -> bytes:
+    marker = f'"{name}'.encode()
+    assert content.count(marker) == 1
+    updated = content.replace(marker, f'"{replacement}'.encode(), 1)
+    assert updated != content
+    return updated
+
+
 def _canonical_bundle(*, files: dict[str, bytes] | None = None) -> Any:
     return PUBLISHER.ArtifactBundle(
         repository=REPOSITORY,
@@ -728,21 +768,22 @@ def test_trusted_validator_rejects_contaminated_lock_with_unrelated_upgrades() -
     validator = getattr(PUBLISHER, "validate_canonical_dependencies", None)
     assert callable(validator), "trusted publisher must independently validate generated dependency bytes"
     trusted_pyproject = (PROJECT_ROOT / "pyproject.toml").read_bytes()
-    candidate_pyproject = trusted_pyproject.replace(
-        b'"types-PyYAML>=6.0"',
-        b'"types-PyYAML>=6.0.12.20260724"',
+    candidate_pyproject = _replace_dependency_declaration(
+        trusted_pyproject,
+        "types-PyYAML",
+        "types-PyYAML>=999.0.0",
     )
     trusted_lock = (PROJECT_ROOT / "uv.lock").read_bytes()
-    canonical_lock = trusted_lock.replace(
-        b'name = "types-pyyaml"\nversion = "6.0.12.20260518"',
-        b'name = "types-pyyaml"\nversion = "6.0.12.20260724"',
-        1,
+    canonical_lock = _replace_locked_version(
+        trusted_lock,
+        "types-pyyaml",
+        "999.0.0",
     )
     files = _real_generated_contents()
-    files["uv.lock"] = canonical_lock.replace(
-        b'name = "gitpython"\nversion = "3.1.55"',
-        b'name = "gitpython"\nversion = "99.0.0"',
-        1,
+    files["uv.lock"] = _replace_locked_version(
+        canonical_lock,
+        "gitpython",
+        "999.0.0",
     )
     commands: list[list[str]] = []
 
@@ -768,15 +809,16 @@ def test_trusted_validator_accepts_clean_recreated_dependency_head() -> None:
     validator = getattr(PUBLISHER, "validate_canonical_dependencies", None)
     assert callable(validator), "trusted publisher must independently validate generated dependency bytes"
     trusted_pyproject = (PROJECT_ROOT / "pyproject.toml").read_bytes()
-    candidate_pyproject = trusted_pyproject.replace(
-        b'"types-PyYAML>=6.0"',
-        b'"types-PyYAML>=6.0.12.20260724"',
+    candidate_pyproject = _replace_dependency_declaration(
+        trusted_pyproject,
+        "types-PyYAML",
+        "types-PyYAML>=999.0.0",
     )
     trusted_lock = (PROJECT_ROOT / "uv.lock").read_bytes()
-    canonical_lock = trusted_lock.replace(
-        b'name = "types-pyyaml"\nversion = "6.0.12.20260518"',
-        b'name = "types-pyyaml"\nversion = "6.0.12.20260724"',
-        1,
+    canonical_lock = _replace_locked_version(
+        trusted_lock,
+        "types-pyyaml",
+        "999.0.0",
     )
     files = _real_generated_contents()
     files["uv.lock"] = canonical_lock
@@ -808,9 +850,10 @@ def test_trusted_validator_rejects_identity_only_rewrite_without_upgrade_authori
     validator = getattr(PUBLISHER, "validate_canonical_dependencies", None)
     assert callable(validator), "trusted publisher must independently validate generated dependency bytes"
     trusted_pyproject = (PROJECT_ROOT / "pyproject.toml").read_bytes()
-    candidate_pyproject = trusted_pyproject.replace(
-        b'"gitpython>=3.1.55"',
-        f'"{rewritten_name}>=3.1.55"'.encode(),
+    candidate_pyproject = _replace_dependency_name(
+        trusted_pyproject,
+        "gitpython",
+        rewritten_name,
     )
 
     with pytest.raises(PUBLISHER.PublishError, match="identit"):


### PR DESCRIPTION
## Summary

Make the trusted dependency publisher fixtures derive mutations from the repository current dependency records instead of historical version bytes.

## Changes Made

- Add fail-closed helpers that locate exactly one dependency declaration or lock record, mutate exactly one occurrence, and assert that bytes changed.
- Keep the clean allowed-update fixture active with a synthetic types-PyYAML version.
- Keep the contaminated-lock fixture exercising one authorized update plus an unrelated GitPython change.
- Preserve all three identity-only rewrite regressions independent of the current GitPython lower bound.

## Verification

- RED on a synthetic GitPython 3.1.57 baseline: 4 failed, 78 passed before this patch.
- GREEN on current main and synthetic 3.1.57 baseline: 82 passed each.
- Full Python suite, including mandatory pre-push repetition: 1,447 passed, 228 skipped.
- Ruff check/format, mypy, pre-commit, uv lock check, and requirements export sync pass.
- Independent review found no issues and nine helper boundary cases fail closed.

Closes #5755