### PR TITLE
fix(ci): render PR reports from trusted API data

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -76,7 +76,7 @@ ls .github/workflows/*.yml | wc -l
 | --- | --- | --- | --- |
 | **Test Workflows** | | | |
 | [comprehensive-tests.yml](#comprehensive-tests) | PR, push main, manual | All Mojo tests in 17 groups | < 10 min |
-| [comprehensive-test-pr-comments.yml](#comprehensive-test-pr-comments) | Completed comprehensive PR tests | Trusted test-report PR comments | < 1 min |
+| [comprehensive-test-pr-comments.yml](#comprehensive-test-pr-comments) | Completed comprehensive PR tests | Trusted test-report PR comments | < 1 min normally; up to 130 min for dispatch monitoring |
 | [test-gradients.yml](#test-gradients) | PR on gradient changes, push main | Backward pass validation | < 5 min |
 | [test-data-utilities.yml](#test-data-utilities) | PR/push on data changes | Data loading and processing | < 5 min |
 | [coverage.yml](#coverage) | PR, push main, manual | Code coverage tracking | < 5 min |
@@ -178,18 +178,22 @@ ls .github/workflows/*.yml | wc -l
 
 **File**: `comprehensive-test-pr-comments.yml`
 
-**Triggers**: Completed `Comprehensive Tests` runs whose source event is `pull_request`, or a
-trusted default-branch dispatch bound to an exact same-repository Dependabot head
+**Triggers**: Completed `Comprehensive Tests` runs whose source event is `pull_request` or
+`workflow_dispatch`, or a typed default-branch `repository_dispatch` bound to an exact
+same-repository Dependabot head
 
-**Purpose**: Post or update the test-metrics and comprehensive-test reports on the pull request.
-The workflow runs from the trusted default branch, downloads reports as data, and never checks out
-or executes pull-request code with its narrowly scoped `pull-requests: write` token. For Dependabot,
-the trusted dependency writer dispatches this workflow as a sibling monitor. The monitor polls the
-single exact Comprehensive dispatch because its completion does not create the downstream
-`workflow_run` consumer in this GitHub Actions event chain, then validates the current PR/head before
-consuming its artifacts.
+**Purpose**: Post or update a trusted comprehensive-test summary on the pull request. The workflow
+uses its immutable default-branch renderer and exact GitHub API run/job data; it never downloads,
+reads, or relays pull-request artifacts with its narrowly scoped `pull-requests: write` token. For
+Dependabot, the trusted dependency writer dispatches this workflow as a sibling monitor. The monitor
+polls the single exact Comprehensive dispatch because its completion does not create the downstream
+`workflow_run` consumer in this GitHub Actions event chain. A read-only resolver revalidates the
+current PR source tuple before admitting a PR-number-serialized, fully queued writer. The writer
+revalidates the head, workflow identity, run attempt, conclusion, and jobs, and proves again after
+comment discovery that its run number and attempt are still newest across both accepted source
+events. An obsolete writer exits without changing comments.
 
-**Artifacts**: Consumes `test-metrics` and `comprehensive-test-report`; creates none
+**Artifacts**: Consumes none; creates none. Source-workflow artifacts remain diagnostic downloads.
 
 ---
 

--- a/.github/workflows/comprehensive-test-pr-comments.yml
+++ b/.github/workflows/comprehensive-test-pr-comments.yml
@@ -222,16 +222,46 @@ jobs:
               sourceHeadRepository = run.head_repository.full_name;
             }
 
-            const associated = await github.paginate(
-              github.rest.repos.listPullRequestsAssociatedWithCommit,
-              {
+            if (
+              typeof sourceHeadRepository !== 'string' ||
+              !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(
+                sourceHeadRepository,
+              )
+            ) {
+              core.setFailed(
+                'Resolved PR has no valid source repository identity.',
+              );
+              return;
+            }
+
+            const [sourceHeadOwner] = sourceHeadRepository.split('/');
+            let listedPullRequests;
+            try {
+              const response = await github.rest.pulls.list({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                commit_sha: sourceHeadSha,
+                state: 'open',
+                head: `${sourceHeadOwner}:${sourceHeadBranch}`,
                 per_page: 100,
-              },
-            );
-            const candidates = associated.filter(
+                page: 1,
+              });
+              listedPullRequests = response.data;
+            } catch (error) {
+              core.setFailed(
+                'Unable to discover the open PR for the exact source head.',
+              );
+              return;
+            }
+            if (
+              !Array.isArray(listedPullRequests) ||
+              listedPullRequests.length >= 100
+            ) {
+              core.setFailed(
+                'Open PR discovery returned an invalid or unbounded result.',
+              );
+              return;
+            }
+            const candidates = listedPullRequests.filter(
               pullRequest =>
                 pullRequest.state === 'open' &&
                 pullRequest.head.sha === sourceHeadSha &&
@@ -266,18 +296,6 @@ jobs:
               pullRequest.head.repo?.full_name !== sourceHeadRepository
             ) {
               core.setFailed('Resolved PR is no longer open at the exact workflow head.');
-              return;
-            }
-
-            if (
-              typeof sourceHeadRepository !== 'string' ||
-              !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(
-                sourceHeadRepository,
-              )
-            ) {
-              core.setFailed(
-                'Resolved PR has no valid source repository identity.',
-              );
               return;
             }
 
@@ -855,6 +873,9 @@ jobs:
             const METRICS_RETIRED_MARKER =
               '<!-- odyssey:test-metrics-retired:v1 -->';
             const MAX_COMMENT_BYTES = 60_000;
+            const MAX_DISCOVERED_COMMENT_BYTES = 65_536;
+            const COMMENT_PAGE_SIZE = 100;
+            const MAX_COMMENT_PAGES = 10;
             const BOT_USER_ID = 41898282;
             const ACTIONS_APP_ID = 15368;
             const SOURCE_RUN_EVENTS = new Set([
@@ -1016,7 +1037,10 @@ jobs:
                 return 'unknown';
               }
               const seenRunIds = new Set();
+              const seenRunOrders = new Set();
               for (const candidate of exactRuns) {
+                const order =
+                  `${candidate.run_number}:${candidate.run_attempt}`;
                 if (
                   !Number.isSafeInteger(candidate.id) ||
                   candidate.id < 1 ||
@@ -1024,11 +1048,13 @@ jobs:
                   !Number.isSafeInteger(candidate.run_number) ||
                   candidate.run_number < 1 ||
                   !Number.isSafeInteger(candidate.run_attempt) ||
-                  candidate.run_attempt < 1
+                  candidate.run_attempt < 1 ||
+                  seenRunOrders.has(order)
                 ) {
                   return 'unknown';
                 }
                 seenRunIds.add(candidate.id);
+                seenRunOrders.add(order);
               }
               const latest = exactRuns.reduce((current, candidate) => {
                 if (candidate.run_number !== current.run_number) {
@@ -1278,15 +1304,64 @@ jobs:
               }
             }
 
-            const comments = await github.paginate(
-              github.rest.issues.listComments,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number,
-                per_page: 100,
-              },
-            );
+            let comments = [];
+            let commentDiscoveryFailed = false;
+            try {
+              const seenCommentIds = new Set();
+              for (
+                let commentPage = 1;
+                commentPage <= MAX_COMMENT_PAGES + 1;
+                commentPage += 1
+              ) {
+                const response =
+                  await github.rest.issues.listComments({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number,
+                    per_page: COMMENT_PAGE_SIZE,
+                    page: commentPage,
+                  });
+                const pageComments = response.data;
+                if (
+                  !Array.isArray(pageComments) ||
+                  pageComments.length > COMMENT_PAGE_SIZE
+                ) {
+                  throw new Error('Invalid comment page.');
+                }
+                for (const comment of pageComments) {
+                  if (
+                    !comment ||
+                    typeof comment !== 'object' ||
+                    !Number.isSafeInteger(comment.id) ||
+                    comment.id < 1 ||
+                    seenCommentIds.has(comment.id) ||
+                    typeof comment.body !== 'string' ||
+                    Buffer.byteLength(comment.body, 'utf8') >
+                      MAX_DISCOVERED_COMMENT_BYTES
+                  ) {
+                    throw new Error('Invalid comment metadata.');
+                  }
+                  seenCommentIds.add(comment.id);
+                  comments.push(comment);
+                }
+                if (commentPage > MAX_COMMENT_PAGES) {
+                  if (pageComments.length > 0) {
+                    throw new Error('Comment discovery limit exceeded.');
+                  }
+                  break;
+                }
+                if (pageComments.length < COMMENT_PAGE_SIZE) {
+                  break;
+                }
+              }
+            } catch (error) {
+              commentDiscoveryFailed = true;
+              reportBody = fallbackBody;
+              usedFallback = true;
+              core.info(
+                'Comment discovery failed or exceeded the bounded limit.',
+              );
+            }
 
             let mutationTimePullRequest;
             try {
@@ -1363,6 +1438,49 @@ jobs:
             ) {
               core.setFailed(
                 'Source run changed during comment discovery.',
+              );
+              return;
+            }
+
+            if (commentDiscoveryFailed) {
+              const discoveredReports = comments.filter(
+                comment =>
+                  isExpectedActionsComment(comment) &&
+                  (hasExactMarker(comment) || legacyReport(comment)),
+              );
+              let fallbackMutationFailed = false;
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                  body: fallbackBody,
+                });
+              } catch (error) {
+                fallbackMutationFailed = true;
+                core.info(
+                  'Unable to create the red comment-discovery fallback.',
+                );
+              }
+              for (const existing of discoveredReports) {
+                try {
+                  await github.rest.issues.updateComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: existing.id,
+                    body: fallbackBody,
+                  });
+                } catch (error) {
+                  fallbackMutationFailed = true;
+                  core.info(
+                    `Unable to retire discovered report ${existing.id}.`,
+                  );
+                }
+              }
+              core.setFailed(
+                fallbackMutationFailed
+                  ? 'Comment discovery failed; red fallback mutation was incomplete.'
+                  : 'Comment discovery failed; posted a red fallback.',
               );
               return;
             }

--- a/.github/workflows/comprehensive-test-pr-comments.yml
+++ b/.github/workflows/comprehensive-test-pr-comments.yml
@@ -1,48 +1,53 @@
 name: Comprehensive Test PR Comments
 
-# This trusted default-branch workflow consumes reports as data. It never
-# checks out or executes pull-request code with its write-scoped token.
+# This write-scoped workflow never consumes pull-request artifacts. It renders
+# GitHub API job results with validated code from its immutable trusted commit.
 on:
   workflow_run:
     workflows: ["Comprehensive Tests"]
     types: [completed]
-  workflow_dispatch:
-    inputs:
-      source_head_sha:
-        description: Exact Dependabot head whose Comprehensive run must be reported
-        required: true
-        type: string
-      source_head_branch:
-        description: Exact same-repository Dependabot branch
-        required: true
-        type: string
+  repository_dispatch:
+    types: [dependabot-comprehensive-test-comment]
 
 permissions:
   contents: read
 
 jobs:
-  post-pr-comments:
+  resolve-pr-context:
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.event == 'pull_request'
-    concurrency:
-      group: comprehensive-test-pr-comment-${{ inputs.source_head_sha || github.event.workflow_run.head_sha }}
-      cancel-in-progress: true
+      github.event_name == 'repository_dispatch' ||
+      github.event.workflow_run.event == 'pull_request' ||
+      github.event.workflow_run.event == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 130
-    name: "Post Comprehensive Test PR Comments"
+    name: "Resolve Comprehensive PR Context"
     permissions:
       actions: read
       contents: read
-      pull-requests: write
+      pull-requests: read
+    outputs:
+      pr_number: ${{ steps.resolve-context.outputs.pr_number }}
+      source_error: ${{ steps.resolve-context.outputs.source_error }}
+      source_head_branch: ${{ steps.resolve-context.outputs.source_head_branch }}
+      source_head_repository: ${{ steps.resolve-context.outputs.source_head_repository }}
+      source_head_sha: ${{ steps.resolve-context.outputs.source_head_sha }}
+      source_ready: ${{ steps.resolve-context.outputs.source_ready }}
+      source_run_attempt: ${{ steps.resolve-context.outputs.source_run_attempt }}
+      source_run_conclusion: ${{ steps.resolve-context.outputs.source_run_conclusion }}
+      source_run_event: ${{ steps.resolve-context.outputs.source_run_event }}
+      source_run_id: ${{ steps.resolve-context.outputs.source_run_id }}
+      source_run_number: ${{ steps.resolve-context.outputs.source_run_number }}
+      source_run_url: ${{ steps.resolve-context.outputs.source_run_url }}
+      source_workflow_id: ${{ steps.resolve-context.outputs.source_workflow_id }}
+      writer_ready: ${{ steps.resolve-context.outputs.writer_ready }}
 
     steps:
       - name: Resolve trusted source run and exactly one current pull request
         id: resolve-context
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
-          SOURCE_HEAD_SHA: ${{ inputs.source_head_sha }}
-          SOURCE_HEAD_BRANCH: ${{ inputs.source_head_branch }}
+          SOURCE_HEAD_SHA: ${{ github.event.client_payload.source_head_sha }}
+          SOURCE_HEAD_BRANCH: ${{ github.event.client_payload.source_head_branch }}
         with:
           script: |
             const expectedRepository =
@@ -50,11 +55,60 @@ jobs:
             const comprehensiveWorkflowUrl =
               `https://github.com/${expectedRepository}/actions/workflows/` +
               `comprehensive-tests.yml`;
+            const commentDispatchEvent =
+              'dependabot-comprehensive-test-comment';
             const isTrustedDispatch =
-              context.eventName === 'workflow_dispatch';
+              context.eventName === 'repository_dispatch';
+            const sourceWorkflowRunEvents = new Set([
+              'pull_request',
+              'workflow_dispatch',
+            ]);
+            if (
+              isTrustedDispatch &&
+              context.payload.action !== commentDispatchEvent
+            ) {
+              core.setFailed(
+                'Repository dispatch has an unexpected activity type.',
+              );
+              return;
+            }
+            const defaultRef =
+              `refs/heads/${context.payload.repository.default_branch}`;
+            if (context.ref !== defaultRef) {
+              core.setFailed(
+                'The write-scoped commenter must run from the default branch.',
+              );
+              return;
+            }
+
+            let expectedWorkflow;
+            try {
+              const response = await github.rest.actions.getWorkflow({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'comprehensive-tests.yml',
+              });
+              expectedWorkflow = response.data;
+            } catch (error) {
+              core.setFailed(
+                'Unable to resolve the trusted Comprehensive workflow identity.',
+              );
+              return;
+            }
+            if (
+              expectedWorkflow.name !== 'Comprehensive Tests' ||
+              expectedWorkflow.path !== '.github/workflows/comprehensive-tests.yml'
+            ) {
+              core.setFailed(
+                'The trusted Comprehensive workflow identity is invalid.',
+              );
+              return;
+            }
+
             let run = context.payload.workflow_run;
             let sourceHeadSha;
             let sourceHeadBranch;
+            let sourceHeadRepository;
 
             const setSourceFailure = (message) => {
               core.setOutput('source_ready', 'false');
@@ -70,6 +124,27 @@ jobs:
               if (run?.id) {
                 core.setOutput('source_run_id', String(run.id));
               }
+              if (run?.run_attempt) {
+                core.setOutput(
+                  'source_run_attempt',
+                  String(run.run_attempt),
+                );
+              }
+              if (run?.event) {
+                core.setOutput('source_run_event', String(run.event));
+              }
+              if (run?.run_number) {
+                core.setOutput(
+                  'source_run_number',
+                  String(run.run_number),
+                );
+              }
+              if (run?.workflow_id) {
+                core.setOutput(
+                  'source_workflow_id',
+                  String(run.workflow_id),
+                );
+              }
             };
 
             const setSourceReady = () => {
@@ -78,6 +153,19 @@ jobs:
               core.setOutput('source_run_id', String(run.id));
               core.setOutput('source_run_url', run.html_url);
               core.setOutput('source_run_conclusion', run.conclusion);
+              core.setOutput(
+                'source_run_attempt',
+                String(run.run_attempt),
+              );
+              core.setOutput('source_run_event', run.event);
+              core.setOutput(
+                'source_run_number',
+                String(run.run_number),
+              );
+              core.setOutput(
+                'source_workflow_id',
+                String(run.workflow_id),
+              );
             };
 
             if (isTrustedDispatch) {
@@ -90,28 +178,48 @@ jobs:
                 !requestedHeadBranch.startsWith('dependabot/')
               ) {
                 core.setFailed(
-                  'Comment workflow dispatch inputs are not an exact Dependabot head.',
+                  'Comment repository dispatch payload is not an exact Dependabot head.',
                 );
                 return;
               }
               sourceHeadSha = requestedHeadSha;
               sourceHeadBranch = requestedHeadBranch;
+              sourceHeadRepository = expectedRepository;
             } else {
               if (
                 !run ||
                 run.name !== 'Comprehensive Tests' ||
                 run.path !== '.github/workflows/comprehensive-tests.yml' ||
-                run.event !== 'pull_request' ||
+                run.workflow_id !== expectedWorkflow.id ||
+                run.repository?.full_name !== expectedRepository ||
+                run.repository?.id !== context.payload.repository.id ||
+                !sourceWorkflowRunEvents.has(run.event) ||
+                (
+                  run.event === 'workflow_dispatch' &&
+                  run.head_repository?.full_name !== expectedRepository
+                ) ||
                 run.status !== 'completed' ||
-                typeof run.conclusion !== 'string'
+                typeof run.conclusion !== 'string' ||
+                !/^[0-9a-f]{40}$/.test(run.head_sha || '') ||
+                typeof run.head_branch !== 'string' ||
+                run.head_branch.length < 1 ||
+                run.head_branch.length > 255 ||
+                !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(
+                  run.head_repository?.full_name || '',
+                ) ||
+                !Number.isSafeInteger(run.run_attempt) ||
+                run.run_attempt < 1 ||
+                !Number.isSafeInteger(run.run_number) ||
+                run.run_number < 1
               ) {
                 core.setFailed(
-                  'Source run is not a completed pull-request Comprehensive workflow.',
+                  'Source run is not a completed PR or dispatch Comprehensive workflow.',
                 );
                 return;
               }
               sourceHeadSha = run.head_sha;
               sourceHeadBranch = run.head_branch;
+              sourceHeadRepository = run.head_repository.full_name;
             }
 
             const associated = await github.paginate(
@@ -126,9 +234,18 @@ jobs:
             const candidates = associated.filter(
               pullRequest =>
                 pullRequest.state === 'open' &&
-                pullRequest.head.sha === sourceHeadSha,
+                pullRequest.head.sha === sourceHeadSha &&
+                pullRequest.head.ref === sourceHeadBranch &&
+                pullRequest.head.repo?.full_name === sourceHeadRepository,
             );
-            if (candidates.length !== 1) {
+            if (candidates.length === 0) {
+              core.info(
+                'No current open PR remains at the source head. ' +
+                  'No comment is required.',
+              );
+              return;
+            }
+            if (candidates.length > 1) {
               core.setFailed(
                 `Expected exactly one open PR at ${sourceHeadSha}; ` +
                 `found ${candidates.length}.`,
@@ -144,9 +261,23 @@ jobs:
             });
             if (
               pullRequest.state !== 'open' ||
-              pullRequest.head.sha !== sourceHeadSha
+              pullRequest.head.sha !== sourceHeadSha ||
+              pullRequest.head.ref !== sourceHeadBranch ||
+              pullRequest.head.repo?.full_name !== sourceHeadRepository
             ) {
               core.setFailed('Resolved PR is no longer open at the exact workflow head.');
+              return;
+            }
+
+            if (
+              typeof sourceHeadRepository !== 'string' ||
+              !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(
+                sourceHeadRepository,
+              )
+            ) {
+              core.setFailed(
+                'Resolved PR has no valid source repository identity.',
+              );
               return;
             }
 
@@ -154,7 +285,7 @@ jobs:
               if (
                 pullRequest.user.login !== 'dependabot[bot]' ||
                 pullRequest.head.ref !== sourceHeadBranch ||
-                pullRequest.head.repo.full_name !== expectedRepository
+                sourceHeadRepository !== expectedRepository
               ) {
                 core.setFailed(
                   'Comment dispatch is not bound to a current same-repository ' +
@@ -165,8 +296,58 @@ jobs:
             }
             core.setOutput('pr_number', String(pullRequest.number));
             core.setOutput('source_head_sha', sourceHeadSha);
+            core.setOutput('source_head_branch', sourceHeadBranch);
+            core.setOutput(
+              'source_head_repository',
+              sourceHeadRepository,
+            );
+
+            const authorizeWriterForCurrentPullRequest = async () => {
+              let currentPullRequest;
+              try {
+                const response = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pullRequest.number,
+                });
+                currentPullRequest = response.data;
+              } catch (error) {
+                core.setFailed(
+                  'Unable to revalidate the PR before scheduling its writer.',
+                );
+                return false;
+              }
+              if (
+                currentPullRequest.number !== pullRequest.number ||
+                currentPullRequest.state !== 'open' ||
+                currentPullRequest.head.sha !== sourceHeadSha ||
+                currentPullRequest.head.ref !== sourceHeadBranch ||
+                currentPullRequest.head.repo?.full_name !==
+                  sourceHeadRepository ||
+                (
+                  isTrustedDispatch &&
+                  currentPullRequest.user.login !== 'dependabot[bot]'
+                )
+              ) {
+                core.info(
+                  'Resolved PR changed before writer scheduling. ' +
+                    'No writer is required.',
+                );
+                return false;
+              }
+              core.setOutput('writer_ready', 'true');
+              return true;
+            };
+
+            const setCurrentSourceFailure = async message => {
+              setSourceFailure(message);
+              await authorizeWriterForCurrentPullRequest();
+            };
 
             if (!isTrustedDispatch) {
+              if (!(await authorizeWriterForCurrentPullRequest())) {
+                return;
+              }
               setSourceReady();
               return;
             }
@@ -185,37 +366,71 @@ jobs:
                 },
               );
             } catch (error) {
-              setSourceFailure(
+              await setCurrentSourceFailure(
                 `Unable to locate the exact Comprehensive run: ${error.message}`,
               );
               return;
             }
 
+            if (!Array.isArray(runs) || runs.length > 1_000) {
+              await setCurrentSourceFailure(
+                'Comprehensive run lookup returned an invalid result set.',
+              );
+              return;
+            }
             const matches = runs.filter(
               candidateRun =>
+                candidateRun.name === 'Comprehensive Tests' &&
+                candidateRun.path ===
+                  '.github/workflows/comprehensive-tests.yml' &&
                 candidateRun.head_sha === sourceHeadSha &&
                 candidateRun.head_branch === sourceHeadBranch &&
-                candidateRun.head_repository?.full_name === expectedRepository,
+                candidateRun.head_repository?.full_name === expectedRepository &&
+                candidateRun.workflow_id === expectedWorkflow.id &&
+                candidateRun.repository?.full_name === expectedRepository &&
+                candidateRun.repository?.id === context.payload.repository.id &&
+                candidateRun.event === 'workflow_dispatch',
             );
-            if (matches.length !== 1) {
-              setSourceFailure(
-                `Expected exactly one dispatched Comprehensive run for ` +
-                `${sourceHeadSha}; found ${matches.length}.`,
+            if (matches.length < 1) {
+              await setCurrentSourceFailure(
+                `No dispatched Comprehensive run exists for ${sourceHeadSha}.`,
               );
               return;
             }
 
-            run = matches[0];
-            if (
-              run.name !== 'Comprehensive Tests' ||
-              run.path !== '.github/workflows/comprehensive-tests.yml' ||
-              run.event !== 'workflow_dispatch'
-            ) {
-              setSourceFailure(
-                'Located run is not the trusted Comprehensive workflow dispatch.',
-              );
-              return;
+            const seenRunIds = new Set();
+            const seenRunOrders = new Set();
+            for (const candidateRun of matches) {
+              const order =
+                `${candidateRun.run_number}:${candidateRun.run_attempt}`;
+              if (
+                !Number.isSafeInteger(candidateRun.id) ||
+                candidateRun.id < 1 ||
+                seenRunIds.has(candidateRun.id) ||
+                !Number.isSafeInteger(candidateRun.run_number) ||
+                candidateRun.run_number < 1 ||
+                !Number.isSafeInteger(candidateRun.run_attempt) ||
+                candidateRun.run_attempt < 1 ||
+                seenRunOrders.has(order)
+              ) {
+                await setCurrentSourceFailure(
+                  'Dispatched Comprehensive runs have invalid ordering metadata.',
+                );
+                return;
+              }
+              seenRunIds.add(candidateRun.id);
+              seenRunOrders.add(order);
             }
+            run = matches.reduce((current, candidate) => {
+              if (candidate.run_number !== current.run_number) {
+                return candidate.run_number > current.run_number
+                  ? candidate
+                  : current;
+              }
+              return candidate.run_attempt > current.run_attempt
+                ? candidate
+                : current;
+            });
 
             const sourceRunId = run.id;
             try {
@@ -237,139 +452,831 @@ jobs:
                   run.head_branch !== sourceHeadBranch ||
                   run.head_repository?.full_name !== expectedRepository ||
                   run.path !== '.github/workflows/comprehensive-tests.yml' ||
+                  run.workflow_id !== expectedWorkflow.id ||
+                  run.repository?.full_name !== expectedRepository ||
+                  run.repository?.id !== context.payload.repository.id ||
                   run.event !== 'workflow_dispatch'
                 ) {
-                  setSourceFailure(
+                  await setCurrentSourceFailure(
                     'Comprehensive run identity changed while it was monitored.',
                   );
                   return;
                 }
               }
             } catch (error) {
-              setSourceFailure(
+              await setCurrentSourceFailure(
                 `Unable to monitor the exact Comprehensive run: ${error.message}`,
               );
               return;
             }
             if (run.status !== 'completed') {
-              setSourceFailure(
+              await setCurrentSourceFailure(
                 'Comprehensive run did not complete within 120 minutes.',
               );
               return;
             }
             if (typeof run.conclusion !== 'string') {
-              setSourceFailure(
+              await setCurrentSourceFailure(
                 'Completed Comprehensive run has no authoritative conclusion.',
               );
               return;
             }
+            if (
+              !Number.isSafeInteger(run.run_attempt) ||
+              run.run_attempt < 1 ||
+              !Number.isSafeInteger(run.run_number) ||
+              run.run_number < 1
+            ) {
+              await setCurrentSourceFailure(
+                'Completed Comprehensive run has invalid ordering metadata.',
+              );
+              return;
+            }
+            if (!(await authorizeWriterForCurrentPullRequest())) {
+              return;
+            }
             setSourceReady();
 
-      - name: Discover report artifacts
-        id: discover_artifacts
+  post-pr-comments:
+    needs: resolve-pr-context
+    if: >-
+      always() &&
+      needs.resolve-pr-context.result == 'success' &&
+      needs.resolve-pr-context.outputs.pr_number != '' &&
+      needs.resolve-pr-context.outputs.writer_ready == 'true'
+    concurrency:
+      group: comprehensive-test-pr-comment-pr-${{ needs.resolve-pr-context.outputs.pr_number }}
+      queue: max
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    name: "Post Comprehensive Test PR Comments"
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout immutable trusted comment renderer
         if: >-
-          steps.resolve-context.outcome == 'success' &&
-          steps.resolve-context.outputs.source_ready == 'true'
+          needs.resolve-pr-context.result == 'success' &&
+          needs.resolve-pr-context.outputs.source_ready == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: |
+            .github/workflows/comprehensive-tests.yml
+            scripts/ci/comprehensive_pr_comment.py
+            scripts/ci/comprehensive_report.py
+          sparse-checkout-cone-mode: false
+
+      - name: Collect authoritative source jobs
+        id: collect-jobs
+        if: >-
+          needs.resolve-pr-context.result == 'success' &&
+          needs.resolve-pr-context.outputs.source_ready == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
-          SOURCE_RUN_ID: ${{ steps.resolve-context.outputs.source_run_id }}
-        with:
-          script: |
-            const artifacts = await github.paginate(
-              github.rest.actions.listWorkflowRunArtifacts,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                run_id: Number(process.env.SOURCE_RUN_ID),
-                per_page: 100,
-              },
-            );
-            const available = new Set(
-              artifacts
-                .filter(artifact => !artifact.expired)
-                .map(artifact => artifact.name),
-            );
-            core.setOutput('has_metrics', String(available.has('test-metrics')));
-            core.setOutput(
-              'has_report',
-              String(available.has('comprehensive-test-report')),
-            );
-
-      - name: Download test metrics report
-        id: download-metrics
-        if: >-
-          steps.resolve-context.outcome == 'success' &&
-          steps.resolve-context.outputs.source_ready == 'true' &&
-          steps.discover_artifacts.outputs.has_metrics == 'true'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
-        with:
-          name: test-metrics
-          path: reports/metrics
-          github-token: ${{ github.token }}
-          run-id: ${{ steps.resolve-context.outputs.source_run_id }}
-
-      - name: Download comprehensive test report
-        id: download-report
-        if: >-
-          always() &&
-          steps.resolve-context.outcome == 'success' &&
-          steps.resolve-context.outputs.source_ready == 'true' &&
-          steps.discover_artifacts.outputs.has_report == 'true'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
-        with:
-          name: comprehensive-test-report
-          path: reports/comprehensive
-          github-token: ${{ github.token }}
-          run-id: ${{ steps.resolve-context.outputs.source_run_id }}
-
-      - name: Post or update PR comments
-        if: always() && steps.resolve-context.outcome == 'success'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
-        env:
-          PR_NUMBER: ${{ steps.resolve-context.outputs.pr_number }}
-          REPORT_AVAILABLE: ${{ steps.discover_artifacts.outputs.has_report }}
-          METRICS_AVAILABLE: ${{ steps.discover_artifacts.outputs.has_metrics }}
-          REPORT_DOWNLOAD_OUTCOME: ${{ steps.download-report.outcome }}
-          METRICS_DOWNLOAD_OUTCOME: ${{ steps.download-metrics.outcome }}
-          WORKFLOW_RUN_URL: ${{ steps.resolve-context.outputs.source_run_url }}
-          WORKFLOW_CONCLUSION: ${{ steps.resolve-context.outputs.source_run_conclusion }}
-          SOURCE_HEAD_SHA: ${{ steps.resolve-context.outputs.source_head_sha }}
-          SOURCE_RESOLUTION_ERROR: ${{ steps.resolve-context.outputs.source_error }}
+          COMMENT_CONTEXT_PATH: ${{ runner.temp }}/comprehensive-pr-comment-context.json
+          SOURCE_HEAD_BRANCH: ${{ needs.resolve-pr-context.outputs.source_head_branch }}
+          SOURCE_HEAD_REPOSITORY: ${{ needs.resolve-pr-context.outputs.source_head_repository }}
+          SOURCE_HEAD_SHA: ${{ needs.resolve-pr-context.outputs.source_head_sha }}
+          SOURCE_RUN_ATTEMPT: ${{ needs.resolve-pr-context.outputs.source_run_attempt }}
+          SOURCE_RUN_CONCLUSION: ${{ needs.resolve-pr-context.outputs.source_run_conclusion }}
+          SOURCE_RUN_EVENT: ${{ needs.resolve-pr-context.outputs.source_run_event }}
+          SOURCE_RUN_ID: ${{ needs.resolve-pr-context.outputs.source_run_id }}
+          SOURCE_RUN_NUMBER: ${{ needs.resolve-pr-context.outputs.source_run_number }}
+          SOURCE_WORKFLOW_ID: ${{ needs.resolve-pr-context.outputs.source_workflow_id }}
         with:
           script: |
             const fs = require('fs');
-            const issue_number = Number(process.env.PR_NUMBER);
-            const metricsPath = 'reports/metrics/metrics-pr-comment.md';
-            const reportPath = 'reports/comprehensive/test-report.md';
+            const path = require('path');
+            const MAX_INPUT_BYTES = 262_144;
+            const MAX_JOBS = 128;
+            const MAX_JOB_NAME_BYTES = 256;
+            const MAX_POLICY_FILE_BYTES = 262_144;
+            const TRUSTED_POLICY_PATHS = [
+              '.github/workflows/comprehensive-tests.yml',
+              'scripts/ci/comprehensive_report.py',
+            ];
+            const repository = `${context.repo.owner}/${context.repo.repo}`;
+            const sourceRunId = Number(process.env.SOURCE_RUN_ID);
+            const sourceRunAttempt = Number(process.env.SOURCE_RUN_ATTEMPT);
+            const sourceRunEvent = process.env.SOURCE_RUN_EVENT;
+            const sourceRunNumber = Number(process.env.SOURCE_RUN_NUMBER);
+            const sourceWorkflowId = Number(process.env.SOURCE_WORKFLOW_ID);
+            const sourceHeadRepository =
+              process.env.SOURCE_HEAD_REPOSITORY;
+            const sourceHeadBranch = process.env.SOURCE_HEAD_BRANCH;
             const sourceHeadSha = process.env.SOURCE_HEAD_SHA;
+            const sourceConclusion = process.env.SOURCE_RUN_CONCLUSION;
+            const contextPath = process.env.COMMENT_CONTEXT_PATH;
+
+            if (
+              !Number.isSafeInteger(sourceRunId) ||
+              sourceRunId < 1 ||
+              !Number.isSafeInteger(sourceRunAttempt) ||
+              sourceRunAttempt < 1 ||
+              !['pull_request', 'workflow_dispatch'].includes(
+                sourceRunEvent,
+              ) ||
+              !Number.isSafeInteger(sourceRunNumber) ||
+              sourceRunNumber < 1 ||
+              !Number.isSafeInteger(sourceWorkflowId) ||
+              sourceWorkflowId < 1 ||
+              !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(
+                sourceHeadRepository || '',
+              ) ||
+              typeof sourceHeadBranch !== 'string' ||
+              sourceHeadBranch.length < 1 ||
+              sourceHeadBranch.length > 255 ||
+              !/^[0-9a-f]{40}$/.test(sourceHeadSha || '') ||
+              typeof sourceConclusion !== 'string' ||
+              path.dirname(contextPath) !== process.env.RUNNER_TEMP
+            ) {
+              core.setFailed('Trusted source job context is invalid.');
+              return;
+            }
+
+            const [sourceOwner, sourceRepo] =
+              sourceHeadRepository.split('/');
+            try {
+              for (const trustedPath of TRUSTED_POLICY_PATHS) {
+                const trustedStat = fs.lstatSync(trustedPath);
+                if (
+                  !trustedStat.isFile() ||
+                  trustedStat.isSymbolicLink() ||
+                  trustedStat.size < 1 ||
+                  trustedStat.size > MAX_POLICY_FILE_BYTES
+                ) {
+                  core.setFailed(
+                    'Trusted Comprehensive policy file is invalid.',
+                  );
+                  return;
+                }
+                const trustedContent = fs.readFileSync(trustedPath);
+                const response = await github.rest.repos.getContent({
+                  owner: sourceOwner,
+                  repo: sourceRepo,
+                  path: trustedPath,
+                  ref: sourceHeadSha,
+                });
+                const sourceFile = response.data;
+                if (
+                  Array.isArray(sourceFile) ||
+                  sourceFile.type !== 'file' ||
+                  sourceFile.path !== trustedPath ||
+                  sourceFile.encoding !== 'base64' ||
+                  !Number.isSafeInteger(sourceFile.size) ||
+                  sourceFile.size < 1 ||
+                  sourceFile.size > MAX_POLICY_FILE_BYTES ||
+                  typeof sourceFile.content !== 'string'
+                ) {
+                  core.setFailed(
+                    'Source Comprehensive policy file is invalid.',
+                  );
+                  return;
+                }
+                const sourceContent = Buffer.from(
+                  sourceFile.content.replace(/\n/g, ''),
+                  'base64',
+                );
+                if (
+                  sourceContent.length !== sourceFile.size ||
+                  !trustedContent.equals(sourceContent)
+                ) {
+                  core.setFailed(
+                    'Source Comprehensive policy differs from trusted main.',
+                  );
+                  return;
+                }
+              }
+            } catch (error) {
+              core.setFailed(
+                'Unable to authenticate source Comprehensive policy files.',
+              );
+              return;
+            }
+
+            const runMatchesSnapshot = run =>
+              run.id === sourceRunId &&
+              run.run_attempt === sourceRunAttempt &&
+              run.run_number === sourceRunNumber &&
+              run.workflow_id === sourceWorkflowId &&
+              run.head_sha === sourceHeadSha &&
+              run.head_branch === sourceHeadBranch &&
+              run.head_repository?.full_name === sourceHeadRepository &&
+              run.event === sourceRunEvent &&
+              run.status === 'completed' &&
+              run.conclusion === sourceConclusion &&
+              run.path === '.github/workflows/comprehensive-tests.yml' &&
+              run.repository?.full_name === repository;
+
+            const getFreshRun = async () => {
+              const response = await github.rest.actions.getWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: sourceRunId,
+              });
+              return response.data;
+            };
+
+            let before;
+            try {
+              before = await getFreshRun();
+            } catch (error) {
+              core.setFailed('Unable to revalidate the exact source run.');
+              return;
+            }
+            if (!runMatchesSnapshot(before)) {
+              core.setFailed('Source run changed before job collection.');
+              return;
+            }
+
+            let jobs = [];
+            let totalCount = null;
+            try {
+              for (let page = 1; page <= 2; page += 1) {
+                const response =
+                  await github.rest.actions.listJobsForWorkflowRun({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: sourceRunId,
+                    filter: 'latest',
+                    per_page: 100,
+                    page,
+                  });
+                if (page === 1) {
+                  totalCount = response.data.total_count;
+                  if (
+                    !Number.isSafeInteger(totalCount) ||
+                    totalCount < 1 ||
+                    totalCount > MAX_JOBS
+                  ) {
+                    core.setFailed(
+                      'Source run has an invalid authoritative job count.',
+                    );
+                    return;
+                  }
+                }
+                jobs.push(...response.data.jobs);
+                if (jobs.length >= totalCount) {
+                  break;
+                }
+              }
+            } catch (error) {
+              core.setFailed('Unable to collect source-run jobs.');
+              return;
+            }
+            if (jobs.length !== totalCount || jobs.length > MAX_JOBS) {
+              core.setFailed('Source-run job pagination was incomplete.');
+              return;
+            }
+
+            const seenJobIds = new Set();
+            for (const job of jobs) {
+              if (
+                !Number.isSafeInteger(job.id) ||
+                job.id < 1 ||
+                seenJobIds.has(job.id) ||
+                job.run_id !== sourceRunId ||
+                job.head_sha !== sourceHeadSha ||
+                !Number.isSafeInteger(job.run_attempt) ||
+                job.run_attempt < 1 ||
+                job.run_attempt > sourceRunAttempt ||
+                typeof job.name !== 'string' ||
+                Buffer.byteLength(job.name, 'utf8') < 1 ||
+                Buffer.byteLength(job.name, 'utf8') > MAX_JOB_NAME_BYTES
+              ) {
+                core.setFailed('Source-run jobs violated the bounded contract.');
+                return;
+              }
+              seenJobIds.add(job.id);
+            }
+            const reportJobs = jobs.filter(
+              job => job.name === 'Test Report',
+            );
+            if (
+              reportJobs.length !== 1 ||
+              reportJobs[0].run_attempt !== sourceRunAttempt
+            ) {
+              core.setFailed(
+                'The authoritative Test Report is not from the current run attempt.',
+              );
+              return;
+            }
+
+            let after;
+            try {
+              after = await getFreshRun();
+            } catch (error) {
+              core.setFailed('Unable to revalidate the source run after collection.');
+              return;
+            }
+            if (!runMatchesSnapshot(after)) {
+              core.setFailed('Source run changed during job collection.');
+              return;
+            }
+
+            const runUrl =
+              `https://github.com/${repository}/actions/runs/${sourceRunId}`;
+            const payload = {
+              schema_version: 1,
+              repository,
+              run: {
+                id: sourceRunId,
+                status: after.status,
+                conclusion: after.conclusion,
+                head_sha: after.head_sha,
+                url: runUrl,
+              },
+              jobs: jobs.map(job => ({
+                id: job.id,
+                name: job.name,
+                status: job.status,
+                conclusion: job.conclusion,
+                url: `${runUrl}/job/${job.id}`,
+              })),
+            };
+            const encoded = JSON.stringify(payload);
+            if (Buffer.byteLength(encoded, 'utf8') > MAX_INPUT_BYTES) {
+              core.setFailed('Source-run job context exceeds the size limit.');
+              return;
+            }
+            fs.writeFileSync(contextPath, encoded, {
+              encoding: 'utf8',
+              flag: 'wx',
+              mode: 0o600,
+            });
+
+      - name: Render trusted PR comment
+        id: render-comment
+        if: >-
+          needs.resolve-pr-context.result == 'success' &&
+          needs.resolve-pr-context.outputs.source_ready == 'true' &&
+          steps.collect-jobs.outcome == 'success'
+        env:
+          COMMENT_CONTEXT_PATH: ${{ runner.temp }}/comprehensive-pr-comment-context.json
+          COMMENT_OUTPUT_PATH: ${{ runner.temp }}/comprehensive-pr-comment.md
+          EXPECTED_REPOSITORY: ${{ github.repository }}
+        run: |
+          python3 scripts/ci/comprehensive_pr_comment.py \
+            --input "$COMMENT_CONTEXT_PATH" \
+            --output "$COMMENT_OUTPUT_PATH" \
+            --expected-repository "$EXPECTED_REPOSITORY"
+
+      - name: Post or update trusted PR comment
+        if: always() && !cancelled()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          COLLECT_JOBS_OUTCOME: ${{ steps.collect-jobs.outcome }}
+          COMMENT_OUTPUT_PATH: ${{ runner.temp }}/comprehensive-pr-comment.md
+          PR_NUMBER: ${{ needs.resolve-pr-context.outputs.pr_number }}
+          RENDER_COMMENT_OUTCOME: ${{ steps.render-comment.outcome }}
+          SOURCE_HEAD_BRANCH: ${{ needs.resolve-pr-context.outputs.source_head_branch }}
+          SOURCE_HEAD_REPOSITORY: ${{ needs.resolve-pr-context.outputs.source_head_repository }}
+          SOURCE_HEAD_SHA: ${{ needs.resolve-pr-context.outputs.source_head_sha }}
+          SOURCE_READY: ${{ needs.resolve-pr-context.outputs.source_ready }}
+          SOURCE_RUN_ATTEMPT: ${{ needs.resolve-pr-context.outputs.source_run_attempt }}
+          SOURCE_RUN_EVENT: ${{ needs.resolve-pr-context.outputs.source_run_event }}
+          SOURCE_RUN_ID: ${{ needs.resolve-pr-context.outputs.source_run_id }}
+          SOURCE_RUN_NUMBER: ${{ needs.resolve-pr-context.outputs.source_run_number }}
+          SOURCE_WORKFLOW_ID: ${{ needs.resolve-pr-context.outputs.source_workflow_id }}
+          WORKFLOW_CONCLUSION: ${{ needs.resolve-pr-context.outputs.source_run_conclusion }}
+          WORKFLOW_RUN_URL: ${{ needs.resolve-pr-context.outputs.source_run_url }}
+        with:
+          script: |
+            const fs = require('fs');
+            const MARKER =
+              '<!-- odyssey:comprehensive-test-report:v1 -->';
+            const METRICS_RETIRED_MARKER =
+              '<!-- odyssey:test-metrics-retired:v1 -->';
+            const MAX_COMMENT_BYTES = 60_000;
+            const BOT_USER_ID = 41898282;
+            const ACTIONS_APP_ID = 15368;
+            const SOURCE_RUN_EVENTS = new Set([
+              'pull_request',
+              'workflow_dispatch',
+            ]);
+            const issue_number = Number(process.env.PR_NUMBER);
+            const sourceRunId = Number(process.env.SOURCE_RUN_ID);
+            const sourceRunAttempt = Number(process.env.SOURCE_RUN_ATTEMPT);
+            const sourceRunEvent = process.env.SOURCE_RUN_EVENT;
+            const sourceRunNumber = Number(process.env.SOURCE_RUN_NUMBER);
+            const sourceWorkflowId = Number(process.env.SOURCE_WORKFLOW_ID);
+            const sourceHeadBranch = process.env.SOURCE_HEAD_BRANCH;
+            const sourceHeadRepository =
+              process.env.SOURCE_HEAD_REPOSITORY;
+            const sourceHeadSha = process.env.SOURCE_HEAD_SHA;
+            const repository = `${context.repo.owner}/${context.repo.repo}`;
+            const sourceReady = process.env.SOURCE_READY === 'true';
+            const comprehensiveWorkflowUrl =
+              `https://github.com/${repository}/actions/workflows/` +
+              'comprehensive-tests.yml';
+            const hasResolvedRunId =
+              Number.isSafeInteger(sourceRunId) && sourceRunId > 0;
+            const runUrl =
+              `https://github.com/${repository}/actions/runs/${sourceRunId}`;
+            const reportUrl =
+              hasResolvedRunId ? runUrl : comprehensiveWorkflowUrl;
+            const reportLinkLabel =
+              hasResolvedRunId ? 'Workflow run' : 'Comprehensive workflow';
+
+            if (
+              !Number.isSafeInteger(issue_number) ||
+              issue_number < 1 ||
+              typeof sourceHeadBranch !== 'string' ||
+              sourceHeadBranch.length < 1 ||
+              sourceHeadBranch.length > 255 ||
+              !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(
+                sourceHeadRepository || '',
+              ) ||
+              !/^[0-9a-f]{40}$/.test(sourceHeadSha || '')
+            ) {
+              core.setFailed('Resolved comment context is invalid.');
+              return;
+            }
+
             const { data: pullRequest } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: issue_number,
             });
-            if (!sourceHeadSha || pullRequest.head.sha !== sourceHeadSha) {
+            if (pullRequest.state !== 'open') {
+              core.info('Resolved pull request is closed. No comment updated.');
+              return;
+            }
+            if (
+              pullRequest.head.sha !== sourceHeadSha ||
+              pullRequest.head.ref !== sourceHeadBranch ||
+              pullRequest.head.repo?.full_name !== sourceHeadRepository
+            ) {
               core.info(
-                `Stale workflow run for ${sourceHeadSha || 'unknown head'}; ` +
-                `current PR head is ${pullRequest.head.sha}. No comment updated.`,
+                'Stale workflow run for the current PR source tuple. ' +
+                  'No comment updated.',
               );
               return;
             }
 
-            const readDownloadedFile = (available, outcome, path) => {
-              if (available !== 'true' || outcome !== 'success') {
-                return null;
-              }
+            let freshRun = null;
+            const hasResolvedSourceIdentity =
+              Number.isSafeInteger(sourceRunId) &&
+              hasResolvedRunId &&
+              Number.isSafeInteger(sourceRunAttempt) &&
+              sourceRunAttempt > 0 &&
+              SOURCE_RUN_EVENTS.has(sourceRunEvent) &&
+              Number.isSafeInteger(sourceRunNumber) &&
+              sourceRunNumber > 0 &&
+              Number.isSafeInteger(sourceWorkflowId) &&
+              sourceWorkflowId > 0;
+            let sourceIdentityValid =
+              sourceReady && hasResolvedSourceIdentity;
+            if (!hasResolvedSourceIdentity) {
+              core.setFailed(
+                sourceReady
+                  ? 'Resolved source-run ordering context is invalid.'
+                  : 'No authoritative source-run ordering identity is available.',
+              );
+              return;
+            }
+            const sourceRunHasExactOrderingIdentity = run =>
+              Boolean(run) &&
+              run.name === 'Comprehensive Tests' &&
+              run.id === sourceRunId &&
+              run.run_attempt === sourceRunAttempt &&
+              run.run_number === sourceRunNumber &&
+              run.workflow_id === sourceWorkflowId &&
+              run.head_sha === sourceHeadSha &&
+              run.head_branch === sourceHeadBranch &&
+              run.head_repository?.full_name === sourceHeadRepository &&
+              run.event === sourceRunEvent &&
+              run.path === '.github/workflows/comprehensive-tests.yml' &&
+              run.repository?.full_name === repository;
+            const sourceRunMatches = run =>
+              sourceRunHasExactOrderingIdentity(run) &&
+              run.status === 'completed' &&
+              run.conclusion === process.env.WORKFLOW_CONCLUSION &&
+              run.html_url === process.env.WORKFLOW_RUN_URL;
+            const sourceRunIsNewerAttempt = run =>
+              Boolean(run) &&
+              run.name === 'Comprehensive Tests' &&
+              run.id === sourceRunId &&
+              Number.isSafeInteger(run.run_attempt) &&
+              run.run_attempt > sourceRunAttempt &&
+              run.run_number === sourceRunNumber &&
+              run.workflow_id === sourceWorkflowId &&
+              run.head_sha === sourceHeadSha &&
+              run.head_branch === sourceHeadBranch &&
+              run.head_repository?.full_name === sourceHeadRepository &&
+              run.event === sourceRunEvent &&
+              run.path === '.github/workflows/comprehensive-tests.yml' &&
+              run.repository?.full_name === repository;
+            const getSourceRunOrder = async () => {
+              const MAX_SOURCE_RUNS = 1_000;
+              let runs;
               try {
-                const stat = fs.statSync(path);
-                if (!stat.isFile() || stat.size === 0) {
-                  return null;
-                }
-                return fs.readFileSync(path, 'utf8');
+                runs = await github.paginate(
+                  github.rest.actions.listWorkflowRuns,
+                  {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: sourceWorkflowId,
+                    branch: sourceHeadBranch,
+                    head_sha: sourceHeadSha,
+                    per_page: 100,
+                  },
+                );
               } catch (error) {
-                core.info(`Unable to read ${path}: ${error.message}`);
-                return null;
+                return 'unknown';
               }
+              if (
+                !Array.isArray(runs) ||
+                runs.length < 1 ||
+                runs.length > MAX_SOURCE_RUNS
+              ) {
+                return 'unknown';
+              }
+              const exactRuns = runs.filter(
+                candidate =>
+                  candidate.name === 'Comprehensive Tests' &&
+                  candidate.workflow_id === sourceWorkflowId &&
+                  candidate.path ===
+                    '.github/workflows/comprehensive-tests.yml' &&
+                  candidate.repository?.full_name === repository &&
+                  candidate.head_sha === sourceHeadSha &&
+                  candidate.head_branch === sourceHeadBranch &&
+                  candidate.head_repository?.full_name ===
+                    sourceHeadRepository &&
+                  SOURCE_RUN_EVENTS.has(candidate.event),
+              );
+              if (exactRuns.length < 1) {
+                return 'unknown';
+              }
+              const seenRunIds = new Set();
+              for (const candidate of exactRuns) {
+                if (
+                  !Number.isSafeInteger(candidate.id) ||
+                  candidate.id < 1 ||
+                  seenRunIds.has(candidate.id) ||
+                  !Number.isSafeInteger(candidate.run_number) ||
+                  candidate.run_number < 1 ||
+                  !Number.isSafeInteger(candidate.run_attempt) ||
+                  candidate.run_attempt < 1
+                ) {
+                  return 'unknown';
+                }
+                seenRunIds.add(candidate.id);
+              }
+              const latest = exactRuns.reduce((current, candidate) => {
+                if (candidate.run_number !== current.run_number) {
+                  return candidate.run_number > current.run_number
+                    ? candidate
+                    : current;
+                }
+                return candidate.run_attempt > current.run_attempt
+                  ? candidate
+                  : current;
+              });
+              if (
+                latest.run_number > sourceRunNumber ||
+                (
+                  latest.run_number === sourceRunNumber &&
+                  latest.run_attempt > sourceRunAttempt
+                )
+              ) {
+                return 'obsolete';
+              }
+              if (
+                latest.run_number !== sourceRunNumber ||
+                latest.run_attempt !== sourceRunAttempt ||
+                latest.id !== sourceRunId
+              ) {
+                return 'unknown';
+              }
+              return 'current';
             };
+            if (hasResolvedSourceIdentity) {
+              const initialSourceRunOrder = await getSourceRunOrder();
+              if (initialSourceRunOrder === 'obsolete') {
+                core.info(
+                  'A newer source run exists for this exact PR head. ' +
+                    'No comment updated.',
+                );
+                return;
+              }
+              if (initialSourceRunOrder !== 'current') {
+                core.setFailed(
+                  'Unable to prove the source run is the newest exact PR-head run.',
+                );
+                return;
+              }
+            }
+            if (sourceIdentityValid) {
+              try {
+                const response = await github.rest.actions.getWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: sourceRunId,
+                });
+                freshRun = response.data;
+              } catch (error) {
+                core.info(
+                  'Unable to revalidate the source run before posting.',
+                );
+                sourceIdentityValid = false;
+              }
+            }
+            if (sourceIdentityValid) {
+              if (!sourceRunMatches(freshRun)) {
+                if (sourceRunIsNewerAttempt(freshRun)) {
+                  core.info(
+                    'A newer source run attempt exists for this exact PR head. ' +
+                      'No comment updated.',
+                  );
+                  return;
+                }
+                core.info(
+                  'Source run identity no longer matches; using a red fallback.',
+                );
+                sourceIdentityValid = false;
+              }
+            }
+
+            const isExpectedActionsComment = comment =>
+              comment.user?.login === 'github-actions[bot]' &&
+              comment.user?.id === BOT_USER_ID &&
+              comment.user?.type === 'Bot' &&
+              comment.performed_via_github_app?.id === ACTIONS_APP_ID &&
+              comment.performed_via_github_app?.slug === 'github-actions';
+            const hasExactMarker = comment =>
+              comment.body === MARKER ||
+              comment.body?.startsWith(`${MARKER}\n`);
+            const legacyReport = comment =>
+              comment.body?.includes('🧪 Comprehensive Test Results');
+            const hasRetiredMetricsMarker = comment =>
+              comment.body === METRICS_RETIRED_MARKER ||
+              comment.body?.startsWith(`${METRICS_RETIRED_MARKER}\n`);
+            const legacyMetrics = comment =>
+              comment.body?.includes('Test Metrics Report') ||
+              hasRetiredMetricsMarker(comment);
+
+            const fallbackConclusion = new Set([
+              'action_required',
+              'cancelled',
+              'failure',
+              'neutral',
+              'skipped',
+              'stale',
+              'startup_failure',
+              'success',
+              'timed_out',
+            ]).has(process.env.WORKFLOW_CONCLUSION)
+              ? process.env.WORKFLOW_CONCLUSION
+              : 'unknown';
+            const fallbackBody = [
+              MARKER,
+              '## Comprehensive Test Results',
+              '',
+              '❌ **FAIL — Trusted Comprehensive report unavailable.**',
+              '',
+              'The trusted API-derived result could not be validated. ' +
+                'Treat this run as failed.',
+              '',
+              `- Workflow conclusion: \`${fallbackConclusion}\``,
+              `- [${reportLinkLabel}](${reportUrl})`,
+              '',
+            ].join('\n');
+
+            let reportBody = null;
+            let usedFallback = false;
+            if (
+              process.env.COLLECT_JOBS_OUTCOME === 'success' &&
+              process.env.RENDER_COMMENT_OUTCOME === 'success' &&
+              sourceIdentityValid
+            ) {
+              try {
+                const outputPath = process.env.COMMENT_OUTPUT_PATH;
+                const stat = fs.lstatSync(outputPath);
+                if (
+                  stat.isFile() &&
+                  !stat.isSymbolicLink() &&
+                  stat.size > 0 &&
+                  stat.size <= MAX_COMMENT_BYTES
+                ) {
+                  const candidate = fs.readFileSync(outputPath, 'utf8');
+                  const expectedVerdict =
+                    freshRun.conclusion === 'success'
+                      ? '✅ **PASS —'
+                      : '❌ **FAIL —';
+                  const oppositeVerdict =
+                    freshRun.conclusion === 'success'
+                      ? '❌ **FAIL —'
+                      : '✅ **PASS —';
+                  if (
+                    Buffer.byteLength(candidate, 'utf8') === stat.size &&
+                    candidate.startsWith(`${MARKER}\n`) &&
+                    candidate.indexOf(MARKER, MARKER.length) === -1 &&
+                    candidate.includes(expectedVerdict) &&
+                    !candidate.includes(oppositeVerdict)
+                  ) {
+                    reportBody = candidate;
+                  }
+                }
+              } catch (error) {
+                core.info('Trusted renderer output was unavailable.');
+              }
+            }
+            if (reportBody === null) {
+              reportBody = fallbackBody;
+              usedFallback = true;
+            }
+
+            let postTimePullRequest;
+            try {
+              const response = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: issue_number,
+              });
+              postTimePullRequest = response.data;
+            } catch (error) {
+              core.setFailed(
+                'Unable to revalidate the PR head before comment mutation.',
+              );
+              return;
+            }
+            if (
+              postTimePullRequest.state !== 'open' ||
+              postTimePullRequest.head.sha !== sourceHeadSha ||
+              postTimePullRequest.head.ref !== sourceHeadBranch ||
+              postTimePullRequest.head.repo?.full_name !==
+                sourceHeadRepository
+            ) {
+              core.info(
+                'PR state or head changed before comment mutation. ' +
+                  'No comment updated.',
+              );
+              return;
+            }
+
+            if (hasResolvedSourceIdentity) {
+              const postTimeSourceRunOrder = await getSourceRunOrder();
+              if (postTimeSourceRunOrder === 'obsolete') {
+                core.info(
+                  'A newer source run exists for this exact PR head. ' +
+                    'No comment updated.',
+                );
+                return;
+              }
+              if (postTimeSourceRunOrder !== 'current') {
+                core.setFailed(
+                  'Unable to prove source-run ordering before comment mutation.',
+                );
+                return;
+              }
+            }
+
+            if (sourceIdentityValid) {
+              let postTimeRun = null;
+              try {
+                const response =
+                  await github.rest.actions.getWorkflowRun({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: sourceRunId,
+                  });
+                postTimeRun = response.data;
+              } catch (error) {
+                core.info(
+                  'Unable to revalidate the run before comment mutation.',
+                );
+                sourceIdentityValid = false;
+              }
+              if (
+                sourceIdentityValid &&
+                !sourceRunMatches(postTimeRun)
+              ) {
+                if (sourceRunIsNewerAttempt(postTimeRun)) {
+                  core.info(
+                    'A newer source run attempt exists for this exact PR head. ' +
+                      'No comment updated.',
+                  );
+                  return;
+                }
+                core.info(
+                  'Source run changed before comment mutation; ' +
+                    'using a red fallback.',
+                );
+                sourceIdentityValid = false;
+              }
+              if (!sourceIdentityValid) {
+                reportBody = fallbackBody;
+                usedFallback = true;
+              }
+            }
 
             const comments = await github.paginate(
               github.rest.issues.listComments,
@@ -381,86 +1288,148 @@ jobs:
               },
             );
 
-            const upsertComment = async (marker, body) => {
-              const existing = comments.find(comment =>
-                comment.user.type === 'Bot' && comment.body.includes(marker)
+            let mutationTimePullRequest;
+            try {
+              const response = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: issue_number,
+              });
+              mutationTimePullRequest = response.data;
+            } catch (error) {
+              core.setFailed(
+                'Unable to revalidate the PR after comment discovery.',
               );
+              return;
+            }
+            if (
+              mutationTimePullRequest.state !== 'open' ||
+              mutationTimePullRequest.head.sha !== sourceHeadSha ||
+              mutationTimePullRequest.head.ref !== sourceHeadBranch ||
+              mutationTimePullRequest.head.repo?.full_name !==
+                sourceHeadRepository
+            ) {
+              core.info(
+                'PR state or head changed during comment discovery. ' +
+                  'No comment updated.',
+              );
+              return;
+            }
 
-              if (existing) {
+            const mutationTimeSourceRunOrder =
+              await getSourceRunOrder();
+            if (mutationTimeSourceRunOrder === 'obsolete') {
+              core.info(
+                'A newer source run exists for this exact PR head. ' +
+                  'No comment updated.',
+              );
+              return;
+            }
+            if (mutationTimeSourceRunOrder !== 'current') {
+              core.setFailed(
+                'Unable to prove source-run ordering after comment discovery.',
+              );
+              return;
+            }
+
+            let mutationTimeRun;
+            try {
+              const response =
+                await github.rest.actions.getWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: sourceRunId,
+                });
+              mutationTimeRun = response.data;
+            } catch (error) {
+              core.setFailed(
+                'Unable to revalidate the run after comment discovery.',
+              );
+              return;
+            }
+            if (sourceRunIsNewerAttempt(mutationTimeRun)) {
+              core.info(
+                'A newer source run attempt exists for this exact PR head. ' +
+                  'No comment updated.',
+              );
+              return;
+            }
+            if (
+              !sourceRunHasExactOrderingIdentity(mutationTimeRun) ||
+              (
+                sourceIdentityValid &&
+                !sourceRunMatches(mutationTimeRun)
+              )
+            ) {
+              core.setFailed(
+                'Source run changed during comment discovery.',
+              );
+              return;
+            }
+
+            const reportComments = comments.filter(
+              comment =>
+                isExpectedActionsComment(comment) &&
+                (hasExactMarker(comment) || legacyReport(comment)),
+            );
+            const reportCommentIds = new Set(
+              reportComments.map(comment => comment.id),
+            );
+            if (reportComments.length === 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body: reportBody,
+              });
+            } else {
+              for (const existing of reportComments) {
                 await github.rest.issues.updateComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   comment_id: existing.id,
-                  body,
-                });
-              } else {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number,
-                  body,
+                  body: reportBody,
                 });
               }
-            };
-
-            const metricsBody = readDownloadedFile(
-              process.env.METRICS_AVAILABLE,
-              process.env.METRICS_DOWNLOAD_OUTCOME,
-              metricsPath,
-            );
-            if (metricsBody !== null) {
-              await upsertComment(
-                'Test Metrics Report',
-                metricsBody,
-              );
             }
 
-            const downloadedReport = readDownloadedFile(
-              process.env.REPORT_AVAILABLE,
-              process.env.REPORT_DOWNLOAD_OUTCOME,
-              reportPath,
+            const metricsNotice = [
+              METRICS_RETIRED_MARKER,
+              '## Test Metrics Report',
+              '',
+              'Metrics artifacts are diagnostic only and are no longer ' +
+                'relayed by the write-scoped commenter.',
+              '',
+              `See the [workflow run](${reportUrl}) for downloadable diagnostics.`,
+              '',
+            ].join('\n');
+            const legacyMetricsComments = comments.filter(
+              comment =>
+                isExpectedActionsComment(comment) &&
+                legacyMetrics(comment) &&
+                !reportCommentIds.has(comment.id),
             );
-            const conclusion = process.env.WORKFLOW_CONCLUSION || 'unknown';
-            const expectedVerdict =
-              conclusion === 'success' ? '✅ PASS —' : '❌ FAIL —';
-            const oppositeVerdict =
-              conclusion === 'success' ? '❌ FAIL —' : '✅ PASS —';
-            const reportMatchesConclusion =
-              downloadedReport !== null &&
-              downloadedReport.includes(expectedVerdict) &&
-              !downloadedReport.includes(oppositeVerdict);
-
-            let reportBody = downloadedReport;
-            if (!reportMatchesConclusion) {
-              const runUrl = process.env.WORKFLOW_RUN_URL;
-              const reason = process.env.SOURCE_RESOLUTION_ERROR || (
-                downloadedReport === null
-                  ? 'The workflow did not publish a readable comprehensive report.'
-                  : 'The downloaded report verdict does not match the workflow conclusion.'
-              );
-              reportBody = [
-                '# 🧪 Comprehensive Test Results',
-                '',
-                '❌ **Comprehensive test report unavailable.**',
-                '',
-                reason,
-                'so this result must be treated as a failure.',
-                '',
-                `- Workflow conclusion: \`${conclusion}\``,
-                `- [Workflow run](${runUrl})`,
-                '',
-              ].join('\n');
+            for (const existing of legacyMetricsComments) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: metricsNotice,
+              });
             }
 
-            await upsertComment('🧪 Comprehensive Test Results', reportBody);
+            if (usedFallback) {
+              core.setFailed(
+                'Trusted comment rendering failed; posted a red fallback.',
+              );
+            }
 
       - name: Enforce trusted source resolution
         if: >-
           always() &&
-          steps.resolve-context.outcome == 'success' &&
-          steps.resolve-context.outputs.source_ready != 'true'
+          needs.resolve-pr-context.outputs.source_ready != 'true'
         env:
-          SOURCE_RESOLUTION_ERROR: ${{ steps.resolve-context.outputs.source_error }}
+          SOURCE_RESOLUTION_ERROR: ${{ needs.resolve-pr-context.outputs.source_error }}
         run: |
           echo "ERROR: ${SOURCE_RESOLUTION_ERROR:-trusted source run was not resolved}"
           exit 1

--- a/.github/workflows/comprehensive-tests.yml
+++ b/.github/workflows/comprehensive-tests.yml
@@ -1332,7 +1332,7 @@ jobs:
           RUN_EXTENDED: ${{ github.event_name == 'workflow_dispatch' && inputs.run_extended || false }}
         run: |
           mkdir -p all-results
-          python scripts/ci/comprehensive_report.py \
+          python -I scripts/ci/comprehensive_report.py \
             --artifacts-dir all-results \
             --output test-report.md \
             --event-name "$EVENT_NAME" \

--- a/.github/workflows/dependabot-uv-lock-writer.yml
+++ b/.github/workflows/dependabot-uv-lock-writer.yml
@@ -55,8 +55,8 @@ jobs:
           python scripts/ci/commit_generated_dependencies.py publish
           --event-path "$GITHUB_EVENT_PATH"
 
-# The trusted publisher also dispatches the default-branch comment monitor as
-# a sibling workflow. The monitor waits for the exact Comprehensive run because
-# that dispatched run does not create the downstream workflow_run consumer in
-# this GitHub Actions event chain.
+# The trusted publisher also emits a typed repository_dispatch for the
+# default-branch comment monitor. The monitor waits for the exact Comprehensive
+# run because that dispatched run does not create the downstream workflow_run
+# consumer in this GitHub Actions event chain.
 # No PR-code checkout is added to either privileged workflow.

--- a/.github/workflows/workflow-smoke-test.yml
+++ b/.github/workflows/workflow-smoke-test.yml
@@ -53,9 +53,12 @@ on:
       - 'docker-compose.yml'
       - 'justfile'
       - 'scripts/ci/commit_generated_dependencies.py'
+      - 'scripts/ci/comprehensive_pr_comment.py'
       - 'scripts/ci/ensure-podman-runtime.sh'
       - 'tests/smoke/test_container_runtime_workflow_properties.py'
       - 'tests/scripts/test_commit_generated_dependencies.py'
+      - 'tests/scripts/test_comprehensive_pr_comment.py'
+      - 'tests/scripts/test_comprehensive_pr_comment_publisher.py'
   workflow_dispatch:
 
 permissions:
@@ -233,6 +236,8 @@ jobs:
             tests/smoke/test_comprehensive_tests_workflow_properties.py \
             tests/smoke/test_comprehensive_report_workflow_properties.py \
             tests/smoke/test_comprehensive_pr_comments_workflow_properties.py \
+            tests/scripts/test_comprehensive_pr_comment.py \
+            tests/scripts/test_comprehensive_pr_comment_publisher.py \
             tests/smoke/test_gradient_soak_workflow_properties.py \
             tests/smoke/test_dependabot_uv_lock_workflow_properties.py \
             tests/scripts/test_commit_generated_dependencies.py \

--- a/scripts/ci/commit_generated_dependencies.py
+++ b/scripts/ci/commit_generated_dependencies.py
@@ -4,7 +4,8 @@
 The ``package`` command runs in a read-only pull-request workflow and emits
 untrusted data. The ``publish`` command runs only from the default branch,
 validates the artifact and live pull request, creates a GitHub-signed exact
-child commit, and dispatches a literal allowlist of read-only checks.
+child commit, dispatches a literal allowlist of read-only checks, and emits a
+typed default-branch event for the trusted PR commenter.
 
 Python is used because this automation needs authenticated HTTPS, JSON,
 base64, hashing, and explicit error handling (ADR-001). It uses only the
@@ -53,7 +54,7 @@ REQUIRED_WORKFLOWS = (
     "pre-commit.yml",
     "workflow-smoke-test.yml",
 )
-COMMENT_WORKFLOW = "comprehensive-test-pr-comments.yml"
+COMMENT_DISPATCH_EVENT = "dependabot-comprehensive-test-comment"
 REQUIRED_WORKFLOW_PATHS = tuple(f".github/workflows/{workflow}" for workflow in REQUIRED_WORKFLOWS)
 PROJECT_METADATA_PATH = "pyproject.toml"
 PYTHON_VERSION_PATH = ".python-version"
@@ -1691,19 +1692,8 @@ def _dispatch_workflow(
     *,
     token: str,
     opener: UrlOpener,
-    inputs: Mapping[str, str] | None = None,
 ) -> None:
-    payload: dict[str, object] = {"ref": branch}
-    if inputs is not None:
-        if not isinstance(inputs, Mapping):
-            raise PublishError("workflow dispatch inputs must be a string mapping")
-        normalized_inputs: dict[str, str] = {}
-        for key, value in inputs.items():
-            if not isinstance(key, str) or not key or not isinstance(value, str) or not value:
-                raise PublishError("workflow dispatch inputs must be non-empty strings")
-            normalized_inputs[key] = value
-        payload["inputs"] = normalized_inputs
-
+    payload = {"ref": branch}
     encoded_workflow = urllib.parse.quote(workflow, safe="")
     request = urllib.request.Request(
         f"{_api_root(repository)}/actions/workflows/{encoded_workflow}/dispatches",
@@ -1732,30 +1722,46 @@ def _dispatch_workflow(
 def dispatch_comment_workflow(
     *,
     repository: str,
-    default_branch: str,
     head_ref: str,
     commit_oid: str,
     token: str,
     opener: UrlOpener = urllib.request.urlopen,
 ) -> None:
-    """Dispatch the trusted commenter beside the required Dependabot checks."""
+    """Dispatch the default-branch commenter beside the required checks."""
     _validate_repository(repository)
-    _validate_branch(default_branch)
     _validate_branch(head_ref)
     _validate_oid(commit_oid, "published GraphQL commit OID")
     if not head_ref.startswith("dependabot/"):
         raise PublishError("comment workflow requires a Dependabot branch")
-    _dispatch_workflow(
-        repository,
-        COMMENT_WORKFLOW,
-        default_branch,
-        token=token,
-        opener=opener,
-        inputs={
+    payload = {
+        "event_type": COMMENT_DISPATCH_EVENT,
+        "client_payload": {
             "source_head_sha": commit_oid,
             "source_head_branch": head_ref,
         },
+    }
+    request = urllib.request.Request(
+        f"{_api_root(repository)}/dispatches",
+        data=json.dumps(payload, separators=(",", ":")).encode(),
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "Odyssey-dependency-publisher",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        method="POST",
     )
+    try:
+        with opener(request, timeout=30) as response:
+            status_code = int(response.status)
+            response.read()
+    except urllib.error.HTTPError as error:
+        raise PublishError(f"comment repository dispatch failed with HTTP {error.code}") from error
+    except (urllib.error.URLError, TimeoutError, OSError) as error:
+        raise PublishError(f"comment repository dispatch failed: {error}") from error
+    if status_code != 204:
+        raise PublishError(f"comment repository dispatch failed with HTTP {status_code}")
 
 
 def authenticate_required_workflows(
@@ -2003,7 +2009,6 @@ def publish_dependencies(
     )
     dispatch_comment_workflow(
         repository=context.repository,
-        default_branch=context.default_branch,
         head_ref=context.head_ref,
         commit_oid=verified.oid,
         token=token,

--- a/scripts/ci/comprehensive_pr_comment.py
+++ b/scripts/ci/comprehensive_pr_comment.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Validate API-derived Comprehensive results and render a safe PR comment.
+
+The write-scoped ``workflow_run`` consumer must not trust artifacts produced by
+pull-request code.  This module accepts only a small, closed JSON document built
+from GitHub's API by the trusted default-branch workflow.  It validates that
+document before rendering bounded Markdown and neutralizes all untrusted job
+names.
+
+Python is used because this is JSON-heavy CI automation, as permitted by
+ADR-001 (``docs/adr/ADR-001-language-selection-tooling.md``). The
+implementation is standard-library-only so the trusted consumer does not
+install or execute pull-request dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import sys
+from typing import Any
+import unicodedata
+
+
+SCHEMA_VERSION = 1
+COMMENT_MARKER = "<!-- odyssey:comprehensive-test-report:v1 -->"
+MAX_INPUT_BYTES = 262_144
+MAX_COMMENT_BYTES = 60_000
+MAX_JOBS = 128
+MAX_JOB_NAME_BYTES = 256
+MAX_REPOSITORY_BYTES = 200
+MAX_URL_BYTES = 512
+
+_TOP_LEVEL_KEYS = {"schema_version", "repository", "run", "jobs"}
+_RUN_KEYS = {"id", "status", "conclusion", "head_sha", "url"}
+_JOB_KEYS = {"id", "name", "status", "conclusion", "url"}
+_COMPLETED_CONCLUSIONS = {
+    "action_required",
+    "cancelled",
+    "failure",
+    "neutral",
+    "skipped",
+    "stale",
+    "startup_failure",
+    "success",
+    "timed_out",
+}
+_REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\Z")
+_SHA_RE = re.compile(r"[0-9a-f]{40}\Z")
+
+# Table and inline-Markdown metacharacters are encoded.  Mentions use a
+# full-width at sign so GitHub cannot notify users or teams.
+_MARKDOWN_TRANSLATION = str.maketrans(
+    {
+        "\\": "&#92;",
+        "`": "&#96;",
+        "*": "&#42;",
+        "_": "&#95;",
+        "{": "&#123;",
+        "}": "&#125;",
+        "[": "&#91;",
+        "]": "&#93;",
+        "<": "&lt;",
+        ">": "&gt;",
+        "(": "&#40;",
+        ")": "&#41;",
+        "#": "&#35;",
+        "+": "&#43;",
+        "-": "&#45;",
+        ".": "&#46;",
+        "!": "&#33;",
+        "|": "&#124;",
+        "&": "&amp;",
+        "@": "＠",
+    }
+)
+
+
+class ValidationError(ValueError):
+    """Raised when API-derived comment context violates the closed contract."""
+
+
+def _fail(message: str) -> ValidationError:
+    """Create a validation error containing only trusted static prose."""
+    return ValidationError(message)
+
+
+def _require_mapping(value: object, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise _fail(f"{label} must be an object")
+    if not all(isinstance(key, str) for key in value):
+        raise _fail(f"{label} keys must be strings")
+    return value
+
+
+def _require_exact_keys(
+    value: dict[str, Any],
+    expected: set[str],
+    label: str,
+) -> None:
+    if set(value) != expected:
+        raise _fail(f"{label} fields do not match schema version {SCHEMA_VERSION}")
+
+
+def _require_positive_integer(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise _fail(f"{label} must be an integer")
+    if value <= 0 or value > 9_007_199_254_740_991:
+        raise _fail(f"{label} is outside the supported range")
+    return value
+
+
+def _require_string(
+    value: object,
+    label: str,
+    *,
+    maximum_bytes: int,
+    allow_multiline: bool = False,
+) -> str:
+    if not isinstance(value, str):
+        raise _fail(f"{label} must be a string")
+    size = len(value.encode("utf-8"))
+    if size == 0 or size > maximum_bytes:
+        raise _fail(f"{label} has an invalid size")
+    if "\x00" in value:
+        raise _fail(f"{label} contains a forbidden control character")
+    if not allow_multiline and any(character in value for character in "\r\n"):
+        raise _fail(f"{label} must be one line")
+    return value
+
+
+def _require_conclusion(value: object, label: str) -> str:
+    conclusion = _require_string(value, label, maximum_bytes=32)
+    if conclusion not in _COMPLETED_CONCLUSIONS:
+        raise _fail(f"{label} is not a completed GitHub conclusion")
+    return conclusion
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _fail("JSON contains a duplicate object field")
+        result[key] = value
+    return result
+
+
+def load_context(path: Path) -> dict[str, Any]:
+    """Load one bounded, duplicate-key-free JSON object from a regular file."""
+    try:
+        stat = path.lstat()
+    except OSError as error:
+        raise _fail("comment context is unavailable") from error
+    if path.is_symlink() or not path.is_file():
+        raise _fail("comment context must be a regular file")
+    if stat.st_size <= 0 or stat.st_size > MAX_INPUT_BYTES:
+        raise _fail("comment context has an invalid size")
+
+    try:
+        raw = path.read_bytes()
+        text = raw.decode("utf-8")
+        value = json.loads(text, object_pairs_hook=_reject_duplicate_keys)
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise _fail("comment context is not valid UTF-8 JSON") from error
+    return _require_mapping(value, "comment context")
+
+
+def _validated_repository(value: object, expected_repository: str) -> str:
+    expected = _require_string(
+        expected_repository,
+        "expected repository",
+        maximum_bytes=MAX_REPOSITORY_BYTES,
+    )
+    if _REPOSITORY_RE.fullmatch(expected) is None:
+        raise _fail("expected repository has an invalid form")
+
+    repository = _require_string(
+        value,
+        "repository",
+        maximum_bytes=MAX_REPOSITORY_BYTES,
+    )
+    if repository != expected:
+        raise _fail("repository does not match the trusted workflow repository")
+    return repository
+
+
+def _validated_run(
+    value: object,
+    repository: str,
+) -> tuple[int, str, str]:
+    run = _require_mapping(value, "run")
+    _require_exact_keys(run, _RUN_KEYS, "run")
+
+    run_id = _require_positive_integer(run["id"], "run.id")
+    status = _require_string(run["status"], "run.status", maximum_bytes=32)
+    if status != "completed":
+        raise _fail("run.status must be completed")
+    conclusion = _require_conclusion(run["conclusion"], "run.conclusion")
+    head_sha = _require_string(run["head_sha"], "run.head_sha", maximum_bytes=40)
+    if _SHA_RE.fullmatch(head_sha) is None:
+        raise _fail("run.head_sha must be a lowercase full commit SHA")
+
+    run_url = _require_string(
+        run["url"],
+        "run.url",
+        maximum_bytes=MAX_URL_BYTES,
+    )
+    expected_url = f"https://github.com/{repository}/actions/runs/{run_id}"
+    if run_url != expected_url:
+        raise _fail("run.url does not match the trusted run identity")
+    return run_id, conclusion, run_url
+
+
+def _validated_jobs(
+    value: object,
+    *,
+    repository: str,
+    run_id: int,
+    workflow_conclusion: str,
+) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        raise _fail("jobs must be an array")
+    if not value or len(value) > MAX_JOBS:
+        raise _fail("jobs has an invalid item count")
+
+    validated: list[dict[str, object]] = []
+    seen_ids: set[int] = set()
+    seen_names: set[str] = set()
+    report_conclusions: list[str] = []
+    run_url = f"https://github.com/{repository}/actions/runs/{run_id}"
+
+    for index, raw_job in enumerate(value):
+        job = _require_mapping(raw_job, f"jobs[{index}]")
+        _require_exact_keys(job, _JOB_KEYS, f"jobs[{index}]")
+
+        job_id = _require_positive_integer(job["id"], f"jobs[{index}].id")
+        if job_id in seen_ids:
+            raise _fail("jobs contains a duplicate job id")
+        seen_ids.add(job_id)
+
+        name = _require_string(
+            job["name"],
+            f"jobs[{index}].name",
+            maximum_bytes=MAX_JOB_NAME_BYTES,
+            allow_multiline=True,
+        )
+        if name == "Test Report" and name in seen_names:
+            raise _fail("jobs must contain exactly one Test Report")
+        if name in seen_names:
+            raise _fail("jobs contains a duplicate job name")
+        seen_names.add(name)
+
+        status = _require_string(
+            job["status"],
+            f"jobs[{index}].status",
+            maximum_bytes=32,
+        )
+        if status != "completed":
+            raise _fail("every source job must be completed")
+        conclusion = _require_conclusion(
+            job["conclusion"],
+            f"jobs[{index}].conclusion",
+        )
+
+        url = _require_string(
+            job["url"],
+            f"jobs[{index}].url",
+            maximum_bytes=MAX_URL_BYTES,
+        )
+        if url != f"{run_url}/job/{job_id}":
+            raise _fail("job URL does not match its trusted run and job ids")
+
+        if name == "Test Report":
+            report_conclusions.append(conclusion)
+        validated.append(
+            {
+                "id": job_id,
+                "name": name,
+                "status": status,
+                "conclusion": conclusion,
+                "url": url,
+            }
+        )
+
+    if len(report_conclusions) != 1:
+        raise _fail("jobs must contain exactly one Test Report")
+    if report_conclusions[0] != workflow_conclusion:
+        raise _fail("Test Report conclusion contradicts the workflow conclusion")
+    return validated
+
+
+def _safe_markdown_text(value: str) -> str:
+    """Collapse layout controls and neutralize Markdown, HTML, and mentions."""
+    without_controls = "".join(
+        " " if unicodedata.category(character).startswith("C") else character for character in value
+    )
+    collapsed = " ".join(without_controls.split())
+    return collapsed.translate(_MARKDOWN_TRANSLATION)
+
+
+def render_comment(
+    context: object,
+    *,
+    expected_repository: str,
+) -> str:
+    """Validate one API context and return bounded trusted Markdown."""
+    payload = _require_mapping(context, "comment context")
+    _require_exact_keys(payload, _TOP_LEVEL_KEYS, "comment context")
+    if type(payload["schema_version"]) is not int or payload["schema_version"] != SCHEMA_VERSION:
+        raise _fail(f"schema_version must equal {SCHEMA_VERSION}")
+
+    repository = _validated_repository(payload["repository"], expected_repository)
+    run_id, workflow_conclusion, run_url = _validated_run(
+        payload["run"],
+        repository,
+    )
+    jobs = _validated_jobs(
+        payload["jobs"],
+        repository=repository,
+        run_id=run_id,
+        workflow_conclusion=workflow_conclusion,
+    )
+
+    if workflow_conclusion == "success":
+        verdict = "✅ **PASS — authoritative Test Report and workflow conclusion agree.**"
+    else:
+        verdict = "❌ **FAIL — authoritative Test Report and workflow conclusion agree.**"
+
+    lines = [
+        COMMENT_MARKER,
+        "## Comprehensive Test Results",
+        "",
+        verdict,
+        "",
+        f"- Workflow conclusion: `{workflow_conclusion}`",
+        f"- [Workflow run]({run_url})",
+        "",
+        "| Job | Status | Conclusion |",
+        "| --- | --- | --- |",
+    ]
+    for job in jobs:
+        safe_name = _safe_markdown_text(str(job["name"]))
+        lines.append(f"| [{safe_name}]({job['url']}) | `{job['status']}` | `{job['conclusion']}` |")
+    lines.extend(
+        [
+            "",
+            "_This comment is rendered by trusted default-branch code from "
+            "GitHub API job results. Test artifacts remain diagnostic only._",
+            "",
+        ]
+    )
+    body = "\n".join(lines)
+    if body.count(COMMENT_MARKER) != 1:
+        raise _fail("rendered comment marker is not unique")
+    if len(body.encode("utf-8")) > MAX_COMMENT_BYTES:
+        raise _fail("rendered comment exceeds the supported size")
+    return body
+
+
+def render_comment_file(
+    input_path: Path,
+    output_path: Path,
+    *,
+    expected_repository: str,
+) -> None:
+    """Validate an input file and atomically create a fresh trusted body file."""
+    try:
+        output_path.unlink(missing_ok=True)
+    except OSError as error:
+        raise _fail("stale comment output could not be removed") from error
+
+    context = load_context(input_path)
+    body = render_comment(context, expected_repository=expected_repository)
+    encoded = body.encode("utf-8")
+    if not output_path.parent.is_dir():
+        raise _fail("comment output parent is unavailable")
+
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(output_path, flags, 0o600)
+        with os.fdopen(descriptor, "wb") as output:
+            output.write(encoded)
+    except OSError as error:
+        try:
+            output_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise _fail("trusted comment output could not be written") from error
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Render a trusted comment from bounded API-derived JSON."""
+    parser = argparse.ArgumentParser(
+        description="Render a trusted Comprehensive PR comment",
+    )
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--expected-repository", required=True)
+    arguments = parser.parse_args(argv)
+
+    try:
+        render_comment_file(
+            arguments.input,
+            arguments.output,
+            expected_repository=arguments.expected_repository,
+        )
+    except ValidationError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_commit_generated_dependencies.py
+++ b/tests/scripts/test_commit_generated_dependencies.py
@@ -1500,52 +1500,9 @@ def test_dispatch_allowlist_skips_existing_oid_runs_and_polls_new_ones(
     assert count == 2
 
 
-def test_commenter_dispatch_binds_default_branch_and_exact_dependabot_head(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_commenter_dispatch_uses_typed_repository_event_and_exact_dependabot_head() -> None:
     dispatch_commenter = getattr(PUBLISHER, "dispatch_comment_workflow", None)
     assert callable(dispatch_commenter), "trusted writer must dispatch the commenter as a sibling workflow"
-    calls: list[dict[str, Any]] = []
-
-    def dispatch(
-        repository: str,
-        workflow: str,
-        branch: str,
-        **kwargs: Any,
-    ) -> None:
-        calls.append(
-            {
-                "repository": repository,
-                "workflow": workflow,
-                "branch": branch,
-                "inputs": kwargs.get("inputs"),
-            }
-        )
-
-    monkeypatch.setattr(PUBLISHER, "_dispatch_workflow", dispatch)
-
-    dispatch_commenter(
-        repository=REPOSITORY,
-        default_branch="main",
-        head_ref=BRANCH,
-        commit_oid=CHILD_SHA,
-        token="token",
-    )
-
-    assert calls == [
-        {
-            "repository": REPOSITORY,
-            "workflow": "comprehensive-test-pr-comments.yml",
-            "branch": "main",
-            "inputs": {
-                "source_head_sha": CHILD_SHA,
-                "source_head_branch": BRANCH,
-            },
-        }
-    ]
-
-
-def test_workflow_dispatch_serializes_exact_string_inputs() -> None:
     recorded: dict[str, Any] = {}
 
     class FakeResponse:
@@ -1566,26 +1523,19 @@ def test_workflow_dispatch_serializes_exact_string_inputs() -> None:
         recorded["timeout"] = timeout
         return FakeResponse()
 
-    PUBLISHER._dispatch_workflow(
-        REPOSITORY,
-        "comprehensive-test-pr-comments.yml",
-        "main",
+    dispatch_commenter(
+        repository=REPOSITORY,
+        head_ref=BRANCH,
+        commit_oid=CHILD_SHA,
         token="token",
         opener=opener,
-        inputs={
-            "source_head_sha": CHILD_SHA,
-            "source_head_branch": BRANCH,
-        },
     )
 
     assert recorded == {
-        "url": (
-            "https://api.github.com/repos/HomericIntelligence/Odyssey/actions/"
-            "workflows/comprehensive-test-pr-comments.yml/dispatches"
-        ),
+        "url": "https://api.github.com/repos/HomericIntelligence/Odyssey/dispatches",
         "payload": {
-            "ref": "main",
-            "inputs": {
+            "event_type": "dependabot-comprehensive-test-comment",
+            "client_payload": {
                 "source_head_sha": CHILD_SHA,
                 "source_head_branch": BRANCH,
             },
@@ -1595,22 +1545,23 @@ def test_workflow_dispatch_serializes_exact_string_inputs() -> None:
 
 
 @pytest.mark.parametrize(
-    "inputs",
+    ("head_ref", "commit_oid"),
     [
-        {"source_head_sha": ""},
-        {"source_head_sha": CHILD_SHA, 1: BRANCH},
-        {"source_head_sha": CHILD_SHA, "source_head_branch": 1},
+        ("feature/not-dependabot", CHILD_SHA),
+        (BRANCH, ""),
     ],
 )
-def test_workflow_dispatch_rejects_non_string_or_empty_inputs(inputs: Any) -> None:
-    with pytest.raises(PUBLISHER.PublishError, match="inputs"):
-        PUBLISHER._dispatch_workflow(
-            REPOSITORY,
-            "comprehensive-test-pr-comments.yml",
-            "main",
+def test_comment_repository_dispatch_rejects_invalid_payload(
+    head_ref: str,
+    commit_oid: str,
+) -> None:
+    with pytest.raises(PUBLISHER.PublishError):
+        PUBLISHER.dispatch_comment_workflow(
+            repository=REPOSITORY,
+            head_ref=head_ref,
+            commit_oid=commit_oid,
             token="token",
             opener=lambda *_args, **_kwargs: pytest.fail("invalid input must not dispatch"),
-            inputs=inputs,
         )
 
 
@@ -1652,7 +1603,6 @@ def test_publisher_dispatches_commenter_after_exact_required_runs(
     assert commenter_calls == [
         {
             "repository": REPOSITORY,
-            "default_branch": "main",
             "head_ref": BRANCH,
             "commit_oid": CHILD_SHA,
             "token": "token",

--- a/tests/scripts/test_comprehensive_pr_comment.py
+++ b/tests/scripts/test_comprehensive_pr_comment.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Behavior tests for the trusted Comprehensive PR-comment renderer."""
+
+from copy import deepcopy
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[2] / "scripts" / "ci"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from comprehensive_pr_comment import (  # noqa: E402
+    COMMENT_MARKER,
+    MAX_INPUT_BYTES,
+    MAX_JOBS,
+    ValidationError,
+    load_context,
+    main,
+    render_comment,
+    render_comment_file,
+)
+
+
+REPOSITORY = "HomericIntelligence/Odyssey"
+RUN_ID = 123456
+RUN_URL = f"https://github.com/{REPOSITORY}/actions/runs/{RUN_ID}"
+
+
+def _job(job_id: int, name: str, conclusion: str = "success") -> dict[str, object]:
+    return {
+        "id": job_id,
+        "name": name,
+        "status": "completed",
+        "conclusion": conclusion,
+        "url": f"{RUN_URL}/job/{job_id}",
+    }
+
+
+def _context(conclusion: str = "success") -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "repository": REPOSITORY,
+        "run": {
+            "id": RUN_ID,
+            "status": "completed",
+            "conclusion": conclusion,
+            "head_sha": "a" * 40,
+            "url": RUN_URL,
+        },
+        "jobs": [
+            _job(101, "Mojo Syntax Validation"),
+            _job(102, "Test Report", conclusion),
+        ],
+    }
+
+
+def test_complete_api_context_is_rendered_by_trusted_code() -> None:
+    body = render_comment(_context(), expected_repository=REPOSITORY)
+
+    assert body.startswith(f"{COMMENT_MARKER}\n")
+    assert body.count(COMMENT_MARKER) == 1
+    assert "## Comprehensive Test Results" in body
+    assert "PASS" in body
+    assert "Mojo Syntax Validation" in body
+    assert "Test Report" in body
+    assert f"[Workflow run]({RUN_URL})" in body
+    assert "global test" not in body.lower()
+    assert "pass rate" not in body.lower()
+
+
+def test_failed_authoritative_run_renders_a_red_verdict() -> None:
+    payload = _context("failure")
+    jobs = payload["jobs"]
+    assert isinstance(jobs, list)
+    jobs[0] = _job(101, "Mojo Syntax Validation", "failure")
+
+    body = render_comment(payload, expected_repository=REPOSITORY)
+
+    assert "FAIL" in body
+    assert "failure" in body
+    assert "PASS" not in body
+
+
+def test_markup_links_comment_markers_and_mentions_are_neutralized() -> None:
+    payload = _context()
+    jobs = payload["jobs"]
+    assert isinstance(jobs, list)
+    jobs[0] = _job(
+        101,
+        "<script>alert(1)</script> @everyone @org/team "
+        "[click](javascript:alert(1)) | `code` "
+        "<!-- odyssey:comprehensive-test-report:v1 --> \u202eevil",
+    )
+
+    body = render_comment(payload, expected_repository=REPOSITORY)
+
+    assert "<script>" not in body
+    assert "[click](javascript:" not in body
+    assert "@everyone" not in body
+    assert "@org/team" not in body
+    assert "\u202e" not in body
+    assert body.count(COMMENT_MARKER) == 1
+    assert "&lt;script&gt;" in body
+    assert "＠everyone" in body
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("schema_version",), 2),
+        (("schema_version",), 1.0),
+        (("schema_version",), True),
+        (("repository",), "attacker/example"),
+        (("run", "status"), "in_progress"),
+        (("run", "conclusion"), "unknown"),
+        (("run", "head_sha"), "not-a-sha"),
+        (("run", "url"), "javascript:alert(1)"),
+        (("jobs", 0, "status"), "queued"),
+        (("jobs", 0, "conclusion"), "unknown"),
+        (("jobs", 0, "url"), "https://evil.example/job/101"),
+    ],
+)
+def test_closed_schema_rejects_invalid_identity_and_enums(
+    path: tuple[str | int, ...],
+    value: object,
+) -> None:
+    payload = _context()
+    target: object = payload
+    for component in path[:-1]:
+        assert isinstance(target, (dict, list))
+        target = target[component]  # type: ignore[index]
+    assert isinstance(target, (dict, list))
+    target[path[-1]] = value  # type: ignore[index]
+
+    with pytest.raises(ValidationError):
+        render_comment(payload, expected_repository=REPOSITORY)
+
+
+@pytest.mark.parametrize(
+    ("container", "field"),
+    [
+        ("top", "unexpected"),
+        ("run", "unexpected"),
+        ("job", "unexpected"),
+    ],
+)
+def test_closed_schema_rejects_unknown_fields(container: str, field: str) -> None:
+    payload = _context()
+    if container == "top":
+        payload[field] = True
+    elif container == "run":
+        run = payload["run"]
+        assert isinstance(run, dict)
+        run[field] = True
+    else:
+        jobs = payload["jobs"]
+        assert isinstance(jobs, list)
+        job = jobs[0]
+        assert isinstance(job, dict)
+        job[field] = True
+
+    with pytest.raises(ValidationError):
+        render_comment(payload, expected_repository=REPOSITORY)
+
+
+def test_requires_exactly_one_test_report_job() -> None:
+    missing = _context()
+    missing_jobs = missing["jobs"]
+    assert isinstance(missing_jobs, list)
+    missing_jobs[1] = _job(102, "Not The Report")
+
+    duplicate = _context()
+    duplicate_jobs = duplicate["jobs"]
+    assert isinstance(duplicate_jobs, list)
+    duplicate_jobs.append(_job(103, "Test Report"))
+
+    for payload in (missing, duplicate):
+        with pytest.raises(ValidationError, match="Test Report"):
+            render_comment(payload, expected_repository=REPOSITORY)
+
+
+def test_rejects_duplicate_job_ids_and_empty_job_lists() -> None:
+    duplicate = _context()
+    duplicate_jobs = duplicate["jobs"]
+    assert isinstance(duplicate_jobs, list)
+    second = duplicate_jobs[1]
+    assert isinstance(second, dict)
+    second["id"] = 101
+
+    empty = _context()
+    empty["jobs"] = []
+
+    for payload in (duplicate, empty):
+        with pytest.raises(ValidationError):
+            render_comment(payload, expected_repository=REPOSITORY)
+
+
+@pytest.mark.parametrize(
+    ("workflow_conclusion", "report_conclusion"),
+    [
+        ("success", "failure"),
+        ("failure", "success"),
+        ("cancelled", "failure"),
+    ],
+)
+def test_test_report_conclusion_must_match_workflow_conclusion(
+    workflow_conclusion: str,
+    report_conclusion: str,
+) -> None:
+    payload = _context(workflow_conclusion)
+    jobs = payload["jobs"]
+    assert isinstance(jobs, list)
+    jobs[1] = _job(102, "Test Report", report_conclusion)
+
+    with pytest.raises(ValidationError, match="conclusion"):
+        render_comment(payload, expected_repository=REPOSITORY)
+
+
+def test_job_count_and_string_lengths_are_bounded() -> None:
+    too_many = _context()
+    too_many["jobs"] = [
+        _job(index + 1, "Test Report" if index == 0 else f"Job {index}") for index in range(MAX_JOBS + 1)
+    ]
+
+    overlong = _context()
+    overlong_jobs = overlong["jobs"]
+    assert isinstance(overlong_jobs, list)
+    overlong_jobs[0] = _job(101, "x" * 257)
+
+    for payload in (too_many, overlong):
+        with pytest.raises(ValidationError):
+            render_comment(payload, expected_repository=REPOSITORY)
+
+
+def test_file_loader_rejects_malformed_empty_and_oversized_json(tmp_path: Path) -> None:
+    context_path = tmp_path / "context.json"
+
+    for raw in (b"", b"{", b"[]", b"x" * (MAX_INPUT_BYTES + 1)):
+        context_path.write_bytes(raw)
+        with pytest.raises(ValidationError):
+            load_context(context_path)
+
+
+def test_file_loader_rejects_duplicate_json_fields(tmp_path: Path) -> None:
+    context_path = tmp_path / "context.json"
+    context_path.write_text(
+        '{"schema_version":1,"schema_version":1}',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError, match="duplicate"):
+        load_context(context_path)
+
+
+def test_file_loader_rejects_a_symlink(tmp_path: Path) -> None:
+    target = tmp_path / "target.json"
+    target.write_text(json.dumps(_context()), encoding="utf-8")
+    context_path = tmp_path / "context.json"
+    try:
+        context_path.symlink_to(target)
+    except OSError:
+        pytest.skip("symlinks are unavailable on this platform")
+
+    with pytest.raises(ValidationError, match="regular file"):
+        load_context(context_path)
+
+
+def test_maximum_valid_input_that_expands_past_comment_limit_is_rejected() -> None:
+    payload = _context()
+    payload["jobs"] = [_job(1, "Test Report")]
+    jobs = payload["jobs"]
+    assert isinstance(jobs, list)
+    jobs.extend(_job(index + 2, f"{index:03d}" + "&" * 253) for index in range(MAX_JOBS - 1))
+
+    with pytest.raises(ValidationError, match="exceeds"):
+        render_comment(payload, expected_repository=REPOSITORY)
+
+
+def test_render_failure_removes_any_stale_output(tmp_path: Path) -> None:
+    input_path = tmp_path / "context.json"
+    output_path = tmp_path / "comment.md"
+    invalid = deepcopy(_context())
+    invalid["schema_version"] = 999
+    input_path.write_text(json.dumps(invalid), encoding="utf-8")
+    output_path.write_text(f"{COMMENT_MARKER}\nPASS\n", encoding="utf-8")
+
+    with pytest.raises(ValidationError):
+        render_comment_file(
+            input_path,
+            output_path,
+            expected_repository=REPOSITORY,
+        )
+
+    assert not output_path.exists()
+
+
+def test_cli_failure_leaves_no_postable_output(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    input_path = tmp_path / "context.json"
+    output_path = tmp_path / "comment.md"
+    input_path.write_text("{}", encoding="utf-8")
+    output_path.write_text(f"{COMMENT_MARKER}\nPASS\n", encoding="utf-8")
+
+    result = main(
+        [
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_path),
+            "--expected-repository",
+            REPOSITORY,
+        ]
+    )
+
+    assert result == 1
+    assert not output_path.exists()
+    assert "ERROR:" in capsys.readouterr().err
+
+
+def test_render_file_writes_only_a_validated_bounded_comment(tmp_path: Path) -> None:
+    input_path = tmp_path / "context.json"
+    output_path = tmp_path / "comment.md"
+    input_path.write_text(json.dumps(_context()), encoding="utf-8")
+
+    render_comment_file(
+        input_path,
+        output_path,
+        expected_repository=REPOSITORY,
+    )
+
+    body = output_path.read_text(encoding="utf-8")
+    assert body.startswith(COMMENT_MARKER)
+    assert len(body.encode("utf-8")) < 65_536

--- a/tests/scripts/test_comprehensive_pr_comment_publisher.py
+++ b/tests/scripts/test_comprehensive_pr_comment_publisher.py
@@ -444,11 +444,12 @@ const github = {
         + " console.error(error); process.exit(1); });\n"
     )
     completed = subprocess.run(
-        ["node", "-e", harness],
+        ["node"],
         cwd=REPO_ROOT,
         check=True,
         capture_output=True,
         text=True,
+        input=harness,
     )
     return json.loads(completed.stdout)
 
@@ -515,11 +516,12 @@ const github = {
         + " console.error(error); process.exit(1); });\n"
     )
     completed = subprocess.run(
-        ["node", "-e", harness],
+        ["node"],
         cwd=REPO_ROOT,
         check=True,
         capture_output=True,
         text=True,
+        input=harness,
     )
     return json.loads(completed.stdout)
 
@@ -587,11 +589,12 @@ const github = {
         + " console.error(error); process.exit(1); });\n"
     )
     completed = subprocess.run(
-        ["node", "-e", harness],
+        ["node"],
         cwd=REPO_ROOT,
         check=True,
         capture_output=True,
         text=True,
+        input=harness,
     )
     return json.loads(completed.stdout)
 

--- a/tests/scripts/test_comprehensive_pr_comment_publisher.py
+++ b/tests/scripts/test_comprehensive_pr_comment_publisher.py
@@ -1,0 +1,1126 @@
+#!/usr/bin/env python3
+"""Execute the trusted inline publisher against mocked GitHub APIs."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+import shutil
+import subprocess
+from typing import Any
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github/workflows/comprehensive-test-pr-comments.yml"
+MARKER = "<!-- odyssey:comprehensive-test-report:v1 -->"
+HEAD_SHA = "a" * 40
+HEAD_BRANCH = "feature/trusted-comment"
+DEPENDABOT_BRANCH = "dependabot/pip/uv-1.2.3"
+REPOSITORY = "HomericIntelligence/Odyssey"
+REPOSITORY_ID = 12345
+RUN_ID = 123456
+RUN_ATTEMPT = 1
+RUN_NUMBER = 789
+WORKFLOW_ID = 209513613
+RUN_URL = f"https://github.com/{REPOSITORY}/actions/runs/{RUN_ID}"
+
+
+def _publisher_script() -> str:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["post-pr-comments"]["steps"]
+    post = next(step for step in steps if step.get("name") == "Post or update trusted PR comment")
+    script = post["with"]["script"]
+    injected = script.replace(
+        "const fs = require('fs');",
+        "const fs = mockFs;",
+        1,
+    )
+    assert injected != script
+    return injected
+
+
+def _collector_script() -> str:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["post-pr-comments"]["steps"]
+    collect = next(step for step in steps if step.get("id") == "collect-jobs")
+    script = collect["with"]["script"]
+    injected = script.replace(
+        "const fs = require('fs');",
+        "const fs = mockFs;",
+        1,
+    )
+    assert injected != script
+    return injected
+
+
+def _resolver_script() -> str:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["resolve-pr-context"]["steps"]
+    resolve = next(step for step in steps if step.get("id") == "resolve-context")
+    return resolve["with"]["script"]
+
+
+def _github_scripts() -> list[str]:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    return [
+        step["with"]["script"]
+        for job in workflow["jobs"].values()
+        for step in job["steps"]
+        if str(step.get("uses", "")).startswith("actions/github-script@")
+    ]
+
+
+def _actions_identity() -> dict[str, Any]:
+    return {
+        "user": {
+            "login": "github-actions[bot]",
+            "id": 41898282,
+            "type": "Bot",
+        },
+        "performed_via_github_app": {
+            "id": 15368,
+            "slug": "github-actions",
+        },
+    }
+
+
+def _comment(comment_id: int, body: str, *, expected_bot: bool = True) -> dict[str, Any]:
+    if expected_bot:
+        identity = _actions_identity()
+    else:
+        identity = {
+            "user": {"login": "attacker", "id": 999, "type": "User"},
+            "performed_via_github_app": None,
+        }
+    return {"id": comment_id, "body": body, **identity}
+
+
+def _run(
+    *,
+    run_id: int = RUN_ID,
+    attempt: int = RUN_ATTEMPT,
+    run_number: int = RUN_NUMBER,
+    conclusion: str = "success",
+    event: str = "pull_request",
+) -> dict[str, Any]:
+    return {
+        "id": run_id,
+        "name": "Comprehensive Tests",
+        "run_attempt": attempt,
+        "run_number": run_number,
+        "workflow_id": WORKFLOW_ID,
+        "head_sha": HEAD_SHA,
+        "head_branch": HEAD_BRANCH,
+        "head_repository": {"full_name": REPOSITORY},
+        "event": event,
+        "status": "completed",
+        "conclusion": conclusion,
+        "path": ".github/workflows/comprehensive-tests.yml",
+        "repository": {"full_name": REPOSITORY},
+        "html_url": f"https://github.com/{REPOSITORY}/actions/runs/{run_id}",
+    }
+
+
+def _fixture() -> dict[str, Any]:
+    trusted_body = f"{MARKER}\n## Comprehensive Test Results\n\n✅ **PASS — authoritative results agree.**\n"
+    return {
+        "env": {
+            "COLLECT_JOBS_OUTCOME": "success",
+            "COMMENT_OUTPUT_PATH": "/runner/temp/comment.md",
+            "PR_NUMBER": "42",
+            "RENDER_COMMENT_OUTCOME": "success",
+            "SOURCE_HEAD_BRANCH": HEAD_BRANCH,
+            "SOURCE_HEAD_REPOSITORY": REPOSITORY,
+            "SOURCE_HEAD_SHA": HEAD_SHA,
+            "SOURCE_READY": "true",
+            "SOURCE_RUN_ATTEMPT": str(RUN_ATTEMPT),
+            "SOURCE_RUN_EVENT": "pull_request",
+            "SOURCE_RUN_ID": str(RUN_ID),
+            "SOURCE_RUN_NUMBER": str(RUN_NUMBER),
+            "SOURCE_WORKFLOW_ID": str(WORKFLOW_ID),
+            "WORKFLOW_CONCLUSION": "success",
+            "WORKFLOW_RUN_URL": RUN_URL,
+        },
+        "pulls": [
+            {
+                "state": "open",
+                "head": {
+                    "sha": HEAD_SHA,
+                    "ref": HEAD_BRANCH,
+                    "repo": {"full_name": REPOSITORY},
+                },
+            },
+            {
+                "state": "open",
+                "head": {
+                    "sha": HEAD_SHA,
+                    "ref": HEAD_BRANCH,
+                    "repo": {"full_name": REPOSITORY},
+                },
+            },
+            {
+                "state": "open",
+                "head": {
+                    "sha": HEAD_SHA,
+                    "ref": HEAD_BRANCH,
+                    "repo": {"full_name": REPOSITORY},
+                },
+            },
+        ],
+        "runs": [_run(), _run(), _run()],
+        "latest_runs": [[_run()], [_run()], [_run()]],
+        "comments": [
+            _comment(10, f"{MARKER}\nold green"),
+            _comment(11, f"{MARKER}\nattacker marker", expected_bot=False),
+            _comment(12, "prefix\n## Test Metrics Report\nraw artifact"),
+        ],
+        "trusted_body": trusted_body,
+        "trusted_file_available": True,
+    }
+
+
+def _collector_fixture() -> dict[str, Any]:
+    trusted_policy = {
+        ".github/workflows/comprehensive-tests.yml": "trusted workflow\n",
+        "scripts/ci/comprehensive_report.py": "trusted report\n",
+    }
+    jobs = [
+        {
+            "id": 101,
+            "run_id": RUN_ID,
+            "run_attempt": RUN_ATTEMPT,
+            "head_sha": HEAD_SHA,
+            "name": "Mojo Syntax Validation",
+            "status": "completed",
+            "conclusion": "success",
+        },
+        {
+            "id": 102,
+            "run_id": RUN_ID,
+            "run_attempt": RUN_ATTEMPT,
+            "head_sha": HEAD_SHA,
+            "name": "Test Report",
+            "status": "completed",
+            "conclusion": "success",
+        },
+    ]
+    return {
+        "env": {
+            "COMMENT_CONTEXT_PATH": "/runner/temp/context.json",
+            "RUNNER_TEMP": "/runner/temp",
+            "SOURCE_HEAD_BRANCH": HEAD_BRANCH,
+            "SOURCE_HEAD_REPOSITORY": REPOSITORY,
+            "SOURCE_HEAD_SHA": HEAD_SHA,
+            "SOURCE_RUN_ATTEMPT": str(RUN_ATTEMPT),
+            "SOURCE_RUN_CONCLUSION": "success",
+            "SOURCE_RUN_EVENT": "pull_request",
+            "SOURCE_RUN_ID": str(RUN_ID),
+            "SOURCE_RUN_NUMBER": str(RUN_NUMBER),
+            "SOURCE_WORKFLOW_ID": str(WORKFLOW_ID),
+        },
+        "trusted_policy": trusted_policy,
+        "source_policy": deepcopy(trusted_policy),
+        "run": _run(),
+        "jobs": jobs,
+    }
+
+
+def _resolver_run(
+    *,
+    run_id: int = RUN_ID,
+    attempt: int = RUN_ATTEMPT,
+    run_number: int = RUN_NUMBER,
+    event: str = "workflow_dispatch",
+) -> dict[str, Any]:
+    return {
+        **_run(
+            run_id=run_id,
+            attempt=attempt,
+            run_number=run_number,
+            event=event,
+        ),
+        "name": "Comprehensive Tests",
+        "head_branch": DEPENDABOT_BRANCH,
+        "repository": {
+            "full_name": REPOSITORY,
+            "id": REPOSITORY_ID,
+        },
+    }
+
+
+def _resolver_pull(
+    *,
+    sha: str = HEAD_SHA,
+    branch: str = DEPENDABOT_BRANCH,
+) -> dict[str, Any]:
+    return {
+        "number": 42,
+        "state": "open",
+        "user": {"login": "dependabot[bot]"},
+        "head": {
+            "sha": sha,
+            "ref": branch,
+            "repo": {"full_name": REPOSITORY},
+        },
+    }
+
+
+def _resolver_fixture() -> dict[str, Any]:
+    pull_request = _resolver_pull()
+    return {
+        "context": {
+            "eventName": "repository_dispatch",
+            "ref": "refs/heads/main",
+            "repo": {
+                "owner": "HomericIntelligence",
+                "repo": "Odyssey",
+            },
+            "payload": {
+                "action": "dependabot-comprehensive-test-comment",
+                "repository": {
+                    "id": REPOSITORY_ID,
+                    "default_branch": "main",
+                },
+                "workflow_run": None,
+            },
+        },
+        "env": {
+            "SOURCE_HEAD_BRANCH": DEPENDABOT_BRANCH,
+            "SOURCE_HEAD_SHA": HEAD_SHA,
+        },
+        "workflow": {
+            "id": WORKFLOW_ID,
+            "name": "Comprehensive Tests",
+            "path": ".github/workflows/comprehensive-tests.yml",
+        },
+        "associated": [pull_request],
+        "pulls": [deepcopy(pull_request), deepcopy(pull_request)],
+        "runs": [_resolver_run()],
+        "fresh_runs": [],
+    }
+
+
+def _workflow_run_resolver_fixture(event: str) -> dict[str, Any]:
+    fixture = _resolver_fixture()
+    source_run = _resolver_run(event=event)
+    fixture["context"] = {
+        "eventName": "workflow_run",
+        "ref": "refs/heads/main",
+        "repo": {
+            "owner": "HomericIntelligence",
+            "repo": "Odyssey",
+        },
+        "payload": {
+            "action": "completed",
+            "repository": {
+                "id": REPOSITORY_ID,
+                "default_branch": "main",
+            },
+            "workflow_run": source_run,
+        },
+    }
+    fixture["env"] = {
+        "SOURCE_HEAD_BRANCH": "",
+        "SOURCE_HEAD_SHA": "",
+    }
+    return fixture
+
+
+def _execute(fixture: dict[str, Any]) -> dict[str, Any]:
+    if shutil.which("node") is None:
+        pytest.skip("Node.js is unavailable")
+
+    preamble = """
+const fixture = FIXTURE;
+Object.assign(process.env, fixture.env);
+const state = { created: [], updated: [], failed: [], info: [] };
+const pullResponses = [...fixture.pulls];
+const runResponses = [...fixture.runs];
+const latestRunResponses = [...fixture.latest_runs];
+const mockFs = {
+  lstatSync: () => {
+    if (!fixture.trusted_file_available) {
+      throw new Error('missing');
+    }
+    return {
+      isFile: () => true,
+      isSymbolicLink: () => false,
+      size: Buffer.byteLength(fixture.trusted_body, 'utf8'),
+    };
+  },
+  readFileSync: () => fixture.trusted_body,
+};
+const context = { repo: { owner: 'HomericIntelligence', repo: 'Odyssey' } };
+const core = {
+  info: message => state.info.push(message),
+  setFailed: message => state.failed.push(message),
+};
+const listComments = async () => ({ data: fixture.comments });
+const listWorkflowRuns = async () => ({ data: { workflow_runs: [] } });
+const github = {
+  paginate: async method => {
+    if (method === listComments) return fixture.comments;
+    if (method === listWorkflowRuns) {
+      if (latestRunResponses.length === 0) {
+        throw new Error('no latest-run response');
+      }
+      return latestRunResponses.shift();
+    }
+    throw new Error('unexpected pagination method');
+  },
+  rest: {
+    pulls: {
+      get: async () => {
+        if (pullResponses.length === 0) throw new Error('no pull response');
+        return { data: pullResponses.shift() };
+      },
+    },
+    actions: {
+      listWorkflowRuns,
+      getWorkflowRun: async () => {
+        if (runResponses.length === 0) throw new Error('no run response');
+        const response = runResponses.shift();
+        if (response === null) throw new Error('run unavailable');
+        return { data: response };
+      },
+    },
+    issues: {
+      listComments,
+      createComment: async args => state.created.push(args),
+      updateComment: async args => state.updated.push(args),
+    },
+  },
+};
+"""
+    harness = (
+        preamble.replace("FIXTURE", json.dumps(fixture))
+        + "\n(async () => {\n"
+        + _publisher_script()
+        + "\n})().then(() => console.log(JSON.stringify(state))).catch(error => {"
+        + " console.error(error); process.exit(1); });\n"
+    )
+    completed = subprocess.run(
+        ["node", "-e", harness],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def _execute_collector(fixture: dict[str, Any]) -> dict[str, Any]:
+    if shutil.which("node") is None:
+        pytest.skip("Node.js is unavailable")
+
+    preamble = """
+const fixture = FIXTURE;
+Object.assign(process.env, fixture.env);
+const state = { failed: [], info: [], writes: [] };
+const mockFs = {
+  lstatSync: filePath => {
+    const value = fixture.trusted_policy[filePath];
+    if (value === undefined) throw new Error('missing trusted policy');
+    return {
+      isFile: () => true,
+      isSymbolicLink: () => false,
+      size: Buffer.byteLength(value, 'utf8'),
+    };
+  },
+  readFileSync: filePath => Buffer.from(fixture.trusted_policy[filePath], 'utf8'),
+  writeFileSync: (filePath, content, options) => {
+    state.writes.push({ filePath, content, options });
+  },
+};
+const context = { repo: { owner: 'HomericIntelligence', repo: 'Odyssey' } };
+const core = {
+  info: message => state.info.push(message),
+  setFailed: message => state.failed.push(message),
+};
+const github = {
+  rest: {
+    repos: {
+      getContent: async args => {
+        const value = fixture.source_policy[args.path];
+        if (value === undefined) throw new Error('missing source policy');
+        return {
+          data: {
+            type: 'file',
+            path: args.path,
+            encoding: 'base64',
+            size: Buffer.byteLength(value, 'utf8'),
+            content: Buffer.from(value, 'utf8').toString('base64'),
+          },
+        };
+      },
+    },
+    actions: {
+      getWorkflowRun: async () => ({ data: fixture.run }),
+      listJobsForWorkflowRun: async () => ({
+        data: { total_count: fixture.jobs.length, jobs: fixture.jobs },
+      }),
+    },
+  },
+};
+"""
+    harness = (
+        preamble.replace("FIXTURE", json.dumps(fixture))
+        + "\n(async () => {\n"
+        + _collector_script()
+        + "\n})().then(() => console.log(JSON.stringify(state))).catch(error => {"
+        + " console.error(error); process.exit(1); });\n"
+    )
+    completed = subprocess.run(
+        ["node", "-e", harness],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def _execute_resolver(fixture: dict[str, Any]) -> dict[str, Any]:
+    if shutil.which("node") is None:
+        pytest.skip("Node.js is unavailable")
+
+    preamble = """
+const fixture = FIXTURE;
+Object.assign(process.env, fixture.env);
+const state = { failed: [], info: [], outputs: {} };
+const pullResponses = [...fixture.pulls];
+const freshRunResponses = [...fixture.fresh_runs];
+const listAssociated = async () => ({ data: fixture.associated });
+const listRuns = async () => ({ data: { workflow_runs: fixture.runs } });
+const context = fixture.context;
+const core = {
+  info: message => state.info.push(message),
+  setFailed: message => state.failed.push(message),
+  setOutput: (name, value) => { state.outputs[name] = String(value); },
+};
+const github = {
+  paginate: async method => {
+    if (method === listAssociated) return fixture.associated;
+    if (method === listRuns) return fixture.runs;
+    throw new Error('unexpected pagination method');
+  },
+  rest: {
+    actions: {
+      getWorkflow: async () => ({ data: fixture.workflow }),
+      listWorkflowRuns: listRuns,
+      getWorkflowRun: async () => {
+        if (freshRunResponses.length === 0) {
+          throw new Error('no fresh run response');
+        }
+        return { data: freshRunResponses.shift() };
+      },
+    },
+    repos: {
+      listPullRequestsAssociatedWithCommit: listAssociated,
+    },
+    pulls: {
+      get: async () => {
+        if (pullResponses.length === 0) throw new Error('no pull response');
+        return { data: pullResponses.shift() };
+      },
+    },
+  },
+};
+"""
+    harness = (
+        preamble.replace("FIXTURE", json.dumps(fixture)).replace(
+            "REPOSITORY_ID",
+            str(REPOSITORY_ID),
+        )
+        + "\n(async () => {\n"
+        + _resolver_script()
+        + "\n})().then(() => console.log(JSON.stringify(state))).catch(error => {"
+        + " console.error(error); process.exit(1); });\n"
+    )
+    completed = subprocess.run(
+        ["node", "-e", harness],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def test_every_inline_github_script_compiles_as_an_async_function() -> None:
+    if shutil.which("node") is None:
+        pytest.skip("Node.js is unavailable")
+
+    scripts = _github_scripts()
+    assert len(scripts) == 3
+    compiler = (
+        "const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;"
+        "for (const source of JSON.parse(process.argv[1])) new AsyncFunction(source);"
+    )
+    subprocess.run(
+        ["node", "-e", compiler, json.dumps(scripts)],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_resolver_authorizes_current_dependabot_pr_for_writer() -> None:
+    state = _execute_resolver(_resolver_fixture())
+
+    assert state["failed"] == []
+    assert state["outputs"]["pr_number"] == "42"
+    assert state["outputs"]["source_head_branch"] == DEPENDABOT_BRANCH
+    assert state["outputs"]["source_head_repository"] == REPOSITORY
+    assert state["outputs"]["source_head_sha"] == HEAD_SHA
+    assert state["outputs"]["source_ready"] == "true"
+    assert state["outputs"]["source_run_attempt"] == str(RUN_ATTEMPT)
+    assert state["outputs"]["source_run_event"] == "workflow_dispatch"
+    assert state["outputs"]["source_run_id"] == str(RUN_ID)
+    assert state["outputs"]["source_run_number"] == str(RUN_NUMBER)
+    assert state["outputs"]["source_workflow_id"] == str(WORKFLOW_ID)
+    assert state["outputs"]["writer_ready"] == "true"
+
+
+@pytest.mark.parametrize("event", ["pull_request", "workflow_dispatch"])
+def test_resolver_authorizes_each_supported_workflow_run_event(
+    event: str,
+) -> None:
+    state = _execute_resolver(_workflow_run_resolver_fixture(event))
+
+    assert state["failed"] == []
+    assert state["outputs"]["pr_number"] == "42"
+    assert state["outputs"]["source_head_branch"] == DEPENDABOT_BRANCH
+    assert state["outputs"]["source_head_repository"] == REPOSITORY
+    assert state["outputs"]["source_head_sha"] == HEAD_SHA
+    assert state["outputs"]["source_ready"] == "true"
+    assert state["outputs"]["source_run_event"] == event
+    assert state["outputs"]["source_run_id"] == str(RUN_ID)
+    assert state["outputs"]["writer_ready"] == "true"
+
+
+def test_resolver_selects_newest_same_head_dispatch_run() -> None:
+    fixture = _resolver_fixture()
+    fixture["runs"] = [
+        _resolver_run(),
+        _resolver_run(
+            run_id=RUN_ID + 1,
+            run_number=RUN_NUMBER + 1,
+        ),
+    ]
+
+    state = _execute_resolver(fixture)
+
+    assert state["failed"] == []
+    assert state["outputs"]["source_ready"] == "true"
+    assert state["outputs"]["source_run_id"] == str(RUN_ID + 1)
+    assert state["outputs"]["source_run_number"] == str(RUN_NUMBER + 1)
+    assert state["outputs"]["writer_ready"] == "true"
+
+
+def test_resolver_does_not_enqueue_stale_dependabot_writer() -> None:
+    fixture = _resolver_fixture()
+    fixture["pulls"][1] = _resolver_pull(sha="b" * 40)
+
+    state = _execute_resolver(fixture)
+
+    assert state["failed"] == []
+    assert state["outputs"]["pr_number"] == "42"
+    assert state["outputs"].get("source_ready") != "true"
+    assert state["outputs"].get("writer_ready") != "true"
+    assert any("changed before writer scheduling" in item for item in state["info"])
+
+
+def test_resolver_schedules_fail_closed_writer_for_current_source_failure() -> None:
+    fixture = _resolver_fixture()
+    fixture["runs"] = []
+
+    state = _execute_resolver(fixture)
+
+    assert state["failed"] == []
+    assert state["outputs"]["source_ready"] == "false"
+    assert state["outputs"]["writer_ready"] == "true"
+
+
+def test_collector_authenticates_policy_and_writes_bounded_context() -> None:
+    state = _execute_collector(_collector_fixture())
+
+    assert state["failed"] == []
+    assert len(state["writes"]) == 1
+    payload = json.loads(state["writes"][0]["content"])
+    assert payload["run"]["id"] == RUN_ID
+    assert [job["name"] for job in payload["jobs"]] == [
+        "Mojo Syntax Validation",
+        "Test Report",
+    ]
+
+
+@pytest.mark.parametrize(
+    "policy_path",
+    [
+        ".github/workflows/comprehensive-tests.yml",
+        "scripts/ci/comprehensive_report.py",
+    ],
+)
+def test_collector_rejects_source_policy_drift(policy_path: str) -> None:
+    fixture = _collector_fixture()
+    fixture["source_policy"][policy_path] = "attacker policy\n"
+
+    state = _execute_collector(fixture)
+
+    assert state["writes"] == []
+    assert state["failed"] == ["Source Comprehensive policy differs from trusted main."]
+
+
+def test_collector_requires_current_attempt_test_report() -> None:
+    fixture = _collector_fixture()
+    fixture["env"]["SOURCE_RUN_ATTEMPT"] = "2"
+    fixture["run"]["run_attempt"] = 2
+    fixture["jobs"][0]["run_attempt"] = 1
+    fixture["jobs"][1]["run_attempt"] = 1
+
+    state = _execute_collector(fixture)
+
+    assert state["writes"] == []
+    assert state["failed"] == ["The authoritative Test Report is not from the current run attempt."]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("event", "workflow_dispatch"),
+        ("run_number", RUN_NUMBER + 1),
+    ],
+)
+def test_collector_rejects_run_order_identity_drift(
+    field: str,
+    value: object,
+) -> None:
+    fixture = _collector_fixture()
+    fixture["run"][field] = value
+
+    state = _execute_collector(fixture)
+
+    assert state["writes"] == []
+    assert state["failed"] == ["Source run changed before job collection."]
+
+
+def test_valid_body_updates_only_owned_comments_and_retires_metrics() -> None:
+    state = _execute(_fixture())
+
+    updated = {item["comment_id"]: item["body"] for item in state["updated"]}
+    assert state["created"] == []
+    assert state["failed"] == []
+    assert updated[10].startswith(f"{MARKER}\n")
+    assert "PASS" in updated[10]
+    assert 11 not in updated
+    assert "diagnostic only" in updated[12]
+    assert RUN_URL in updated[12]
+
+
+def test_missing_renderer_output_replaces_stale_green_with_red_fallback() -> None:
+    fixture = _fixture()
+    fixture["trusted_file_available"] = False
+
+    state = _execute(fixture)
+
+    updated = {item["comment_id"]: item["body"] for item in state["updated"]}
+    assert "FAIL" in updated[10]
+    assert "PASS" not in updated[10]
+    assert RUN_URL in updated[10]
+    assert state["failed"] == ["Trusted comment rendering failed; posted a red fallback."]
+
+
+@pytest.mark.parametrize(
+    "runs",
+    [
+        [
+            _run(conclusion="failure"),
+            _run(conclusion="failure"),
+        ],
+        [
+            _run(),
+            _run(conclusion="failure"),
+            _run(conclusion="failure"),
+        ],
+        [None, _run()],
+    ],
+)
+def test_source_run_drift_or_unavailability_posts_red(
+    runs: list[dict[str, Any] | None],
+) -> None:
+    fixture = _fixture()
+    fixture["runs"] = runs
+
+    state = _execute(fixture)
+
+    updated = {item["comment_id"]: item["body"] for item in state["updated"]}
+    assert "FAIL" in updated[10]
+    assert "PASS" not in updated[10]
+    assert RUN_URL in updated[10]
+    assert state["failed"]
+
+
+def test_post_time_head_change_never_mutates_comments() -> None:
+    fixture = _fixture()
+    fixture["pulls"][1] = {
+        "state": "open",
+        "head": {"sha": "b" * 40},
+    }
+
+    state = _execute(fixture)
+
+    assert state["created"] == []
+    assert state["updated"] == []
+    assert any("head changed before comment mutation" in item for item in state["info"])
+
+
+@pytest.mark.parametrize(
+    "head",
+    [
+        {
+            "sha": HEAD_SHA,
+            "ref": "feature/same-commit-other-branch",
+            "repo": {"full_name": REPOSITORY},
+        },
+        {
+            "sha": HEAD_SHA,
+            "ref": HEAD_BRANCH,
+            "repo": {"full_name": "attacker/Odyssey"},
+        },
+    ],
+)
+def test_post_time_source_tuple_change_never_mutates_comments(
+    head: dict[str, Any],
+) -> None:
+    fixture = _fixture()
+    fixture["pulls"][1] = {"state": "open", "head": head}
+
+    state = _execute(fixture)
+
+    assert state["created"] == []
+    assert state["updated"] == []
+    assert any("head changed before comment mutation" in item for item in state["info"])
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("head_branch", "feature/same-commit-other-branch"),
+        ("head_repository", {"full_name": "attacker/Odyssey"}),
+    ],
+)
+def test_source_run_branch_or_repository_drift_posts_red(
+    field: str,
+    value: object,
+) -> None:
+    fixture = _fixture()
+    fixture["runs"][0][field] = value
+
+    state = _execute(fixture)
+
+    updated = {item["comment_id"]: item["body"] for item in state["updated"]}
+    assert "FAIL" in updated[10]
+    assert "PASS" not in updated[10]
+    assert state["failed"]
+
+
+def test_obsolete_run_attempt_never_overwrites_newer_same_head_comment() -> None:
+    fixture = _fixture()
+    newer = _run(attempt=RUN_ATTEMPT + 1)
+    fixture["latest_runs"] = [[_run()], [newer]]
+
+    state = _execute(fixture)
+
+    assert state["created"] == []
+    assert state["updated"] == []
+    assert any("newer source run" in item for item in state["info"])
+
+
+@pytest.mark.parametrize(
+    "newer",
+    [
+        _run(attempt=RUN_ATTEMPT + 1),
+        _run(run_id=RUN_ID + 1, run_number=RUN_NUMBER + 1),
+    ],
+    ids=["newer-attempt", "newer-distinct-run"],
+)
+def test_initially_obsolete_source_run_never_mutates_comment(
+    newer: dict[str, Any],
+) -> None:
+    fixture = _fixture()
+    fixture["latest_runs"] = [[newer]]
+
+    state = _execute(fixture)
+
+    assert state["created"] == []
+    assert state["updated"] == []
+    assert any("newer source run" in item for item in state["info"])
+
+
+def test_newer_attempt_observed_after_order_check_never_mutates_comment() -> None:
+    fixture = _fixture()
+    fixture["runs"] = [_run(attempt=RUN_ATTEMPT + 1)]
+
+    state = _execute(fixture)
+
+    assert state["created"] == []
+    assert state["updated"] == []
+    assert any("newer source run attempt" in item for item in state["info"])
+
+
+def test_newer_attempt_observed_after_final_order_check_never_mutates_comment() -> None:
+    fixture = _fixture()
+    fixture["runs"] = [_run(), _run(attempt=RUN_ATTEMPT + 1)]
+
+    state = _execute(fixture)
+
+    assert state["created"] == []
+    assert state["updated"] == []
+    assert any("newer source run attempt" in item for item in state["info"])
+
+
+def test_obsolete_distinct_run_never_overwrites_newer_same_head_comment() -> None:
+    fixture = _fixture()
+    newer = _run(run_id=RUN_ID + 1, run_number=RUN_NUMBER + 1)
+    fixture["latest_runs"] = [[_run()], [newer]]
+
+    state = _execute(fixture)
+
+    assert state["created"] == []
+    assert state["updated"] == []
+    assert any("newer source run" in item for item in state["info"])
+
+
+def test_newer_run_appearing_during_comment_discovery_never_gets_overwritten() -> None:
+    fixture = _fixture()
+    newer = _run(run_id=RUN_ID + 1, run_number=RUN_NUMBER + 1)
+    fixture["latest_runs"] = [[_run()], [_run()], [_run(), newer]]
+
+    state = _execute(fixture)
+
+    assert state["created"] == []
+    assert state["updated"] == []
+    assert any("newer source run" in item for item in state["info"])
+
+
+@pytest.mark.parametrize(
+    ("source_event", "newer_event"),
+    [
+        ("pull_request", "workflow_dispatch"),
+        ("workflow_dispatch", "pull_request"),
+    ],
+)
+def test_cross_event_newer_run_never_gets_overwritten(
+    source_event: str,
+    newer_event: str,
+) -> None:
+    fixture = _fixture()
+    source = _run(event=source_event)
+    newer = _run(
+        run_id=RUN_ID + 1,
+        run_number=RUN_NUMBER + 1,
+        event=newer_event,
+    )
+    fixture["env"]["SOURCE_RUN_EVENT"] = source_event
+    fixture["runs"] = [source, source]
+    fixture["latest_runs"] = [[source], [source, newer]]
+
+    state = _execute(fixture)
+
+    assert state["created"] == []
+    assert state["updated"] == []
+    assert any("newer source run" in item for item in state["info"])
+
+
+@pytest.mark.parametrize(
+    "latest_runs",
+    [
+        [],
+        [[]],
+        [[_run(run_id=0)]],
+        [[_run(run_number=0)]],
+        [[_run(attempt=0)]],
+        [[_run(), _run()]],
+    ],
+    ids=[
+        "api-failure",
+        "empty",
+        "invalid-id",
+        "invalid-run-number",
+        "invalid-attempt",
+        "duplicate",
+    ],
+)
+def test_unknown_initial_source_run_order_fails_without_mutating_comment(
+    latest_runs: list[list[dict[str, Any]]],
+) -> None:
+    fixture = _fixture()
+    fixture["latest_runs"] = latest_runs
+
+    state = _execute(fixture)
+
+    assert state["created"] == []
+    assert state["updated"] == []
+    assert state["failed"] == ["Unable to prove the source run is the newest exact PR-head run."]
+
+
+@pytest.mark.parametrize(
+    "latest_runs",
+    [
+        [[_run()]],
+        [[_run()], []],
+        [[_run()], [_run(run_number=0)]],
+        [[_run()], [_run(), _run()]],
+    ],
+    ids=["api-failure", "empty", "malformed", "duplicate"],
+)
+def test_unknown_final_source_run_order_fails_without_mutating_comment(
+    latest_runs: list[list[dict[str, Any]]],
+) -> None:
+    fixture = _fixture()
+    fixture["latest_runs"] = latest_runs
+
+    state = _execute(fixture)
+
+    assert state["created"] == []
+    assert state["updated"] == []
+    assert state["failed"] == ["Unable to prove source-run ordering before comment mutation."]
+
+
+@pytest.mark.parametrize(
+    "latest_runs",
+    [
+        [[_run()], [_run()]],
+        [[_run()], [_run()], []],
+        [[_run()], [_run()], [_run(run_number=0)]],
+        [[_run()], [_run()], [_run(), _run()]],
+    ],
+    ids=["api-failure", "empty", "malformed", "duplicate"],
+)
+def test_unknown_mutation_time_source_order_fails_without_mutating_comment(
+    latest_runs: list[list[dict[str, Any]]],
+) -> None:
+    fixture = _fixture()
+    fixture["latest_runs"] = latest_runs
+
+    state = _execute(fixture)
+
+    assert state["created"] == []
+    assert state["updated"] == []
+    assert state["failed"] == ["Unable to prove source-run ordering after comment discovery."]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("SOURCE_RUN_NUMBER", ""),
+        ("SOURCE_RUN_NUMBER", "0"),
+        ("SOURCE_RUN_NUMBER", "not-a-number"),
+        ("SOURCE_RUN_EVENT", "push"),
+    ],
+)
+def test_invalid_ready_source_ordering_context_never_mutates_comment(
+    field: str,
+    value: str,
+) -> None:
+    fixture = _fixture()
+    fixture["env"][field] = value
+
+    state = _execute(fixture)
+
+    assert state["created"] == []
+    assert state["updated"] == []
+    assert state["failed"] == ["Resolved source-run ordering context is invalid."]
+
+
+def test_overlapping_legacy_report_and_metrics_comment_keeps_report() -> None:
+    fixture = _fixture()
+    fixture["comments"] = [
+        _comment(
+            25,
+            "# 🧪 Comprehensive Test Results\nPASS\n## Test Metrics Report\nraw",
+        ),
+    ]
+
+    state = _execute(fixture)
+
+    updated = {item["comment_id"]: item["body"] for item in state["updated"]}
+    assert set(updated) == {25}
+    assert updated[25].startswith(f"{MARKER}\n")
+    assert "PASS" in updated[25]
+    assert "diagnostic only and are no longer" not in updated[25]
+
+
+def test_collection_failure_replaces_stale_green_with_red_fallback() -> None:
+    fixture = _fixture()
+    fixture["env"]["COLLECT_JOBS_OUTCOME"] = "failure"
+    fixture["env"]["RENDER_COMMENT_OUTCOME"] = "skipped"
+    fixture["trusted_file_available"] = False
+
+    state = _execute(fixture)
+
+    updated = {item["comment_id"]: item["body"] for item in state["updated"]}
+    assert "FAIL" in updated[10]
+    assert "PASS" not in updated[10]
+    assert state["failed"]
+
+
+def test_wrong_identity_marker_is_ignored_and_safe_comment_is_created() -> None:
+    fixture = _fixture()
+    fixture["comments"] = [
+        _comment(20, f"{MARKER}\nattacker green", expected_bot=False),
+    ]
+
+    state = _execute(fixture)
+
+    assert state["updated"] == []
+    assert len(state["created"]) == 1
+    assert state["created"][0]["body"].startswith(f"{MARKER}\n")
+    assert "PASS" in state["created"][0]["body"]
+
+
+def test_all_owned_legacy_duplicates_are_neutralized() -> None:
+    fixture = _fixture()
+    fixture["trusted_file_available"] = False
+    fixture["comments"] = [
+        _comment(30, "attacker prefix\n# 🧪 Comprehensive Test Results\nPASS"),
+        _comment(31, "other prefix\n# 🧪 Comprehensive Test Results\nPASS"),
+        _comment(32, "attacker prefix\n## Test Metrics Report\n[bad](javascript:x)"),
+    ]
+
+    state = _execute(fixture)
+
+    updated = {item["comment_id"]: item["body"] for item in state["updated"]}
+    assert set(updated) == {30, 31, 32}
+    assert "FAIL" in updated[30]
+    assert "FAIL" in updated[31]
+    assert "javascript:" not in updated[32]
+
+
+def test_unresolved_source_without_ordering_identity_never_mutates_comment() -> None:
+    fixture = _fixture()
+    fixture["env"].update(
+        {
+            "COLLECT_JOBS_OUTCOME": "skipped",
+            "RENDER_COMMENT_OUTCOME": "skipped",
+            "SOURCE_READY": "false",
+            "SOURCE_RUN_ATTEMPT": "",
+            "SOURCE_RUN_ID": "",
+            "SOURCE_WORKFLOW_ID": "",
+            "WORKFLOW_CONCLUSION": "unknown",
+            "WORKFLOW_RUN_URL": (f"https://github.com/{REPOSITORY}/actions/workflows/comprehensive-tests.yml"),
+        }
+    )
+    fixture["runs"] = []
+
+    state = _execute(fixture)
+
+    assert state["created"] == []
+    assert state["updated"] == []
+    assert state["failed"] == ["No authoritative source-run ordering identity is available."]

--- a/tests/scripts/test_comprehensive_pr_comment_publisher.py
+++ b/tests/scripts/test_comprehensive_pr_comment_publisher.py
@@ -178,6 +178,10 @@ def _fixture() -> dict[str, Any]:
             _comment(11, f"{MARKER}\nattacker marker", expected_bot=False),
             _comment(12, "prefix\n## Test Metrics Report\nraw artifact"),
         ],
+        "comment_error": False,
+        "comment_page_responses": {},
+        "create_error": False,
+        "update_fail_ids": [],
         "trusted_body": trusted_body,
         "trusted_file_available": True,
     }
@@ -297,7 +301,7 @@ def _resolver_fixture() -> dict[str, Any]:
             "name": "Comprehensive Tests",
             "path": ".github/workflows/comprehensive-tests.yml",
         },
-        "associated": [pull_request],
+        "head_pulls": [pull_request],
         "pulls": [deepcopy(pull_request), deepcopy(pull_request)],
         "runs": [_resolver_run()],
         "fresh_runs": [],
@@ -337,7 +341,14 @@ def _execute(fixture: dict[str, Any]) -> dict[str, Any]:
     preamble = """
 const fixture = FIXTURE;
 Object.assign(process.env, fixture.env);
-const state = { created: [], updated: [], failed: [], info: [] };
+const state = {
+  created: [],
+  updated: [],
+  failed: [],
+  info: [],
+  commentQueries: [],
+  updateAttempts: [],
+};
 const pullResponses = [...fixture.pulls];
 const runResponses = [...fixture.runs];
 const latestRunResponses = [...fixture.latest_runs];
@@ -359,11 +370,29 @@ const core = {
   info: message => state.info.push(message),
   setFailed: message => state.failed.push(message),
 };
-const listComments = async () => ({ data: fixture.comments });
+const listComments = async args => {
+  state.commentQueries.push(args);
+  if (fixture.comment_error) {
+    throw new Error('comment API unavailable');
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(
+      fixture.comment_page_responses,
+      String(args.page),
+    )
+  ) {
+    return {
+      data: fixture.comment_page_responses[String(args.page)],
+    };
+  }
+  const start = (args.page - 1) * args.per_page;
+  return {
+    data: fixture.comments.slice(start, start + args.per_page),
+  };
+};
 const listWorkflowRuns = async () => ({ data: { workflow_runs: [] } });
 const github = {
   paginate: async method => {
-    if (method === listComments) return fixture.comments;
     if (method === listWorkflowRuns) {
       if (latestRunResponses.length === 0) {
         throw new Error('no latest-run response');
@@ -390,8 +419,19 @@ const github = {
     },
     issues: {
       listComments,
-      createComment: async args => state.created.push(args),
-      updateComment: async args => state.updated.push(args),
+      createComment: async args => {
+        if (fixture.create_error) {
+          throw new Error('comment creation unavailable');
+        }
+        state.created.push(args);
+      },
+      updateComment: async args => {
+        state.updateAttempts.push(args);
+        if (fixture.update_fail_ids.includes(args.comment_id)) {
+          throw new Error('comment update unavailable');
+        }
+        state.updated.push(args);
+      },
     },
   },
 };
@@ -491,10 +531,17 @@ def _execute_resolver(fixture: dict[str, Any]) -> dict[str, Any]:
     preamble = """
 const fixture = FIXTURE;
 Object.assign(process.env, fixture.env);
-const state = { failed: [], info: [], outputs: {} };
+const state = { failed: [], info: [], outputs: {}, pullQueries: [] };
 const pullResponses = [...fixture.pulls];
 const freshRunResponses = [...fixture.fresh_runs];
-const listAssociated = async () => ({ data: fixture.associated });
+const listPulls = async args => {
+  state.pullQueries.push(args);
+  return { data: fixture.head_pulls };
+};
+const setTimeout = callback => {
+  callback();
+  return 0;
+};
 const listRuns = async () => ({ data: { workflow_runs: fixture.runs } });
 const context = fixture.context;
 const core = {
@@ -504,7 +551,7 @@ const core = {
 };
 const github = {
   paginate: async method => {
-    if (method === listAssociated) return fixture.associated;
+    if (method === listPulls) return fixture.head_pulls;
     if (method === listRuns) return fixture.runs;
     throw new Error('unexpected pagination method');
   },
@@ -519,10 +566,8 @@ const github = {
         return { data: freshRunResponses.shift() };
       },
     },
-    repos: {
-      listPullRequestsAssociatedWithCommit: listAssociated,
-    },
     pulls: {
+      list: listPulls,
       get: async () => {
         if (pullResponses.length === 0) throw new Error('no pull response');
         return { data: pullResponses.shift() };
@@ -601,6 +646,122 @@ def test_resolver_authorizes_each_supported_workflow_run_event(
     assert state["outputs"]["source_ready"] == "true"
     assert state["outputs"]["source_run_event"] == event
     assert state["outputs"]["source_run_id"] == str(RUN_ID)
+    assert state["outputs"]["writer_ready"] == "true"
+
+
+def test_resolver_discovers_a_fork_pr_by_its_exact_head_owner_and_branch() -> None:
+    fixture = _workflow_run_resolver_fixture("pull_request")
+    fork_repository = "contributor/Odyssey"
+    fork_branch = "feature/fork-head"
+    source_run = fixture["context"]["payload"]["workflow_run"]
+    source_run["head_repository"] = {"full_name": fork_repository}
+    source_run["head_branch"] = fork_branch
+    pull_request = _resolver_pull(branch=fork_branch)
+    pull_request["user"] = {"login": "contributor"}
+    pull_request["head"]["repo"] = {"full_name": fork_repository}
+    fixture["head_pulls"] = [pull_request]
+    fixture["pulls"] = [
+        deepcopy(pull_request),
+        deepcopy(pull_request),
+    ]
+
+    state = _execute_resolver(fixture)
+
+    assert state["failed"] == []
+    assert state["outputs"]["pr_number"] == "42"
+    assert state["outputs"]["source_head_branch"] == fork_branch
+    assert state["outputs"]["source_head_repository"] == fork_repository
+    assert state["outputs"]["source_ready"] == "true"
+    assert state["outputs"]["writer_ready"] == "true"
+    assert state["pullQueries"] == [
+        {
+            "owner": "HomericIntelligence",
+            "repo": "Odyssey",
+            "state": "open",
+            "head": "contributor:feature/fork-head",
+            "per_page": 100,
+            "page": 1,
+        }
+    ]
+
+
+def test_resolver_monitors_an_in_progress_dispatch_to_completion() -> None:
+    fixture = _resolver_fixture()
+    in_progress = _resolver_run()
+    in_progress["status"] = "in_progress"
+    in_progress["conclusion"] = None
+    fixture["runs"] = [in_progress]
+    fixture["fresh_runs"] = [_resolver_run()]
+
+    state = _execute_resolver(fixture)
+
+    assert state["failed"] == []
+    assert state["outputs"]["source_ready"] == "true"
+    assert state["outputs"]["source_run_conclusion"] == "success"
+    assert state["outputs"]["writer_ready"] == "true"
+
+
+def test_resolver_schedules_a_red_writer_when_dispatch_monitoring_fails() -> None:
+    fixture = _resolver_fixture()
+    in_progress = _resolver_run()
+    in_progress["status"] = "in_progress"
+    in_progress["conclusion"] = None
+    fixture["runs"] = [in_progress]
+
+    state = _execute_resolver(fixture)
+
+    assert state["failed"] == []
+    assert state["outputs"]["source_ready"] == "false"
+    assert "Unable to monitor" in state["outputs"]["source_error"]
+    assert state["outputs"]["writer_ready"] == "true"
+
+
+def test_resolver_schedules_a_red_writer_when_monitored_identity_drifts() -> None:
+    fixture = _resolver_fixture()
+    in_progress = _resolver_run()
+    in_progress["status"] = "in_progress"
+    in_progress["conclusion"] = None
+    fixture["runs"] = [in_progress]
+    drifted = _resolver_run()
+    drifted["head_branch"] = "dependabot/pip/different"
+    fixture["fresh_runs"] = [drifted]
+
+    state = _execute_resolver(fixture)
+
+    assert state["failed"] == []
+    assert state["outputs"]["source_ready"] == "false"
+    assert "identity changed" in state["outputs"]["source_error"]
+    assert state["outputs"]["writer_ready"] == "true"
+
+
+def test_resolver_schedules_a_red_writer_when_dispatch_monitoring_times_out() -> None:
+    fixture = _resolver_fixture()
+    in_progress = _resolver_run()
+    in_progress["status"] = "in_progress"
+    in_progress["conclusion"] = None
+    fixture["runs"] = [in_progress]
+    fixture["fresh_runs"] = [deepcopy(in_progress) for _ in range(120)]
+
+    state = _execute_resolver(fixture)
+
+    assert state["failed"] == []
+    assert state["outputs"]["source_ready"] == "false"
+    assert "did not complete within 120 minutes" in state["outputs"]["source_error"]
+    assert state["outputs"]["writer_ready"] == "true"
+
+
+def test_resolver_rejects_duplicate_dispatch_run_ordering() -> None:
+    fixture = _resolver_fixture()
+    fixture["runs"] = [
+        _resolver_run(),
+        _resolver_run(run_id=RUN_ID + 1),
+    ]
+
+    state = _execute_resolver(fixture)
+
+    assert state["failed"] == []
+    assert state["outputs"]["source_ready"] == "false"
+    assert "invalid ordering metadata" in state["outputs"]["source_error"]
     assert state["outputs"]["writer_ready"] == "true"
 
 
@@ -734,6 +895,225 @@ def test_missing_renderer_output_replaces_stale_green_with_red_fallback() -> Non
     assert "PASS" not in updated[10]
     assert RUN_URL in updated[10]
     assert state["failed"] == ["Trusted comment rendering failed; posted a red fallback."]
+
+
+def test_comment_discovery_failure_posts_a_new_red_fallback() -> None:
+    fixture = _fixture()
+    fixture["comment_error"] = True
+
+    state = _execute(fixture)
+
+    assert state["updated"] == []
+    assert len(state["created"]) == 1
+    assert state["created"][0]["body"].startswith(f"{MARKER}\n")
+    assert "FAIL" in state["created"][0]["body"]
+    assert "PASS" not in state["created"][0]["body"]
+    assert state["failed"] == ["Comment discovery failed; posted a red fallback."]
+    assert len(state["commentQueries"]) == 1
+
+
+def test_comment_discovery_overflow_replaces_discovered_green_with_red() -> None:
+    fixture = _fixture()
+    fixture["comments"] = [
+        _comment(10, f"{MARKER}\nold green"),
+        *[
+            _comment(
+                comment_id,
+                "untrusted noise",
+                expected_bot=False,
+            )
+            for comment_id in range(11, 1_011)
+        ],
+    ]
+
+    state = _execute(fixture)
+
+    assert len(state["created"]) == 1
+    assert "FAIL" in state["created"][0]["body"]
+    assert len(state["updated"]) == 1
+    assert state["updated"][0]["comment_id"] == 10
+    assert state["updated"][0]["body"].startswith(f"{MARKER}\n")
+    assert "FAIL" in state["updated"][0]["body"]
+    assert "PASS" not in state["updated"][0]["body"]
+    assert state["failed"] == ["Comment discovery failed; posted a red fallback."]
+    assert [query["page"] for query in state["commentQueries"]] == list(range(1, 12))
+
+
+def test_comment_discovery_overflow_replaces_owned_report_on_sentinel_page() -> None:
+    fixture = _fixture()
+    fixture["comments"] = [
+        *[
+            _comment(
+                comment_id,
+                "untrusted noise",
+                expected_bot=False,
+            )
+            for comment_id in range(10, 1_010)
+        ],
+        _comment(1_010, f"{MARKER}\nold green"),
+    ]
+
+    state = _execute(fixture)
+
+    assert len(state["created"]) == 1
+    assert "FAIL" in state["created"][0]["body"]
+    assert len(state["updated"]) == 1
+    assert state["updated"][0]["comment_id"] == 1_010
+    assert "FAIL" in state["updated"][0]["body"]
+    assert "PASS" not in state["updated"][0]["body"]
+    assert state["failed"] == ["Comment discovery failed; posted a red fallback."]
+
+
+def test_comment_discovery_overflow_posts_red_with_an_unseen_owned_report() -> None:
+    fixture = _fixture()
+    fixture["comments"] = [
+        _comment(10, f"{MARKER}\nknown old green"),
+        *[
+            _comment(
+                comment_id,
+                "untrusted noise",
+                expected_bot=False,
+            )
+            for comment_id in range(11, 1_110)
+        ],
+        _comment(1_110, f"{MARKER}\nunseen old green"),
+    ]
+
+    state = _execute(fixture)
+
+    assert len(state["created"]) == 1
+    assert "FAIL" in state["created"][0]["body"]
+    assert [item["comment_id"] for item in state["updated"]] == [10]
+    assert "FAIL" in state["updated"][0]["body"]
+    assert state["failed"] == ["Comment discovery failed; posted a red fallback."]
+
+
+def test_comment_discovery_failure_best_effort_retires_all_known_reports() -> None:
+    fixture = _fixture()
+    fixture["comments"] = [
+        _comment(10, f"{MARKER}\nfirst old green"),
+        _comment(11, f"{MARKER}\nsecond old green"),
+        *[
+            _comment(
+                comment_id,
+                "untrusted noise",
+                expected_bot=False,
+            )
+            for comment_id in range(12, 1_011)
+        ],
+    ]
+    fixture["update_fail_ids"] = [10]
+
+    state = _execute(fixture)
+
+    assert len(state["created"]) == 1
+    assert "FAIL" in state["created"][0]["body"]
+    assert [item["comment_id"] for item in state["updateAttempts"]] == [10, 11]
+    assert [item["comment_id"] for item in state["updated"]] == [11]
+    assert "FAIL" in state["updated"][0]["body"]
+    assert state["failed"] == ["Comment discovery failed; red fallback mutation was incomplete."]
+
+
+def test_comment_discovery_failure_retires_known_report_when_create_fails() -> None:
+    fixture = _fixture()
+    fixture["comments"] = [
+        _comment(10, f"{MARKER}\nold green"),
+        *[
+            _comment(
+                comment_id,
+                "untrusted noise",
+                expected_bot=False,
+            )
+            for comment_id in range(11, 1_011)
+        ],
+    ]
+    fixture["create_error"] = True
+
+    state = _execute(fixture)
+
+    assert state["created"] == []
+    assert [item["comment_id"] for item in state["updated"]] == [10]
+    assert "FAIL" in state["updated"][0]["body"]
+    assert state["failed"] == ["Comment discovery failed; red fallback mutation was incomplete."]
+
+
+@pytest.mark.parametrize(
+    "page_response",
+    [
+        {"not": "an array"},
+        [
+            _comment(
+                comment_id,
+                "untrusted noise",
+                expected_bot=False,
+            )
+            for comment_id in range(10, 111)
+        ],
+    ],
+    ids=["non-array", "overfull-page"],
+)
+def test_invalid_comment_page_posts_a_new_red_fallback(
+    page_response: object,
+) -> None:
+    fixture = _fixture()
+    fixture["comment_page_responses"] = {"1": page_response}
+
+    state = _execute(fixture)
+
+    assert state["updated"] == []
+    assert len(state["created"]) == 1
+    assert "FAIL" in state["created"][0]["body"]
+    assert "PASS" not in state["created"][0]["body"]
+    assert state["failed"] == ["Comment discovery failed; posted a red fallback."]
+
+
+@pytest.mark.parametrize(
+    "comments",
+    [
+        [
+            _comment(10, "untrusted noise", expected_bot=False),
+            _comment(10, "duplicate identifier", expected_bot=False),
+        ],
+        [
+            {
+                **_comment(10, f"{MARKER}\nold green"),
+                "id": 0,
+            },
+        ],
+        [
+            {
+                **_comment(10, f"{MARKER}\nold green"),
+                "body": None,
+            },
+        ],
+        [
+            _comment(
+                10,
+                "x" * 65_537,
+                expected_bot=False,
+            ),
+        ],
+    ],
+    ids=[
+        "duplicate-id",
+        "invalid-id",
+        "non-string-body",
+        "oversized-body",
+    ],
+)
+def test_invalid_comment_metadata_posts_a_new_red_fallback(
+    comments: list[dict[str, Any]],
+) -> None:
+    fixture = _fixture()
+    fixture["comments"] = comments
+
+    state = _execute(fixture)
+
+    assert state["updated"] == []
+    assert len(state["created"]) == 1
+    assert "FAIL" in state["created"][0]["body"]
+    assert "PASS" not in state["created"][0]["body"]
+    assert state["failed"] == ["Comment discovery failed; posted a red fallback."]
 
 
 @pytest.mark.parametrize(
@@ -947,6 +1327,7 @@ def test_cross_event_newer_run_never_gets_overwritten(
         [[_run(run_number=0)]],
         [[_run(attempt=0)]],
         [[_run(), _run()]],
+        [[_run(), _run(run_id=RUN_ID + 1)]],
     ],
     ids=[
         "api-failure",
@@ -954,7 +1335,8 @@ def test_cross_event_newer_run_never_gets_overwritten(
         "invalid-id",
         "invalid-run-number",
         "invalid-attempt",
-        "duplicate",
+        "duplicate-id",
+        "duplicate-order",
     ],
 )
 def test_unknown_initial_source_run_order_fails_without_mutating_comment(
@@ -977,8 +1359,15 @@ def test_unknown_initial_source_run_order_fails_without_mutating_comment(
         [[_run()], []],
         [[_run()], [_run(run_number=0)]],
         [[_run()], [_run(), _run()]],
+        [[_run()], [_run(), _run(run_id=RUN_ID + 1)]],
     ],
-    ids=["api-failure", "empty", "malformed", "duplicate"],
+    ids=[
+        "api-failure",
+        "empty",
+        "malformed",
+        "duplicate-id",
+        "duplicate-order",
+    ],
 )
 def test_unknown_final_source_run_order_fails_without_mutating_comment(
     latest_runs: list[list[dict[str, Any]]],
@@ -1000,8 +1389,19 @@ def test_unknown_final_source_run_order_fails_without_mutating_comment(
         [[_run()], [_run()], []],
         [[_run()], [_run()], [_run(run_number=0)]],
         [[_run()], [_run()], [_run(), _run()]],
+        [
+            [_run()],
+            [_run()],
+            [_run(), _run(run_id=RUN_ID + 1)],
+        ],
     ],
-    ids=["api-failure", "empty", "malformed", "duplicate"],
+    ids=[
+        "api-failure",
+        "empty",
+        "malformed",
+        "duplicate-id",
+        "duplicate-order",
+    ],
 )
 def test_unknown_mutation_time_source_order_fails_without_mutating_comment(
     latest_runs: list[list[dict[str, Any]]],

--- a/tests/scripts/test_comprehensive_report.py
+++ b/tests/scripts/test_comprehensive_report.py
@@ -8,6 +8,7 @@ define the stdlib-only report evaluator contract before its implementation.
 
 import importlib.util
 import json
+import subprocess
 import sys
 from functools import lru_cache
 from pathlib import Path
@@ -408,3 +409,30 @@ def test_cli_aggregation_crash_writes_red_report_before_failing(
     contents = output.read_text(encoding="utf-8")
     assert "❌ FAIL —" in contents
     assert "simulated aggregation crash" in contents
+
+
+def test_isolated_report_cli_ignores_adjacent_stdlib_shadow(
+    tmp_path: Path,
+) -> None:
+    script_dir = tmp_path / "scripts" / "ci"
+    script_dir.mkdir(parents=True)
+    copied_report = script_dir / REPORT_SCRIPT.name
+    copied_report.write_bytes(REPORT_SCRIPT.read_bytes())
+    shadow_marker = tmp_path / "shadow-json-imported"
+    (script_dir / "json.py").write_text(
+        "from pathlib import Path\n"
+        f"Path({str(shadow_marker)!r}).write_text('executed', encoding='utf-8')\n"
+        "raise RuntimeError('shadow json imported')\n",
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-I", str(copied_report), "--help"],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert not shadow_marker.exists()

--- a/tests/smoke/test_comprehensive_pr_comments_workflow_properties.py
+++ b/tests/smoke/test_comprehensive_pr_comments_workflow_properties.py
@@ -148,8 +148,10 @@ def test_write_scoped_commenter_never_consumes_pr_artifacts() -> None:
     assert ".includes(MARKER)" not in script
     assert ".startsWith(`${MARKER}\\n`)" in script
     assert "readFileSync" in script
-    assert "65_536" not in script
     assert "MAX_COMMENT_BYTES" in script
+    assert "const MAX_DISCOVERED_COMMENT_BYTES = 65_536;" in script
+    assert "MAX_COMMENT_PAGES" in script
+    assert "COMMENT_PAGE_SIZE" in script
     assert "Trusted Comprehensive report unavailable" in script
     assert "core.setFailed" in script
     assert "Source run identity no longer matches" in script
@@ -173,6 +175,10 @@ def test_write_scoped_commenter_never_consumes_pr_artifacts() -> None:
     assert script.index("mutationTimeRun") > script.index("github.rest.issues.listComments")
     assert script.index("github.rest.issues.createComment") > script.index("mutationTimeRun")
     assert script.index("github.rest.issues.updateComment") > script.index("mutationTimeRun")
+    assert "await github.paginate(\n              github.rest.issues.listComments" not in script
+    assert "commentPage <= MAX_COMMENT_PAGES + 1" in script
+    assert "seenCommentIds.has(comment.id)" in script
+    assert "Comment discovery failed; posted a red fallback." in script
     assert "comment.body?.includes('🧪 Comprehensive Test Results')" in script
     assert "comment.body?.includes('Test Metrics Report')" in script
     assert "hasRetiredMetricsMarker" in script
@@ -253,8 +259,10 @@ def test_writer_dispatches_commenter_as_a_sibling_bound_to_the_exact_comprehensi
     assert script.count("github.rest.pulls.get") >= 2
     assert "core.setOutput('writer_ready', 'true')" in script
 
-    assert "listPullRequestsAssociatedWithCommit" in script
-    assert "commit_sha: sourceHeadSha" in script
+    assert "github.rest.pulls.list" in script
+    assert "state: 'open'" in script
+    assert "head: `${sourceHeadOwner}:${sourceHeadBranch}`" in script
+    assert "listPullRequestsAssociatedWithCommit" not in script
     assert "pullRequest.state === 'open'" in script
     assert "pullRequest.head.sha === sourceHeadSha" in script
     assert "pullRequest.head.ref === sourceHeadBranch" in script

--- a/tests/smoke/test_comprehensive_pr_comments_workflow_properties.py
+++ b/tests/smoke/test_comprehensive_pr_comments_workflow_properties.py
@@ -32,57 +32,165 @@ def _load_job() -> dict[str, Any]:
     return job
 
 
-def test_missing_report_replaces_stale_green_comment_with_failure_fallback() -> None:
+def _load_resolver_job() -> dict[str, Any]:
+    workflow = _load_workflow()
+    job = workflow["jobs"]["resolve-pr-context"]
+    assert isinstance(job, dict)
+    return job
+
+
+def test_write_scoped_commenter_never_consumes_pr_artifacts() -> None:
     job = _load_job()
     steps = job["steps"]
 
-    downloads = {
-        str(step.get("id", "")): step
-        for step in steps
-        if str(step.get("uses", "")).startswith("actions/download-artifact@")
+    serialized = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "actions/download-artifact@" not in serialized
+    assert "listWorkflowRunArtifacts" not in serialized
+    assert "downloadArtifact" not in serialized
+    assert "/actions/artifacts" not in serialized
+    assert "metrics-pr-comment.md" not in serialized
+    assert "test-report.md" not in serialized
+    assert "reports/metrics" not in serialized
+    assert "reports/comprehensive" not in serialized
+
+    collect_step = next(step for step in steps if step.get("id") == "collect-jobs")
+    assert "actions/github-script@" in collect_step["uses"]
+    assert collect_step["env"]["SOURCE_RUN_ID"] == ("${{ needs.resolve-pr-context.outputs.source_run_id }}")
+    assert collect_step["env"]["SOURCE_HEAD_SHA"] == ("${{ needs.resolve-pr-context.outputs.source_head_sha }}")
+    assert collect_step["env"]["SOURCE_RUN_CONCLUSION"] == (
+        "${{ needs.resolve-pr-context.outputs.source_run_conclusion }}"
+    )
+    assert collect_step["env"]["SOURCE_RUN_ATTEMPT"] == ("${{ needs.resolve-pr-context.outputs.source_run_attempt }}")
+    assert collect_step["env"]["SOURCE_RUN_EVENT"] == ("${{ needs.resolve-pr-context.outputs.source_run_event }}")
+    assert collect_step["env"]["SOURCE_RUN_NUMBER"] == ("${{ needs.resolve-pr-context.outputs.source_run_number }}")
+    assert collect_step["env"]["SOURCE_WORKFLOW_ID"] == ("${{ needs.resolve-pr-context.outputs.source_workflow_id }}")
+    assert collect_step["env"]["COMMENT_CONTEXT_PATH"] == ("${{ runner.temp }}/comprehensive-pr-comment-context.json")
+    collect_script = collect_step["with"]["script"]
+    assert "listJobsForWorkflowRun" in collect_script
+    assert "filter: 'latest'" in collect_script
+    assert "run_id: sourceRunId" in collect_script
+    assert "github.rest.actions.getWorkflowRun" in collect_script
+    assert collect_script.count("await getFreshRun()") == 2
+    assert "run_attempt" in collect_script
+    assert "workflow_id" in collect_script
+    assert "job.run_id" in collect_script
+    assert "job.head_sha" in collect_script
+    assert "job.name === 'Test Report'" in collect_script
+    assert "reportJobs.length !== 1" in collect_script
+    assert "reportJobs[0].run_attempt !== sourceRunAttempt" in collect_script
+    assert "TRUSTED_POLICY_PATHS" in collect_script
+    assert ".github/workflows/comprehensive-tests.yml" in collect_script
+    assert "scripts/ci/comprehensive_report.py" in collect_script
+    assert "github.rest.repos.getContent" in collect_script
+    assert "ref: sourceHeadSha" in collect_script
+    assert "trustedContent.equals(sourceContent)" in collect_script
+    assert "jobs.length" in collect_script
+    assert "MAX_JOBS" in collect_script
+    assert "SOURCE_HEAD_SHA" in collect_script
+    assert "SOURCE_RUN_CONCLUSION" in collect_script
+    assert "schema_version: 1" in collect_script
+    assert "writeFileSync" in collect_script
+
+    action_methods = set(re.findall(r"github\.rest\.actions\.([A-Za-z0-9_]+)", serialized))
+    assert action_methods == {
+        "getWorkflow",
+        "getWorkflowRun",
+        "listJobsForWorkflowRun",
+        "listWorkflowRuns",
     }
-    assert set(downloads) == {"download-metrics", "download-report"}
-    assert downloads["download-metrics"].get("continue-on-error") is not True
-    assert downloads["download-report"].get("continue-on-error") is not True
-    assert "discover_artifacts.outputs.has_metrics" in downloads["download-metrics"]["if"]
-    assert "always()" in downloads["download-report"]["if"]
-    assert "discover_artifacts.outputs.has_report" in downloads["download-report"]["if"]
 
-    discovery_step = next(step for step in steps if step.get("id") == "discover_artifacts")
-    assert "actions/github-script@" in discovery_step["uses"]
-    discovery_script = discovery_step["with"]["script"]
-    assert "listWorkflowRunArtifacts" in discovery_script
-    assert "has_metrics" in discovery_script
-    assert "has_report" in discovery_script
+    render_step = next(step for step in steps if step.get("id") == "render-comment")
+    assert "steps.collect-jobs.outcome == 'success'" in render_step["if"]
+    assert render_step["env"] == {
+        "COMMENT_CONTEXT_PATH": "${{ runner.temp }}/comprehensive-pr-comment-context.json",
+        "COMMENT_OUTPUT_PATH": "${{ runner.temp }}/comprehensive-pr-comment.md",
+        "EXPECTED_REPOSITORY": "${{ github.repository }}",
+    }
+    assert "scripts/ci/comprehensive_pr_comment.py" in render_step["run"]
+    assert '"$COMMENT_CONTEXT_PATH"' in render_step["run"]
+    assert '"$COMMENT_OUTPUT_PATH"' in render_step["run"]
+    assert '"$EXPECTED_REPOSITORY"' in render_step["run"]
+    assert "${{" not in render_step["run"]
 
-    post_step = next(step for step in steps if step.get("name") == "Post or update PR comments")
-    assert post_step.get("if") == "always() && steps.resolve-context.outcome == 'success'"
+    post_step = next(step for step in steps if step.get("name") == "Post or update trusted PR comment")
+    assert post_step.get("if") == "always() && !cancelled()"
 
     environment = post_step.get("env", {})
-    assert environment["REPORT_AVAILABLE"] == ("${{ steps.discover_artifacts.outputs.has_report }}")
-    assert environment["METRICS_AVAILABLE"] == ("${{ steps.discover_artifacts.outputs.has_metrics }}")
-    assert environment["REPORT_DOWNLOAD_OUTCOME"] == ("${{ steps.download-report.outcome }}")
-    assert environment["METRICS_DOWNLOAD_OUTCOME"] == ("${{ steps.download-metrics.outcome }}")
-    assert environment["WORKFLOW_RUN_URL"] == ("${{ steps.resolve-context.outputs.source_run_url }}")
-    assert environment["WORKFLOW_CONCLUSION"] == ("${{ steps.resolve-context.outputs.source_run_conclusion }}")
-    assert environment["SOURCE_HEAD_SHA"] == ("${{ steps.resolve-context.outputs.source_head_sha }}")
+    assert environment["COLLECT_JOBS_OUTCOME"] == "${{ steps.collect-jobs.outcome }}"
+    assert environment["RENDER_COMMENT_OUTCOME"] == "${{ steps.render-comment.outcome }}"
+    assert environment["COMMENT_OUTPUT_PATH"] == ("${{ runner.temp }}/comprehensive-pr-comment.md")
+    assert environment["WORKFLOW_RUN_URL"] == ("${{ needs.resolve-pr-context.outputs.source_run_url }}")
+    assert environment["WORKFLOW_CONCLUSION"] == ("${{ needs.resolve-pr-context.outputs.source_run_conclusion }}")
+    assert environment["SOURCE_HEAD_SHA"] == ("${{ needs.resolve-pr-context.outputs.source_head_sha }}")
+    assert environment["SOURCE_RUN_ATTEMPT"] == ("${{ needs.resolve-pr-context.outputs.source_run_attempt }}")
+    assert environment["SOURCE_RUN_EVENT"] == ("${{ needs.resolve-pr-context.outputs.source_run_event }}")
+    assert environment["SOURCE_RUN_ID"] == ("${{ needs.resolve-pr-context.outputs.source_run_id }}")
+    assert environment["SOURCE_RUN_NUMBER"] == ("${{ needs.resolve-pr-context.outputs.source_run_number }}")
+    assert environment["SOURCE_WORKFLOW_ID"] == ("${{ needs.resolve-pr-context.outputs.source_workflow_id }}")
 
     script = post_step["with"]["script"]
-    assert "REPORT_DOWNLOAD_OUTCOME" in script
+    assert "RENDER_COMMENT_OUTCOME" in script
+    assert "COLLECT_JOBS_OUTCOME" in script
+    assert "COMMENT_OUTPUT_PATH" in script
     assert "WORKFLOW_RUN_URL" in script
     assert "WORKFLOW_CONCLUSION" in script
-    assert "🧪 Comprehensive Test Results" in script
-    assert "report unavailable" in script.lower()
+    assert "SOURCE_READY" in script
+    assert "sourceReady" in script
+    assert "comprehensiveWorkflowUrl" in script
+    assert "hasResolvedRunId ? runUrl : comprehensiveWorkflowUrl" in script
+    assert "<!-- odyssey:comprehensive-test-report:v1 -->" in script
+    assert "github-actions[bot]" in script
+    assert "41898282" in script
+    assert "15368" in script
+    assert "performed_via_github_app" in script
+    assert "comment.user.type === 'Bot'" not in script
+    assert ".includes(marker)" not in script
+    assert ".includes(MARKER)" not in script
+    assert ".startsWith(`${MARKER}\\n`)" in script
+    assert "readFileSync" in script
+    assert "65_536" not in script
+    assert "MAX_COMMENT_BYTES" in script
+    assert "Trusted Comprehensive report unavailable" in script
+    assert "core.setFailed" in script
+    assert "Source run identity no longer matches" in script
+    assert "sourceIdentityValid = false" in script
+    assert script.count("github.rest.pulls.get") >= 2
+    assert script.count("github.rest.actions.getWorkflowRun") >= 2
+    assert "postTimePullRequest" in script
+    assert "postTimeRun" in script
+    assert "mutationTimePullRequest" in script
+    assert "mutationTimeRun" in script
+    assert "getSourceRunOrder" in script
+    assert script.count("await getSourceRunOrder()") >= 3
+    assert "SOURCE_RUN_EVENTS.has(candidate.event)" in script
+    assert "event: sourceRunEvent" not in script
+    assert "newer source run" in script
+    assert "head changed before comment mutation" in script
+    assert "run changed before comment mutation" in script
+    assert script.index("github.rest.issues.listComments") > script.index("postTimePullRequest")
+    assert script.index("github.rest.issues.listComments") > script.index("postTimeRun")
+    assert script.index("mutationTimePullRequest") > script.index("github.rest.issues.listComments")
+    assert script.index("mutationTimeRun") > script.index("github.rest.issues.listComments")
+    assert script.index("github.rest.issues.createComment") > script.index("mutationTimeRun")
+    assert script.index("github.rest.issues.updateComment") > script.index("mutationTimeRun")
+    assert "comment.body?.includes('🧪 Comprehensive Test Results')" in script
+    assert "comment.body?.includes('Test Metrics Report')" in script
+    assert "hasRetiredMetricsMarker" in script
 
 
 def test_commenter_rejects_stale_runs_and_verdict_mismatches() -> None:
     job = _load_job()
     concurrency = job.get("concurrency", {})
-    assert "workflow_run.head_sha" in str(concurrency.get("group", ""))
-    assert "pull_requests[0].number" not in str(concurrency.get("group", ""))
-    assert concurrency.get("cancel-in-progress") is True
+    assert concurrency.get("group") == (
+        "comprehensive-test-pr-comment-pr-${{ needs.resolve-pr-context.outputs.pr_number }}"
+    )
+    assert concurrency.get("queue") == "max"
+    assert concurrency.get("cancel-in-progress") is False
+    assert job.get("needs") == "resolve-pr-context"
+    assert "needs.resolve-pr-context.outputs.pr_number != ''" in str(job.get("if"))
+    assert "needs.resolve-pr-context.outputs.writer_ready == 'true'" in str(job.get("if"))
 
-    post_step = next(step for step in job["steps"] if step.get("name") == "Post or update PR comments")
+    post_step = next(step for step in job["steps"] if step.get("name") == "Post or update trusted PR comment")
     script = post_step["with"]["script"]
 
     assert "github.rest.pulls.get" in script
@@ -92,9 +200,9 @@ def test_commenter_rejects_stale_runs_and_verdict_mismatches() -> None:
     assert "Stale workflow run" in script
 
     assert "WORKFLOW_CONCLUSION" in script
-    assert "✅ PASS —" in script
-    assert "❌ FAIL —" in script
-    assert "does not match the workflow conclusion" in script
+    assert "RENDER_COMMENT_OUTCOME" in script
+    assert "COLLECT_JOBS_OUTCOME" in script
+    assert "Trusted Comprehensive report unavailable" in script
     assert "try {" in script
     assert "catch" in script
 
@@ -102,44 +210,37 @@ def test_commenter_rejects_stale_runs_and_verdict_mismatches() -> None:
 def test_writer_dispatches_commenter_as_a_sibling_bound_to_the_exact_comprehensive_run() -> None:
     workflow = _load_workflow()
     triggers = _on_block(workflow)
-    dispatch = triggers.get("workflow_dispatch")
-    assert dispatch == {
-        "inputs": {
-            "source_head_sha": {
-                "description": "Exact Dependabot head whose Comprehensive run must be reported",
-                "required": True,
-                "type": "string",
-            },
-            "source_head_branch": {
-                "description": "Exact same-repository Dependabot branch",
-                "required": True,
-                "type": "string",
-            },
-        }
-    }
+    assert "workflow_dispatch" not in triggers
+    assert triggers.get("repository_dispatch") == {"types": ["dependabot-comprehensive-test-comment"]}
 
-    job = _load_job()
-    condition = str(job["if"])
-    assert "github.event_name == 'workflow_dispatch'" in condition
+    resolver_job = _load_resolver_job()
+    condition = str(resolver_job["if"])
+    assert "github.event_name == 'repository_dispatch'" in condition
     assert "github.event.workflow_run.event == 'pull_request'" in condition
-    assert "github.event.workflow_run.event == 'workflow_dispatch'" not in condition
+    assert "github.event.workflow_run.event == 'workflow_dispatch'" in condition
 
-    concurrency = str(job["concurrency"]["group"])
-    assert "inputs.source_head_sha" in concurrency
-    assert "github.event.workflow_run.head_sha" in concurrency
-
-    resolve = next(step for step in job["steps"] if step.get("id") == "resolve-context")
+    resolve = next(step for step in resolver_job["steps"] if step.get("id") == "resolve-context")
     assert resolve["env"] == {
-        "SOURCE_HEAD_SHA": "${{ inputs.source_head_sha }}",
-        "SOURCE_HEAD_BRANCH": "${{ inputs.source_head_branch }}",
+        "SOURCE_HEAD_SHA": "${{ github.event.client_payload.source_head_sha }}",
+        "SOURCE_HEAD_BRANCH": "${{ github.event.client_payload.source_head_branch }}",
     }
     script = resolve["with"]["script"]
-    assert "context.eventName === 'workflow_dispatch'" in script
+    assert "context.eventName === 'repository_dispatch'" in script
+    assert "context.payload.action" in script
+    assert "dependabot-comprehensive-test-comment" in script
+    assert "github.rest.actions.getWorkflow" in script
+    assert "expectedWorkflow.id" in script
+    assert "run.workflow_id" in script
+    assert "run.repository?.full_name" in script
+    assert "sourceHeadBranch = run.head_branch" in script
+    assert "sourceHeadRepository = run.head_repository.full_name" in script
+    assert "sourceWorkflowRunEvents.has(run.event)" in script
     assert "listWorkflowRuns" in script
     assert "workflow_id: 'comprehensive-tests.yml'" in script
     assert "candidateRun.head_sha === sourceHeadSha" in script
     assert "candidateRun.head_branch === sourceHeadBranch" in script
-    assert "matches.length !== 1" in script
+    assert "matches.length < 1" in script
+    assert "matches.reduce" in script
     assert "github.rest.actions.getWorkflowRun" in script
     assert "run.status !== 'completed'" in script
     assert "Comprehensive run did not complete" in script
@@ -148,50 +249,87 @@ def test_writer_dispatches_commenter_as_a_sibling_bound_to_the_exact_comprehensi
     assert "setSourceFailure" in script
     assert "core.setOutput('source_ready', 'false')" in script
     assert "core.setOutput('source_error', message)" in script
+    assert "authorizeWriterForCurrentPullRequest" in script
+    assert script.count("github.rest.pulls.get") >= 2
+    assert "core.setOutput('writer_ready', 'true')" in script
 
     assert "listPullRequestsAssociatedWithCommit" in script
     assert "commit_sha: sourceHeadSha" in script
     assert "pullRequest.state === 'open'" in script
     assert "pullRequest.head.sha === sourceHeadSha" in script
-    assert "candidates.length !== 1" in script
+    assert "pullRequest.head.ref === sourceHeadBranch" in script
+    assert "pullRequest.head.repo?.full_name === sourceHeadRepository" in script
+    assert "candidates.length === 0" in script
+    assert "No current open PR remains" in script
+    assert "candidates.length > 1" in script
     assert "github.rest.pulls.get" in script
     assert "pullRequest.head.sha !== sourceHeadSha" in script
-    assert "context.eventName === 'workflow_dispatch'" in script
+    assert "pullRequest.head.ref !== sourceHeadBranch" in script
+    assert "pullRequest.head.repo?.full_name !== sourceHeadRepository" in script
+    assert "context.eventName === 'repository_dispatch'" in script
     assert "pullRequest.user.login !== 'dependabot[bot]'" in script
     assert "pullRequest.head.ref !== sourceHeadBranch" in script
-    assert "pullRequest.head.repo.full_name !== expectedRepository" in script
+    assert "sourceHeadRepository !== expectedRepository" in script
     assert "core.setFailed" in script
     assert "core.setOutput('pr_number'" in script
     assert "core.setOutput('source_run_id'" in script
     assert "core.setOutput('source_run_url'" in script
     assert "core.setOutput('source_run_conclusion'" in script
+    assert "source_run_attempt" in script
+    assert "source_workflow_id" in script
+    assert "source_head_repository" in script
+    assert "source_head_branch" in script
+    for output_name in (
+        "source_run_attempt",
+        "source_run_event",
+        "source_run_id",
+        "source_run_number",
+        "source_workflow_id",
+    ):
+        assert resolver_job["outputs"][output_name] == (f"${{{{ steps.resolve-context.outputs.{output_name} }}}}")
+    assert resolver_job["outputs"]["writer_ready"] == ("${{ steps.resolve-context.outputs.writer_ready }}")
 
-    for step in job["steps"][1:]:
-        assert "steps.resolve-context.outcome == 'success'" in str(step.get("if", ""))
+    job = _load_job()
+    collect = next(step for step in job["steps"] if step.get("id") == "collect-jobs")
+    assert "needs.resolve-pr-context.outputs.source_run_id" in collect["env"]["SOURCE_RUN_ID"]
+    assert collect["env"]["SOURCE_HEAD_BRANCH"] == ("${{ needs.resolve-pr-context.outputs.source_head_branch }}")
+    assert "run_id: sourceRunId" in collect["with"]["script"]
+    assert "run.head_branch === sourceHeadBranch" in collect["with"]["script"]
+    assert "run.head_repository?.full_name === sourceHeadRepository" in collect["with"]["script"]
 
-    discovery = next(step for step in job["steps"] if step.get("id") == "discover_artifacts")
-    assert "steps.resolve-context.outputs.source_run_id" in discovery["env"]["SOURCE_RUN_ID"]
-    assert "run_id: Number(process.env.SOURCE_RUN_ID)" in discovery["with"]["script"]
-
-    post = next(step for step in job["steps"] if step.get("name") == "Post or update PR comments")
-    assert post["env"]["PR_NUMBER"] == "${{ steps.resolve-context.outputs.pr_number }}"
-    assert post["env"]["WORKFLOW_RUN_URL"] == "${{ steps.resolve-context.outputs.source_run_url }}"
-    assert post["env"]["WORKFLOW_CONCLUSION"] == ("${{ steps.resolve-context.outputs.source_run_conclusion }}")
-    assert post["env"]["SOURCE_RESOLUTION_ERROR"] == ("${{ steps.resolve-context.outputs.source_error }}")
-    assert "source_ready" not in str(post["if"])
-    assert "SOURCE_RESOLUTION_ERROR" in post["with"]["script"]
+    post = next(step for step in job["steps"] if step.get("name") == "Post or update trusted PR comment")
+    assert post["env"]["PR_NUMBER"] == ("${{ needs.resolve-pr-context.outputs.pr_number }}")
+    assert post["env"]["WORKFLOW_RUN_URL"] == ("${{ needs.resolve-pr-context.outputs.source_run_url }}")
+    assert post["env"]["WORKFLOW_CONCLUSION"] == ("${{ needs.resolve-pr-context.outputs.source_run_conclusion }}")
+    assert post["env"]["SOURCE_HEAD_BRANCH"] == ("${{ needs.resolve-pr-context.outputs.source_head_branch }}")
+    assert post["env"]["SOURCE_HEAD_REPOSITORY"] == ("${{ needs.resolve-pr-context.outputs.source_head_repository }}")
+    assert post["env"]["SOURCE_RUN_ATTEMPT"] == ("${{ needs.resolve-pr-context.outputs.source_run_attempt }}")
+    assert post["env"]["SOURCE_RUN_EVENT"] == ("${{ needs.resolve-pr-context.outputs.source_run_event }}")
+    assert post["env"]["SOURCE_RUN_ID"] == ("${{ needs.resolve-pr-context.outputs.source_run_id }}")
+    assert post["env"]["SOURCE_RUN_NUMBER"] == ("${{ needs.resolve-pr-context.outputs.source_run_number }}")
+    assert post["env"]["SOURCE_WORKFLOW_ID"] == ("${{ needs.resolve-pr-context.outputs.source_workflow_id }}")
+    assert "pullRequest.head.ref !== sourceHeadBranch" in post["with"]["script"]
+    assert "pullRequest.head.repo?.full_name !== sourceHeadRepository" in post["with"]["script"]
+    assert "run.head_branch === sourceHeadBranch" in post["with"]["script"]
+    assert "run.head_repository?.full_name === sourceHeadRepository" in post["with"]["script"]
+    assert post["if"] == "always() && !cancelled()"
+    assert "SOURCE_RESOLUTION_ERROR" not in post["env"]
+    assert "SOURCE_RESOLUTION_ERROR" not in post["with"]["script"]
 
     enforcement = next(step for step in job["steps"] if step.get("name") == "Enforce trusted source resolution")
     assert "always()" in enforcement["if"]
-    assert "outputs.source_ready != 'true'" in enforcement["if"]
+    assert "needs.resolve-pr-context.outputs.source_ready != 'true'" in enforcement["if"]
     assert "exit 1" in enforcement["run"]
 
 
 def test_comment_monitor_budget_exceeds_the_declared_comprehensive_needs_dag() -> None:
-    job = _load_job()
-    resolve = next(step for step in job["steps"] if step.get("id") == "resolve-context")
+    resolver_job = _load_resolver_job()
+    resolve = next(step for step in resolver_job["steps"] if step.get("id") == "resolve-context")
     script = resolve["with"]["script"]
-    attempt_match = re.search(r"attempt < (\d+)", script)
+    attempt_match = re.search(
+        r"let attempt = 0;\s+attempt < (\d+)",
+        script,
+    )
     interval_match = re.search(r"setTimeout\(resolve, (\d+)\)", script)
     assert attempt_match is not None
     assert interval_match is not None
@@ -218,11 +356,34 @@ def test_comment_monitor_budget_exceeds_the_declared_comprehensive_needs_dag() -
 
     comprehensive_bound = declared_path_minutes("test-report")
     assert poll_minutes >= comprehensive_bound + 10
-    assert job["timeout-minutes"] >= poll_minutes + 10
+    assert resolver_job["timeout-minutes"] >= poll_minutes + 10
 
 
-def test_trusted_commenter_never_checks_out_or_executes_pr_code() -> None:
+def test_trusted_commenter_checks_out_only_its_immutable_trusted_renderer() -> None:
     job = _load_job()
+    checkouts = [step for step in job["steps"] if str(step.get("uses", "")).startswith("actions/checkout@")]
+    assert len(checkouts) == 1
+    assert checkouts[0]["with"] == {
+        "repository": "${{ github.repository }}",
+        "ref": "${{ github.sha }}",
+        "fetch-depth": 1,
+        "persist-credentials": False,
+        "sparse-checkout": (
+            ".github/workflows/comprehensive-tests.yml\n"
+            "scripts/ci/comprehensive_pr_comment.py\n"
+            "scripts/ci/comprehensive_report.py\n"
+        ),
+        "sparse-checkout-cone-mode": False,
+    }
+
+    resolver_job = _load_resolver_job()
+    resolve = next(step for step in resolver_job["steps"] if step.get("id") == "resolve-context")
+    script = resolve["with"]["script"]
+    assert "context.ref" in script
+    assert "context.payload.repository.default_branch" in script
+    assert "must run from the default branch" in script
+
     uses = [str(step.get("uses", "")) for step in job["steps"]]
-    assert all(not action.startswith("actions/checkout@") for action in uses)
     assert all(not action.startswith("./") for action in uses)
+    serialized = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "pullRequest.head.sha }}" not in serialized

--- a/tests/smoke/test_comprehensive_report_workflow_properties.py
+++ b/tests/smoke/test_comprehensive_report_workflow_properties.py
@@ -139,6 +139,7 @@ def test_report_job_passes_needs_json_to_the_stdlib_validator() -> None:
         step for step in _steps_for(report_job) if "scripts/ci/comprehensive_report.py" in str(step.get("run", ""))
     )
     validator_command = validator_step["run"]
+    assert "python -I scripts/ci/comprehensive_report.py" in validator_command
     assert "--artifacts-dir all-results" in validator_command
     assert "--output test-report.md" in validator_command
     assert '--event-name "$EVENT_NAME"' in validator_command

--- a/tests/smoke/test_dependabot_uv_lock_workflow_properties.py
+++ b/tests/smoke/test_dependabot_uv_lock_workflow_properties.py
@@ -233,8 +233,10 @@ def test_dispatch_allowlist_is_literal_exact_and_every_target_is_read_only() -> 
 def test_writer_dispatches_the_comment_monitor_beside_required_checks() -> None:
     source = PUBLISHER_SCRIPT.read_text(encoding="utf-8")
 
-    assert 'COMMENT_WORKFLOW = "comprehensive-test-pr-comments.yml"' in source
+    assert 'COMMENT_DISPATCH_EVENT = "dependabot-comprehensive-test-comment"' in source
     assert "def dispatch_comment_workflow(" in source
+    assert '"event_type": COMMENT_DISPATCH_EVENT' in source
+    assert '"client_payload": {' in source
     assert '"source_head_sha": commit_oid' in source
     assert '"source_head_branch": head_ref' in source
     assert source.index("dispatched = dispatch_required_workflows(") < source.index(

--- a/tests/smoke/test_merge_queue_workflow_properties.py
+++ b/tests/smoke/test_merge_queue_workflow_properties.py
@@ -190,11 +190,14 @@ def test_existing_pull_request_and_push_triggers_are_preserved() -> None:
         "docker-compose.yml",
         "justfile",
         "scripts/ci/commit_generated_dependencies.py",
+        "scripts/ci/comprehensive_pr_comment.py",
         "scripts/ci/dependency_audit_contract.py",
         "scripts/ci/ensure-podman-runtime.sh",
         "scripts/ci/parse_pip_audit.py",
         "scripts/sync_requirements.py",
         "tests/scripts/test_commit_generated_dependencies.py",
+        "tests/scripts/test_comprehensive_pr_comment.py",
+        "tests/scripts/test_comprehensive_pr_comment_publisher.py",
         "tests/scripts/test_dependency_audit_contract.py",
         "tests/scripts/test_parse_pip_audit.py",
         "tests/smoke/test_comprehensive_pr_comments_workflow_properties.py",
@@ -262,32 +265,33 @@ def test_merge_group_cannot_receive_write_scope() -> None:
             "workflows": ["Comprehensive Tests"],
             "types": ["completed"],
         },
-        "workflow_dispatch": {
-            "inputs": {
-                "source_head_sha": {
-                    "description": "Exact Dependabot head whose Comprehensive run must be reported",
-                    "required": True,
-                    "type": "string",
-                },
-                "source_head_branch": {
-                    "description": "Exact same-repository Dependabot branch",
-                    "required": True,
-                    "type": "string",
-                },
-            }
-        },
+        "repository_dispatch": {"types": ["dependabot-comprehensive-test-comment"]},
     }
     assert comment_workflow.get("permissions") == {"contents": "read"}
 
     comment_jobs = comment_workflow.get("jobs")
     assert isinstance(comment_jobs, dict)
-    assert set(comment_jobs) == {"post-pr-comments"}
+    assert set(comment_jobs) == {"resolve-pr-context", "post-pr-comments"}
+    resolver_job = comment_jobs["resolve-pr-context"]
+    resolver_condition = str(resolver_job.get("if"))
+    assert "github.event_name == 'repository_dispatch'" in resolver_condition
+    assert "github.event.workflow_run.event == 'pull_request'" in resolver_condition
+    assert resolver_job.get("permissions") == {
+        "actions": "read",
+        "contents": "read",
+        "pull-requests": "read",
+    }
     comment_job = comment_jobs["post-pr-comments"]
     comment_condition = str(comment_job.get("if"))
-    assert "github.event_name == 'workflow_dispatch'" in comment_condition
-    assert "github.event.workflow_run.event == 'pull_request'" in comment_condition
-    assert "github.event.workflow_run.event == 'workflow_dispatch'" not in comment_condition
-    assert "workflow_run.head_sha" in str(comment_job.get("concurrency", {}).get("group"))
+    assert "needs.resolve-pr-context.result == 'success'" in comment_condition
+    assert "needs.resolve-pr-context.outputs.pr_number != ''" in comment_condition
+    assert "needs.resolve-pr-context.outputs.writer_ready == 'true'" in comment_condition
+    assert comment_job.get("needs") == "resolve-pr-context"
+    assert comment_job.get("concurrency", {}).get("group") == (
+        "comprehensive-test-pr-comment-pr-${{ needs.resolve-pr-context.outputs.pr_number }}"
+    )
+    assert comment_job.get("concurrency", {}).get("queue") == "max"
+    assert comment_job.get("concurrency", {}).get("cancel-in-progress") is False
     assert comment_job.get("permissions") == {
         "actions": "read",
         "contents": "read",
@@ -295,7 +299,22 @@ def test_merge_group_cannot_receive_write_scope() -> None:
     }
 
     uses = [str(step.get("uses", "")) for step in comment_job.get("steps", [])]
-    assert all(not action.startswith("actions/checkout@") for action in uses)
+    checkouts = [
+        step for step in comment_job.get("steps", []) if str(step.get("uses", "")).startswith("actions/checkout@")
+    ]
+    assert len(checkouts) == 1
+    assert checkouts[0].get("with") == {
+        "repository": "${{ github.repository }}",
+        "ref": "${{ github.sha }}",
+        "fetch-depth": 1,
+        "persist-credentials": False,
+        "sparse-checkout": (
+            ".github/workflows/comprehensive-tests.yml\n"
+            "scripts/ci/comprehensive_pr_comment.py\n"
+            "scripts/ci/comprehensive_report.py\n"
+        ),
+        "sparse-checkout-cone-mode": False,
+    }
     assert all(not action.startswith("./") for action in uses)
 
 


### PR DESCRIPTION
Closes #5761

## Summary

Replaces the write-scoped Comprehensive PR commenter with a fail-closed, API-derived renderer so pull-request-controlled artifacts can never be posted by github-actions[bot].

## Changes Made

- Resolve exact Comprehensive workflow runs and current PR heads in a read-only job, including ordinary contributor forks.
- Authenticate source workflow/report policy bytes against immutable trusted main.
- Collect bounded job data from the GitHub API and render Markdown with standard-library-only trusted Python.
- Preserve red fallback reporting while rejecting malformed, stale, contradictory, oversized, duplicate, or incomplete inputs.
- Enforce exact workflow/repository/branch/SHA/run/attempt identity and unique monotonic ordering across PR and dispatch runs.
- Serialize all writers for one PR with queue:max and repeat PR/run/order validation immediately before mutation.
- Replace selectable Dependabot workflow dispatch with a typed default-branch repository dispatch.
- Bound comment discovery, append a newest red fallback on incomplete discovery, and best-effort retire every safely discovered bot-owned green report.
- Stream executable Node test harnesses through stdin so large overflow fixtures are portable to hosted Linux.

## Verification

- Full pre-push suite: 1,553 passed, 228 known skips.
- Focused report/comment/workflow suite: 249 passed.
- Workflow smoke suite: 81 passed.
- Renderer, publisher, and commenter property suite: 111 passed.
- Ruff, mypy, pre-commit, YAML, Markdown, Bandit, and diff checks passed.
- Independent architecture, implementation, Actions, security, integration, and test reviews found no remaining source blockers.

## Security

The write-scoped job never downloads source-run artifacts or checks out pull-request code. Any source policy drift, missing authoritative identity, ordering uncertainty, rendering failure, or incomplete comment discovery fails closed. On incomplete discovery it first posts a new red fallback, then independently attempts to replace every safely discovered owned green report.
