### PR TITLE
fix(ci): isolate optional Claude Code container install

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,14 @@
 # BUILD_PARALLELISM=1
 
 # ---------------------------------------------------------------------------
+# Optional development tooling
+# ---------------------------------------------------------------------------
+# Claude Code is not required to build or test Odyssey and is excluded from
+# container images by default. Opt in only when the CLI is needed in the
+# development container; this adds an external download during image build.
+# INSTALL_CLAUDE_CODE=true
+
+# ---------------------------------------------------------------------------
 # Mojo runtime logging (used by src/odyssey/utils/logging.mojo)
 # ---------------------------------------------------------------------------
 # Controls the log verbosity for ML Odyssey Mojo code.

--- a/.github/actions/setup-container/action.yml
+++ b/.github/actions/setup-container/action.yml
@@ -14,6 +14,7 @@ runs:
       run: |
         echo "USER_ID=$(id -u)" >> "$GITHUB_ENV"
         echo "GROUP_ID=$(id -g)" >> "$GITHUB_ENV"
+        echo "INSTALL_CLAUDE_CODE=false" >> "$GITHUB_ENV"
         echo "user_id=$(id -u)" >> "$GITHUB_OUTPUT"
 
     - name: Select compatible Podman runtime

--- a/.github/workflows/workflow-smoke-test.yml
+++ b/.github/workflows/workflow-smoke-test.yml
@@ -49,6 +49,7 @@ on:
       - '.github/actions/setup-container/action.yml'
       - '.github/workflows/container-publish.yml'
       - '.github/workflows/release.yml'
+      - 'Dockerfile'
       - 'docker-compose.yml'
       - 'justfile'
       - 'scripts/ci/commit_generated_dependencies.py'

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,15 +82,24 @@ FROM base AS development
 
 # Re-declare ARG so it's available in this stage (ARGs don't persist across FROM)
 ARG USER_NAME=dev
+ARG INSTALL_CLAUDE_CODE=false
 
 # Switch to dev user
 USER ${USER_NAME}
 WORKDIR /workspace
 
-# Install Claude Code CLI as the dev user (development-only — production
-# stage stays clean per #5328 because it FROM base, not FROM development).
-# Installs into ~/.local/bin which is in PATH.
-RUN curl -fsSL https://claude.ai/install.sh | bash -s -- stable
+# Claude Code is optional agent tooling, not a build or test dependency.
+# Keep its external installer off the default local and CI container path.
+# Developers can opt in with INSTALL_CLAUDE_CODE=true; the CLI installs into
+# ~/.local/bin, which is already on PATH.
+RUN if [ "$INSTALL_CLAUDE_CODE" = "true" ]; then \
+        installer="$(mktemp)" && \
+        curl -fsSL --output "$installer" https://claude.ai/install.sh && \
+        bash "$installer" stable && \
+        rm -f "$installer"; \
+    else \
+        echo "Skipping optional Claude Code CLI installation"; \
+    fi
 
 # uv cache + Modular home. Keeping the venv inside the image (not /workspace)
 # means the runtime bind-mount does not shadow it.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
         USER_ID: ${USER_ID}
         GROUP_ID: ${GROUP_ID}
         USER_NAME: dev
+        INSTALL_CLAUDE_CODE: ${INSTALL_CLAUDE_CODE:-false}
     image: odyssey:dev
     volumes:
       - .:/workspace:Z

--- a/tests/smoke/test_container_runtime_workflow_properties.py
+++ b/tests/smoke/test_container_runtime_workflow_properties.py
@@ -16,6 +16,7 @@ SETUP_ACTION = REPO_ROOT / ".github" / "actions" / "setup-container" / "action.y
 CONTAINER_PUBLISH = REPO_ROOT / ".github" / "workflows" / "container-publish.yml"
 RELEASE = REPO_ROOT / ".github" / "workflows" / "release.yml"
 WORKFLOW_SMOKE = REPO_ROOT / ".github" / "workflows" / "workflow-smoke-test.yml"
+DOCKERFILE = REPO_ROOT / "Dockerfile"
 COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
 JUSTFILE = REPO_ROOT / "justfile"
 
@@ -145,6 +146,27 @@ class TestSetupContainerAction:
             "mojo --version",
         )
 
+    def test_ci_disables_the_optional_claude_code_download(self) -> None:
+        """Required container setup cannot depend on optional agent tooling."""
+        action = _read(SETUP_ACTION)
+        dockerfile = _read(DOCKERFILE)
+        compose = _compose_service_block(_read(COMPOSE_FILE), "odyssey-dev")
+
+        assert "ARG INSTALL_CLAUDE_CODE=false" in dockerfile
+        assert dockerfile.count("https://claude.ai/install.sh") == 1
+        assert re.search(
+            r'if \[ "\$INSTALL_CLAUDE_CODE" = "true" \]; then.*?'
+            r"https://claude\.ai/install\.sh.*?fi",
+            dockerfile,
+            re.DOTALL,
+        )
+        assert "INSTALL_CLAUDE_CODE: ${INSTALL_CLAUDE_CODE:-false}" in compose
+        _assert_order(
+            action,
+            'echo "INSTALL_CLAUDE_CODE=false" >> "$GITHUB_ENV"',
+            "podman compose build",
+        )
+
 
 class TestRootlessWorkspaceMapping:
     """Writable bind mounts must preserve the invoking user's UID and GID."""
@@ -250,6 +272,7 @@ class TestWorkflowSmokeWiring:
             ".github/actions/setup-container/action.yml",
             ".github/workflows/container-publish.yml",
             ".github/workflows/release.yml",
+            "Dockerfile",
             "docker-compose.yml",
             "justfile",
             "scripts/ci/ensure-podman-runtime.sh",

--- a/tests/smoke/test_merge_queue_workflow_properties.py
+++ b/tests/smoke/test_merge_queue_workflow_properties.py
@@ -185,6 +185,7 @@ def test_existing_pull_request_and_push_triggers_are_preserved() -> None:
         ".github/workflows/security.yml",
         ".github/workflows/validate-configs.yml",
         ".github/workflows/workflow-smoke-test.yml",
+        "Dockerfile",
         "configs/github/merge-queue-policy.json",
         "docker-compose.yml",
         "justfile",


### PR DESCRIPTION
## Summary

Removes the optional Claude Code download from the required development-container path that blocked Gradient Soak run 30562314191 before any tests ran.

Closes #5759

## Changes Made

- Default `INSTALL_CLAUDE_CODE` to `false` in the development image.
- Make the shared CI container action explicitly force the no-Claude contract.
- Preserve an opt-in `INSTALL_CLAUDE_CODE=true` Compose build argument for local developers.
- Add fail-closed container/workflow property coverage and make `Dockerfile` changes trigger it.

## Files Modified

- `Dockerfile`, `docker-compose.yml`, `.env.example`
- `.github/actions/setup-container/action.yml`
- `.github/workflows/workflow-smoke-test.yml`
- container and merge-queue workflow property tests

## Verification

- Regression test observed red before implementation, then green.
- Focused container/preflight/soak properties: 71 passed.
- Smoke + foundation + preflight: 274 passed, 157 documented skips.
- Full pre-push Python suite: 1448 passed, 228 documented skips.
- All changed-file pre-commit hooks passed.
- Constrained local Podman preflight passed (6 CPUs, 7905 MiB, one build job).
- Default development image built successfully; the changed layer printed `Skipping optional Claude Code CLI installation`.
- Image smoke: Mojo 1.0.0b2, pre-commit 4.6.1, and no `claude` executable.

## Failure Evidence

- https://github.com/HomericIntelligence/Odyssey/actions/runs/30562314191